### PR TITLE
feat: staged replay (stage= handlers + projection reader) in core

### DIFF
--- a/docs/staged-replay.md
+++ b/docs/staged-replay.md
@@ -1,8 +1,44 @@
-# Staged replay (design spike)
+# Staged replay
 
-> Status: **design spike** for [issue #7](https://github.com/joshbrooks/rakaia/issues/7)
-> feature #1. Prototyped in [`examples/partisipa_staged`](../examples/partisipa_staged);
-> not yet part of rakaia core. This page is the design; the example is the proof.
+> Status: **in core** ([issue #7](https://github.com/joshbrooks/rakaia/issues/7)
+> feature #1). Prototyped in
+> [`examples/partisipa_staged`](../examples/partisipa_staged); the spike's
+> `stage=` / `refs` shape now ships in `register_handler` and `replay()`. This
+> page is the design; the sections below show the real API.
+
+## Using it
+
+Declare a handler's stage; replay runs stages in ascending order, and a stage > 0
+handler is called `fn(event, reader)` with a read-only projection reader:
+
+```python
+from rakaia.registry import register_handler
+from rakaia.replay import replay
+from django_rakaia.effect_executor import DjangoExecutor
+from django_rakaia.projection_reader import DjangoProjectionReader
+
+@register_handler(name="project", event_match="TF_6_1_1",
+                  match_field="form_type", stage=0)
+def project(event):                         # stage 0: build the reference
+    return Effect(op="update_or_create", model_label="ida.Project",
+                  lookup={"suku": event["suku"], "output": event["output"]},
+                  defaults={"name": event["project_name"]})
+
+@register_handler(name="sf12", event_match="SF_1_2",
+                  match_field="form_type", stage=1)
+def sf12(event, refs):                      # stage 1: resolve via the reader
+    project = refs.get("ida.Project", suku=event["suku"], output=event["output"])
+    return Effect(op="update_or_create", model_label="ida_forms.Sf_1_2",
+                  lookup={"submission_id": event["key"]},
+                  defaults={"project_id": project.pk if project else None})
+
+replay(store, "submissions", DjangoExecutor(), reader=DjangoProjectionReader())
+```
+
+`replay()` requires `reader=` whenever any handler declares stage > 0; with only
+stage 0 handlers it is a single pass and no reader is needed (backward
+compatible). The reader is any `rakaia.protocols.ProjectionReader`
+(`get` / `filter` / `query`); the Django one reads `apps.get_model(...).objects`.
 
 ## The problem: late-arriving cross-form links
 

--- a/src/django_rakaia/projection_reader.py
+++ b/src/django_rakaia/projection_reader.py
@@ -1,0 +1,39 @@
+"""
+Django implementation of rakaia's `ProjectionReader`.
+
+`replay()` passes a reader to every stage > 0 handler as its second argument
+during staged replay, so the handler can resolve facts that earlier stages
+committed. This reader is a thin, read-only accessor over the Django ORM:
+
+    from rakaia.replay import replay
+    from django_rakaia.effect_executor import DjangoExecutor
+    from django_rakaia.projection_reader import DjangoProjectionReader
+
+    replay(store, path, DjangoExecutor(), reader=DjangoProjectionReader())
+
+Because it only ever reads committed projections (themselves a pure function of
+the log), a handler using it stays deterministic across replays.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from django.apps import apps
+from django.db.models import QuerySet
+
+
+class DjangoProjectionReader:
+    """Read-only projection accessor over `apps.get_model(...).objects`."""
+
+    def get(self, model_label: str, /, **lookup: Any) -> Any | None:
+        """The single row matching `lookup`, or None (never raises on absence)."""
+        return apps.get_model(model_label).objects.filter(**lookup).first()
+
+    def filter(self, model_label: str, /, **lookup: Any) -> QuerySet:
+        """A queryset of the rows matching `lookup`."""
+        return apps.get_model(model_label).objects.filter(**lookup)
+
+    def query(self, model_label: str, /) -> QuerySet:
+        """A queryset of every row of the model."""
+        return apps.get_model(model_label).objects.all()

--- a/src/rakaia/protocols.py
+++ b/src/rakaia/protocols.py
@@ -9,7 +9,7 @@ backend that can return a stream's messages in order — the in-memory
 
 from __future__ import annotations
 
-from typing import Protocol, runtime_checkable
+from typing import Any, Protocol, runtime_checkable
 
 from .types import StreamMessage
 
@@ -26,4 +26,31 @@ class ReadableStore(Protocol):
         With no `offset`, returns every message; with an `offset`, returns the
         messages after it. Raises `KeyError` if the stream does not exist.
         """
+        ...
+
+
+@runtime_checkable
+class ProjectionReader(Protocol):
+    """Read-only view over materialised projections.
+
+    During staged replay, `replay()` passes a reader to every stage > 0 handler
+    as its second argument, so the handler can resolve facts that earlier stages
+    produced (e.g. link a form to the reference entity another form created).
+    `replay()` never calls these methods itself — it only forwards the reader —
+    so backends are free to shape it to their storage; the Django integration
+    provides one over `apps.get_model(...).objects`. Because a reader only ever
+    reads committed projections (themselves a pure function of the log), a
+    handler using it stays deterministic.
+    """
+
+    def get(self, model_label: str, /, **lookup: Any) -> Any | None:
+        """Return the single row matching `lookup`, or None."""
+        ...
+
+    def filter(self, model_label: str, /, **lookup: Any) -> Any:
+        """Return the rows matching `lookup` (a queryset-like iterable)."""
+        ...
+
+    def query(self, model_label: str, /) -> Any:
+        """Return all rows of the model (a queryset-like iterable)."""
         ...

--- a/src/rakaia/registry.py
+++ b/src/rakaia/registry.py
@@ -88,6 +88,13 @@ class HandlerVersion:
     """When set, `event_match` is matched against `event[match_field]` (e.g.
     'form_type') instead of the stream path. None = match the stream path."""
 
+    stage: int = 0
+    """Replay stage. Handlers run in ascending stage order; every event is fed
+    through stage 0 in full before stage 1 begins, and a stage > 0 handler is
+    called with a read-only projection reader as its second argument so it can
+    resolve facts materialised by earlier stages. Default 0 = single-stage,
+    called with just the event (backward compatible)."""
+
 
 # =============================================================================
 # Registry
@@ -120,7 +127,7 @@ class HandlerRegistry:
         self._stream_path = stream_path
         # Identity tuples already persisted to the stream — used for dedup.
         self._persisted_ids: set[
-            tuple[str, str, int, int | None, str, str, str | None]
+            tuple[str, str, int, int | None, str, str, str | None, int]
         ] = set()
         if store is not None:
             self._ensure_stream()
@@ -135,16 +142,21 @@ class HandlerRegistry:
         effective_to: int | None = None,
         *,
         match_field: str | None = None,
+        stage: int = 0,
     ) -> HandlerVersion:
         """
         Register a handler version. Raises HandlerOverlapError on overlap.
 
         Re-registering with identical (name, event_match, from, to,
-        dotted_path, source_hash, match_field) is a no-op that returns the
-        existing version without re-appending to the meta-stream.
+        dotted_path, source_hash, match_field, stage) is a no-op that returns
+        the existing version without re-appending to the meta-stream.
 
         When `match_field` is set, `event_match` is matched against
         `event[match_field]` (e.g. 'form_type') instead of the stream path.
+
+        `stage` (default 0) controls replay ordering: replay runs stages in
+        ascending order, and a stage > 0 handler is invoked as `fn(event,
+        reader)` so it can read earlier stages' projections.
         """
         if effective_from < 0:
             raise ValueError(
@@ -155,6 +167,8 @@ class HandlerRegistry:
                 f"effective_to ({effective_to}) must be > effective_from "
                 f"({effective_from})"
             )
+        if stage < 0:
+            raise ValueError(f"stage must be non-negative, got {stage}")
 
         version = HandlerVersion(
             name=name,
@@ -165,6 +179,7 @@ class HandlerRegistry:
             dotted_path=f"{fn.__module__}.{fn.__qualname__}",
             source_hash=hash_function_source(fn),
             match_field=match_field,
+            stage=stage,
         )
 
         key = (name, event_match)
@@ -189,6 +204,8 @@ class HandlerRegistry:
         event_match: str,
         seq: int,
         event: dict[str, Any] | None = None,
+        *,
+        stage: int | None = None,
     ) -> list[HandlerVersion]:
         """
         Return all handler versions whose pattern matches AND whose [from, to)
@@ -196,6 +213,10 @@ class HandlerRegistry:
         `event_match` string (the stream path); a series registered with a
         `match_field` is instead matched against `event[match_field]`, so pass
         the decoded `event` when any content-routed handlers exist.
+
+        When `stage` is given, only versions in that stage are returned; the
+        coverage check still runs across every matching series, so a genuine
+        gap surfaces regardless of which stage is being resolved.
 
         Raises HandlerGapError if any matching handler series has no version
         covering seq (a gap, not "no handlers").
@@ -222,8 +243,17 @@ class HandlerRegistry:
                     f"{[(v.effective_from, v.effective_to) for v in versions]}"
                 )
             # Overlap is rejected at registration, so at most one matches.
-            resolved.append(covering[0])
+            if stage is None or covering[0].stage == stage:
+                resolved.append(covering[0])
         return resolved
+
+    def stages(self) -> list[int]:
+        """Sorted list of the distinct stages any registered version declares.
+
+        `[0]` (or `[]` when empty) means single-stage replay; more than one
+        entry drives staged replay in ascending order.
+        """
+        return sorted({v.stage for v in self.all_versions()})
 
     @staticmethod
     def _match_subject(
@@ -313,6 +343,7 @@ class HandlerRegistry:
             "dotted_path": version.dotted_path,
             "source_hash": version.source_hash,
             "match_field": version.match_field,
+            "stage": version.stage,
         }
         self._store.append(
             self._stream_path,
@@ -556,8 +587,9 @@ class UpcasterRegistry:
 
 def _identity(
     v: HandlerVersion,
-) -> tuple[str, str, int, int | None, str, str, str | None]:
-    # match_field is appended LAST so dotted_path stays at index 4 (rehydrate()).
+) -> tuple[str, str, int, int | None, str, str, str | None, int]:
+    # match_field / stage are appended after dotted_path (index 4) and
+    # source_hash (index 5) so rehydrate()'s ident[4] lookup stays valid.
     return (
         v.name,
         v.event_match,
@@ -566,12 +598,13 @@ def _identity(
         v.dotted_path,
         v.source_hash,
         v.match_field,
+        v.stage,
     )
 
 
 def _identity_from_payload(
     p: dict[str, Any],
-) -> tuple[str, str, int, int | None, str, str, str | None]:
+) -> tuple[str, str, int, int | None, str, str, str | None, int]:
     return (
         p["name"],
         p["event_match"],
@@ -580,6 +613,7 @@ def _identity_from_payload(
         p["dotted_path"],
         p["source_hash"],
         p.get("match_field"),  # tolerate pre-match_field persisted payloads
+        int(p.get("stage", 0)),  # tolerate pre-stage persisted payloads
     )
 
 
@@ -641,13 +675,15 @@ def register_handler(
     effective_to: int | None = None,
     *,
     match_field: str | None = None,
+    stage: int = 0,
     registry: HandlerRegistry | None = None,
 ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
     """
     Decorator that registers a handler version with the default registry.
 
     Pass `match_field` to route on a payload field (e.g. 'form_type') instead
-    of the stream path.
+    of the stream path. Pass `stage` (default 0) to place the handler in a
+    replay stage; stage > 0 handlers are called `fn(event, reader)`.
 
     Example:
         @register_handler(
@@ -674,6 +710,7 @@ def register_handler(
             effective_from=effective_from,
             effective_to=effective_to,
             match_field=match_field,
+            stage=stage,
         )
         return fn
 

--- a/src/rakaia/replay.py
+++ b/src/rakaia/replay.py
@@ -23,7 +23,7 @@ from dataclasses import dataclass, field
 from typing import Literal
 
 from .effects import Effect, Executor
-from .protocols import ReadableStore
+from .protocols import ProjectionReader, ReadableStore
 from .registry import (
     HandlerDriftError,
     HandlerRegistry,
@@ -63,6 +63,7 @@ def replay(
     event_match: str | None = None,
     include_external: bool = False,
     on_drift: OnDriftPolicy = "warn",
+    reader: ProjectionReader | None = None,
 ) -> ReplayResult:
     """
     Replay events in `stream_path` from `start_seq` (inclusive) to `end_seq`
@@ -86,6 +87,17 @@ def replay(
         on_drift: 'warn' (default) emits a warning and continues if a
             handler's source has changed since registration; 'raise' raises
             HandlerDriftError. (Drift detection itself lands in Step 6.)
+        reader: A read-only projection reader forwarded to every stage > 0
+            handler as its second argument. Required when any registered
+            handler declares stage > 0; unused for single-stage replay.
+
+    Staged replay: when handlers span more than one stage (see
+    `register_handler(stage=...)`), replay runs the whole event range through
+    stage 0, then stage 1, and so on. Stage 0 handlers are called `fn(event)`;
+    stage > 0 handlers are called `fn(event, reader)` so they can resolve facts
+    earlier stages materialised (a form linking to a reference entity another
+    form created, regardless of arrival order). With only stage 0 handlers,
+    replay is a single pass, exactly as before.
     """
     handlers = handler_registry or get_default_registry()
     upcasters = upcaster_registry or get_default_upcaster_registry()
@@ -106,12 +118,14 @@ def replay(
             result=result,
         )
 
+    # Decode + upcast each in-range event once; the stage passes below replay
+    # over this shared list rather than re-reading the stream per stage.
+    decoded: list[tuple[int, dict]] = []
     for seq, msg in enumerate(messages):
         if seq < start_seq:
             continue
         if end_seq is not None and seq >= end_seq:
             break
-
         event_dict = _decode_event(msg.data, stream_path, seq)
         upcasted = upcasters.apply_chain(
             event_dict,
@@ -119,27 +133,39 @@ def replay(
             target_version,
             drift_callback=_upcaster_drift,
         )
+        decoded.append((seq, upcasted))
 
-        versions = handlers.resolve(match_str, seq, event=upcasted)
-        all_effects: list[Effect] = []
-        for version in versions:
-            _check_handler_drift(version, on_drift, result)
-            effects = _call_handler(version, upcasted)
-            all_effects.extend(effects)
-
-        external_count = sum(1 for e in all_effects if e.op == "external")
-        result.external_effects_skipped += external_count if not include_external else 0
-        to_apply = (
-            all_effects
-            if include_external
-            else [e for e in all_effects if e.op != "external"]
+    stage_numbers = handlers.stages()
+    staged = any(s > 0 for s in stage_numbers)
+    if staged and reader is None:
+        raise ValueError(
+            "Replay has stage > 0 handlers but no reader was provided; pass "
+            "reader= so staged handlers can read earlier stages' projections."
         )
-        if to_apply:
-            executor.apply(to_apply)
-            result.effects_applied += len(to_apply)
+    # One pass per stage in ascending order; a single unfiltered pass otherwise.
+    passes: list[int | None] = list(stage_numbers) if staged else [None]
 
-        result.events_processed += 1
+    for stage in passes:
+        for seq, upcasted in decoded:
+            versions = handlers.resolve(match_str, seq, event=upcasted, stage=stage)
+            all_effects: list[Effect] = []
+            for version in versions:
+                _check_handler_drift(version, on_drift, result)
+                all_effects.extend(_call_handler(version, upcasted, reader))
 
+            external_count = sum(1 for e in all_effects if e.op == "external")
+            if not include_external:
+                result.external_effects_skipped += external_count
+            to_apply = (
+                all_effects
+                if include_external
+                else [e for e in all_effects if e.op != "external"]
+            )
+            if to_apply:
+                executor.apply(to_apply)
+                result.effects_applied += len(to_apply)
+
+    result.events_processed = len(decoded)
     return result
 
 
@@ -191,8 +217,14 @@ def _decode_event(data: bytes, stream_path: str, seq: int) -> dict:
         ) from exc
 
 
-def _call_handler(version: HandlerVersion, event: dict) -> Iterable[Effect]:
-    result = version.fn(event)
+def _call_handler(
+    version: HandlerVersion,
+    event: dict,
+    reader: ProjectionReader | None,
+) -> Iterable[Effect]:
+    # Stage > 0 handlers take (event, reader); stage 0 keeps the (event)
+    # signature so existing single-stage handlers are unchanged.
+    result = version.fn(event, reader) if version.stage > 0 else version.fn(event)
     if result is None:
         return []
     if isinstance(result, Effect):

--- a/src/rakaia/replay.py
+++ b/src/rakaia/replay.py
@@ -2,13 +2,20 @@
 Replay orchestrator: re-derive materialized state from a stream by running
 versioned handlers and an effect executor.
 
-Pipeline per event:
+Per event the pipeline is:
     1. Load the raw event bytes from the stream
     2. Decode as JSON, upcast to current schema via UpcasterRegistry
-    3. Resolve handlers via HandlerRegistry.resolve(event_match, seq, event)
+    3. Resolve handlers via HandlerRegistry.resolve(event_match, seq, event, stage)
     4. Call each handler -> collect Effects
     5. Filter out op="external" effects unless include_external=True
     6. executor.apply(effects)
+
+When every handler is stage 0 (the default), replay is a single streaming pass
+over the range — one event decoded and applied at a time. When handlers span
+more than one stage, replay decodes the range once and runs the pipeline as one
+pass per stage in ascending order: the whole range through stage 0, then stage
+1, and so on, so a stage > 0 handler (called `fn(event, reader)`) can read the
+projections earlier stages committed. See `register_handler(stage=...)`.
 
 Re-running the same range twice produces identical materialized state because
 all Effects use update_or_create (idempotent).
@@ -118,53 +125,67 @@ def replay(
             result=result,
         )
 
-    # Decode + upcast each in-range event once; the stage passes below replay
-    # over this shared list rather than re-reading the stream per stage.
-    decoded: list[tuple[int, dict]] = []
-    for seq, msg in enumerate(messages):
-        if seq < start_seq:
-            continue
-        if end_seq is not None and seq >= end_seq:
-            break
-        event_dict = _decode_event(msg.data, stream_path, seq)
-        upcasted = upcasters.apply_chain(
-            event_dict,
+    def _decode_upcast(seq: int, data: bytes) -> dict:
+        return upcasters.apply_chain(
+            _decode_event(data, stream_path, seq),
             match_str,
             target_version,
             drift_callback=_upcaster_drift,
         )
-        decoded.append((seq, upcasted))
+
+    def _dispatch(seq: int, upcasted: dict, stage: int | None) -> None:
+        versions = handlers.resolve(match_str, seq, event=upcasted, stage=stage)
+        all_effects: list[Effect] = []
+        for version in versions:
+            _check_handler_drift(version, on_drift, result)
+            all_effects.extend(_call_handler(version, upcasted, reader))
+
+        external_count = sum(1 for e in all_effects if e.op == "external")
+        if not include_external:
+            result.external_effects_skipped += external_count
+        to_apply = (
+            all_effects
+            if include_external
+            else [e for e in all_effects if e.op != "external"]
+        )
+        if to_apply:
+            executor.apply(to_apply)
+            result.effects_applied += len(to_apply)
+
+    def _in_range(seq: int) -> bool:
+        return seq >= start_seq and (end_seq is None or seq < end_seq)
 
     stage_numbers = handlers.stages()
     staged = any(s > 0 for s in stage_numbers)
-    if staged and reader is None:
+
+    if not staged:
+        # Single stage: stream one event at a time (bounded memory, and drift /
+        # partial-progress semantics identical to pre-staged replay).
+        for seq, msg in enumerate(messages):
+            if end_seq is not None and seq >= end_seq:
+                break
+            if not _in_range(seq):
+                continue
+            _dispatch(seq, _decode_upcast(seq, msg.data), stage=None)
+            result.events_processed += 1
+        return result
+
+    if reader is None:
         raise ValueError(
             "Replay has stage > 0 handlers but no reader was provided; pass "
             "reader= so staged handlers can read earlier stages' projections."
         )
-    # One pass per stage in ascending order; a single unfiltered pass otherwise.
-    passes: list[int | None] = list(stage_numbers) if staged else [None]
-
-    for stage in passes:
+    # Staged: decode + upcast each in-range event once, then run one pass per
+    # stage in ascending order over that shared list.
+    decoded: list[tuple[int, dict]] = []
+    for seq, msg in enumerate(messages):
+        if end_seq is not None and seq >= end_seq:
+            break
+        if _in_range(seq):
+            decoded.append((seq, _decode_upcast(seq, msg.data)))
+    for stage in stage_numbers:
         for seq, upcasted in decoded:
-            versions = handlers.resolve(match_str, seq, event=upcasted, stage=stage)
-            all_effects: list[Effect] = []
-            for version in versions:
-                _check_handler_drift(version, on_drift, result)
-                all_effects.extend(_call_handler(version, upcasted, reader))
-
-            external_count = sum(1 for e in all_effects if e.op == "external")
-            if not include_external:
-                result.external_effects_skipped += external_count
-            to_apply = (
-                all_effects
-                if include_external
-                else [e for e in all_effects if e.op != "external"]
-            )
-            if to_apply:
-                executor.apply(to_apply)
-                result.effects_applied += len(to_apply)
-
+            _dispatch(seq, upcasted, stage=stage)
     result.events_processed = len(decoded)
     return result
 

--- a/tests/test_django_rakaia/test_projection_reader.py
+++ b/tests/test_django_rakaia/test_projection_reader.py
@@ -1,0 +1,87 @@
+"""Tests for DjangoProjectionReader + end-to-end staged replay over the ORM."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from django_rakaia.effect_executor import DjangoExecutor
+from django_rakaia.projection_reader import DjangoProjectionReader
+from django_rakaia.store import get_store
+from rakaia.effects import Effect
+from rakaia.registry import HandlerRegistry, UpcasterRegistry
+from rakaia.replay import replay
+
+from .models import Area
+
+
+@pytest.mark.django_db
+class TestDjangoProjectionReader:
+    def test_get_returns_row_or_none(self):
+        Area.objects.create(name="present")
+        reader = DjangoProjectionReader()
+        assert reader.get("test_django_rakaia.Area", name="present").name == "present"
+        assert reader.get("test_django_rakaia.Area", name="absent") is None
+
+    def test_filter_and_query(self):
+        for name in ("a", "b", "c"):
+            Area.objects.create(name=name)
+        reader = DjangoProjectionReader()
+        assert reader.filter("test_django_rakaia.Area", name="b").count() == 1
+        assert reader.query("test_django_rakaia.Area").count() == 3
+
+
+def _ref_handler(event):
+    return Effect(
+        op="update_or_create",
+        model_label="test_django_rakaia.Area",
+        lookup={"name": event["name"]},
+        defaults={},
+    )
+
+
+def _dep_handler(event, reader):
+    ref = reader.get("test_django_rakaia.Area", name=event["ref"])
+    tag = "FOUND" if ref is not None else "MISSING"
+    return Effect(
+        op="update_or_create",
+        model_label="test_django_rakaia.Area",
+        lookup={"name": f"{event['key']}->{tag}"},
+        defaults={},
+    )
+
+
+# The dependent event arrives BEFORE the reference it needs.
+_EVENTS = [
+    {"schema_version": 1, "kind": "DEP", "key": "dep-1", "ref": "the-ref"},
+    {"schema_version": 1, "kind": "REF", "key": "ref-1", "name": "the-ref"},
+]
+
+
+@pytest.mark.django_db
+class TestStagedReplayOverOrm:
+    def test_stage1_reads_stage0_committed_rows(self):
+        store = get_store()
+        store.delete("s")
+        store.create("s")
+        for event in _EVENTS:
+            store.append("s", json.dumps(event).encode("utf-8"))
+
+        reg = HandlerRegistry()
+        reg.register("ref", "REF", _ref_handler, 0, None, match_field="kind", stage=0)
+        reg.register("dep", "DEP", _dep_handler, 0, None, match_field="kind", stage=1)
+
+        replay(
+            store,
+            "s",
+            DjangoExecutor(),
+            handler_registry=reg,
+            upcaster_registry=UpcasterRegistry(),
+            reader=DjangoProjectionReader(),
+        )
+
+        # Stage 0 created the reference Area before stage 1 read it, so the
+        # dependent — despite arriving first in the stream — resolves FOUND.
+        assert Area.objects.filter(name="dep-1->FOUND").exists()
+        assert not Area.objects.filter(name="dep-1->MISSING").exists()

--- a/tests/test_rakaia/test_registry.py
+++ b/tests/test_rakaia/test_registry.py
@@ -179,6 +179,49 @@ class TestMatchField:
             reg.resolve("room:5", 0)
 
 
+class TestStage:
+    def test_register_with_stage(self, reg: HandlerRegistry):
+        v = reg.register("m", "e", _fn("v1"), 0, None, stage=1)
+        assert v.stage == 1
+
+    def test_default_stage_is_zero(self, reg: HandlerRegistry):
+        v = reg.register("m", "e", _fn("v1"), 0, None)
+        assert v.stage == 0
+
+    def test_negative_stage_raises(self, reg: HandlerRegistry):
+        with pytest.raises(ValueError, match="stage must be non-negative"):
+            reg.register("m", "e", _fn("v1"), 0, None, stage=-1)
+
+    def test_stages_returns_sorted_distinct(self, reg: HandlerRegistry):
+        reg.register("a", "e", _fn("a"), 0, None, stage=2)
+        reg.register("b", "e", _fn("b"), 0, None, stage=0)
+        reg.register("c", "e", _fn("c"), 0, None, stage=2)
+        assert reg.stages() == [0, 2]
+
+    def test_stages_empty_registry(self, reg: HandlerRegistry):
+        assert reg.stages() == []
+
+    def test_resolve_filters_by_stage(self, reg: HandlerRegistry):
+        v0 = reg.register("ref", "room:*", _fn("ref"), 0, None, stage=0)
+        v1 = reg.register("dep", "room:*", _fn("dep"), 0, None, stage=1)
+        assert reg.resolve("room:5", 0, stage=0) == [v0]
+        assert reg.resolve("room:5", 0, stage=1) == [v1]
+        assert reg.resolve("room:5", 0, stage=2) == []
+
+    def test_resolve_without_stage_returns_all_stages(self, reg: HandlerRegistry):
+        v0 = reg.register("ref", "room:*", _fn("ref"), 0, None, stage=0)
+        v1 = reg.register("dep", "room:*", _fn("dep"), 0, None, stage=1)
+        assert set(reg.resolve("room:5", 0)) == {v0, v1}
+
+    def test_resolve_stage_filter_still_detects_gap(self, reg: HandlerRegistry):
+        # A coverage gap in ANY matching series is an error, even while
+        # resolving a different stage — a gap is a misconfiguration.
+        reg.register("m", "e", _fn("v1"), 0, 10, stage=0)
+        reg.register("m", "e", _fn("v2"), 20, None, stage=0)
+        with pytest.raises(HandlerGapError):
+            reg.resolve("e", 15, stage=1)
+
+
 class TestDecorator:
     def test_decorator_registers_with_explicit_registry(self):
         reg = HandlerRegistry()

--- a/tests/test_rakaia/test_registry_persistence.py
+++ b/tests/test_rakaia/test_registry_persistence.py
@@ -90,6 +90,46 @@ class TestPersistence:
         payload = json.loads(messages[0].data)
         assert payload["match_field"] is None
 
+    def test_stage_persisted_and_dedups(self, store: StreamStore):
+        reg = HandlerRegistry(store=store)
+        reg.register("m", "e", _fn("v1"), 0, None, stage=2)
+        messages, _ = store.read(HANDLERS_META_STREAM)
+        assert json.loads(messages[0].data)["stage"] == 2
+
+        # A fresh registry over the same store dedups the identical
+        # registration (stage included in the identity) — no re-append.
+        reg2 = HandlerRegistry(store=store)
+        reg2.register("m", "e", _fn("v1"), 0, None, stage=2)
+        messages2, _ = store.read(HANDLERS_META_STREAM)
+        assert len(messages2) == 1
+
+    def test_stage_change_appends_new_event(self, store: StreamStore):
+        # Moving a handler to a different stage is a real change -> new event.
+        reg = HandlerRegistry(store=store)
+        fn = _fn("v1")
+        reg.register("m", "e", fn, 0, 10, stage=0)
+        reg.register("m", "e", fn, 10, 20, stage=1)  # different range + stage
+        messages, _ = store.read(HANDLERS_META_STREAM)
+        assert len(messages) == 2
+        assert {json.loads(m.data)["stage"] for m in messages} == {0, 1}
+
+    def test_missing_stage_defaults_to_zero(self, store: StreamStore):
+        # A payload persisted before `stage` existed rehydrates as stage 0.
+        store.create(HANDLERS_META_STREAM)
+        payload = {
+            "name": "ghost",
+            "event_match": "x",
+            "effective_from": 0,
+            "effective_to": 5,
+            "dotted_path": "some.module.ghost",
+            "source_hash": "deadbeef" * 8,
+            # no "stage" key
+        }
+        store.append(HANDLERS_META_STREAM, json.dumps(payload).encode("utf-8"))
+        reg = HandlerRegistry(store=store)
+        ident = next(iter(reg._persisted_ids))  # type: ignore[attr-defined]
+        assert ident[-1] == 0  # stage defaulted to 0
+
 
 class TestIdempotency:
     def test_same_registration_twice_in_one_process_is_noop(self, store: StreamStore):

--- a/tests/test_rakaia/test_replay.py
+++ b/tests/test_rakaia/test_replay.py
@@ -551,3 +551,204 @@ class TestMatchFieldRouting:
         assert ("x.TF", 3) in models
         assert ("x.SF", 1) not in models
         assert ("x.TF", 2) not in models
+
+
+# ---------------------------------------------------------------------------
+# Staged replay (stage= handlers + a projection reader)
+# ---------------------------------------------------------------------------
+
+from types import SimpleNamespace  # noqa: E402
+
+
+class DictProjections:
+    """In-memory materialiser: an Executor that applies update_or_create/delete
+    effects, and a ProjectionReader over the same rows. Enough to exercise
+    staged replay without Django — stage 1 reads what stage 0 committed."""
+
+    def __init__(self) -> None:
+        self.rows: dict[str, list[dict]] = {}
+
+    # -- Executor side --
+    def apply(self, effects) -> None:
+        for e in effects:
+            table = self.rows.setdefault(e.model_label, [])
+            if e.op == "update_or_create":
+                row = self._find(table, e.lookup)
+                if row is None:
+                    row = dict(e.lookup)
+                    table.append(row)
+                row.update(e.defaults or {})
+            elif e.op == "delete":
+                self.rows[e.model_label] = [
+                    r
+                    for r in table
+                    if not (
+                        self._match(r, e.lookup or {})
+                        and not self._excluded(r, e.exclude or {})
+                    )
+                ]
+
+    @staticmethod
+    def _find(table, lookup):
+        return next((r for r in table if DictProjections._match(r, lookup)), None)
+
+    @staticmethod
+    def _match(row, lookup):
+        return all(row.get(k) == v for k, v in lookup.items())
+
+    @staticmethod
+    def _excluded(row, exclude):
+        for key, val in exclude.items():
+            if key.endswith("__in") and row.get(key[:-4]) in val:
+                return True
+        return False
+
+    # -- ProjectionReader side --
+    def get(self, model_label, **lookup):
+        row = self._find(self.rows.get(model_label, []), lookup)
+        return SimpleNamespace(**row) if row is not None else None
+
+    def filter(self, model_label, **lookup):
+        return [
+            SimpleNamespace(**r)
+            for r in self.rows.get(model_label, [])
+            if self._match(r, lookup)
+        ]
+
+    def query(self, model_label):
+        return [SimpleNamespace(**r) for r in self.rows.get(model_label, [])]
+
+
+def _project(event, reader):  # noqa: ARG001  (stage 0 ignores reader — see call)
+    return Effect(
+        op="update_or_create",
+        model_label="app.Project",
+        lookup={"suku": event["suku"], "output": event["output"]},
+        defaults={"name": event["project_name"]},
+    )
+
+
+def _sf12(event, reader):
+    project = reader.get("app.Project", suku=event["suku"], output=event["output"])
+    return Effect(
+        op="update_or_create",
+        model_label="app.Sf12",
+        lookup={"submission_id": event["key"]},
+        defaults={"project_id": project.name if project else None},
+    )
+
+
+# TF (defines the project) deliberately arrives AFTER the SF that needs it.
+_STAGED_EVENTS = [
+    {
+        "schema_version": 1,
+        "form_type": "SF_1_2",
+        "key": "sf-1",
+        "suku": "Fatuberliu",
+        "output": "WATER",
+    },
+    {
+        "schema_version": 1,
+        "form_type": "TF_6_1_1",
+        "key": "tf-1",
+        "suku": "Fatuberliu",
+        "output": "WATER",
+        "project_name": "WS-014",
+    },
+]
+
+
+def _staged_registry():
+    reg = HandlerRegistry()
+    # stage 0 is defined with a reader param but registered at stage 0, so it is
+    # called `fn(event)`; that must not error even though the fn accepts reader.
+    reg.register(
+        "project",
+        "TF_6_1_1",
+        lambda event: _project(event, None),
+        0,
+        None,
+        match_field="form_type",
+        stage=0,
+    )
+    reg.register("sf12", "SF_1_2", _sf12, 0, None, match_field="form_type", stage=1)
+    return reg
+
+
+class TestStagedReplay:
+    def test_late_reference_still_links(self, store: StreamStore):
+        _seed_stream(store, "s", _STAGED_EVENTS)
+        reg = _staged_registry()
+        proj = DictProjections()
+        result = replay(
+            store,
+            "s",
+            proj,
+            handler_registry=reg,
+            upcaster_registry=UpcasterRegistry(),
+            reader=proj,
+        )
+        # The SF arrived before its TF, yet stage 0 built every Project before
+        # stage 1 linked, so the link resolves.
+        sf = proj.get("app.Sf12", submission_id="sf-1")
+        assert sf.project_id == "WS-014"
+        assert result.events_processed == 2  # counted once, not per stage
+
+    def test_missing_reader_raises(self, store: StreamStore):
+        _seed_stream(store, "s", _STAGED_EVENTS)
+        reg = _staged_registry()
+        with pytest.raises(ValueError, match="reader"):
+            replay(
+                store,
+                "s",
+                DictProjections(),
+                handler_registry=reg,
+                upcaster_registry=UpcasterRegistry(),
+            )  # no reader=
+
+    def test_self_heals_on_re_replay(self, store: StreamStore):
+        # Only the SF exists: its project is unresolved.
+        _seed_stream(store, "s", [_STAGED_EVENTS[0]])
+        reg = _staged_registry()
+        proj = DictProjections()
+        replay(
+            store,
+            "s",
+            proj,
+            handler_registry=reg,
+            upcaster_registry=UpcasterRegistry(),
+            reader=proj,
+        )
+        assert proj.get("app.Sf12", submission_id="sf-1").project_id is None
+
+        # The TF finally arrives; re-replaying links it — no backfill.
+        store.append("s", json.dumps(_STAGED_EVENTS[1]).encode("utf-8"))
+        proj2 = DictProjections()
+        replay(
+            store,
+            "s",
+            proj2,
+            handler_registry=reg,
+            upcaster_registry=UpcasterRegistry(),
+            reader=proj2,
+        )
+        assert proj2.get("app.Sf12", submission_id="sf-1").project_id == "WS-014"
+
+    def test_stage_zero_only_is_single_pass_without_reader(self, store: StreamStore):
+        # A registry with only stage-0 handlers needs no reader (backward compat).
+        _seed_stream(store, "s", [_STAGED_EVENTS[1]])
+        reg = HandlerRegistry()
+        reg.register(
+            "project",
+            "TF_6_1_1",
+            lambda event: _project(event, None),
+            0,
+            None,
+            match_field="form_type",
+            stage=0,
+        )
+        proj = DictProjections()
+        replay(
+            store, "s", proj, handler_registry=reg, upcaster_registry=UpcasterRegistry()
+        )  # no reader needed
+        assert proj.get("app.Project", suku="Fatuberliu", output="WATER") is not None


### PR DESCRIPTION
Third core promotion, and the keystone the close/merge/tree spikes all lean on — issue #7 feature #1, prototyped in #8. Turns `replay()` from one per-event pass into a deterministic multi-stage pipeline.

## What it adds
- **`@register_handler(..., stage=N)`** — a handler declares a replay stage.
- **`replay(..., reader=...)`** — when handlers span more than one stage, replay runs the whole event range through **stage 0, then stage 1, …**. Stage 0 handlers are called `fn(event)`; **stage > 0 handlers are called `fn(event, reader)`** so they resolve facts earlier stages materialised.

The payoff (from the spike): a form links to a reference entity another form created **regardless of arrival order** — because the entire stage-0 reference set exists before stage 1 runs — and appending a late reference event and re-replaying **self-heals** the link with no backfill task. This is what replaces Partisipa's reactive re-save signals + `post_migration_tasks` backfills.

## Pieces
- **Registry:** `HandlerVersion.stage` (default 0), validated; persisted in the meta-stream (identity tuple extended with `stage` appended last, so `rehydrate()`'s `dotted_path` index is unchanged; pre-`stage` payloads default to 0). New `HandlerRegistry.stages()` and a `stage=` filter on `resolve()` (the coverage/gap check stays global).
- **replay():** staged passes; `events_processed` counted once; requires `reader=` iff any stage > 0 handler exists.
- **`rakaia.protocols.ProjectionReader`** (`get`/`filter`/`query`) — replay forwards it opaquely. **`django_rakaia.projection_reader.DjangoProjectionReader`** implements it over `apps.get_model(...).objects`.

## Backward compatibility
A registry with only stage-0 handlers replays as a **single pass with no reader** — byte-for-byte the old behavior. All 22 existing replay tests pass unchanged.

## Tests (TDD)
Registry stage tests (filter, `stages()`, gap-still-detected, persistence round-trip + pre-stage default); core staged replay over an in-memory materialiser (late link resolves; missing-reader raises; **self-heal** on re-replay; stage-0-only needs no reader); and an **end-to-end `django_db`** staged replay through `DjangoProjectionReader`. **395 passed, 1 skipped**; ruff check + format clean. `docs/staged-replay.md` updated from spike to real API.

Follow-up (separate PR): `reduce=` — per-stage whole-collection recompute steps (aggregates).