### PR TITLE
feat: append_if_changed — no-op-suppressed append (PR C / Decision #9)

### DIFF
--- a/src/rakaia/__init__.py
+++ b/src/rakaia/__init__.py
@@ -17,6 +17,7 @@ Usage:
     # Run with: uvicorn rakaia:app
 """
 
+from .append import append_if_changed, snapshots_equal
 from .context import get_provenance, provenance
 from .cursor import CursorOptions, calculate_cursor, generate_response_cursor
 from .effects import (
@@ -92,6 +93,8 @@ __all__ = [
     "StreamStore",
     "provenance",
     "get_provenance",
+    "append_if_changed",
+    "snapshots_equal",
     "history_effects",
     "recover_peak_snapshot",
     "label_marker",

--- a/src/rakaia/append.py
+++ b/src/rakaia/append.py
@@ -1,0 +1,75 @@
+"""
+No-op-suppressed append — the write-side of the pghistory-parity story.
+
+`django-pghistory` only records an event when the row actually changed
+(``WHEN OLD.* IS DISTINCT FROM NEW.*``). A naive ``store.append(new_state)``
+records an event on *every* save, so a stream-native audit log would diverge
+from ``pgh_event`` on no-op saves, and bulk-import retries would duplicate rows.
+
+`append_if_changed` closes that: it appends only when the new payload differs
+from the subject's **current** snapshot (which the caller supplies — it's what
+they're about to overwrite, from the current-state projection). Comparing
+against the subject's own current state, not the stream's last message, is what
+makes this correct for form-family streams that interleave many subjects.
+
+    changed = append_if_changed(
+        store, "submissions/tf", data,
+        current=SubmissionRecord.objects.filter(key=sub).values_list("fields", flat=True).first(),
+        snapshot_of=lambda ev: ev["fields"],   # compare just the form fields
+        options=AppendOptions(label="update"),
+    )
+
+This is the append-layer analogue of the `skip_unchanged` executor (#18).
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from typing import Any
+
+
+def snapshots_equal(a: Any, b: Any) -> bool:
+    """Whether two decoded snapshots are equal.
+
+    Plain ``==`` is a deep, key-order-insensitive comparison for JSON-native
+    values (dicts compare unordered, lists ordered) — exactly the right
+    semantics for "did anything change".
+    """
+    return a == b
+
+
+def append_if_changed(
+    store: Any,
+    path: str,
+    data: bytes,
+    *,
+    current: Any,
+    options: Any = None,
+    snapshot_of: Callable[[dict[str, Any]], Any] | None = None,
+) -> bool:
+    """Append `data` to `path` only if its snapshot differs from `current`.
+
+    Args:
+        store: any store with an ``append(path, data, options)`` method.
+        path: the stream path.
+        data: the JSON-encoded event bytes to append.
+        current: the subject's current snapshot (in the same shape `snapshot_of`
+            produces), or ``None`` if the subject is new — a new subject always
+            appends.
+        options: forwarded to ``store.append`` (e.g. the envelope
+            ``AppendOptions(label=…, metadata=…)``).
+        snapshot_of: extracts the comparable snapshot from the decoded payload
+            (default: the whole payload). Use it to ignore volatile fields (a
+            server timestamp) so they don't defeat suppression.
+
+    Returns:
+        True if the event was appended, False if it was suppressed as a no-op.
+    """
+    new_snapshot = json.loads(data)
+    if snapshot_of is not None:
+        new_snapshot = snapshot_of(new_snapshot)
+    if current is not None and snapshots_equal(new_snapshot, current):
+        return False
+    store.append(path, data, options)
+    return True

--- a/src/rakaia/append.py
+++ b/src/rakaia/append.py
@@ -65,6 +65,20 @@ def append_if_changed(
 
     Returns:
         True if the event was appended, False if it was suppressed as a no-op.
+
+    Caveats (all silent — a mismatch over-appends rather than errors):
+        - ``None`` — not ``{}`` — means "no prior state, always append". A
+          genuine empty current state (``current={}``) *can* suppress an equally
+          empty new snapshot, so don't pass ``{}`` to mean "new".
+        - ``current`` must already be in the shape ``snapshot_of`` produces
+          (typically the stored snapshot from the current-state projection). If
+          you pass a full record but a field-extracting ``snapshot_of``, the two
+          never compare equal and nothing is ever suppressed.
+        - Comparison is Python ``==`` on JSON-native values, so both sides should
+          come from the same JSON round-trip. ``Decimal``/``datetime`` in
+          ``current`` never equal a parsed payload (suppression disabled), and
+          ``2 == 2.0`` / ``True == 1`` compare equal — keep types consistent.
+        - ``data`` must be JSON-encodable event bytes; a non-JSON payload raises.
     """
     new_snapshot = json.loads(data)
     if snapshot_of is not None:

--- a/tests/test_rakaia/test_append.py
+++ b/tests/test_rakaia/test_append.py
@@ -1,0 +1,85 @@
+"""Tests for rakaia.append: no-op-suppressed append."""
+
+from __future__ import annotations
+
+import json
+
+from rakaia.append import append_if_changed, snapshots_equal
+from rakaia.store import StreamStore
+
+
+class TestSnapshotsEqual:
+    def test_dict_order_insensitive(self):
+        assert snapshots_equal({"a": 1, "b": 2}, {"b": 2, "a": 1})
+
+    def test_list_order_sensitive(self):
+        assert not snapshots_equal([1, 2], [2, 1])
+
+    def test_nested_deep_equal(self):
+        assert snapshots_equal({"x": {"y": [1, 2]}}, {"x": {"y": [1, 2]}})
+        assert not snapshots_equal({"x": {"y": [1, 2]}}, {"x": {"y": [1, 3]}})
+
+
+def _count(store: StreamStore, path: str) -> int:
+    messages, _ = store.read(path)
+    return len(messages)
+
+
+class TestAppendIfChanged:
+    def _store(self):
+        store = StreamStore()
+        store.create("s", content_type="application/octet-stream")
+        return store
+
+    def test_new_subject_always_appends(self):
+        store = self._store()
+        appended = append_if_changed(store, "s", b'{"a": 1}', current=None)
+        assert appended is True
+        assert _count(store, "s") == 1
+
+    def test_unchanged_payload_is_suppressed(self):
+        store = self._store()
+        appended = append_if_changed(
+            store, "s", b'{"a": 1, "b": 2}', current={"a": 1, "b": 2}
+        )
+        assert appended is False
+        assert _count(store, "s") == 0  # nothing written
+
+    def test_changed_payload_appends(self):
+        store = self._store()
+        appended = append_if_changed(
+            store, "s", b'{"a": 1, "b": 9}', current={"a": 1, "b": 2}
+        )
+        assert appended is True
+        assert _count(store, "s") == 1
+
+    def test_snapshot_of_ignores_volatile_fields(self):
+        # The payload's `ts` always changes, but only `fields` is compared, so an
+        # otherwise-identical save is still suppressed.
+        store = self._store()
+        current = {"x": 1}
+        appended = append_if_changed(
+            store,
+            "s",
+            b'{"fields": {"x": 1}, "ts": "later"}',
+            current=current,
+            snapshot_of=lambda ev: ev["fields"],
+        )
+        assert appended is False
+        assert _count(store, "s") == 0
+
+    def test_forwards_options_when_appending(self):
+        from rakaia.types import AppendOptions
+
+        store = self._store()
+        append_if_changed(
+            store,
+            "s",
+            b'{"a": 2}',
+            current={"a": 1},
+            options=AppendOptions(label="update", metadata={"user": 5}),
+        )
+        messages, _ = store.read("s")
+        assert messages[-1].label == "update"
+        assert messages[-1].metadata == {"user": 5}
+        assert json.loads(messages[-1].data) == {"a": 2}


### PR DESCRIPTION
**PR C — the last core piece** of the pghistory-retirement path (RFC #22), completing the envelope trilogy (PR A #25 + PR B #26).

## Why
`django-pghistory` only records an event when the row actually changed (`WHEN OLD.* IS DISTINCT FROM NEW.*`). A naive `store.append(new_state)` writes an event on **every** save — so a stream-native audit log would diverge from `pgh_event` on no-op saves, and bulk-import **retries** would duplicate rows.

## What
`rakaia.append.append_if_changed(store, path, data, *, current, options=None, snapshot_of=None) -> bool` appends only when the new snapshot differs from the subject's **current** snapshot — which the caller supplies from the current-state projection (it's what they're about to overwrite). Comparing against **the subject's own state, not the stream's last message**, is what makes it correct for form-family streams that interleave many subjects. Returns whether it appended.

- `snapshot_of` lets volatile fields (a server timestamp) be excluded so they don't defeat suppression.
- `snapshots_equal` is the deep, key-order-insensitive compare (plain `==` on JSON-native values: dicts unordered, lists ordered).
- The **append-layer analogue** of the `skip_unchanged` executor (#18).

## Tests (TDD)
`snapshots_equal` (dict order-insensitive, list order-sensitive, nested); new-subject-appends, unchanged-suppressed (0 written), changed-appends, `snapshot_of`-ignores-volatile, envelope-options-forwarded. **463 passed, 1 skipped**; ruff check + format clean. Purely additive.

## The trilogy is complete
With #25 (envelope) + #26 (history read-model) + this, an adopter can: append **enveloped, no-op-suppressed** Submission events, and materialise `/history` + recovery from the stream — matching pghistory's write-on-change semantics and read consumers. The remaining acceptance is the **byte-for-byte `pgh_event` parity test**, which is cross-repo (needs a real dump) and best hosted in Partisipa's #2382.