### PR TITLE
fix(django): lock stream row when allocating durable-store append offset

### DIFF
--- a/src/django_rakaia/decorators.py
+++ b/src/django_rakaia/decorators.py
@@ -10,7 +10,6 @@ from collections.abc import Callable
 from typing import Any
 
 from django.db import models, transaction
-from django.db.models import Max
 from django.db.models.signals import post_delete, post_save
 from django.dispatch import receiver
 
@@ -32,20 +31,12 @@ def _get_or_create_stream(stream_id: str) -> Stream:
 
 
 def _get_next_offset(stream: Stream) -> int:
-    """
-    Calculate the next monotonic offset for a stream.
+    """Locking offset allocation — see ``Stream.get_next_offset``.
 
-    Must be called inside a transaction: locks the stream row with
-    select_for_update() so concurrent writers serialize on offset
-    allocation instead of colliding on unique_together(stream, offset).
+    Thin wrapper kept for backwards compatibility; the canonical, row-locking
+    implementation now lives on the model so every write path shares it.
     """
-    # Lock the stream row for the duration of the enclosing transaction.
-    Stream.objects.select_for_update().get(pk=stream.pk)
-    agg = stream.entries.aggregate(max_offset=Max("offset"))
-    max_offset = agg["max_offset"]
-    if max_offset is None:
-        return 1
-    return max_offset + 1
+    return stream.get_next_offset()
 
 
 def create_stream_event(

--- a/src/django_rakaia/django_store.py
+++ b/src/django_rakaia/django_store.py
@@ -23,6 +23,8 @@ from __future__ import annotations
 import json
 from typing import Any
 
+from django.db import transaction
+
 from rakaia.context import merge_provenance
 from rakaia.types import StreamMessage
 
@@ -48,24 +50,30 @@ class DjangoStreamStore:
         The event-sourcing envelope on `options` (an ``AppendOptions``) is
         persisted: ``label`` maps to ``event_type`` (a raw append keeps the
         stable ``"append"`` label) and ``metadata`` to the JSON column.
-        """
-        try:
-            stream = Stream.objects.get(stream_id=path)
-        except Stream.DoesNotExist as exc:
-            raise KeyError(f"Stream not found: {path}") from exc
 
-        label = getattr(options, "label", "") or ""
-        metadata = merge_provenance(getattr(options, "metadata", None))
-        event = StreamEvent.objects.create(
-            data=json.loads(data),
-            event_type=label or _APPEND_EVENT_TYPE,
-            metadata=metadata or {},
-        )
-        return StreamEntry.objects.create(
-            stream=stream,
-            event=event,
-            offset=stream.get_next_offset(),
-        )
+        Runs in a transaction so ``get_next_offset()`` can lock the stream row:
+        concurrent appends serialize on offset allocation instead of racing to
+        the same value and failing the ``unique_together(stream, offset)``
+        constraint.
+        """
+        with transaction.atomic():
+            try:
+                stream = Stream.objects.get(stream_id=path)
+            except Stream.DoesNotExist as exc:
+                raise KeyError(f"Stream not found: {path}") from exc
+
+            label = getattr(options, "label", "") or ""
+            metadata = merge_provenance(getattr(options, "metadata", None))
+            event = StreamEvent.objects.create(
+                data=json.loads(data),
+                event_type=label or _APPEND_EVENT_TYPE,
+                metadata=metadata or {},
+            )
+            return StreamEntry.objects.create(
+                stream=stream,
+                event=event,
+                offset=stream.get_next_offset(),
+            )
 
     def read(
         self, path: str, offset: str | None = None

--- a/src/django_rakaia/models.py
+++ b/src/django_rakaia/models.py
@@ -45,8 +45,16 @@ class Stream(models.Model):
         return self.stream_id
 
     def get_next_offset(self) -> int:
-        """Calculate the next monotonic offset for this stream."""
+        """Calculate the next monotonic offset for this stream.
 
+        Must be called inside a transaction: locks this stream row with
+        select_for_update() so concurrent writers serialize on offset
+        allocation instead of colliding on unique_together(stream, offset).
+        This is the single offset-allocation path shared by every write
+        surface (durable store, ``@stream_model`` signals, protocol views).
+        """
+        # Lock the stream row for the duration of the enclosing transaction.
+        Stream.objects.select_for_update().get(pk=self.pk)
         agg = self.entries.aggregate(max_offset=Max("offset"))
         max_offset = agg["max_offset"]
         if max_offset is None:

--- a/src/django_rakaia/protocol_views.py
+++ b/src/django_rakaia/protocol_views.py
@@ -107,19 +107,16 @@ def get_next_offset(stream: Stream) -> int:
     select_for_update() so concurrent appends serialize on offset
     allocation instead of colliding on unique_together(stream, offset).
 
+    Thin wrapper over the canonical ``Stream.get_next_offset`` so every write
+    path shares one row-locking implementation.
+
     Args:
         stream: The stream to calculate offset for.
 
     Returns:
         Next offset value (1-indexed).
     """
