### PR TITLE
Run Durable Streams conformance suite in CI; close feasible protocol gaps

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -1,0 +1,68 @@
+name: Conformance
+
+# Runs the upstream Durable Streams server-conformance-tests suite against a
+# live rakaia server. It is currently INFORMATIONAL (non-blocking): the suite
+# step uses `continue-on-error` so failures are reported without blocking
+# merges while rakaia's protocol coverage matures (stream forking is not yet
+# implemented). Flip `continue-on-error` off to make it a required check once
+# rakaia passes the full suite.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  conformance:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          enable-cache: true
+
+      - name: Set up Python 3.12
+        run: uv python install 3.12
+
+      - name: Install Python dependencies
+        run: uv sync --extra dev
+
+      - name: Set up Node 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: conformance/package-lock.json
+
+      - name: Install conformance suite
+        working-directory: conformance
+        run: npm ci
+
+      - name: Run Durable Streams conformance suite (informational)
+        id: conformance
+        continue-on-error: true
+        run: ./conformance/run.sh 4437 2>&1 | tee conformance-results.log
+
+      - name: Summarize results
+        if: always()
+        run: |
+          {
+            echo "### Durable Streams conformance results"
+            echo ""
+            echo '```'
+            grep -E "Test Files|Tests " conformance-results.log | tail -5 \
+              || echo "(no summary captured — see the uploaded log)"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload full log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: conformance-log
+          path: conformance-results.log
+          if-no-files-found: warn

--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,4 @@ examples/chat/staticfiles/
 # Conformance harness (JS deps + run logs)
 conformance/node_modules/
 conformance-results.log
+conformance-server.log

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,7 @@ examples/chat/staticfiles/
 # Zensical build output
 /site/
 .zensical-cache/
+
+# Conformance harness (JS deps + run logs)
+conformance/node_modules/
+conformance-results.log

--- a/README.md
+++ b/README.md
@@ -144,6 +144,20 @@ uv run ruff check src/
 uv run pyright src/
 ```
 
+### Protocol conformance
+
+Beyond the pytest suite, rakaia is checked against the upstream, language-agnostic
+[`@durable-streams/server-conformance-tests`](https://github.com/durable-streams/durable-streams/tree/main/packages/server-conformance-tests)
+compliance suite:
+
+```bash
+just conformance   # starts rakaia, runs the suite against it, tears it down (needs node/npm)
+```
+
+This runs in CI as a non-blocking check (`.github/workflows/conformance.yml`).
+rakaia passes the full protocol surface today except the stream **forking**
+family, which is not yet implemented. See [`conformance/README.md`](conformance/README.md).
+
 ## License
 
 MIT.

--- a/conformance/README.md
+++ b/conformance/README.md
@@ -1,0 +1,45 @@
+# Durable Streams conformance tests
+
+This directory runs the upstream, language-agnostic protocol compliance suite —
+[`@durable-streams/server-conformance-tests`](https://github.com/durable-streams/durable-streams/tree/main/packages/server-conformance-tests)
+— against a running rakaia server. It gives us an independent signal that
+rakaia implements the [Durable Streams protocol](../docs/protocol.md) correctly,
+separate from rakaia's own pytest suite.
+
+## Running locally
+
+From the repo root:
+
+```bash
+just conformance          # starts rakaia on :4437, runs the suite, tears it down
+just conformance 4500     # use a different port
+```
+
+Or drive it directly:
+
+```bash
+conformance/run.sh 4437
+```
+
+To run against a server you started yourself:
+
+```bash
+cd conformance
+npm ci
+CONFORMANCE_TEST_URL=http://127.0.0.1:4437 npm test
+```
+
+## Version pinning
+
+The suite version is pinned in `package.json` (and `package-lock.json`) for
+reproducibility. Bump `@durable-streams/server-conformance-tests` there and
+re-run `npm install` to pick up a newer protocol revision.
+
+## Status
+
+The suite runs in CI as a **non-blocking / informational** check
+(`.github/workflows/conformance.yml`) while rakaia's coverage matures. rakaia
+currently passes the full protocol surface **except the stream forking family**
+(`Stream-Forked-From` / `Stream-Fork-Offset` / `Stream-Fork-Sub-Offset`,
+sub-offset prefix materialization, cascade GC, and fork TTL inheritance), which
+is not yet implemented. See the tracking issue for details.

--- a/conformance/conformance.test.mjs
+++ b/conformance/conformance.test.mjs
@@ -1,0 +1,23 @@
+// Vitest entry point for the Durable Streams server conformance suite.
+//
+// The upstream package registers its `describe`/`test` blocks when
+// `runConformanceTests()` is called, so this file simply invokes it against
+// the server URL provided via CONFORMANCE_TEST_URL. Point it at a running
+// rakaia instance:
+//
+//   CONFORMANCE_TEST_URL=http://127.0.0.1:4437 npm test
+//
+// or use `../conformance/run.sh` / `just conformance`, which start the server
+// for you.
+
+import { runConformanceTests } from "@durable-streams/server-conformance-tests"
+
+const baseUrl = process.env.CONFORMANCE_TEST_URL
+if (!baseUrl) {
+  throw new Error(
+    "CONFORMANCE_TEST_URL is required (e.g. http://127.0.0.1:4437). " +
+      "Use `just conformance` or conformance/run.sh to start the server automatically.",
+  )
+}
+
+runConformanceTests({ baseUrl })

--- a/conformance/package-lock.json
+++ b/conformance/package-lock.json
@@ -1,0 +1,1400 @@
+{
+  "name": "rakaia-conformance",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "rakaia-conformance",
+      "version": "0.0.0",
+      "devDependencies": {
+        "@durable-streams/server-conformance-tests": "0.3.6",
+        "vitest": "^4.0.0"
+      }
+    },
+    "node_modules/@durable-streams/client": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/@durable-streams/client/-/client-0.2.6.tgz",
+      "integrity": "sha512-uHKKbWpsKLhFMeGjG0PgM6LXE3oEIi7FHKlJZkmYGxcqd4Yjjd/QEvnQnDzteRP4Av1uJVM8qjTL7kfKsgeS/w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@microsoft/fetch-event-source": "^2.0.1",
+        "fastq": "^1.19.1"
+      },
+      "bin": {
+        "intent": "bin/intent.js"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@durable-streams/server-conformance-tests": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@durable-streams/server-conformance-tests/-/server-conformance-tests-0.3.6.tgz",
+      "integrity": "sha512-mYuErUvlUpRCWIHlkkaKltImMGYl9La2VRMhq9ic6uz7uaW/fUqSiiKnzrzrdKa0g1khUjeTGuhIfwVKgd1J2Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@durable-streams/client": "0.2.6",
+        "fast-check": "^4.4.0",
+        "vitest": "^4.0.0"
+      },
+      "bin": {
+        "durable-streams-server-conformance": "dist/cli.js",
+        "durable-streams-server-conformance-dev": "bin/conformance-dev.mjs",
+        "server-conformance-tests": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@microsoft/fetch-event-source": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/fetch-event-source/-/fetch-event-source-2.0.1.tgz",
+      "integrity": "sha512-W6CLUJ2eBMw3Rec70qrsEW0jOm/3twwJv21mrmj2yORiaVmVYGS4sSS5yUwvQc1ZlDLYGPnClVWmUUMagKNsfA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.139.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
+      "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
+      "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
+      "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
+      "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
+      "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
+      "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
+      "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
+      "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
+      "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
+      "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
+      "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
+      "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
+      "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
+      "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
+      "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
+      "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fast-check": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.9.0.tgz",
+      "integrity": "sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=12.17.0"
+      }
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.19",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
+      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/pure-rand": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.2.tgz",
+      "integrity": "sha512-vvuOGgcuPJAirlHvuQw1TrOiw7ptaIXXmIbNuiNOY6lNGJJH49PQ1Kj4nd783nPdQhQdicgOjVI2yI/9BD6/Ng==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
+      "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.139.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.1.5",
+        "@rolldown/binding-darwin-arm64": "1.1.5",
+        "@rolldown/binding-darwin-x64": "1.1.5",
+        "@rolldown/binding-freebsd-x64": "1.1.5",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.5",
+        "@rolldown/binding-linux-arm64-musl": "1.1.5",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.5",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-musl": "1.1.5",
+        "@rolldown/binding-openharmony-arm64": "1.1.5",
+        "@rolldown/binding-wasm32-wasi": "1.1.5",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.5",
+        "@rolldown/binding-win32-x64-msvc": "1.1.5"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/vite": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
+      "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.17",
+        "rolldown": "~1.1.5",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.3.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/conformance/package.json
+++ b/conformance/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "rakaia-conformance",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Runs the upstream @durable-streams/server-conformance-tests suite against a running rakaia server.",
+  "scripts": {
+    "test": "vitest run --no-coverage --reporter=default"
+  },
+  "devDependencies": {
+    "@durable-streams/server-conformance-tests": "0.3.6",
+    "vitest": "^4.0.0"
+  }
+}

--- a/conformance/run.sh
+++ b/conformance/run.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+#
+# Start the standalone rakaia server, run the Durable Streams conformance
+# suite against it, then tear the server down. Exits with the suite's status.
+#
+# Usage:
+#   conformance/run.sh [port]
+#
+# Requires: uv (with the Python env synced), node/npm. The JS dependencies are
+# installed on first run if conformance/node_modules is missing.
+set -uo pipefail
+
+PORT="${1:-4437}"
+BASE_URL="http://127.0.0.1:${PORT}"
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "${HERE}/.." && pwd)"
+
+# Install the JS conformance dependencies if needed.
+if [ ! -d "${HERE}/node_modules" ]; then
+  echo "==> Installing conformance dependencies (npm ci)"
+  (cd "${HERE}" && npm ci)
+fi
+
+# Start the standalone rakaia server in the background.
+echo "==> Starting rakaia on ${BASE_URL}"
+(
+  cd "${ROOT}" &&
+    exec uv run uvicorn rakaia:app --host 127.0.0.1 --port "${PORT}" --log-level warning
+) &
+SERVER_PID=$!
+
+cleanup() {
+  # Stop the uvicorn worker (child of the uv launcher) and the launcher
+  # itself, addressed by PID so we never match an unrelated process. Avoid a
+  # blocking `wait` so teardown can't hang the job if SIGTERM is slow.
+  pkill -P "${SERVER_PID}" 2>/dev/null || true
+  kill "${SERVER_PID}" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+# Wait for readiness (a PUT creates a throwaway stream; 2xx means we're up).
+echo "==> Waiting for the server to accept requests"
+ready=""
+for _ in $(seq 1 60); do
+  if curl -fsS -o /dev/null -X PUT -H "content-type: text/plain" \
+      "${BASE_URL}/__conformance_probe" 2>/dev/null; then
+    ready="yes"
+    break
+  fi
+  sleep 0.5
+done
+if [ -z "${ready}" ]; then
+  echo "!! Server did not become ready on ${BASE_URL}" >&2
+  exit 1
+fi
+
+# Run the conformance suite.
+echo "==> Running Durable Streams conformance suite against ${BASE_URL}"
+CONFORMANCE_TEST_URL="${BASE_URL}" npm --prefix "${HERE}" test
+exit $?

--- a/conformance/run.sh
+++ b/conformance/run.sh
@@ -14,6 +14,7 @@ PORT="${1:-4437}"
 BASE_URL="http://127.0.0.1:${PORT}"
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT="$(cd "${HERE}/.." && pwd)"
+SERVER_LOG="${ROOT}/conformance-server.log"
 
 # Install the JS conformance dependencies if needed.
 if [ ! -d "${HERE}/node_modules" ]; then
@@ -21,12 +22,14 @@ if [ ! -d "${HERE}/node_modules" ]; then
   (cd "${HERE}" && npm ci)
 fi
 
-# Start the standalone rakaia server in the background.
-echo "==> Starting rakaia on ${BASE_URL}"
+# Start the standalone rakaia server in the background. Its stdout/stderr go to
+# a log file (NOT this script's stdout) so the server never holds a pipe open —
+# otherwise a `| tee` on the caller side would block waiting for EOF at teardown.
+echo "==> Starting rakaia on ${BASE_URL} (server log: ${SERVER_LOG})"
 (
   cd "${ROOT}" &&
     exec uv run uvicorn rakaia:app --host 127.0.0.1 --port "${PORT}" --log-level warning
-) &
+) >"${SERVER_LOG}" 2>&1 &
 SERVER_PID=$!
 
 cleanup() {
@@ -51,6 +54,8 @@ for _ in $(seq 1 60); do
 done
 if [ -z "${ready}" ]; then
   echo "!! Server did not become ready on ${BASE_URL}" >&2
+  echo "---- server log ----" >&2
+  cat "${SERVER_LOG}" >&2 || true
   exit 1
 fi
 

--- a/justfile
+++ b/justfile
@@ -194,6 +194,15 @@ rakaia port="4437":
     uv run uvicorn rakaia:app --host 0.0.0.0 --port {{port}}
 
 # ---------------------------------------------------------------------------
+# Durable Streams conformance suite
+# ---------------------------------------------------------------------------
+
+# Start rakaia, run the upstream conformance suite against it, tear it down.
+# Requires node/npm. See conformance/README.md.
+conformance port="4437":
+    ./conformance/run.sh {{port}}
+
+# ---------------------------------------------------------------------------
 # Quality gates
 # ---------------------------------------------------------------------------
 

--- a/src/rakaia/handler.py
+++ b/src/rakaia/handler.py
@@ -95,8 +95,13 @@ class InjectedFault:
 class ServerOptions:
     """Configuration for the ASGI handler."""
 
-    long_poll_timeout: float = float(os.environ.get("LONG_POLL_TIMEOUT", "30.0"))
-    """Default long-poll timeout in seconds."""
+    long_poll_timeout: float = float(os.environ.get("LONG_POLL_TIMEOUT", "3.0"))
+    """Default long-poll hold window in seconds.
+
+    Kept short so a caught-up long-poll (e.g. ``?offset=now&live=long-poll``)
+    returns a ``204`` promptly rather than blocking a client for tens of
+    seconds. Override with the ``LONG_POLL_TIMEOUT`` environment variable.
+    """
 
     cursor_options: CursorOptions = field(default_factory=CursorOptions)
     """Cursor calculation options."""
@@ -131,8 +136,8 @@ def create_app(
             "access-control-allow-origin": "*",
             "access-control-allow-methods": "GET, POST, PUT, DELETE, HEAD, OPTIONS",
             "access-control-allow-headers": (
-                "content-type, authorization, Stream-Seq, Stream-TTL, "
-                "Stream-Expires-At, Stream-Closed, Producer-Id, "
+                "content-type, authorization, If-None-Match, Stream-Seq, "
+                "Stream-TTL, Stream-Expires-At, Stream-Closed, Producer-Id, "
                 "Producer-Epoch, Producer-Seq"
             ),
             "access-control-expose-headers": (
@@ -390,6 +395,12 @@ async def _handle_head(
     if stream.closed:
         headers[STREAM_CLOSED_HEADER_RESP] = "true"
 
+    # Surface configured expiry metadata (HEAD must not extend the TTL window).
+    if stream.ttl_seconds is not None:
+        headers["Stream-TTL"] = str(stream.ttl_seconds)
+    if stream.expires_at:
+        headers["Stream-Expires-At"] = stream.expires_at
+
     # ETag: {path_b64}:-1:{offset}[:c]
     path_b64 = base64.b64encode(path.encode()).decode()
     closed_suffix = ":c" if stream.closed else ""
@@ -499,6 +510,8 @@ async def _handle_read(
     # Catch-up mode with offset=now: return empty with tail offset
     # For regular GET, return 200 with empty body. For long-poll, fall through to wait.
     if offset == "now" and live != "long-poll":
+        # A catch-up read extends the sliding TTL window.
+        store.touch(path)
         headers: dict[str, str] = {
             **cors,
             STREAM_OFFSET_HEADER_RESP: stream.current_offset,
@@ -655,6 +668,33 @@ def _encode_sse_data(payload: str) -> str:
     return result
 
 
+def _build_sse_control(
+    control_offset: str,
+    tail_offset: str,
+    stream_is_closed: bool,
+    up_to_date: bool,
+    cursor: str | None,
+    cursor_options: CursorOptions,
+) -> bytes:
+    """Build an SSE ``control`` event frame for a given offset.
+
+    Emitted immediately after each ``data`` event during catch-up so consumers
+    can rely on strict data -> control pairing. Signals closure at the tail and
+    otherwise carries the collapse cursor and (at the tail) the up-to-date flag.
+    """
+    at_tail = control_offset == tail_offset
+    control_data: dict[str, str | bool] = {SSE_OFFSET_FIELD: control_offset}
+    if stream_is_closed and at_tail:
+        control_data[SSE_CLOSED_FIELD] = True
+    else:
+        control_data[SSE_CURSOR_FIELD] = generate_response_cursor(
+            cursor, cursor_options
+        )
+        if at_tail and up_to_date:
+            control_data[SSE_UP_TO_DATE_FIELD] = True
+    return f"event: control\n{_encode_sse_data(json.dumps(control_data))}".encode()
+
+
 async def _handle_sse(
     path: str,
     stream: Any,
@@ -694,52 +734,56 @@ async def _handle_sse(
         except KeyError:
             break
 
-        buffer = b""
-
-        # Send data events
-        for message in messages:
-            if use_base64:
-                data_payload = base64.b64encode(message.data).decode()
-            elif is_json_stream:
-                json_bytes = store.format_response(path, [message])
-                data_payload = json_bytes.decode("utf-8")
-            else:
-                data_payload = message.data.decode("utf-8")
-
-            sse_data = f"event: data\n{_encode_sse_data(data_payload)}"
-            buffer += sse_data.encode("utf-8")
-            current_offset = message.offset
-
-        # Build control event
         current_stream = store.get(path)
         if current_stream is None:
-            if buffer:
-                await send_body_chunk(send, buffer)
             break
 
-        control_offset = (
-            messages[-1].offset if messages else current_stream.current_offset
-        )
+        tail_offset = current_stream.current_offset
         stream_is_closed = current_stream.closed
-        client_at_tail = control_offset == current_stream.current_offset
+        cursor_opts = opts.cursor_options
 
-        control_data: dict[str, str | bool] = {
-            SSE_OFFSET_FIELD: control_offset,
-        }
+        buffer = b""
 
-        if stream_is_closed and client_at_tail:
-            control_data[SSE_CLOSED_FIELD] = True
+        if messages:
+            # Pair every data event with its own control event so consumers can
+            # rely on a strict data -> control framing during catch-up.
+            for message in messages:
+                if use_base64:
+                    data_payload = base64.b64encode(message.data).decode()
+                elif is_json_stream:
+                    json_bytes = store.format_response(path, [message])
+                    data_payload = json_bytes.decode("utf-8")
+                else:
+                    data_payload = message.data.decode("utf-8")
+
+                sse_data = f"event: data\n{_encode_sse_data(data_payload)}"
+                buffer += sse_data.encode("utf-8")
+                buffer += _build_sse_control(
+                    message.offset,
+                    tail_offset,
+                    stream_is_closed,
+                    up_to_date,
+                    cursor,
+                    cursor_opts,
+                )
+                current_offset = message.offset
+
+            control_offset = messages[-1].offset
         else:
-            resp_cursor = generate_response_cursor(cursor, opts.cursor_options)
-            control_data[SSE_CURSOR_FIELD] = resp_cursor
-            if up_to_date:
-                control_data[SSE_UP_TO_DATE_FIELD] = True
-
-        control_json = json.dumps(control_data)
-        sse_control = f"event: control\n{_encode_sse_data(control_json)}"
-        buffer += sse_control.encode("utf-8")
+            # Caught up with nothing new: emit a single control event.
+            control_offset = tail_offset
+            buffer += _build_sse_control(
+                control_offset,
+                tail_offset,
+                stream_is_closed,
+                up_to_date,
+                cursor,
+                cursor_opts,
+            )  # noqa: B023
 
         await send_body_chunk(send, buffer)
+
+        client_at_tail = control_offset == tail_offset
 
         # If closed and at tail, end connection
         if stream_is_closed and client_at_tail:

--- a/src/rakaia/store.py
+++ b/src/rakaia/store.py
@@ -56,12 +56,17 @@ class StreamStore:
     # =========================================================================
 
     def _is_expired(self, stream: Stream) -> bool:
-        """Check if a stream is expired based on TTL or Expires-At."""
+        """Check if a stream is expired based on TTL or Expires-At.
+
+        Stream-TTL is a sliding window anchored on ``last_activity_at`` (reset
+        on read/write/close). Stream-Expires-At is an absolute deadline that
+        does not slide.
+        """
         now = time.time()
 
         if (
             stream.ttl_seconds is not None
-            and now - stream.created_at > stream.ttl_seconds
+            and now - stream.last_activity_at > stream.ttl_seconds
         ):
             return True
 
@@ -86,6 +91,21 @@ class StreamStore:
             self.delete(path)
             return None
         return stream
+
+    def _touch(self, stream: Stream) -> None:
+        """Extend the sliding TTL window for a stream (no-op without a TTL)."""
+        if stream.ttl_seconds is not None:
+            stream.last_activity_at = time.time()
+
+    def touch(self, path: str) -> None:
+        """Reset the TTL sliding window for a stream if it exists.
+
+        Called for TTL-extending activity that does not otherwise mutate the
+        stream (e.g. a ``GET ?offset=now`` catch-up read).
+        """
+        stream = self._get_if_not_expired(path)
+        if stream is not None:
+            self._touch(stream)
 
     def create(
         self,
@@ -121,13 +141,15 @@ class StreamStore:
                 f"Stream already exists with different configuration: {path}"
             )
 
+        now = time.time()
         stream = Stream(
             path=path,
             content_type=content_type,
             current_offset=INITIAL_OFFSET,
             ttl_seconds=ttl_seconds,
             expires_at=expires_at,
-            created_at=time.time(),
+            created_at=now,
+            last_activity_at=now,
             closed=closed,
         )
 
@@ -243,6 +265,9 @@ class StreamStore:
 
         # === STATE MUTATION (only after successful append) ===
 
+        # A write extends the sliding TTL window.
+        self._touch(stream)
+
         if producer_result is not None:
             self._commit_producer_state(stream, producer_result)
 
@@ -301,6 +326,9 @@ class StreamStore:
         already_closed = stream.closed
         stream.closed = True
 
+        # A close extends the sliding TTL window.
+        self._touch(stream)
+
         self._notify_closed(path)
 
         return CloseResult(
@@ -356,6 +384,10 @@ class StreamStore:
             # Commit and close
             self._commit_producer_state(stream, producer_result)
             stream.closed = True
+
+            # A close extends the sliding TTL window.
+            self._touch(stream)
+
             from .types import ClosedBy
 
             stream.closed_by = ClosedBy(
@@ -388,6 +420,9 @@ class StreamStore:
         stream = self._get_if_not_expired(path)
         if stream is None:
             raise KeyError(f"Stream not found: {path}")
+
+        # A read extends the sliding TTL window.
+        self._touch(stream)
 
         if not offset or offset == "-1":
             return list(stream.messages), True

--- a/src/rakaia/types.py
+++ b/src/rakaia/types.py
@@ -125,6 +125,13 @@ class Stream:
     created_at: float = 0.0
     """Timestamp when the stream was created."""
 
+    last_activity_at: float = 0.0
+    """Timestamp of the last TTL-extending activity (sliding-window anchor).
+
+    Reset to now on read/write/close so that Stream-TTL behaves as a sliding
+    expiry window. Absolute Stream-Expires-At streams ignore this field.
+    """
+
     producers: dict[str, ProducerState] = field(default_factory=dict)
     """Producer states for idempotent writes. Maps producer ID to state."""
 

--- a/tests/test_rakaia/test_handler.py
+++ b/tests/test_rakaia/test_handler.py
@@ -13,7 +13,17 @@ import pytest
 import pytest_asyncio
 
 from rakaia import StreamStore, create_app
+from rakaia.handler import ServerOptions
 from rakaia.types import INITIAL_OFFSET
+
+
+def _fast_client(timeout: float = 0.2) -> httpx.AsyncClient:
+    """A client whose server uses a short long-poll window (for wait tests)."""
+    app = create_app(
+        store=StreamStore(), options=ServerOptions(long_poll_timeout=timeout)
+    )
+    transport = httpx.ASGITransport(app=app)
+    return httpx.AsyncClient(transport=transport, base_url="http://test")
 
 
 @pytest_asyncio.fixture
@@ -275,6 +285,100 @@ class TestMethods:
     async def test_patch_returns_405(self, client: httpx.AsyncClient):
         response = await client.patch("/foo")
         assert response.status_code == 405
+
+
+# =============================================================================
+# Conformance-gap regressions
+#
+# These cover protocol behaviors exercised by the upstream
+# @durable-streams/server-conformance-tests suite that were previously missing.
+# =============================================================================
+
+
+class TestConformanceGaps:
+    async def test_cors_preflight_allows_if_none_match(self, client: httpx.AsyncClient):
+        response = await client.options(
+            "/foo",
+            headers={
+                "origin": "https://example.com",
+                "access-control-request-method": "GET",
+                "access-control-request-headers": "if-none-match",
+            },
+        )
+        assert response.status_code in (200, 204)
+        allow = response.headers.get("access-control-allow-headers", "").lower()
+        assert "if-none-match" in allow
+
+    async def test_head_returns_ttl_metadata(self, client: httpx.AsyncClient):
+        await client.put(
+            "/foo",
+            headers={"content-type": "text/plain", "Stream-TTL": "3600"},
+        )
+        response = await client.head("/foo")
+        assert response.status_code == 200
+        assert response.headers.get("Stream-TTL") == "3600"
+
+    async def test_head_returns_expires_at_metadata(self, client: httpx.AsyncClient):
+        await client.put(
+            "/foo",
+            headers={
+                "content-type": "text/plain",
+                "Stream-Expires-At": "2999-01-01T00:00:00Z",
+            },
+        )
+        response = await client.head("/foo")
+        assert response.status_code == 200
+        assert response.headers.get("Stream-Expires-At") == "2999-01-01T00:00:00Z"
+
+    async def test_offset_now_long_poll_returns_204_when_idle(self):
+        """offset=now + long-poll with no new data returns 204 promptly."""
+        async with _fast_client() as client:
+            await client.put(
+                "/foo", headers={"content-type": "text/plain"}, content=b"existing"
+            )
+            read = await client.get("/foo")
+            tail = read.headers.get("Stream-Next-Offset")
+
+            response = await client.get("/foo?offset=now&live=long-poll")
+            assert response.status_code == 204
+            assert response.headers.get("Stream-Up-To-Date") == "true"
+            assert response.headers.get("Stream-Next-Offset") == tail
+
+    async def test_sse_catch_up_pairs_each_data_event_with_control(self):
+        """During catch-up every SSE data event is followed by a control event.
+
+        Uses a closed stream so the SSE response terminates cleanly (a live
+        stream would block on the long-poll wait loop).
+        """
+        async with _fast_client() as client:
+            await client.put(
+                "/foo", headers={"content-type": "text/plain"}, content=b"one"
+            )
+            # Second append also closes the stream so SSE ends at the tail.
+            await client.post(
+                "/foo",
+                headers={"content-type": "text/plain", "Stream-Closed": "true"},
+                content=b"two",
+            )
+
+            response = await client.get("/foo?offset=-1&live=sse")
+            assert response.status_code == 200
+            received = response.text
+
+            # Parse event frames in order.
+            frames = []
+            for block in received.split("\n\n"):
+                event_line = next(
+                    (ln for ln in block.split("\n") if ln.startswith("event:")), None
+                )
+                if event_line:
+                    frames.append(event_line[len("event:") :].strip())
+
+            data_indices = [i for i, e in enumerate(frames) if e == "data"]
+            assert len(data_indices) == 2
+            # Every data frame must be immediately followed by a control frame.
+            for i in data_indices:
+                assert frames[i + 1] == "control"
 
 
 # Mark all tests as async via pytest-asyncio auto mode

--- a/tests/test_rakaia/test_store.py
+++ b/tests/test_rakaia/test_store.py
@@ -144,6 +144,55 @@ class TestExpiry:
         # Should not raise; malformed expires_at is treated as not expired
         assert store.get("foo") is not None
 
+    def test_ttl_slides_on_read(self, store: StreamStore):
+        """A read resets the TTL sliding window."""
+        with patch("rakaia.store.time.time") as mock_time:
+            mock_time.return_value = 1000.0
+            store.create("foo", ttl_seconds=10)
+
+            mock_time.return_value = 1005.0  # read within window -> extends
+            store.read("foo")
+
+            mock_time.return_value = 1012.0  # 12s after create, 7s after read
+            assert store.get("foo") is not None  # would be expired without sliding
+
+    def test_ttl_slides_on_append(self, store: StreamStore):
+        """A write resets the TTL sliding window."""
+        with patch("rakaia.store.time.time") as mock_time:
+            mock_time.return_value = 1000.0
+            store.create("foo", content_type="text/plain", ttl_seconds=10)
+
+            mock_time.return_value = 1005.0
+            store.append("foo", b"x", AppendOptions(content_type="text/plain"))
+
+            mock_time.return_value = 1012.0
+            assert store.get("foo") is not None
+
+    def test_ttl_does_not_slide_on_get(self, store: StreamStore):
+        """A metadata lookup (HEAD path) must not extend the TTL window."""
+        with patch("rakaia.store.time.time") as mock_time:
+            mock_time.return_value = 1000.0
+            store.create("foo", ttl_seconds=10)
+
+            mock_time.return_value = 1005.0
+            store.get("foo")  # HEAD-style lookup, no extension
+
+            mock_time.return_value = 1012.0
+            assert store.get("foo") is None
+
+    def test_expires_at_does_not_slide_on_read(self, store: StreamStore):
+        """Absolute Stream-Expires-At is not affected by activity."""
+        with patch("rakaia.store.time.time") as mock_time:
+            mock_time.return_value = 1000.0
+            store.create("foo", expires_at="2024-01-01T00:00:00Z")
+
+            # A read at a still-valid time must not push the absolute deadline out.
+            mock_time.return_value = 1000.0
+            store.read("foo")
+
+            mock_time.return_value = 1893456000.0  # 2030
+            assert store.get("foo") is None
+
 
 # =============================================================================
 # Append


### PR DESCRIPTION
Closes part of #9.

Adds CI that runs the upstream, language-agnostic Durable Streams compliance
suite ([`@durable-streams/server-conformance-tests`](https://github.com/durable-streams/durable-streams/tree/main/packages/server-conformance-tests))
against a live rakaia server, and fixes the feasible protocol gaps it surfaced.

## Why draft

The suite is wired **non-blocking** and rakaia is **not yet fully green** — the
remaining 56 failures are the unimplemented **stream forking** subsystem, which
needs human design decisions before implementation. This PR should be reviewed
for (a) the conformance fixes and CI wiring, and (b) confirmation of the plan to
defer forking to a follow-up. Do not flip the job to required yet.

## Conformance results

| | Passed | Failed | Skipped |
|---|--:|--:|--:|
| `main` baseline | 262 | 70 | 6 |
| this PR | **276** | 56 | 6 |

All 56 remaining failures are in `Fork - *` describe blocks.

Run it yourself:

```bash
just conformance   # starts rakaia on :4437, runs the suite, tears it down (needs node/npm)
```

## What changed

**Harness & CI**
- `conformance/` — pinned suite + vitest (`package.json` + `package-lock.json`),
  `conformance.test.mjs` entry point, `run.sh` (starts rakaia, waits for
  readiness, runs the suite, tears the server down by PID), and a README.
- `.github/workflows/conformance.yml` — a separate, **non-blocking**
  (`continue-on-error`) job on push/PR to `main` that installs uv + Python +
  Node 20, runs the suite, writes a step summary, and uploads the full log.
- `just conformance` recipe; README pointer.

**Protocol fixes (each with a pytest regression)**
- **TTL sliding window** (`store.py`, `types.py`): reads / writes / closes /
  `GET ?offset=now` extend `Stream-TTL` via a `last_activity_at` anchor.
  Absolute `Stream-Expires-At` does not slide, and `HEAD` does not extend it.
- **HEAD metadata** (`handler.py`): returns `Stream-TTL` / `Stream-Expires-At`
  when configured.
- **`offset=now` long-poll** (`handler.py`): a caught-up
  `GET ?offset=now&live=long-poll` returns `204` promptly. The default
  long-poll hold window is shortened (still overridable via `LONG_POLL_TIMEOUT`).
- **SSE framing** (`handler.py`): during catch-up every `data` event is paired
  with its own `control` event (the terminal one carries `upToDate`/closure).
- **CORS** (`handler.py`): preflight advertises `If-None-Match` in
  `Access-Control-Allow-Headers`.

## Tests

- `uv run pytest` → **317 passed, 1 skipped** (9 new regressions in
  `TestConformanceGaps` and `TestExpiry`).
- `uv run ruff check` / `ruff format --check` clean.

## Follow-ups (see #9)
- Implement the stream forking family (`Stream-Forked-From` /
  `Stream-Fork-Offset` / `Stream-Fork-Sub-Offset`, sub-offset prefix
  materialization, cascade GC, fork TTL inheritance).
- Once green, flip `conformance.yml` to a required check.
