### PR TITLE
feat: merge_replay — replay several streams merged by an order key

### DIFF
--- a/docs/multi-stream-merge.md
+++ b/docs/multi-stream-merge.md
@@ -1,8 +1,35 @@
-# Multi-stream merge replay (design spike)
+# Multi-stream merge replay
 
-> Status: **design spike** for [issue #7](https://github.com/joshbrooks/rakaia/issues/7)
-> feature #2. Prototyped in [`examples/partisipa_merge`](../examples/partisipa_merge);
-> not yet part of rakaia core. This page is the design; the example is the proof.
+> Status: **in core** ([issue #7](https://github.com/joshbrooks/rakaia/issues/7)
+> feature #2). Prototyped in [`examples/partisipa_merge`](../examples/partisipa_merge);
+> now shipped as `rakaia.merge_replay`. This page is the design; the section below
+> shows the real API.
+
+## Using it
+
+```python
+from rakaia.replay import merge_replay
+from django_rakaia.effect_executor import DjangoExecutor
+from django_rakaia.projection_reader import DjangoProjectionReader
+
+merge_replay(
+    store,
+    ["forms/sf", "forms/tf", "forms/ff"],   # several streams
+    DjangoExecutor(),
+    order_key="ts",                         # merge key (the envelope timestamp)
+    reader=DjangoProjectionReader(),        # required iff staged / reducers
+)
+```
+
+`merge_replay` decodes and upcasts every event of every stream, tags each with
+`(event[order_key], stream_path, offset)`, sorts, and feeds the merged sequence
+through the **same staged handler + reducer pipeline as `replay()`**. The
+`(stream_path, offset)` tiebreak makes the order a pure function of the streams'
+contents and **independent of the order `stream_paths` is passed**. `order_key`
+defaults to `"ts"`; a missing key raises. By default each event routes by its
+**source stream path** (so per-stream upcasters and `match_field` content routing
+both work); pass `event_match` to route every merged event by one string. Merged
+`seq` is the event's position in the merged order.
 
 ## The problem: one projection, many streams
 

--- a/src/rakaia/__init__.py
+++ b/src/rakaia/__init__.py
@@ -53,7 +53,7 @@ from .registry import (
     register_upcaster,
     upcast,
 )
-from .replay import ReplayResult, replay
+from .replay import ReplayResult, merge_replay, replay
 from .store import StreamStore
 from .types import (
     AppendOptions,
@@ -138,6 +138,7 @@ __all__ = [
     "UPCASTERS_META_STREAM",
     # Versioned handlers — replay
     "replay",
+    "merge_replay",
     "ReplayResult",
     # Version
     "__version__",

--- a/src/rakaia/replay.py
+++ b/src/rakaia/replay.py
@@ -30,7 +30,7 @@ import json
 import logging
 from collections.abc import Iterable
 from dataclasses import dataclass, field
-from typing import Literal
+from typing import Any, Literal
 
 from .effects import Effect, Executor
 from .protocols import ProjectionReader, ReadableStore
@@ -60,6 +60,51 @@ class ReplayResult:
     external_effects_skipped: int = 0
     warnings: list[str] = field(default_factory=list)
     drift_detected: list[str] = field(default_factory=list)
+
+
+@dataclass
+class _ReplayCtx:
+    """Bundle of the invariants the pipeline helpers need, shared by `replay()`
+    (single stream) and `merge_replay()` (several streams merged)."""
+
+    handlers: HandlerRegistry
+    executor: Executor
+    reader: ProjectionReader | None
+    include_external: bool
+    on_drift: OnDriftPolicy
+    result: ReplayResult
+
+
+def _apply_effects(ctx: _ReplayCtx, effects: list[Effect]) -> None:
+    external_count = sum(1 for e in effects if e.op == "external")
+    if not ctx.include_external:
+        ctx.result.external_effects_skipped += external_count
+    to_apply = (
+        effects if ctx.include_external else [e for e in effects if e.op != "external"]
+    )
+    if to_apply:
+        ctx.executor.apply(to_apply)
+        ctx.result.effects_applied += len(to_apply)
+
+
+def _dispatch_event(
+    ctx: _ReplayCtx, seq: int, match_str: str, upcasted: dict, stage: int | None
+) -> None:
+    versions = ctx.handlers.resolve(match_str, seq, event=upcasted, stage=stage)
+    all_effects: list[Effect] = []
+    for version in versions:
+        _check_handler_drift(version, ctx.on_drift, ctx.result)
+        all_effects.extend(_call_handler(version, upcasted, ctx.reader))
+    _apply_effects(ctx, all_effects)
+
+
+def _run_stage_reducers(ctx: _ReplayCtx, stage: int | None) -> None:
+    # Reducers run once per stage, after that stage's per-event handlers have
+    # committed, reading the accumulated projections via the reader. A None
+    # stage (single, non-staged pass) has no reducers.
+    for reducer in ctx.handlers.reducers_for_stage(stage):
+        _check_reducer_drift(reducer, ctx.on_drift, ctx.result)
+        _apply_effects(ctx, _normalize_effects(reducer.fn(ctx.reader)))
 
 
 def replay(
@@ -140,35 +185,17 @@ def replay(
             drift_callback=_upcaster_drift,
         )
 
-    def _apply(effects: list[Effect]) -> None:
-        external_count = sum(1 for e in effects if e.op == "external")
-        if not include_external:
-            result.external_effects_skipped += external_count
-        to_apply = (
-            effects if include_external else [e for e in effects if e.op != "external"]
-        )
-        if to_apply:
-            executor.apply(to_apply)
-            result.effects_applied += len(to_apply)
-
-    def _dispatch(seq: int, upcasted: dict, stage: int | None) -> None:
-        versions = handlers.resolve(match_str, seq, event=upcasted, stage=stage)
-        all_effects: list[Effect] = []
-        for version in versions:
-            _check_handler_drift(version, on_drift, result)
-            all_effects.extend(_call_handler(version, upcasted, reader))
-        _apply(all_effects)
-
-    def _run_reducers(stage: int) -> None:
-        # Reducers run once per stage, after that stage's per-event handlers
-        # have committed, reading the accumulated projections via `reader`.
-        for reducer in handlers.reducers_for_stage(stage):
-            _check_reducer_drift(reducer, on_drift, result)
-            _apply(_normalize_effects(reducer.fn(reader)))
-
     def _in_range(seq: int) -> bool:
         return seq >= start_seq and (end_seq is None or seq < end_seq)
 
+    ctx = _ReplayCtx(
+        handlers=handlers,
+        executor=executor,
+        reader=reader,
+        include_external=include_external,
+        on_drift=on_drift,
+        result=result,
+    )
     stage_numbers = handlers.stages()
     staged = any(s > 0 for s in stage_numbers) or handlers.has_reducers()
 
@@ -180,7 +207,7 @@ def replay(
                 break
             if not _in_range(seq):
                 continue
-            _dispatch(seq, _decode_upcast(seq, msg.data), stage=None)
+            _dispatch_event(ctx, seq, match_str, _decode_upcast(seq, msg.data), None)
             result.events_processed += 1
         return result
 
@@ -200,9 +227,114 @@ def replay(
             decoded.append((seq, _decode_upcast(seq, msg.data)))
     for stage in stage_numbers:
         for seq, upcasted in decoded:
-            _dispatch(seq, upcasted, stage=stage)
-        _run_reducers(stage)
+            _dispatch_event(ctx, seq, match_str, upcasted, stage)
+        _run_stage_reducers(ctx, stage)
     result.events_processed = len(decoded)
+    return result
+
+
+def merge_replay(
+    store: ReadableStore,
+    stream_paths: list[str],
+    executor: Executor,
+    *,
+    order_key: str = "ts",
+    handler_registry: HandlerRegistry | None = None,
+    upcaster_registry: UpcasterRegistry | None = None,
+    event_match: str | None = None,
+    include_external: bool = False,
+    on_drift: OnDriftPolicy = "warn",
+    reader: ProjectionReader | None = None,
+) -> ReplayResult:
+    """
+    Replay several streams merged into one deterministic total order.
+
+    Each stream is already ordered, so this is a k-way merge; the design point is
+    the **order key**. Every event is decoded, upcast, and tagged with
+    ``(event[order_key], stream_path, offset)``, then the merged sequence is that
+    tuple sorted — so equal order-key values across streams break by stream path
+    then offset, giving an order that is a pure function of the streams and is
+    **independent of the order `stream_paths` is passed**. The merged events then
+    run through exactly the same staged handler + reducer pipeline as `replay()`.
+
+    Args:
+        store: The store holding the events.
+        stream_paths: The streams to merge, each read in full.
+        executor: Effect executor.
+        order_key: The event field to merge on (default ``"ts"`` — the envelope
+            timestamp). Raises KeyError-derived ValueError if an event lacks it.
+        handler_registry / upcaster_registry: default to the process-wide ones.
+        event_match: Match string for handler routing + upcasting. Default None
+            uses each event's **source stream path** as its match string, so
+            content-routed handlers (`match_field`) and per-stream upcasters both
+            work; pass a value to route every merged event by one match string.
+        include_external / on_drift / reader: as for `replay()`. A reader is
+            required when any handler declares stage > 0 or any reducer exists.
+
+    Note: merged `seq` is the event's position in the merged order (0-based), so
+    handlers versioned by sequence range see that global position, not a
+    per-stream one; content-routed handlers with open ranges are unaffected.
+    """
+    handlers = handler_registry or get_default_registry()
+    upcasters = upcaster_registry or get_default_upcaster_registry()
+    result = ReplayResult()
+
+    def _upcaster_drift(uv: UpcasterVersion, live_hash: str) -> None:
+        _record_drift(
+            kind="upcaster",
+            name=uv.dotted_path,
+            stored_hash=uv.source_hash,
+            live_hash=live_hash,
+            on_drift=on_drift,
+            result=result,
+        )
+
+    # Decode + upcast every event of every stream, tag with the sort key.
+    tagged: list[tuple[tuple[Any, str, int], str, dict]] = []
+    for path in stream_paths:
+        match_str = event_match if event_match is not None else path
+        target_version = upcasters.current_version(match_str)
+        messages, _ = store.read(path)
+        for offset, msg in enumerate(messages):
+            upcasted = upcasters.apply_chain(
+                _decode_event(msg.data, path, offset),
+                match_str,
+                target_version,
+                drift_callback=_upcaster_drift,
+            )
+            if order_key not in upcasted:
+                raise ValueError(
+                    f"Event at offset={offset} in stream={path!r} has no "
+                    f"order_key={order_key!r}; cannot merge deterministically."
+                )
+            tagged.append(((upcasted[order_key], path, offset), match_str, upcasted))
+
+    tagged.sort(key=lambda item: item[0])
+
+    ctx = _ReplayCtx(
+        handlers=handlers,
+        executor=executor,
+        reader=reader,
+        include_external=include_external,
+        on_drift=on_drift,
+        result=result,
+    )
+    stage_numbers = handlers.stages()
+    staged = any(s > 0 for s in stage_numbers) or handlers.has_reducers()
+    if staged and reader is None:
+        raise ValueError(
+            "merge_replay has stage > 0 handlers or reducers but no reader was "
+            "provided; pass reader= so they can read earlier stages' projections."
+        )
+
+    # seq is the event's position in the merged order.
+    merged = [(seq, m, ev) for seq, (_, m, ev) in enumerate(tagged)]
+    passes: list[int | None] = list(stage_numbers) if staged else [None]
+    for stage in passes:
+        for seq, match_str, upcasted in merged:
+            _dispatch_event(ctx, seq, match_str, upcasted, stage)
+        _run_stage_reducers(ctx, stage)
+    result.events_processed = len(merged)
     return result
 
 

--- a/src/rakaia/replay.py
+++ b/src/rakaia/replay.py
@@ -271,10 +271,21 @@ def merge_replay(
         include_external / on_drift / reader: as for `replay()`. A reader is
             required when any handler declares stage > 0 or any reducer exists.
 
-    Note: merged `seq` is the event's position in the merged order (0-based), so
-    handlers versioned by sequence range see that global position, not a
-    per-stream one; content-routed handlers with open ranges are unaffected.
+    Note: merged `seq` is the event's position in the *merged* order (0-based),
+    not a per-stream one, so handlers routed by content (`match_field`) or
+    versioned over open ranges (`effective_to=None`) are unaffected, but a
+    handler with a **closed** seq range sized to a single stream will raise
+    `HandlerGapError` under merge (the merged range is longer). Version merged
+    handlers by content or open ranges.
+
+    Raises `ValueError` on duplicate `stream_paths`, or when an event lacks
+    `order_key` / carries `order_key` values that aren't mutually comparable.
     """
+    if len(set(stream_paths)) != len(stream_paths):
+        raise ValueError(
+            f"merge_replay received duplicate stream paths ({stream_paths}); "
+            f"each stream would be processed twice."
+        )
     handlers = handler_registry or get_default_registry()
     upcasters = upcaster_registry or get_default_upcaster_registry()
     result = ReplayResult()
@@ -309,7 +320,13 @@ def merge_replay(
                 )
             tagged.append(((upcasted[order_key], path, offset), match_str, upcasted))
 
-    tagged.sort(key=lambda item: item[0])
+    try:
+        tagged.sort(key=lambda item: item[0])
+    except TypeError as exc:
+        raise ValueError(
+            f"Cannot merge deterministically: order_key={order_key!r} values are "
+            f"not mutually comparable across events (mixed types or None?): {exc}"
+        ) from exc
 
     ctx = _ReplayCtx(
         handlers=handlers,

--- a/tests/test_django_rakaia/test_projection_reader.py
+++ b/tests/test_django_rakaia/test_projection_reader.py
@@ -11,7 +11,7 @@ from django_rakaia.projection_reader import DjangoProjectionReader
 from django_rakaia.store import get_store
 from rakaia.effects import Effect
 from rakaia.registry import HandlerRegistry, UpcasterRegistry
-from rakaia.replay import replay
+from rakaia.replay import merge_replay, replay
 
 from .models import Area
 
@@ -150,4 +150,78 @@ class TestReducerOverOrm:
         )
 
         assert Balance.objects.get(suku="A").total == 70  # 100 - 30
+        assert Balance.objects.get(suku="B").total == 50
+
+
+@pytest.mark.django_db
+class TestMergeReplayOverOrm:
+    def test_merge_two_finance_streams_then_reduce(self):
+        from .models import Balance
+
+        store = get_store()
+        for path in ("fin/a", "fin/b"):
+            store.delete(path)
+            store.create(path)
+        store.append(
+            "fin/a",
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "kind": "FINANCE",
+                    "key": "f1",
+                    "suku": "A",
+                    "delta": 100,
+                    "ts": "2026-01-01T00:00:00Z",
+                }
+            ).encode("utf-8"),
+        )
+        store.append(
+            "fin/b",
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "kind": "FINANCE",
+                    "key": "f2",
+                    "suku": "A",
+                    "delta": -30,
+                    "ts": "2026-01-01T01:00:00Z",
+                }
+            ).encode("utf-8"),
+        )
+        store.append(
+            "fin/b",
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "kind": "FINANCE",
+                    "key": "f3",
+                    "suku": "B",
+                    "delta": 50,
+                    "ts": "2026-01-01T02:00:00Z",
+                }
+            ).encode("utf-8"),
+        )
+
+        reg = HandlerRegistry()
+        reg.register(
+            "finance",
+            "FINANCE",
+            _finance_line_handler,
+            0,
+            None,
+            match_field="kind",
+            stage=0,
+        )
+        reg.register_reducer("balance", 1, _balance_reducer)
+
+        merge_replay(
+            store,
+            ["fin/a", "fin/b"],
+            DjangoExecutor(),
+            handler_registry=reg,
+            upcaster_registry=UpcasterRegistry(),
+            reader=DjangoProjectionReader(),
+        )
+
+        assert Balance.objects.get(suku="A").total == 70  # 100 - 30 across streams
         assert Balance.objects.get(suku="B").total == 50

--- a/tests/test_rakaia/test_replay.py
+++ b/tests/test_rakaia/test_replay.py
@@ -13,7 +13,7 @@ from rakaia.registry import (
     HandlerRegistry,
     UpcasterRegistry,
 )
-from rakaia.replay import replay
+from rakaia.replay import merge_replay, replay
 from rakaia.store import StreamStore
 
 
@@ -895,3 +895,179 @@ class TestReducers:
         )
         assert len(proj.query("app.FinanceLine")) == 3
         assert {b.suku for b in proj.query("app.Balance")} == {"A", "B"}
+
+
+# ---------------------------------------------------------------------------
+# merge_replay (several streams merged by an order key)
+# ---------------------------------------------------------------------------
+
+
+def _touch(event):
+    return Effect(
+        op="update_or_create",
+        model_label="app.Claim",
+        lookup={"slot": event["slot"]},
+        defaults={"claimed_by": event["key"]},
+    )
+
+
+def _touch_registry():
+    reg = HandlerRegistry()
+    reg.register("touch", "TOUCH", _touch, 0, None, match_field="form_type", stage=0)
+    return reg
+
+
+def _ev(key, ts):
+    return {
+        "schema_version": 1,
+        "form_type": "TOUCH",
+        "key": key,
+        "slot": "S",
+        "ts": ts,
+    }
+
+
+# a1 and b1 share a timestamp across streams (the cross-stream tie); they are
+# also the two latest events, so the tie's winner is the final claimant.
+_A = [_ev("a0", "2026-01-01T00:00:00Z"), _ev("a1", "2026-01-01T02:00:00Z")]
+_B = [_ev("b0", "2026-01-01T01:00:00Z"), _ev("b1", "2026-01-01T02:00:00Z")]
+# Canonical merged order by (ts, path, offset): a0, b0, a1, b1  (forms/a < forms/b)
+_CANONICAL = [_A[0], _B[0], _A[1], _B[1]]
+
+
+class TestMergeReplay:
+    def _seed_two(self, store: StreamStore):
+        _seed_stream(store, "forms/a", _A)
+        _seed_stream(store, "forms/b", _B)
+
+    def test_tie_resolved_by_stream_path(self, store: StreamStore):
+        self._seed_two(store)
+        proj = DictProjections()
+        merge_replay(
+            store,
+            ["forms/a", "forms/b"],
+            proj,
+            handler_registry=_touch_registry(),
+            upcaster_registry=UpcasterRegistry(),
+        )
+        # a1 (forms/a) sorts before b1 (forms/b) at the same ts, so b1 is later
+        # in the merged order and wins the shared slot.
+        assert proj.get("app.Claim", slot="S").claimed_by == "b1"
+
+    def test_deterministic_regardless_of_path_order(self, store: StreamStore):
+        self._seed_two(store)
+        proj = DictProjections()
+        merge_replay(
+            store,
+            ["forms/b", "forms/a"],
+            proj,  # reversed
+            handler_registry=_touch_registry(),
+            upcaster_registry=UpcasterRegistry(),
+        )
+        assert proj.get("app.Claim", slot="S").claimed_by == "b1"  # unchanged
+
+    def test_parity_with_single_combined_stream(self, store: StreamStore):
+        self._seed_two(store)
+        merged = DictProjections()
+        merge_replay(
+            store,
+            ["forms/a", "forms/b"],
+            merged,
+            handler_registry=_touch_registry(),
+            upcaster_registry=UpcasterRegistry(),
+        )
+
+        _seed_stream(store, "combined", _CANONICAL)
+        single = DictProjections()
+        replay(
+            store,
+            "combined",
+            single,
+            handler_registry=_touch_registry(),
+            upcaster_registry=UpcasterRegistry(),
+        )
+
+        assert (
+            merged.get("app.Claim", slot="S").claimed_by
+            == single.get("app.Claim", slot="S").claimed_by
+            == "b1"
+        )
+
+    def test_missing_order_key_raises(self, store: StreamStore):
+        _seed_stream(
+            store,
+            "forms/a",
+            [{"schema_version": 1, "form_type": "TOUCH", "key": "x", "slot": "S"}],
+        )  # no ts
+        with pytest.raises(ValueError, match="order_key"):
+            merge_replay(
+                store,
+                ["forms/a"],
+                DictProjections(),
+                handler_registry=_touch_registry(),
+                upcaster_registry=UpcasterRegistry(),
+            )
+
+    def test_requires_reader_when_staged(self, store: StreamStore):
+        _seed_stream(store, "forms/a", _A)
+        reg = _touch_registry()
+        reg.register(
+            "dep", "TOUCH", lambda *_: None, 0, None, match_field="form_type", stage=1
+        )
+        with pytest.raises(ValueError, match="reader"):
+            merge_replay(
+                store,
+                ["forms/a"],
+                DictProjections(),
+                handler_registry=reg,
+                upcaster_registry=UpcasterRegistry(),
+            )
+
+    def test_reducer_runs_over_merged_streams(self, store: StreamStore):
+        _seed_stream(
+            store,
+            "fin/a",
+            [
+                {
+                    "schema_version": 1,
+                    "form_type": "FINANCE",
+                    "key": "f1",
+                    "suku": "A",
+                    "delta": 100,
+                    "ts": "2026-01-01T00:00:00Z",
+                }
+            ],
+        )
+        _seed_stream(
+            store,
+            "fin/b",
+            [
+                {
+                    "schema_version": 1,
+                    "form_type": "FINANCE",
+                    "key": "f2",
+                    "suku": "A",
+                    "delta": -30,
+                    "ts": "2026-01-01T01:00:00Z",
+                },
+                {
+                    "schema_version": 1,
+                    "form_type": "FINANCE",
+                    "key": "f3",
+                    "suku": "B",
+                    "delta": 50,
+                    "ts": "2026-01-01T02:00:00Z",
+                },
+            ],
+        )
+        proj = DictProjections()
+        merge_replay(
+            store,
+            ["fin/a", "fin/b"],
+            proj,
+            handler_registry=_finance_registry(),
+            upcaster_registry=UpcasterRegistry(),
+            reader=proj,
+        )
+        assert proj.get("app.Balance", suku="A").total == 70
+        assert proj.get("app.Balance", suku="B").total == 50

--- a/tests/test_rakaia/test_replay.py
+++ b/tests/test_rakaia/test_replay.py
@@ -1008,6 +1008,55 @@ class TestMergeReplay:
                 upcaster_registry=UpcasterRegistry(),
             )
 
+    def test_duplicate_stream_paths_raise(self, store: StreamStore):
+        _seed_stream(store, "forms/a", _A)
+        with pytest.raises(ValueError, match="duplicate"):
+            merge_replay(
+                store,
+                ["forms/a", "forms/a"],  # same stream twice
+                DictProjections(),
+                handler_registry=_touch_registry(),
+                upcaster_registry=UpcasterRegistry(),
+            )
+
+    def test_incomparable_order_key_raises_clearly(self, store: StreamStore):
+        # One stream's ts is an int, the other's a str -> sort would TypeError;
+        # merge_replay should surface a clear ValueError, not the bare crash.
+        _seed_stream(
+            store,
+            "forms/a",
+            [
+                {
+                    "schema_version": 1,
+                    "form_type": "TOUCH",
+                    "key": "a",
+                    "slot": "S",
+                    "ts": 1,
+                }
+            ],
+        )
+        _seed_stream(
+            store,
+            "forms/b",
+            [
+                {
+                    "schema_version": 1,
+                    "form_type": "TOUCH",
+                    "key": "b",
+                    "slot": "S",
+                    "ts": "2026-01-01T00:00:00Z",
+                }
+            ],
+        )
+        with pytest.raises(ValueError, match="not mutually comparable"):
+            merge_replay(
+                store,
+                ["forms/a", "forms/b"],
+                DictProjections(),
+                handler_registry=_touch_registry(),
+                upcaster_registry=UpcasterRegistry(),
+            )
+
     def test_requires_reader_when_staged(self, store: StreamStore):
         _seed_stream(store, "forms/a", _A)
         reg = _touch_registry()


### PR DESCRIPTION
Fifth core promotion (issue #7 feature #2, spiked in #14). Lets one projection be built from **several separate form streams** — Partisipa's SF/TF/FF pipelines — replacing the SQL stitch.

## API
```python
merge_replay(store, ["forms/sf", "forms/tf", "forms/ff"], DjangoExecutor(),
             order_key="ts", reader=DjangoProjectionReader())
```
Decodes + upcasts every event of every stream, tags each with `(event[order_key], stream_path, offset)`, sorts, and runs the merged sequence through the **same staged handler + reducer pipeline as `replay()`**.

## The order key is the whole game
The `(stream_path, offset)` tiebreak makes the merged order a **pure function of the streams' contents and independent of the order `stream_paths` is passed**. `order_key` defaults to `"ts"` (the envelope timestamp); a missing key raises. Each event routes by its **source stream path** by default (so per-stream upcasters + `match_field` content routing both work); pass `event_match` to route by one string. Merged `seq` = position in the merged order.

## Sharing the pipeline, not duplicating it
Extracted the effect-application leaves into module helpers (`_ReplayCtx` + `_apply_effects` / `_dispatch_event` / `_run_stage_reducers`). `replay()` now calls them but keeps its own single-stream **streaming** loop (bounded memory, unchanged `on_drift` semantics) and staged loop. **All existing replay tests pass unchanged.**

## Tests (TDD)
Core: tie resolved by `stream_path`; determinism under **reversed** path order; **parity** with a single combined stream; missing-order-key raises; requires-reader when staged; a reducer over merged streams. Plus an **end-to-end `django_db`** merge of two finance streams → `reconcile_aggregate`. **424 passed, 1 skipped**; ruff check + format clean. `docs/multi-stream-merge.md` updated spike→real-API.

Composes with everything already landed: merge (cross-stream order) + staged replay (cross-form deps) + reducers (aggregates). Remaining promotion: the event envelope + history read-model (from #12).