### PR TITLE
feat: promote reconcile_tree + reconcile_aggregate to core

### DIFF
--- a/docs/adr/0001-ordering-child-collections-in-projections.md
+++ b/docs/adr/0001-ordering-child-collections-in-projections.md
@@ -1,0 +1,112 @@
+# ADR 0001 — Order child collections by stable id + fractional index
+
+- **Status:** Accepted
+- **Date:** 2026-07-19
+- **Deciders:** rakaia maintainers
+- **Related:** [`projections-and-fan-out.md`](../projections-and-fan-out.md),
+  [`tree-reconcile.md`](../tree-reconcile.md), reconcile helpers (PR #17),
+  spikes #13 / #14 / #16, issue #7
+
+## Context
+
+rakaia projects an event stream into read models. A recurring shape is a parent
+record fanning out into a **reorderable child collection** — FormKit repeaters,
+an order's line items, a form's answers — frequently nested to **unbounded**
+depth via a self-FK (`SeparatedSubmission.repeater_parent`). Replaying such a
+projection must be **idempotent** and **orphan-free**, which the `reconcile_*`
+helpers achieve with one shape: *upsert every current row, then a single
+set-based reconcile `delete` of everything not in the kept set.*
+
+The first helper, `reconcile_children`, keyed each row by its **positional
+index** `(parent, idx)`. Two problems surfaced:
+
+1. **Index-as-identity.** Reordering or inserting a child renumbers every
+   subsequent `idx`, so each row's key changes: replay rewrites O(N) rows, and —
+   worse — an external foreign key to a child row now points at a *logically
+   different* item. Position conflated "which child" with "what position."
+2. **Order representation matters independently.** Even once identity is stable,
+   how you store *order* (dense index vs fractional index vs linked list) has very
+   different reorder cost, read cost, robustness, and reconcile-composition
+   properties.
+
+Consumers in the target deployment (Partisipa → SQL views / Metabase) read
+ordered, paginated data with `ORDER BY` / `LIMIT`, and the reconcile pattern is
+fundamentally a **set** operation.
+
+## Decision
+
+1. **Key every child/tree row by a stable id** (a business key or an id assigned
+   at ingestion), **never by position.** Position is an ordinary field.
+2. **Represent order as a fractional index** field (sparse keys, lexorank-style),
+   sorted with `ORDER BY`.
+3. Use **`reconcile_tree`** (id-keyed, reconcile scoped to the whole subtree) for
+   nested and/or reorderable collections. Keep **`reconcile_children`**
+   (index-keyed) only for **fixed-order / append-only** collections where
+   position *is* a stable identity.
+4. **Reject** positional-index-as-identity and **reject** linked-list ordering
+   (`next`/`prev`) for relational projections.
+
+## Alternatives considered
+
+| Model | Reorder writes | Ordered SQL read | Corruption blast radius | Composes with reconcile-delete |
+|---|---|---|---|---|
+| **Positional index as identity** | O(N) + **FK/identity corruption** | `ORDER BY` | local | ✓ (but identity broken) |
+| **Stable id + dense index field** | O(N) index updates | `ORDER BY` | local | ✓ |
+| **Stable id + fractional index (chosen)** | **O(1)** | `ORDER BY` | local | ✓ |
+| **Linked list (`next`)** | O(1) (~3 pointers) | ✗ pointer-chase / recursive CTE | **global — one dangling `next` severs the tail** | ✗ deletes need pointer surgery |
+
+- **Positional index as identity** — rejected: the renumber-on-reorder corrupts
+  external references and forces O(N) rewrites.
+- **Dense index as a field** — acceptable but O(N) writes per reorder; fine when
+  reorders are rare or the projection is always re-derived from a full snapshot.
+- **Linked list** — rejected for relational projections: it cannot be ordered by
+  a query (you traverse the chain via a recursive CTE, which SQL rollups can't
+  consume), a single dangling pointer loses the entire tail (a cycle hangs the
+  reader), deleting an orphan requires rewriting its predecessor's pointer (so it
+  does **not** compose with the set-based reconcile `delete`), and concurrent
+  "insert after X" races lose updates. Its one advantage — O(1) reorder — is
+  matched by a fractional index **without** any of those costs. Linked lists
+  remain appropriate for in-memory structures, rich-text/CRDT piece tables, and
+  append-only logs — not relational projections.
+
+## Consequences
+
+**Positive**
+
+- O(1) reorder writes (fractional), and identity/FKs stay stable across reorders.
+- Native, set-based ordered reads and pagination (`ORDER BY` / `LIMIT`).
+- Composes with the `reconcile_*` "upsert all + one reconcile delete" pattern.
+- Deterministic snapshot replay (order is a pure function of the snapshot).
+- Graceful degradation: a missed/duplicated event yields at worst a misplaced or
+  duplicate position that self-heals on recompute — the collection stays fully
+  readable.
+
+**Negative / caveats**
+
+- Fractional keys eventually exhaust precision (many inserts between the same two
+  neighbors) and need a **rebalance** — a local or full renumber. Amortized O(1),
+  rare O(N); use lexorank-style rebalancing.
+- Requires the **source to carry a stable child id**. If it does not, assign one
+  at ingestion — otherwise a bare positional snapshot `[A,B,C] → [C,A,B]` is
+  indistinguishable from "every slot's content changed," and no projection can
+  recover "C moved."
+- Position-as-a-field means a reorder still writes the moved row(s). If reorder
+  churn must not disturb **order-insensitive** consumers (aggregates, counts,
+  validation, search), separate order out — see the note below.
+
+**Neutral — separating the order concern (orthogonal, not mandated here)**
+
+Order-insensitivity is the lever: most projections don't care about child order.
+When they don't, order can be split from content along two independent axes:
+
+- **Output feed** — materialize the position projection as its own read-model with
+  its own sync cursor (the change_id/watermark pattern). Order-insensitive
+  consumers ignore it; order-aware consumers tail it. Needs no source change.
+- **Input stream** — *if* the client is command-sourced (distinct `EditChild` vs
+  `MoveChild` events), `MoveChild` events form a position stream that composes with
+  staged replay (content = stage-0 reference, position = stage-1 dependent) and
+  multi-stream merge for order-aware consumers. Not available under full-snapshot
+  submissions.
+
+These remain per-projection choices; this ADR fixes only the **row keying and
+order representation**.

