### PR TITLE
feat: opt-in skip_unchanged executor to avoid no-op writes

### DIFF
--- a/docs/projections-and-fan-out.md
+++ b/docs/projections-and-fan-out.md
@@ -125,3 +125,24 @@ order-agnostic and identity-agnostic:
 See [ADR 0001](adr/0001-ordering-child-collections-in-projections.md) for the full
 rationale (and why a linked list is the wrong choice for a SQL-backed
 projection).
+
+## Avoiding no-op writes on large collections
+
+A reconcile emits one `update_or_create` per current row, and Django's
+`update_or_create` always issues an UPDATE. So re-materialising a 100-row
+collection where a single value changed rewrites all 100 rows — churning
+`auto_now` columns, `post_save` signals, and replication for 99 no-ops.
+
+`DjangoExecutor(skip_unchanged=True)` closes that: it fetches each row, compares
+the effect's `defaults` to the stored values, and writes **only the changed
+columns** — skipping the UPDATE entirely when nothing changed. A big tree with
+one edit, or a reorder that moves one row, then costs one write instead of N.
+
+```python
+DjangoExecutor(skip_unchanged=True).apply(effects)
+```
+
+It trades one UPDATE per row for one SELECT per row, so reach for it when writes
+are the expensive part. It's opt-in because skipping a no-op write is observably
+different — an unchanged row's `auto_now` fields don't advance and its
+`post_save` signal doesn't fire.

--- a/src/django_rakaia/effect_executor.py
+++ b/src/django_rakaia/effect_executor.py
@@ -7,6 +7,18 @@ reconciles a child set (upsert the current rows, then delete the stale ones)
 is deterministic. External effects passed to apply() are silently dropped —
 the replay orchestrator decides whether external effects reach the executor
 based on its include_external setting.
+
+Pass ``skip_unchanged=True`` to avoid writing rows whose values already match.
+By default (matching Django's ``update_or_create``) every upsert issues an
+UPDATE, so re-materialising a large collection where one row changed rewrites
+every row — churning ``auto_now`` columns, ``post_save`` signals, and
+replication. The opt-in path instead fetches the row, compares the effect's
+``defaults`` to the stored values, and writes only the changed columns (or skips
+the write entirely when nothing changed). It trades one UPDATE per row for one
+SELECT per row, so it pays off when writes are the expensive part — a big tree
+with a single edit, or a reorder. It is opt-in because skipping a no-op write is
+*observably* different: ``auto_now`` fields don't advance and ``post_save``
+doesn't fire for an unchanged row.
 """
 
 from __future__ import annotations
@@ -22,6 +34,9 @@ from rakaia.effects import Effect, check_disjoint_defaults
 class DjangoExecutor:
     """Apply Effects via Django's ORM."""
 
+    def __init__(self, *, skip_unchanged: bool = False) -> None:
+        self._skip_unchanged = skip_unchanged
+
     def apply(self, effects: Iterable[Effect]) -> None:
         effects_list = list(effects)
         check_disjoint_defaults(effects_list)
@@ -35,12 +50,35 @@ class DjangoExecutor:
                 if eff.op == "delete":
                     self._delete(eff)
 
-    @staticmethod
-    def _upsert(eff: Effect) -> None:
+    def _upsert(self, eff: Effect) -> None:
         if eff.model_label is None or eff.lookup is None:
             raise ValueError("update_or_create effect requires model_label and lookup")
         model = apps.get_model(eff.model_label)
-        model.objects.update_or_create(**eff.lookup, defaults=eff.defaults or {})
+        defaults = eff.defaults or {}
+        if not self._skip_unchanged:
+            model.objects.update_or_create(**eff.lookup, defaults=defaults)
+            return
+        self._upsert_skip_unchanged(model, eff.lookup, defaults)
+
+    @staticmethod
+    def _upsert_skip_unchanged(
+        model: type, lookup: dict, defaults: dict
+    ) -> None:
+        try:
+            row = model.objects.get(**lookup)
+        except model.DoesNotExist:
+            # Mirror update_or_create's create path: lookup fields + defaults,
+            # dropping any lookup that isn't a concrete field assignment.
+            params = {k: v for k, v in lookup.items() if "__" not in k}
+            params.update(defaults)
+            model.objects.create(**params)
+            return
+        changed = {k: v for k, v in defaults.items() if getattr(row, k) != v}
+        if not changed:
+            return  # nothing to write — skip the UPDATE entirely
+        for field, value in changed.items():
+            setattr(row, field, value)
+        row.save(update_fields=list(changed))
 
     @staticmethod
     def _delete(eff: Effect) -> None:

--- a/src/django_rakaia/effect_executor.py
+++ b/src/django_rakaia/effect_executor.py
@@ -61,9 +61,7 @@ class DjangoExecutor:
         self._upsert_skip_unchanged(model, eff.lookup, defaults)
 
     @staticmethod
-    def _upsert_skip_unchanged(
-        model: type, lookup: dict, defaults: dict
-    ) -> None:
+    def _upsert_skip_unchanged(model: type, lookup: dict, defaults: dict) -> None:
         try:
             row = model.objects.get(**lookup)
         except model.DoesNotExist:

--- a/tests/test_django_rakaia/test_effect_executor.py
+++ b/tests/test_django_rakaia/test_effect_executor.py
@@ -15,7 +15,9 @@ from .models import Area, Project
 
 def _updates(ctx: CaptureQueriesContext) -> list[str]:
     return [
-        q["sql"] for q in ctx.captured_queries if q["sql"].lstrip().upper().startswith("UPDATE")
+        q["sql"]
+        for q in ctx.captured_queries
+        if q["sql"].lstrip().upper().startswith("UPDATE")
     ]
 
 

--- a/tests/test_django_rakaia/test_effect_executor.py
+++ b/tests/test_django_rakaia/test_effect_executor.py
@@ -3,11 +3,20 @@
 from __future__ import annotations
 
 import pytest
+from django.contrib.auth.models import User
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
 
 from django_rakaia.effect_executor import DjangoExecutor
 from rakaia.effects import Effect, EffectCollisionError
 
-from .models import Area
+from .models import Area, Project
+
+
+def _updates(ctx: CaptureQueriesContext) -> list[str]:
+    return [
+        q["sql"] for q in ctx.captured_queries if q["sql"].lstrip().upper().startswith("UPDATE")
+    ]
 
 
 @pytest.mark.django_db
@@ -218,3 +227,86 @@ class TestDjangoExecutorDelete:
                 ]
             )
         assert Area.objects.filter(name="keep").exists()
