### PR TITLE
feat: reduce= — per-stage recompute steps (aggregates) in core

### DIFF
--- a/docs/staged-replay.md
+++ b/docs/staged-replay.md
@@ -35,10 +35,37 @@ def sf12(event, refs):                      # stage 1: resolve via the reader
 replay(store, "submissions", DjangoExecutor(), reader=DjangoProjectionReader())
 ```
 
-`replay()` requires `reader=` whenever any handler declares stage > 0; with only
-stage 0 handlers it is a single pass and no reader is needed (backward
-compatible). The reader is any `rakaia.protocols.ProjectionReader`
-(`get` / `filter` / `query`); the Django one reads `apps.get_model(...).objects`.
+`replay()` requires `reader=` whenever any handler declares stage > 0 (or any
+reducer is registered, see below); with only stage 0 handlers it is a single pass
+and no reader is needed (backward compatible). The reader is any
+`rakaia.protocols.ProjectionReader` (`get` / `filter` / `query`); the Django one
+reads `apps.get_model(...).objects`.
+
+## Per-stage aggregates: reducers
+
+Some projections aren't per-event — a rollup depends on the *whole set* of
+contributing rows, and an increment isn't replay-safe. A **reducer** runs once
+per stage, after that stage's per-event handlers commit, reading the accumulated
+projections and returning idempotent Effects (typically via
+[`reconcile_aggregate`](projections-and-fan-out.md)):
+
+```python
+from rakaia.registry import register_reducer
+from rakaia import reconcile_aggregate
+
+@register_reducer(name="balance", stage=1)
+def balance(reader):                         # runs once, after stage-1 handlers
+    totals = {}
+    for line in reader.query("ida.FinanceLine"):
+        totals[line.suku] = totals.get(line.suku, 0) + line.amount
+    return reconcile_aggregate("ida.Balance", {}, "suku",
+                               {s: {"total": t} for s, t in totals.items()})
+```
+
+Because it **recomputes** from the current rows on every replay, re-running is a
+no-op on the totals — the double-count bug is gone. `reconcile_aggregate` builds
+the effects; the reducer is the replay-time hook that runs it. A registry with
+any reducer replays in staged mode and requires `reader=`.
 
 ## The problem: late-arriving cross-form links
 

--- a/src/rakaia/__init__.py
+++ b/src/rakaia/__init__.py
@@ -34,12 +34,14 @@ from .projections import (
 )
 from .registry import (
     HANDLERS_META_STREAM,
+    REDUCERS_META_STREAM,
     UPCASTERS_META_STREAM,
     HandlerDriftError,
     HandlerGapError,
     HandlerOverlapError,
     HandlerRegistry,
     HandlerVersion,
+    ReducerVersion,
     UpcasterChainError,
     UpcasterConflictError,
     UpcasterRegistry,
@@ -47,6 +49,7 @@ from .registry import (
     get_default_registry,
     get_default_upcaster_registry,
     register_handler,
+    register_reducer,
     register_upcaster,
     upcast,
 )
@@ -115,10 +118,13 @@ __all__ = [
     "reconcile_aggregate",
     # Versioned handlers — registry
     "register_handler",
+    "register_reducer",
     "register_upcaster",
     "HandlerRegistry",
     "UpcasterRegistry",
     "HandlerVersion",
+    "ReducerVersion",
+    "REDUCERS_META_STREAM",
     "UpcasterVersion",
     "HandlerOverlapError",
     "HandlerGapError",

--- a/src/rakaia/registry.py
+++ b/src/rakaia/registry.py
@@ -27,6 +27,7 @@ if TYPE_CHECKING:
 
 HANDLERS_META_STREAM = "__rakaia__:handlers"
 UPCASTERS_META_STREAM = "__rakaia__:upcasters"
+REDUCERS_META_STREAM = "__rakaia__:reducers"
 
 
 # =============================================================================
@@ -96,6 +97,31 @@ class HandlerVersion:
     called with just the event (backward compatible)."""
 
 
+@dataclass(frozen=True)
+class ReducerVersion:
+    """A per-stage reduce step: recompute an aggregate once from the projections.
+
+    Unlike a handler, a reducer is not matched or called per event. During
+    staged replay it runs **once** per its stage, after that stage's per-event
+    handlers have committed, and is invoked as `fn(reader)` — reading the
+    accumulated projections (e.g. all contributing rows for a group) and
+    returning the idempotent Effects that materialise the aggregate. It is the
+    replay-time hook that `reconcile_aggregate` is designed to fill.
+    """
+
+    name: str
+    """Reducer name, unique within a registry."""
+
+    stage: int
+    """The stage this reducer runs in (after that stage's event handlers)."""
+
+    fn: Callable[..., Any]
+    """The reducer callable. reader -> Effect | list[Effect] | None."""
+
+    dotted_path: str
+    source_hash: str
+
+
 # =============================================================================
 # Registry
 # =============================================================================
@@ -123,15 +149,21 @@ class HandlerRegistry:
     ) -> None:
         # (name, event_match) -> sorted list of HandlerVersion by effective_from
         self._versions: dict[tuple[str, str], list[HandlerVersion]] = {}
+        # reducer name -> ReducerVersion
+        self._reducers: dict[str, ReducerVersion] = {}
         self._store = store
         self._stream_path = stream_path
+        self._reducer_stream_path = REDUCERS_META_STREAM
         # Identity tuples already persisted to the stream — used for dedup.
         self._persisted_ids: set[
             tuple[str, str, int, int | None, str, str, str | None, int]
         ] = set()
+        self._reducer_persisted_ids: set[tuple[str, int, str, str]] = set()
         if store is not None:
             self._ensure_stream()
             self._load_persisted_ids()
+            self._ensure_reducer_stream()
+            self._load_reducer_ids()
 
     def register(
         self,
@@ -199,6 +231,53 @@ class HandlerRegistry:
         series.sort(key=lambda v: v.effective_from)
         return version
 
+    def register_reducer(
+        self,
+        name: str,
+        stage: int,
+        fn: Callable[..., Any],
+    ) -> ReducerVersion:
+        """Register a per-stage reduce step (runs once at `stage`, `fn(reader)`).
+
+        Re-registering with identical (name, stage, dotted_path, source_hash) is
+        a no-op. Registering a *different* function under an existing name
+        replaces it (a reducer is a single current definition, not a version
+        series) and appends a new audit event.
+        """
+        if stage < 0:
+            raise ValueError(f"stage must be non-negative, got {stage}")
+
+        reducer = ReducerVersion(
+            name=name,
+            stage=stage,
+            fn=fn,
+            dotted_path=f"{fn.__module__}.{fn.__qualname__}",
+            source_hash=hash_function_source(fn),
+        )
+
+        existing = self._reducers.get(name)
+        if existing is not None and _reducer_identity(existing) == _reducer_identity(
+            reducer
+        ):
+            return existing
+
+        if self._store is not None:
+            self._persist_reducer_if_new(reducer)
+
+        self._reducers[name] = reducer
+        return reducer
+
+    def reducers_for_stage(self, stage: int) -> list[ReducerVersion]:
+        """Reducers registered for `stage`, in deterministic (name) order."""
+        return sorted(
+            (r for r in self._reducers.values() if r.stage == stage),
+            key=lambda r: r.name,
+        )
+
+    def all_reducers(self) -> list[ReducerVersion]:
+        """Every registered reducer (test/debug helper)."""
+        return list(self._reducers.values())
+
     def resolve(
         self,
         event_match: str,
@@ -248,12 +327,19 @@ class HandlerRegistry:
         return resolved
 
     def stages(self) -> list[int]:
-        """Sorted list of the distinct stages any registered version declares.
+        """Sorted list of the distinct stages any handler or reducer declares.
 
         `[0]` (or `[]` when empty) means single-stage replay; more than one
-        entry drives staged replay in ascending order.
+        entry — or any reducer — drives staged replay in ascending order.
         """
-        return sorted({v.stage for v in self.all_versions()})
+        return sorted(
+            {v.stage for v in self.all_versions()}
+            | {r.stage for r in self._reducers.values()}
+        )
+
+    def has_reducers(self) -> bool:
+        """Whether any reducer is registered (reducers require staged replay)."""
+        return bool(self._reducers)
 
     @staticmethod
     def _match_subject(
@@ -306,6 +392,9 @@ class HandlerRegistry:
             dotted_path = ident[4]
             module_name = dotted_path.rsplit(".", 1)[0]
             importlib.import_module(module_name)
+        for r_ident in self._reducer_persisted_ids:
+            module_name = r_ident[2].rsplit(".", 1)[0]  # index 2 = dotted_path
+            importlib.import_module(module_name)
 
     # ------------------------------------------------------------------
     # Internal — persistence
@@ -350,6 +439,42 @@ class HandlerRegistry:
             json.dumps(payload).encode("utf-8"),
         )
         self._persisted_ids.add(ident)
+
+    # ------------------------------------------------------------------
+    # Internal — reducer persistence (parallels the handler helpers)
+    # ------------------------------------------------------------------
+
+    def _ensure_reducer_stream(self) -> None:
+        assert self._store is not None
+        if not self._store.has(self._reducer_stream_path):
+            self._store.create(self._reducer_stream_path)
+
+    def _load_reducer_ids(self) -> None:
+        assert self._store is not None
+        messages, _ = self._store.read(self._reducer_stream_path)
+        for msg in messages:
+            try:
+                payload = json.loads(msg.data)
+            except (ValueError, UnicodeDecodeError):
+                continue
+            self._reducer_persisted_ids.add(_reducer_identity_from_payload(payload))
+
+    def _persist_reducer_if_new(self, reducer: ReducerVersion) -> None:
+        assert self._store is not None
+        ident = _reducer_identity(reducer)
+        if ident in self._reducer_persisted_ids:
+            return
+        payload = {
+            "name": reducer.name,
+            "stage": reducer.stage,
+            "dotted_path": reducer.dotted_path,
+            "source_hash": reducer.source_hash,
+        }
+        self._store.append(
+            self._reducer_stream_path,
+            json.dumps(payload).encode("utf-8"),
+        )
+        self._reducer_persisted_ids.add(ident)
 
     # ------------------------------------------------------------------
     # Internal — overlap check
@@ -617,6 +742,14 @@ def _identity_from_payload(
     )
 
 
+def _reducer_identity(r: ReducerVersion) -> tuple[str, int, str, str]:
+    return (r.name, r.stage, r.dotted_path, r.source_hash)
+
+
+def _reducer_identity_from_payload(p: dict[str, Any]) -> tuple[str, int, str, str]:
+    return (p["name"], int(p["stage"]), p["dotted_path"], p["source_hash"])
+
+
 def _u_identity(v: UpcasterVersion) -> tuple[str, int, str, str]:
     return (v.event_match, v.from_version, v.dotted_path, v.source_hash)
 
@@ -712,6 +845,34 @@ def register_handler(
             match_field=match_field,
             stage=stage,
         )
+        return fn
+
+    return decorator
+
+
+def register_reducer(
+    name: str,
+    stage: int,
+    *,
+    registry: HandlerRegistry | None = None,
+) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    """
+    Decorator that registers a per-stage reduce step with the default registry.
+
+    The decorated function is called `fn(reader)` once during staged replay,
+    after `stage`'s per-event handlers commit, and returns the Effects that
+    materialise the aggregate (typically via `reconcile_aggregate`).
+
+    Example:
+        @register_reducer(name="balance", stage=1)
+        def balance(reader):
+            groups = _recompute_totals(reader)
+            return reconcile_aggregate("ida.Balance", {}, "suku", groups)
+    """
+    target = registry if registry is not None else _default_registry
+
+    def decorator(fn: Callable[..., Any]) -> Callable[..., Any]:
+        target.register_reducer(name=name, stage=stage, fn=fn)
         return fn
 
     return decorator

--- a/src/rakaia/replay.py
+++ b/src/rakaia/replay.py
@@ -15,7 +15,10 @@ over the range — one event decoded and applied at a time. When handlers span
 more than one stage, replay decodes the range once and runs the pipeline as one
 pass per stage in ascending order: the whole range through stage 0, then stage
 1, and so on, so a stage > 0 handler (called `fn(event, reader)`) can read the
-projections earlier stages committed. See `register_handler(stage=...)`.
+projections earlier stages committed. A stage may also declare **reducers**
+(`register_reducer(name, stage, fn)`) that run once, after that stage's per-event
+handlers, to recompute an aggregate from the committed projections via the
+reader. See `register_handler(stage=...)` and `register_reducer(...)`.
 
 Re-running the same range twice produces identical materialized state because
 all Effects use update_or_create (idempotent).
@@ -35,6 +38,7 @@ from .registry import (
     HandlerDriftError,
     HandlerRegistry,
     HandlerVersion,
+    ReducerVersion,
     UpcasterRegistry,
     UpcasterVersion,
     get_default_registry,
@@ -95,16 +99,19 @@ def replay(
             handler's source has changed since registration; 'raise' raises
             HandlerDriftError. (Drift detection itself lands in Step 6.)
         reader: A read-only projection reader forwarded to every stage > 0
-            handler as its second argument. Required when any registered
-            handler declares stage > 0; unused for single-stage replay.
+            handler (as its second argument) and to every reducer. Required when
+            any handler declares stage > 0 or any reducer is registered; unused
+            for single-stage replay.
 
     Staged replay: when handlers span more than one stage (see
     `register_handler(stage=...)`), replay runs the whole event range through
     stage 0, then stage 1, and so on. Stage 0 handlers are called `fn(event)`;
     stage > 0 handlers are called `fn(event, reader)` so they can resolve facts
     earlier stages materialised (a form linking to a reference entity another
-    form created, regardless of arrival order). With only stage 0 handlers,
-    replay is a single pass, exactly as before.
+    form created, regardless of arrival order). After a stage's per-event
+    handlers, its reducers (`register_reducer`) run once as `fn(reader)` to
+    recompute aggregates. With only stage 0 handlers and no reducers, replay is a
+    single pass, exactly as before.
     """
     handlers = handler_registry or get_default_registry()
     upcasters = upcaster_registry or get_default_upcaster_registry()
@@ -133,30 +140,37 @@ def replay(
             drift_callback=_upcaster_drift,
         )
 
+    def _apply(effects: list[Effect]) -> None:
+        external_count = sum(1 for e in effects if e.op == "external")
+        if not include_external:
+            result.external_effects_skipped += external_count
+        to_apply = (
+            effects if include_external else [e for e in effects if e.op != "external"]
+        )
+        if to_apply:
+            executor.apply(to_apply)
+            result.effects_applied += len(to_apply)
+
     def _dispatch(seq: int, upcasted: dict, stage: int | None) -> None:
         versions = handlers.resolve(match_str, seq, event=upcasted, stage=stage)
         all_effects: list[Effect] = []
         for version in versions:
             _check_handler_drift(version, on_drift, result)
             all_effects.extend(_call_handler(version, upcasted, reader))
+        _apply(all_effects)
 
-        external_count = sum(1 for e in all_effects if e.op == "external")
-        if not include_external:
-            result.external_effects_skipped += external_count
-        to_apply = (
-            all_effects
-            if include_external
-            else [e for e in all_effects if e.op != "external"]
-        )
-        if to_apply:
-            executor.apply(to_apply)
-            result.effects_applied += len(to_apply)
+    def _run_reducers(stage: int) -> None:
+        # Reducers run once per stage, after that stage's per-event handlers
+        # have committed, reading the accumulated projections via `reader`.
+        for reducer in handlers.reducers_for_stage(stage):
+            _check_reducer_drift(reducer, on_drift, result)
+            _apply(_normalize_effects(reducer.fn(reader)))
 
     def _in_range(seq: int) -> bool:
         return seq >= start_seq and (end_seq is None or seq < end_seq)
 
     stage_numbers = handlers.stages()
-    staged = any(s > 0 for s in stage_numbers)
+    staged = any(s > 0 for s in stage_numbers) or handlers.has_reducers()
 
     if not staged:
         # Single stage: stream one event at a time (bounded memory, and drift /
@@ -172,11 +186,12 @@ def replay(
 
     if reader is None:
         raise ValueError(
-            "Replay has stage > 0 handlers but no reader was provided; pass "
-            "reader= so staged handlers can read earlier stages' projections."
+            "Replay has stage > 0 handlers or reducers but no reader was "
+            "provided; pass reader= so they can read earlier stages' projections."
         )
     # Staged: decode + upcast each in-range event once, then run one pass per
-    # stage in ascending order over that shared list.
+    # stage in ascending order — that stage's per-event handlers, then its
+    # reducers once — over the shared list.
     decoded: list[tuple[int, dict]] = []
     for seq, msg in enumerate(messages):
         if end_seq is not None and seq >= end_seq:
@@ -186,6 +201,7 @@ def replay(
     for stage in stage_numbers:
         for seq, upcasted in decoded:
             _dispatch(seq, upcasted, stage=stage)
+        _run_reducers(stage)
     result.events_processed = len(decoded)
     return result
 
@@ -202,6 +218,24 @@ def _check_handler_drift(
         kind="handler",
         name=version.name,
         stored_hash=version.source_hash,
+        live_hash=live_hash,
+        on_drift=on_drift,
+        result=result,
+    )
+
+
+def _check_reducer_drift(
+    reducer: ReducerVersion,
+    on_drift: OnDriftPolicy,
+    result: ReplayResult,
+) -> None:
+    live_hash = hash_function_source(reducer.fn)
+    if live_hash == reducer.source_hash:
+        return
+    _record_drift(
+        kind="reducer",
+        name=reducer.name,
+        stored_hash=reducer.source_hash,
         live_hash=live_hash,
         on_drift=on_drift,
         result=result,
@@ -246,8 +280,13 @@ def _call_handler(
     # Stage > 0 handlers take (event, reader); stage 0 keeps the (event)
     # signature so existing single-stage handlers are unchanged.
     result = version.fn(event, reader) if version.stage > 0 else version.fn(event)
+    return _normalize_effects(result)
+
+
+def _normalize_effects(result: object) -> list[Effect]:
+    """Coerce a handler/reducer return (None | Effect | iterable) to a list."""
     if result is None:
         return []
     if isinstance(result, Effect):
         return [result]
-    return list(result)
+    return list(result)  # type: ignore[arg-type]

--- a/tests/test_django_rakaia/migrations/0001_initial.py
+++ b/tests/test_django_rakaia/migrations/0001_initial.py
@@ -50,6 +50,39 @@ class Migration(migrations.Migration):
             ],
         ),
         migrations.CreateModel(
+            name="FinanceLine",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("submission_id", models.CharField(max_length=64, unique=True)),
+                ("suku", models.CharField(max_length=64)),
+                ("delta", models.IntegerField(default=0)),
+            ],
+        ),
+        migrations.CreateModel(
+            name="Balance",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("suku", models.CharField(max_length=64, unique=True)),
+                ("total", models.IntegerField(default=0)),
+            ],
+        ),
+        migrations.CreateModel(
             name="Project",
             fields=[
                 (

--- a/tests/test_django_rakaia/models.py
+++ b/tests/test_django_rakaia/models.py
@@ -196,5 +196,26 @@ class Project(models.Model):
         return self.created_by_id
 
 
+class FinanceLine(models.Model):
+    """Plain contributing-rows model for the reducer/aggregate tests."""
+
+    submission_id = models.CharField(max_length=64, unique=True)
+    suku = models.CharField(max_length=64)
+    delta = models.IntegerField(default=0)
+
+    class Meta:
+        app_label = "test_django_rakaia"
+
+
+class Balance(models.Model):
+    """Plain aggregate model for the reducer/aggregate tests."""
+
+    suku = models.CharField(max_length=64, unique=True)
+    total = models.IntegerField(default=0)
+
+    class Meta:
+        app_label = "test_django_rakaia"
+
+
 # Register the admin interface for AppStreamEvent
 register_stream_event_admin(AppStreamEvent)

--- a/tests/test_django_rakaia/test_projection_reader.py
+++ b/tests/test_django_rakaia/test_projection_reader.py
@@ -85,3 +85,69 @@ class TestStagedReplayOverOrm:
         # dependent — despite arriving first in the stream — resolves FOUND.
         assert Area.objects.filter(name="dep-1->FOUND").exists()
         assert not Area.objects.filter(name="dep-1->MISSING").exists()
+
+
+def _finance_line_handler(event):
+    return Effect(
+        op="update_or_create",
+        model_label="test_django_rakaia.FinanceLine",
+        lookup={"submission_id": event["key"]},
+        defaults={"suku": event["suku"], "delta": event["delta"]},
+    )
+
+
+def _balance_reducer(reader):
+    from rakaia.projections import reconcile_aggregate
+
+    groups: dict[str, int] = {}
+    for line in reader.query("test_django_rakaia.FinanceLine"):
+        groups[line.suku] = groups.get(line.suku, 0) + line.delta
+    return reconcile_aggregate(
+        "test_django_rakaia.Balance",
+        {},
+        "suku",
+        {s: {"total": t} for s, t in groups.items()},
+    )
+
+
+_FINANCE_EVENTS = [
+    {"schema_version": 1, "kind": "FINANCE", "key": "f1", "suku": "A", "delta": 100},
+    {"schema_version": 1, "kind": "FINANCE", "key": "f2", "suku": "A", "delta": -30},
+    {"schema_version": 1, "kind": "FINANCE", "key": "f3", "suku": "B", "delta": 50},
+]
+
+
+@pytest.mark.django_db
+class TestReducerOverOrm:
+    def test_reducer_recomputes_aggregate_via_reconcile_aggregate(self):
+        from .models import Balance
+
+        store = get_store()
+        store.delete("s")
+        store.create("s")
+        for event in _FINANCE_EVENTS:
+            store.append("s", json.dumps(event).encode("utf-8"))
+
+        reg = HandlerRegistry()
+        reg.register(
+            "finance",
+            "FINANCE",
+            _finance_line_handler,
+            0,
+            None,
+            match_field="kind",
+            stage=0,
+        )
+        reg.register_reducer("balance", 1, _balance_reducer)
+
+        replay(
+            store,
+            "s",
+            DjangoExecutor(),
+            handler_registry=reg,
+            upcaster_registry=UpcasterRegistry(),
+            reader=DjangoProjectionReader(),
+        )
+
+        assert Balance.objects.get(suku="A").total == 70  # 100 - 30
+        assert Balance.objects.get(suku="B").total == 50

--- a/tests/test_rakaia/test_registry.py
+++ b/tests/test_rakaia/test_registry.py
@@ -222,6 +222,55 @@ class TestStage:
             reg.resolve("e", 15, stage=1)
 
 
+class TestReducers:
+    def test_register_reducer(self, reg: HandlerRegistry):
+        r = reg.register_reducer("balance", 1, _fn("b"))
+        assert r.name == "balance"
+        assert r.stage == 1
+        assert r.source_hash
+        assert r.dotted_path
+
+    def test_negative_stage_raises(self, reg: HandlerRegistry):
+        with pytest.raises(ValueError, match="stage must be non-negative"):
+            reg.register_reducer("b", -1, _fn("b"))
+
+    def test_reducers_for_stage_sorted_by_name(self, reg: HandlerRegistry):
+        reg.register_reducer("zeta", 1, _fn("z"))
+        reg.register_reducer("alpha", 1, _fn("a"))
+        reg.register_reducer("other", 2, _fn("o"))
+        assert [r.name for r in reg.reducers_for_stage(1)] == ["alpha", "zeta"]
+        assert [r.name for r in reg.reducers_for_stage(2)] == ["other"]
+        assert reg.reducers_for_stage(3) == []
+
+    def test_stages_includes_reducer_stages(self, reg: HandlerRegistry):
+        reg.register("h", "e", _fn("h"), 0, None, stage=0)
+        reg.register_reducer("agg", 2, _fn("a"))
+        assert reg.stages() == [0, 2]
+
+    def test_has_reducers(self, reg: HandlerRegistry):
+        assert reg.has_reducers() is False
+        reg.register_reducer("agg", 1, _fn("a"))
+        assert reg.has_reducers() is True
+
+    def test_identical_reducer_is_noop(self, reg: HandlerRegistry):
+        fn = _fn("b")
+        r1 = reg.register_reducer("balance", 1, fn)
+        r2 = reg.register_reducer("balance", 1, fn)
+        assert r1 is r2
+        assert len(reg.all_reducers()) == 1
+
+    def test_reregister_replaces_definition(self, reg: HandlerRegistry):
+        reg.register_reducer("balance", 1, _fn("v1"))
+
+        def v2(reader):  # noqa: ARG001
+            return "v2"
+
+        v2.__qualname__ = "reducer.<v2>"
+        reg.register_reducer("balance", 2, v2)  # same name, new fn + stage
+        assert len(reg.all_reducers()) == 1
+        assert reg.all_reducers()[0].stage == 2
+
+
 class TestDecorator:
     def test_decorator_registers_with_explicit_registry(self):
         reg = HandlerRegistry()

--- a/tests/test_rakaia/test_registry_persistence.py
+++ b/tests/test_rakaia/test_registry_persistence.py
@@ -9,6 +9,7 @@ import pytest
 
 from rakaia.registry import (
     HANDLERS_META_STREAM,
+    REDUCERS_META_STREAM,
     HandlerRegistry,
     HandlerVersion,
 )
@@ -180,6 +181,38 @@ class TestIdempotency:
 
         messages, _ = store.read(HANDLERS_META_STREAM)
         assert len(messages) == 2
+
+
+class TestReducerPersistence:
+    def test_reducer_appended_to_reducer_stream(self, store: StreamStore):
+        reg = HandlerRegistry(store=store)
+        reg.register_reducer("balance", 1, _fn("b"))
+        messages, _ = store.read(REDUCERS_META_STREAM)
+        assert len(messages) == 1
+        payload = json.loads(messages[0].data)
+        assert payload["name"] == "balance"
+        assert payload["stage"] == 1
+        assert payload["dotted_path"]
+        assert payload["source_hash"]
+
+    def test_reducer_dedups_across_instances(self, store: StreamStore):
+        reg1 = HandlerRegistry(store=store)
+        fn = _fn("b")
+        reg1.register_reducer("balance", 1, fn)
+        assert len(store.read(REDUCERS_META_STREAM)[0]) == 1
+
+        # Simulated restart: same reducer re-registers without a duplicate.
+        reg2 = HandlerRegistry(store=store)
+        reg2.register_reducer("balance", 1, fn)
+        assert len(store.read(REDUCERS_META_STREAM)[0]) == 1
+        assert reg2.all_reducers()[0].name == "balance"
+
+    def test_reducer_and_handler_streams_are_separate(self, store: StreamStore):
+        reg = HandlerRegistry(store=store)
+        reg.register("h", "e", _fn("h"), 0, None)
+        reg.register_reducer("agg", 1, _fn("a"))
+        assert len(store.read(HANDLERS_META_STREAM)[0]) == 1
+        assert len(store.read(REDUCERS_META_STREAM)[0]) == 1
 
 
 class TestRehydrate:

--- a/tests/test_rakaia/test_replay.py
+++ b/tests/test_rakaia/test_replay.py
@@ -752,3 +752,146 @@ class TestStagedReplay:
             store, "s", proj, handler_registry=reg, upcaster_registry=UpcasterRegistry()
         )  # no reader needed
         assert proj.get("app.Project", suku="Fatuberliu", output="WATER") is not None
+
+
+# ---------------------------------------------------------------------------
+# Reducers (per-stage recompute steps)
+# ---------------------------------------------------------------------------
+
+
+def _finance_line(event):
+    return Effect(
+        op="update_or_create",
+        model_label="app.FinanceLine",
+        lookup={"submission_id": event["key"]},
+        defaults={"suku": event["suku"], "delta": event["delta"]},
+    )
+
+
+def _balance_reducer(reader):
+    from rakaia.projections import reconcile_aggregate
+
+    groups: dict[str, int] = {}
+    for line in reader.query("app.FinanceLine"):
+        groups[line.suku] = groups.get(line.suku, 0) + line.delta
+    return reconcile_aggregate(
+        "app.Balance", {}, "suku", {s: {"total": t} for s, t in groups.items()}
+    )
+
+
+_FINANCE_EVENTS = [
+    {
+        "schema_version": 1,
+        "form_type": "FINANCE",
+        "key": "f1",
+        "suku": "A",
+        "delta": 100,
+    },
+    {
+        "schema_version": 1,
+        "form_type": "FINANCE",
+        "key": "f2",
+        "suku": "A",
+        "delta": -30,
+    },
+    {
+        "schema_version": 1,
+        "form_type": "FINANCE",
+        "key": "f3",
+        "suku": "B",
+        "delta": 50,
+    },
+]
+
+
+def _finance_registry(reducer=_balance_reducer):
+    reg = HandlerRegistry()
+    reg.register(
+        "finance", "FINANCE", _finance_line, 0, None, match_field="form_type", stage=0
+    )
+    reg.register_reducer("balance", 1, reducer)
+    return reg
+
+
+class TestReducers:
+    def test_reducer_recomputes_aggregate(self, store: StreamStore):
+        _seed_stream(store, "s", _FINANCE_EVENTS)
+        proj = DictProjections()
+        replay(
+            store,
+            "s",
+            proj,
+            handler_registry=_finance_registry(),
+            upcaster_registry=UpcasterRegistry(),
+            reader=proj,
+        )
+        assert proj.get("app.Balance", suku="A").total == 70  # 100 - 30
+        assert proj.get("app.Balance", suku="B").total == 50
+
+    def test_reducer_runs_once_per_stage_not_per_event(self, store: StreamStore):
+        _seed_stream(store, "s", _FINANCE_EVENTS)  # 3 events
+        calls: list[int] = []
+
+        def counting(reader):  # noqa: ARG001
+            calls.append(1)
+            return []
+
+        proj = DictProjections()
+        replay(
+            store,
+            "s",
+            proj,
+            handler_registry=_finance_registry(counting),
+            upcaster_registry=UpcasterRegistry(),
+            reader=proj,
+        )
+        assert len(calls) == 1  # once for stage 1, not 3x (per event)
+
+    def test_reducer_requires_reader(self, store: StreamStore):
+        _seed_stream(store, "s", _FINANCE_EVENTS)
+        with pytest.raises(ValueError, match="reader"):
+            replay(
+                store,
+                "s",
+                DictProjections(),
+                handler_registry=_finance_registry(),
+                upcaster_registry=UpcasterRegistry(),
+            )  # no reader=
+
+    def test_reducer_recompute_is_replay_safe(self, store: StreamStore):
+        _seed_stream(store, "s", _FINANCE_EVENTS)
+        reg = _finance_registry()
+        proj = DictProjections()
+        replay(
+            store,
+            "s",
+            proj,
+            handler_registry=reg,
+            upcaster_registry=UpcasterRegistry(),
+            reader=proj,
+        )
+        # Re-replay onto existing state: recompute, not increment -> stable.
+        replay(
+            store,
+            "s",
+            proj,
+            handler_registry=reg,
+            upcaster_registry=UpcasterRegistry(),
+            reader=proj,
+        )
+        assert proj.get("app.Balance", suku="A").total == 70  # not 140
+
+    def test_reducer_sees_only_committed_stage0_rows(self, store: StreamStore):
+        # A reducer at stage 1 reads FinanceLine rows all built in stage 0.
+        _seed_stream(store, "s", _FINANCE_EVENTS)
+        proj = DictProjections()
+        replay(
+            store,
+            "s",
+            proj,
+            handler_registry=_finance_registry(),
+            upcaster_registry=UpcasterRegistry(),
+            reader=proj,
+        )
+        assert len(proj.query("app.FinanceLine")) == 3
+        assert {b.suku for b in proj.query("app.Balance")} == {"A", "B"}


### PR DESCRIPTION
Follow-up to #19 (staged replay), completing the stage/reduce pair. A **reducer** runs once per stage — after that stage's per-event handlers commit — reading the accumulated projections via the reader and returning idempotent Effects. It's the replay-time hook that the already-merged `reconcile_aggregate` (#17) is designed to fill.

## Why
Some projections aren't per-event: a rollup depends on the *whole set* of contributing rows, and an increment isn't replay-safe (re-running doubles it). A reducer **recomputes** the aggregate from current rows on every replay, so re-running is a no-op on the totals — the double-count bug is gone.

```python
@register_reducer(name="balance", stage=1)
def balance(reader):                 # runs once, after stage-1 handlers commit
    totals = _sum_by_suku(reader.query("ida.FinanceLine"))
    return reconcile_aggregate("ida.Balance", {}, "suku",
                               {s: {"total": t} for s, t in totals.items()})