--- a/docs/adr/0001-ordering-child-collections-in-projections.md
+++ b/docs/adr/0001-ordering-child-collections-in-projections.md
@@ -46,6 +46,14 @@ fundamentally a **set** operation.
 4. **Reject** positional-index-as-identity and **reject** linked-list ordering
    (`next`/`prev`) for relational projections.
 
+`reconcile_tree` is what makes (1)–(3) ergonomic, but it is **order-agnostic and
+identity-agnostic**: it keys rows by whatever `id_fn` returns and passes the
+row's fields through `defaults_fn`. The **stable id** and the **fractional order
+value** are modeling choices the caller supplies — from source data or assigned
+at ingestion — not something the helper computes or enforces. The helper's
+contribution is the id-keyed, subtree-scoped, orphan-free reconcile; the decision
+above is what you must model *around* it.
+
 ## Alternatives considered
 
 | Model | Reorder writes | Ordered SQL read | Corruption blast radius | Composes with reconcile-delete |

--- a/docs/projections-and-fan-out.md
+++ b/docs/projections-and-fan-out.md
@@ -101,3 +101,15 @@ You can build the same thing by hand with an `op="delete"` Effect — that's all
 the orphan handling for free instead of re-deriving it (and forgetting the
 `exclude`, which is the whole point). Reach for the raw delete only when the
 scope isn't "children of a parent keyed by index".