+
+
+@pytest.mark.django_db
+class TestSkipUnchanged:
+    """The opt-in `skip_unchanged` executor avoids no-op writes on replay."""
+
+    def _area_upsert(self, area_id: int, name: str) -> Effect:
+        return Effect(
+            op="update_or_create",
+            model_label="test_django_rakaia.Area",
+            lookup={"id": area_id},
+            defaults={"name": name},
+        )
+
+    def test_unchanged_upsert_issues_no_update(self):
+        area = Area.objects.create(name="X")
+        executor = DjangoExecutor(skip_unchanged=True)
+        with CaptureQueriesContext(connection) as ctx:
+            executor.apply([self._area_upsert(area.id, "X")])
+        assert _updates(ctx) == []
+        assert Area.objects.get(id=area.id).name == "X"
+
+    def test_changed_upsert_issues_one_update(self):
+        area = Area.objects.create(name="X")
+        executor = DjangoExecutor(skip_unchanged=True)
+        with CaptureQueriesContext(connection) as ctx:
+            executor.apply([self._area_upsert(area.id, "Y")])
+        assert len(_updates(ctx)) == 1
+        assert Area.objects.get(id=area.id).name == "Y"
+
+    def test_creates_missing_row(self):
+        executor = DjangoExecutor(skip_unchanged=True)
+        executor.apply(
+            [
+                Effect(
+                    op="update_or_create",
+                    model_label="test_django_rakaia.Area",
+                    lookup={"name": "New"},
+                    defaults={},
+                )
+            ]
+        )
+        assert Area.objects.filter(name="New").count() == 1
+
+    def test_second_apply_is_a_noop(self):
+        area = Area.objects.create(name="X")
+        executor = DjangoExecutor(skip_unchanged=True)
+        executor.apply([self._area_upsert(area.id, "Y")])  # first: writes
+        with CaptureQueriesContext(connection) as ctx:
+            executor.apply([self._area_upsert(area.id, "Y")])  # now unchanged
+        assert _updates(ctx) == []
+
+    def test_only_changed_column_is_written(self):
+        user = User.objects.create(username="u")
+        area = Area.objects.create(name="A")
+        project = Project.objects.create(name="old", area=area, created_by=user)
+        executor = DjangoExecutor(skip_unchanged=True)
+        with CaptureQueriesContext(connection) as ctx:
+            executor.apply(
+                [
+                    Effect(
+                        op="update_or_create",
+                        model_label="test_django_rakaia.Project",
+                        lookup={"id": project.id},
+                        defaults={"name": "new"},  # only the name changes
+                    )
+                ]
+            )
+        updates = _updates(ctx)
+        assert len(updates) == 1
+        sql = updates[0].lower()
+        # update_fields limits the UPDATE to the changed column
+        assert "name" in sql
+        assert "area_id" not in sql and "created_by_id" not in sql
+
+    def test_default_executor_writes_even_when_unchanged(self):
+        # Backward compatibility: the default path uses update_or_create, which
+        # always issues an UPDATE — the skip is strictly opt-in.
+        area = Area.objects.create(name="X")
+        executor = DjangoExecutor()
+        with CaptureQueriesContext(connection) as ctx:
+            executor.apply([self._area_upsert(area.id, "X")])
+        assert len(_updates(ctx)) == 1


### PR DESCRIPTION
Second core promotion, and the direct answer to the write-amplification concern from the tree/reorder discussion.

## Problem
A reconcile emits one `update_or_create` per current row, and Django's `update_or_create` **always** issues an UPDATE. Re-materialising a 100-row collection where one value changed rewrites all 100 rows — churning `auto_now` columns, `post_save` signals, and replication for 99 no-ops. Same story on a reorder (one moved row, but a dense re-index touches many).

## Change
`DjangoExecutor(skip_unchanged=True)` fetches the row, compares the effect's `defaults` to the stored values, and writes **only the changed columns** (`update_fields`) — skipping the UPDATE entirely when nothing changed:

```python
DjangoExecutor(skip_unchanged=True).apply(effects)
```

A big tree with one edit, or a reorder that moves one row, then costs **one write instead of N**. It trades one UPDATE per row for one SELECT per row, so it pays off when writes are the expensive part.

**Opt-in on purpose:** skipping a no-op write is *observably* different — an unchanged row's `auto_now` fields don't advance and its `post_save` doesn't fire. The default path is byte-for-byte unchanged (backward compatible).

## Tests (TDD)
6 new tests using `CaptureQueriesContext` to assert actual query counts: unchanged → 0 updates; changed → 1; missing row still created; second apply is a no-op; only-the-changed-column written; and the **default** executor still issues an UPDATE when unchanged (pins the opt-in boundary). Full suite: **383 passed, 1 skipped**; ruff clean. Doc note added to `projections-and-fan-out.md`.

Purely additive; no existing behavior changed.