-    # Lock the stream row for the duration of the enclosing transaction.
-    Stream.objects.select_for_update().get(pk=stream.pk)
-    agg = stream.entries.aggregate(max_offset=Max("offset"))
-    max_offset = agg["max_offset"]
-    if max_offset is None:
-        return 1
-    return max_offset + 1
+    return stream.get_next_offset()
 
 
 def create_stream_record(stream_id: str, content_type: str) -> Stream:  # noqa: ARG001

--- a/tests/test_django_rakaia/test_django_store.py
+++ b/tests/test_django_rakaia/test_django_store.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import json
+from unittest.mock import patch
 
 import pytest
+from django.db.models.query import QuerySet
 
 from django_rakaia.django_store import DjangoStreamStore
 from django_rakaia.models import Stream, StreamEntry
@@ -66,6 +68,28 @@ class TestDjangoStreamStore:
         messages, _ = store.read("s")
         assert messages[-1].label == ""
         assert messages[-1].metadata is None
+
+    def test_append_locks_stream_row_for_offset_allocation(self):
+        # Regression guard for the concurrency bug: offset allocation must go
+        # through select_for_update() so concurrent appends serialize on the
+        # stream row instead of racing to the same offset and failing the
+        # unique_together(stream, offset) constraint. SQLite (the CI backend)
+        # can't reproduce the race across connections, so assert the lock is
+        # acquired rather than trying to trigger the collision.
+        store = DjangoStreamStore()
+        store.create("s")
+
+        original = QuerySet.select_for_update
+        locked = []
+
+        def spy(qs, *args, **kwargs):
+            locked.append(True)
+            return original(qs, *args, **kwargs)
+
+        with patch.object(QuerySet, "select_for_update", spy):
+            store.append("s", b'{"id": 1}')
+
+        assert locked, "append must lock the stream row via select_for_update()"
 
     def test_read_returns_events_in_order(self):
         store = DjangoStreamStore()

--- a/tests/test_django_rakaia/test_model_stream_reader.py
+++ b/tests/test_django_rakaia/test_model_stream_reader.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 
 import pytest
+from django.db import transaction
 
 from django_rakaia.decorators import create_stream_event
 from django_rakaia.effect_executor import DjangoExecutor
@@ -161,10 +162,11 @@ class TestReplayAgainstModelStream:
 
 def _append_event(stream_id: str, data: dict) -> None:
     """Helper: write one event to a Django-backed stream."""
-    stream, _ = Stream.objects.get_or_create(stream_id=stream_id)
-    event = StreamEvent.objects.create(data=data, event_type="test")
-    next_offset = stream.get_next_offset()
-    StreamEntry.objects.create(stream=stream, event=event, offset=next_offset)
+    with transaction.atomic():
+        stream, _ = Stream.objects.get_or_create(stream_id=stream_id)
+        event = StreamEvent.objects.create(data=data, event_type="test")
+        next_offset = stream.get_next_offset()
+        StreamEntry.objects.create(stream=stream, event=event, offset=next_offset)
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## What

Fixes gap 2 of #23 — the `DjangoStreamStore.append` concurrency bug.

`append` allocated offsets via a bare `Max(offset)+1` (`Stream.get_next_offset()`) with **no `select_for_update` and no surrounding transaction**. Concurrent appends could compute the same offset and fail the `unique_together(stream, offset)` constraint instead of serialising. The `@stream_model` signal path already locked correctly, so the two write surfaces had inconsistent guarantees — and the durable path (heading for a live `Submission.save()`) was the unsafe one.

## How

- `Stream.get_next_offset()` becomes the **single row-locking implementation** (`select_for_update()` on the stream row, requires an enclosing transaction).
- `DjangoStreamStore.append` now runs inside `transaction.atomic()`.
- The duplicate locking helpers in `decorators.py` (`_get_next_offset`) and `protocol_views.py` (`get_next_offset`) now delegate to the model method — one guarantee, one code path.
- Regression test asserts the lock is acquired on append. SQLite (the CI backend) can't reproduce the cross-connection race, so we assert `select_for_update()` is invoked rather than trying to trigger the collision.

## Test

`pytest tests/test_django_rakaia/` → 97 passed, 1 skipped. `ruff check` + `ruff format --check` clean.

Refs #23. Gap 1 (Submission producer helper) and #7 (merge-replay) tracked separately.