+
+## Reorderable collections: key by id, not index
+
+`reconcile_children` keys rows by **positional index**, which makes it right for
+fixed-order or append-only collections but wrong for **reorderable** ones: a
+reorder renumbers every subsequent index, so replay rewrites O(N) rows *and* any
+foreign key to a child now points at a different logical item. For reorderable
+data, key rows by a **stable id** and store order as a **fractional index** field
+— which is exactly what `reconcile_tree` does (order goes in `defaults_fn`). See
+[ADR 0001](adr/0001-ordering-child-collections-in-projections.md) for the full
+rationale (and why a linked list is the wrong choice for a SQL-backed
+projection).

--- a/docs/projections-and-fan-out.md
+++ b/docs/projections-and-fan-out.md
@@ -107,9 +107,21 @@ scope isn't "children of a parent keyed by index".
 `reconcile_children` keys rows by **positional index**, which makes it right for
 fixed-order or append-only collections but wrong for **reorderable** ones: a
 reorder renumbers every subsequent index, so replay rewrites O(N) rows *and* any
-foreign key to a child now points at a different logical item. For reorderable
-data, key rows by a **stable id** and store order as a **fractional index** field
-— which is exactly what `reconcile_tree` does (order goes in `defaults_fn`). See
-[ADR 0001](adr/0001-ordering-child-collections-in-projections.md) for the full
+foreign key to a child now points at a different logical item.
+
+For reorderable data, key rows by a **stable id** and store order as a
+**fractional index** field. `reconcile_tree` is built for this: it keys each row
+by whatever `id_fn` returns and passes your fields straight through
+`defaults_fn`. Two things stay *your* responsibility, though — the helper is
+order-agnostic and identity-agnostic:
+
+- **the stable id** must come from your data (a business key, or one assigned at
+  ingestion). `reconcile_tree` does not make ids stable; if `id_fn` returns
+  something position-derived, you're back to the index problem.
+- **the order field** is yours to compute (a fractional index is recommended) and
+  return from `defaults_fn`; then read with `ORDER BY`. `reconcile_tree` neither
+  sorts nodes nor adds an order column.
+
+See [ADR 0001](adr/0001-ordering-child-collections-in-projections.md) for the full
 rationale (and why a linked list is the wrong choice for a SQL-backed
 projection).

--- a/src/rakaia/__init__.py
+++ b/src/rakaia/__init__.py
@@ -27,7 +27,11 @@ from .effects import (
 )
 from .executors import CollectingExecutor
 from .handler import ServerOptions, create_app