```

## Pieces
- **Registry:** `ReducerVersion`; `register_reducer(name, stage, fn)`, `reducers_for_stage()`, `all_reducers()`, `has_reducers()`; `stages()` unions handler + reducer stages. Reducers persist to their own meta-stream (`__rakaia__:reducers`, parallel to handlers/upcasters); `rehydrate()` imports reducer modules. Module-level `@register_reducer`. Re-registering a name **replaces** its definition (a reducer is a single current def, not a version series).
- **replay():** after each stage's per-event dispatch, run that stage's reducers once as `fn(reader)`. Any reducer ⇒ staged mode + `reader=` required (even at stage 0). Extracted a shared `_apply()`/`_normalize_effects()`; reducers get the same source-hash **drift detection** as handlers.
- **Exports:** `register_reducer`, `ReducerVersion`, `REDUCERS_META_STREAM`.

## Backward compatibility
No reducers + only stage-0 handlers ⇒ single streaming pass, unchanged. All existing tests pass.

## Tests (TDD)
Registry (stage filter, name ordering, dedup, replace-on-change, `stages()`/`has_reducers()`); persistence (own stream, dedup across instances, separate from handlers); core replay (recompute correct, **once per stage** not per event, requires-reader, **replay-safe** re-run, sees committed stage-0 rows); and an **end-to-end `django_db`** reducer via `reconcile_aggregate` + `DjangoProjectionReader` (added `FinanceLine`/`Balance` test models + migration). **417 passed, 1 skipped**; ruff check + format clean. `docs/staged-replay.md` gains a reducers section.

Completes the `stage=`/`reduce=` promotion pair (issue #7 features #1 + #3's replay hook).