-from .projections import reconcile_children
+from .projections import (
+    reconcile_aggregate,
+    reconcile_children,
+    reconcile_tree,
+)
 from .registry import (
     HANDLERS_META_STREAM,
     UPCASTERS_META_STREAM,
@@ -107,6 +111,8 @@ __all__ = [
     "CollectingExecutor",
     # Versioned handlers — projections
     "reconcile_children",
+    "reconcile_tree",
+    "reconcile_aggregate",
     # Versioned handlers — registry
     "register_handler",
     "register_upcaster",

--- a/src/rakaia/projections.py
+++ b/src/rakaia/projections.py
@@ -95,6 +95,14 @@ def reconcile_tree(
     id regardless of depth, pruning an entire subtree — whose intermediate
     parent is gone — leaves no deep orphans, which a per-parent reconcile would.
 
+    This helper is **order-agnostic**: it neither sorts ``nodes`` nor imposes an
+    order field. To make a reorderable collection read back in order, compute an
+    order value yourself (a fractional index is recommended — see ADR 0001) and
+    return it from ``defaults_fn``, then read with ``ORDER BY``. Likewise the
+    identity stability it enables is only as stable as ``id_fn``: the ids must be
+    **unique within ``nodes``** and persistent across submissions (a business key
+    or one assigned at ingestion). Duplicate ids emit colliding upserts.
+
     Args:
         model_label: 'app_label.ModelName' of the node model.
         scope_lookup: lookup identifying the whole tree, e.g.
@@ -147,6 +155,13 @@ def reconcile_aggregate(
     ``{group_value: defaults}``. This emits one idempotent ``update_or_create``
     per group plus a reconcile ``delete`` that removes aggregate rows for groups
     which no longer have any contributors.
+
+    .. warning::
+        The reconcile delete is scoped to ``scope_lookup``. With a global scope
+        (``scope_lookup={}``) **and** empty ``groups``, the delete matches every
+        row in the model and clears the whole table. Pass a non-empty
+        ``scope_lookup`` whenever the aggregate model holds more than this one
+        rollup, so an empty recompute clears only that scope.
 
     Args:
         model_label: 'app_label.ModelName' of the aggregate model.

--- a/src/rakaia/projections.py
+++ b/src/rakaia/projections.py
@@ -35,6 +35,12 @@ def reconcile_children(
 ) -> list[Effect]:
     """Return Effects that materialise `items` as child rows without orphans.
 
+    Keys each row by its positional index, so this fits **fixed-order or
+    append-only** collections. For **reorderable** collections prefer
+    `reconcile_tree`, keyed by a stable id with order as a fractional-index
+    field — index keying renumbers (and rewrites) the tail on every reorder and
+    breaks external references to a row. See ADR 0001.
+
     Args:
         model_label: 'app_label.ModelName' of the child row model.
         parent_lookup: lookup identifying the parent scope, e.g.

--- a/src/rakaia/projections.py
+++ b/src/rakaia/projections.py
@@ -8,15 +8,19 @@ projection with plain `update_or_create` leaks orphans: if a later version of
 the parent has *fewer* children, the dropped child rows survive forever because
 nothing deletes them.
 
-`reconcile_children` closes that gap. It emits one `update_or_create` per
-current child (keyed by parent + child index) plus a single reconcile `delete`
-that removes every child under the parent *except* the indices still present.
-Re-running it converges, and shrinking the collection prunes the tail.
+Three helpers close that gap, each emitting idempotent upserts plus a single
+reconcile `delete` scoped to spare exactly the rows still present:
+
+* `reconcile_children` — a flat collection keyed by positional index.
+* `reconcile_tree` — an unbounded nested tree keyed by stable node id, with the
+  reconcile scoped to the whole subtree so orphans are pruned at any depth.
+* `reconcile_aggregate` — one recomputed aggregate row per group, with the
+  reconcile removing groups that no longer have any contributors.
 """
 
 from __future__ import annotations
 
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from typing import Any
 
 from .effects import Effect
@@ -63,6 +67,113 @@ def reconcile_children(
             model_label=model_label,
             lookup=dict(parent_lookup),
             exclude={f"{child_key}__in": list(range(len(items)))},
+        )
+    )
+    return effects
+
+
+def reconcile_tree(
+    model_label: str,
+    scope_lookup: dict[str, Any],
+    node_key: str,
+    nodes: Sequence[Any],
+    id_fn: Callable[[Any], Any],
+    defaults_fn: Callable[[Any], dict[str, Any]],
+) -> list[Effect]:
+    """Materialise an unbounded nested tree without orphans at any depth.
+
+    The tree generalisation of `reconcile_children`: where that keys children by
+    positional index under one parent, this keys each node by its **stable id**
+    and scopes the reconcile delete to the whole ``scope_lookup`` (e.g. the
+    submission), not a single parent level. Because the delete spares every kept
+    id regardless of depth, pruning an entire subtree — whose intermediate
+    parent is gone — leaves no deep orphans, which a per-parent reconcile would.
+
+    Args:
+        model_label: 'app_label.ModelName' of the node model.
+        scope_lookup: lookup identifying the whole tree, e.g.
+            ``{"submission_id": sid}``. Each node is keyed by this plus
+            ``{node_key: id}``; the reconcile delete is scoped to it.
+        node_key: the field holding a node's stable id, e.g. ``"node_id"``.
+        nodes: the current node collection, flattened to any depth (order is
+            preserved in the emitted upserts).
+        id_fn: maps one node to its stable id (the ``node_key`` value).
+        defaults_fn: maps one node to its ``defaults=`` field values (typically
+            including its ``parent_node_id`` and payload).
+
+    Returns:
+        One ``update_or_create`` Effect per node, followed by one ``delete``
+        Effect removing every node under ``scope_lookup`` whose id is no longer
+        present. Empty ``nodes`` yields just the delete, clearing the subtree.
+    """
+    kept_ids = [id_fn(node) for node in nodes]
+    effects: list[Effect] = [
+        Effect(
+            op="update_or_create",
+            model_label=model_label,
+            lookup={**scope_lookup, node_key: node_id},
+            defaults=defaults_fn(node),
+        )
+        for node_id, node in zip(kept_ids, nodes, strict=True)
+    ]
+    effects.append(
+        Effect(
+            op="delete",
+            model_label=model_label,
+            lookup=dict(scope_lookup),
+            exclude={f"{node_key}__in": kept_ids},
+        )
+    )
+    return effects
+
+
+def reconcile_aggregate(
+    model_label: str,
+    scope_lookup: dict[str, Any],
+    group_key: str,
+    groups: Mapping[Any, dict[str, Any]],
+) -> list[Effect]:
+    """Materialise one recomputed aggregate row per group, without stale rows.
+
+    The aggregate analogue of `reconcile_children`. An increment is not
+    replay-safe (re-running doubles the total), so the caller **recomputes** each
+    group's aggregate from its contributing rows and passes the results here as
+    ``{group_value: defaults}``. This emits one idempotent ``update_or_create``
+    per group plus a reconcile ``delete`` that removes aggregate rows for groups
+    which no longer have any contributors.
+
+    Args:
+        model_label: 'app_label.ModelName' of the aggregate model.
+        scope_lookup: lookup bounding the aggregate set, e.g. ``{}`` for a global
+            rollup or ``{"report_id": r}`` for a scoped one. Each row is keyed by
+            this plus ``{group_key: value}``; the reconcile delete is scoped to
+            it.
+        group_key: the field identifying a group, e.g. ``"suku"`` or
+            ``"district"``. (Single-field groups; composite groups are out of
+            scope — a simple ``exclude`` cannot express "tuple not in set".)
+        groups: mapping of group value to its recomputed ``defaults=`` values.
+
+    Returns:
+        One ``update_or_create`` Effect per group (in mapping order), followed by
+        one ``delete`` Effect removing rows under ``scope_lookup`` whose group is
+        not present. Empty ``groups`` yields just the delete, clearing the set.
+    """
+    group_values = list(groups)
+    effects: list[Effect] = [
+        Effect(
+            op="update_or_create",
+            model_label=model_label,
+            lookup={**scope_lookup, group_key: value},
+            defaults=dict(groups[value]),
+        )
+        for value in group_values
+    ]
+    effects.append(
+        Effect(
+            op="delete",
+            model_label=model_label,
+            lookup=dict(scope_lookup),
+            exclude={f"{group_key}__in": group_values},
         )
     )
     return effects

--- a/tests/test_rakaia/test_projections.py
+++ b/tests/test_rakaia/test_projections.py
@@ -1,8 +1,12 @@
-"""Tests for rakaia.projections: the reconcile_children fan-out helper."""
+"""Tests for rakaia.projections: the reconcile_* fan-out helpers."""
 
 from __future__ import annotations
 
-from rakaia.projections import reconcile_children
+from rakaia.projections import (
+    reconcile_aggregate,
+    reconcile_children,
+    reconcile_tree,
+)
 
 
 def _reconcile(items: list[dict]):
@@ -59,3 +63,135 @@ class TestReconcileChildren:
             defaults_fn=lambda item: {"name": item["name"]},
         )
         assert parent == {"parent_id": 7}
+
+
+def _tree(nodes: list[dict]):
+    return reconcile_tree(
+        model_label="app.Node",
+        scope_lookup={"submission_id": "s1"},
+        node_key="node_id",
+        nodes=nodes,
+        id_fn=lambda n: n["id"],
+        defaults_fn=lambda n: {"parent_node_id": n["parent"], "value": n["value"]},
+    )
+
+
+class TestReconcileTree:
+    def test_emits_upsert_per_node_keyed_by_id(self):
+        effects = _tree(
+            [
+                {"id": "A", "parent": "", "value": 0},
+                {"id": "B", "parent": "A", "value": 10},
+            ]
+        )
+        upserts = [e for e in effects if e.op == "update_or_create"]
+        assert len(upserts) == 2
+        assert all(e.model_label == "app.Node" for e in upserts)
+        # keyed by the node's explicit id, not a positional index
+        assert upserts[0].lookup == {"submission_id": "s1", "node_id": "A"}
+        assert upserts[0].defaults == {"parent_node_id": "", "value": 0}
+        assert upserts[1].lookup == {"submission_id": "s1", "node_id": "B"}
+
+    def test_reconcile_delete_excludes_all_kept_ids(self):
+        effects = _tree(
+            [
+                {"id": "A", "parent": "", "value": 0},
+                {"id": "B", "parent": "A", "value": 10},
+                {"id": "C", "parent": "A", "value": 20},
+            ]
+        )
+        deletes = [e for e in effects if e.op == "delete"]
+        assert len(deletes) == 1
+        # one submission-scoped delete over the whole subtree, any depth
+        assert deletes[0].lookup == {"submission_id": "s1"}
+        assert deletes[0].exclude == {"node_id__in": ["A", "B", "C"]}
+
+    def test_deep_nodes_keyed_the_same_way_regardless_of_depth(self):
+        # A grandchild is keyed and reconciled identically to a top-level node —
+        # that is what lets one delete prune orphans at any depth.
+        effects = _tree(
+            [
+                {"id": "A", "parent": "", "value": 0},
+                {"id": "B", "parent": "A", "value": 0},
+                {"id": "D", "parent": "B", "value": 10},  # grandchild
+            ]
+        )
+        upserts = [e for e in effects if e.op == "update_or_create"]
+        assert upserts[2].lookup == {"submission_id": "s1", "node_id": "D"}
+        deletes = [e for e in effects if e.op == "delete"]
+        assert deletes[0].exclude == {"node_id__in": ["A", "B", "D"]}
+
+    def test_empty_nodes_deletes_whole_subtree(self):
+        effects = _tree([])
+        assert [e for e in effects if e.op == "update_or_create"] == []
+        deletes = [e for e in effects if e.op == "delete"]
+        assert len(deletes) == 1
+        assert deletes[0].lookup == {"submission_id": "s1"}
+        assert deletes[0].exclude == {"node_id__in": []}
+
+    def test_upserts_precede_delete(self):
+        effects = _tree([{"id": "A", "parent": "", "value": 0}])
+        assert [e.op for e in effects] == ["update_or_create", "delete"]
+
+    def test_scope_lookup_not_mutated(self):
+        scope = {"submission_id": "s1"}
+        reconcile_tree(
+            model_label="app.Node",
+            scope_lookup=scope,
+            node_key="node_id",
+            nodes=[{"id": "A", "parent": "", "value": 0}],
+            id_fn=lambda n: n["id"],
+            defaults_fn=lambda n: {"value": n["value"]},
+        )
+        assert scope == {"submission_id": "s1"}
+
+
+def _agg(groups, scope=None):
+    return reconcile_aggregate(
+        model_label="app.Balance",
+        scope_lookup=scope if scope is not None else {},
+        group_key="suku",
+        groups=groups,
+    )
+
+
+class TestReconcileAggregate:
+    def test_emits_upsert_per_group(self):
+        effects = _agg({"Fatuberliu": {"total": 300}, "Maubara": {"total": -50}})
+        upserts = [e for e in effects if e.op == "update_or_create"]
+        assert len(upserts) == 2
+        assert upserts[0].lookup == {"suku": "Fatuberliu"}
+        assert upserts[0].defaults == {"total": 300}
+        assert upserts[1].lookup == {"suku": "Maubara"}
+        assert upserts[1].defaults == {"total": -50}
+
+    def test_reconcile_delete_excludes_present_groups(self):
+        effects = _agg({"Fatuberliu": {"total": 300}, "Maubara": {"total": -50}})
+        deletes = [e for e in effects if e.op == "delete"]
+        assert len(deletes) == 1
+        assert deletes[0].lookup == {}
+        # groups that vanished (no contributors) get their aggregate removed
+        assert deletes[0].exclude == {"suku__in": ["Fatuberliu", "Maubara"]}
+
+    def test_empty_groups_deletes_all(self):
+        effects = _agg({})
+        assert [e for e in effects if e.op == "update_or_create"] == []
+        deletes = [e for e in effects if e.op == "delete"]
+        assert deletes[0].exclude == {"suku__in": []}
+
+    def test_scope_included_in_lookup_and_delete(self):
+        effects = _agg({"north": {"total": 5}}, scope={"report_id": 42})
+        upserts = [e for e in effects if e.op == "update_or_create"]
+        assert upserts[0].lookup == {"report_id": 42, "suku": "north"}
+        deletes = [e for e in effects if e.op == "delete"]
+        assert deletes[0].lookup == {"report_id": 42}
+        assert deletes[0].exclude == {"suku__in": ["north"]}
+
+    def test_upserts_precede_delete(self):
+        effects = _agg({"a": {"total": 1}})
+        assert [e.op for e in effects] == ["update_or_create", "delete"]
+
+    def test_scope_lookup_not_mutated(self):
+        scope = {"report_id": 42}
+        _agg({"a": {"total": 1}}, scope=scope)
+        assert scope == {"report_id": 42}

--- a/zensical.toml
+++ b/zensical.toml
@@ -32,6 +32,9 @@ nav = [
         { "Protocol specification" = "protocol.md" },
         { "Backend storage" = "streams-backend-storage.md" },
     ] },
+    { "Decision records" = [
+        { "ADR 0001 — Ordering child collections" = "adr/0001-ordering-child-collections-in-projections.md" },
+    ] },
 ]
 
 [project.theme]


### PR DESCRIPTION
First step of promoting the Partisipa spike shapes into real core features. Two pure `list[Effect]` helpers alongside the shipped `reconcile_children`, test-first.

## `reconcile_tree` (from #16)
An unbounded nested tree keyed by **stable node id**, with the reconcile `delete` scoped to the whole subtree (`lookup={scope}, exclude={node_key__in: kept}`) rather than one parent level — so a pruned subtree is removed at **any depth**, leaving no deep orphans. The tree generalization of `reconcile_children` (which keys by positional index under one parent).

## `reconcile_aggregate` (from #13/#14)
One recomputed aggregate row per group + a reconcile `delete` removing groups that no longer have contributors. The caller recomputes each group's total (recompute-not-increment = replay-safe) and passes `{group: defaults}`; the helper handles the idempotent upsert + reconcile. Single-field groups (composite groups noted out of scope — a simple `exclude` can't express "tuple not in set").

## Tests
12 new tests (keying by id vs index, depth-independence, empty-set clears the scope, scope dict not mutated, scoped vs global aggregates). Full suite: **377 passed, 1 skipped**; ruff clean.

Purely additive — no existing behavior changed. These are the smallest promotions; the larger ones (`stage=`/`reduce=`/`order_key=` on `@register_handler`, the event envelope + history read-model) follow.