### PR TITLE
feat: project_latest + materialize_history (RFC #22 adoption helpers)

### DIFF
--- a/src/django_rakaia/history.py
+++ b/src/django_rakaia/history.py
@@ -31,15 +31,18 @@ def materialize_history(
 ) -> list[Effect]:
     """Read `path` and materialise its `/history` audit rows into `model_label`.
 
-    Reads the whole stream, builds one audit-row upsert per event via
-    `rakaia.history_effects` (keyed by ``(subject, version)`` so re-running is a
-    no-op), applies them with a `DjangoExecutor`, and returns the applied
+    Reads the **whole** stream each call (there is no incremental/tail mode
+    here — for that, call `rakaia.history_effects` yourself on a
+    ``store.read(path, offset=…)`` slice). Builds one audit-row upsert per event
+    via `rakaia.history_effects` (keyed by ``(subject, version)`` so re-running
+    is a no-op), applies them with a `DjangoExecutor`, and returns the applied
     Effects.
 
-    Pass ``version_of=lambda m: int(m.offset)`` to key on the durable stream
-    offset (stable under incremental reads); the default list-index version is
-    correct only for a whole-stream read. Pass `executor` to reuse a shared
-    executor (e.g. one with ``skip_unchanged=True``).
+    Pass ``version_of=lambda m: int(m.offset)`` to key rows on the durable stream
+    offset — never renumbered, so the keys match an incremental
+    `history_effects` done elsewhere; the default list-index version is fine for
+    this whole-stream read but is not offset-stable. Pass `executor` to reuse a
+    shared executor (e.g. one with ``skip_unchanged=True``).
     """
     messages, _ = store.read(path)
     effects = history_effects(

--- a/src/django_rakaia/history.py
+++ b/src/django_rakaia/history.py
@@ -1,0 +1,55 @@
+"""Convenience: materialise a `/history` audit table from a stream in one call.
+
+`rakaia.history_effects` builds the audit-row Effects from a stream's messages;
+applying them to the Django ORM is then a `DjangoExecutor().apply(...)` away.
+Every adopter otherwise repeats that read → build → apply dance (see the
+examples). `materialize_history` collapses it into a single call.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+from rakaia.effects import Effect
+from rakaia.history import history_effects
+
+from .effect_executor import DjangoExecutor
+
+
+def materialize_history(
+    store: Any,
+    path: str,
+    model_label: str,
+    *,
+    subject_of: Callable[[dict[str, Any]], Any],
+    defaults_of: Callable[[Any, dict[str, Any]], dict[str, Any]],
+    subject_field: str = "subject",
+    version_field: str = "version",
+    version_of: Callable[[Any], Any] | None = None,
+    executor: Any | None = None,
+) -> list[Effect]:
+    """Read `path` and materialise its `/history` audit rows into `model_label`.
+
+    Reads the whole stream, builds one audit-row upsert per event via
+    `rakaia.history_effects` (keyed by ``(subject, version)`` so re-running is a
+    no-op), applies them with a `DjangoExecutor`, and returns the applied
+    Effects.
+
+    Pass ``version_of=lambda m: int(m.offset)`` to key on the durable stream
+    offset (stable under incremental reads); the default list-index version is
+    correct only for a whole-stream read. Pass `executor` to reuse a shared
+    executor (e.g. one with ``skip_unchanged=True``).
+    """
+    messages, _ = store.read(path)
+    effects = history_effects(
+        messages,
+        model_label,
+        subject_of=subject_of,
+        defaults_of=defaults_of,
+        subject_field=subject_field,
+        version_field=version_field,
+        version_of=version_of,
+    )
+    (executor or DjangoExecutor()).apply(effects)
+    return effects

--- a/src/rakaia/__init__.py
+++ b/src/rakaia/__init__.py
@@ -36,6 +36,7 @@ from .history import (
     recover_peak_snapshot,
 )
 from .projections import (
+    project_latest,
     reconcile_aggregate,
     reconcile_children,
     reconcile_tree,
@@ -132,6 +133,7 @@ __all__ = [
     "reconcile_children",
     "reconcile_tree",
     "reconcile_aggregate",
+    "project_latest",
     # Versioned handlers — registry
     "register_handler",
     "register_reducer",

--- a/src/rakaia/projections.py
+++ b/src/rakaia/projections.py
@@ -20,10 +20,12 @@ reconcile `delete` scoped to spare exactly the rows still present:
 
 from __future__ import annotations
 
+import json
 from collections.abc import Callable, Mapping, Sequence
 from typing import Any
 
 from .effects import Effect
+from .types import StreamMessage
 
 
 def reconcile_children(
@@ -197,4 +199,64 @@ def reconcile_aggregate(
             exclude={f"{group_key}__in": group_values},
         )
     )
+    return effects
+
+
+def project_latest(
+    messages: Sequence[StreamMessage],
+    model_label: str,
+    *,
+    subject_of: Callable[[dict[str, Any]], Any],
+    defaults_of: Callable[[StreamMessage, dict[str, Any]], dict[str, Any]],
+    subject_field: str = "subject",
+    tombstone_labels: Sequence[str] = ("delete",),
+) -> list[Effect]:
+    """Project each subject's **latest** snapshot into one row — the current-state
+    read model behind an event log.
+
+    Folds `messages` to the newest event per subject (oldest-first, last wins)
+    and returns one ``update_or_create`` per live subject, plus a ``delete`` for
+    any subject whose latest event is a **tombstone** (``label in
+    tombstone_labels`` — e.g. a delete, Decision #2). Because every event is a
+    full snapshot, "latest" needs no reducer.
+
+    Unlike `reconcile_children` (parent → child fan-out), this is subject →
+    latest-row, keyed on the aggregate identity (`subject_field`). It only
+    touches subjects **present in** `messages`, so it serves a full-stream
+    rebuild *and* an incremental tail read (``store.read(path, offset=…)``): a
+    subject's absence is never a delete — only an explicit tombstone is.
+
+    Args:
+        messages: the stream's messages (from ``store.read``), oldest-first.
+        model_label: 'app_label.ModelName' of the projection table.
+        subject_of: maps a decoded event to its subject (the aggregate id).
+        defaults_of: maps ``(message, decoded event)`` to the row's ``defaults=``.
+        subject_field: the projection's key column.
+        tombstone_labels: envelope labels that mean "no live row" for the subject.
+    """
+    latest: dict[Any, tuple[StreamMessage, dict[str, Any]]] = {}
+    for msg in messages:
+        event = json.loads(msg.data)
+        latest[subject_of(event)] = (msg, event)
+
+    tombstones = set(tombstone_labels)
+    effects: list[Effect] = []
+    for subject, (msg, event) in latest.items():
+        if msg.label in tombstones:
+            effects.append(
+                Effect(
+                    op="delete",
+                    model_label=model_label,
+                    lookup={subject_field: subject},
+                )
+            )
+        else:
+            effects.append(
+                Effect(
+                    op="update_or_create",
+                    model_label=model_label,
+                    lookup={subject_field: subject},
+                    defaults=defaults_of(msg, event),
+                )
+            )
     return effects

--- a/tests/test_django_rakaia/test_history_materializer.py
+++ b/tests/test_django_rakaia/test_history_materializer.py
@@ -1,0 +1,86 @@
+"""Tests for django_rakaia.materialize_history — the read+build+apply convenience.
+
+The same read -> history_effects -> DjangoExecutor().apply dance as
+test_history_materialization.py, but through the one-call helper.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from django_rakaia.django_store import DjangoStreamStore
+from django_rakaia.history import materialize_history
+from rakaia.history import envelope_actor, label_marker
+from rakaia.types import AppendOptions
+
+from .models import History
+
+
+def _defaults(msg, event):
+    return {
+        "marker": label_marker(msg.label),
+        "actor": envelope_actor(msg, event),
+        "ts": msg.timestamp,
+        "snapshot": event,
+    }
+
+
+def _seed() -> DjangoStreamStore:
+    store = DjangoStreamStore()
+    store.create("submissions")
+    store.append(
+        "submissions",
+        b'{"key": "s1", "user_id": 9, "a": 1}',
+        AppendOptions(label="insert", metadata={"user": 42}),
+    )
+    store.append(
+        "submissions",
+        b'{"key": "s1", "user_id": 9, "a": 2}',
+        AppendOptions(label="update"),  # no context -> actor falls back to owner
+    )
+    return store
+
+
+def _materialize(store, **kw):
+    return materialize_history(
+        store,
+        "submissions",
+        "test_django_rakaia.History",
+        subject_field="submission_id",
+        subject_of=lambda ev: ev["key"],
+        defaults_of=_defaults,
+        **kw,
+    )
+
+
+@pytest.mark.django_db
+class TestMaterializeHistory:
+    def test_reads_builds_and_applies_in_one_call(self):
+        effects = _materialize(_seed())
+        assert len(effects) == 2
+        rows = list(History.objects.order_by("version"))
+        assert [r.marker for r in rows] == ["+", "~"]
+        assert [r.actor for r in rows] == [42, 9]  # context editor, then owner
+        assert rows[1].snapshot == {"key": "s1", "user_id": 9, "a": 2}
+
+    def test_idempotent(self):
+        store = _seed()
+        _materialize(store)
+        _materialize(store)  # keyed by (subject, version) -> no duplicates
+        assert History.objects.count() == 2
+
+    def test_version_of_keys_on_offset(self):
+        _materialize(_seed(), version_of=lambda m: int(m.offset))
+        versions = sorted(History.objects.values_list("version", flat=True))
+        assert versions == [1, 2]  # the durable offsets, not the 0/1 list index
+
+    def test_custom_executor_is_used(self):
+        applied: list = []
+
+        class Recorder:
+            def apply(self, effects):
+                applied.extend(effects)
+
+        _materialize(_seed(), executor=Recorder())
+        assert len(applied) == 2
+        assert History.objects.count() == 0  # recorder didn't write to the ORM

--- a/tests/test_rakaia/test_projections.py
+++ b/tests/test_rakaia/test_projections.py
@@ -2,11 +2,24 @@
 
 from __future__ import annotations
 
+import json
+
 from rakaia.projections import (
+    project_latest,
     reconcile_aggregate,
     reconcile_children,
     reconcile_tree,
 )
+from rakaia.types import StreamMessage
+
+
+def _msg(payload: dict, *, label: str = "update", offset: str = "1") -> StreamMessage:
+    return StreamMessage(
+        data=json.dumps(payload).encode("utf-8"),
+        offset=offset,
+        timestamp=1.0,
+        label=label,
+    )
 
 
 def _reconcile(items: list[dict]):
@@ -195,3 +208,88 @@ class TestReconcileAggregate:
         scope = {"report_id": 42}
         _agg({"a": {"total": 1}}, scope=scope)
         assert scope == {"report_id": 42}
+
+
+class TestProjectLatest:
+    def _project(self, messages):
+        return project_latest(
+            messages,
+            "app.Submission",
+            subject_field="key",
+            subject_of=lambda e: e["key"],
+            defaults_of=lambda _msg, e: {"fields": e["fields"], "status": e["status"]},
+        )
+
+    def test_one_upsert_per_subject(self):
+        effects = self._project(
+            [
+                _msg({"key": "a", "fields": {"v": 1}, "status": 0}, label="create"),
+                _msg({"key": "b", "fields": {"v": 1}, "status": 0}, label="create"),
+            ]
+        )
+        upserts = [e for e in effects if e.op == "update_or_create"]
+        assert len(upserts) == 2
+        assert {tuple(e.lookup.items()) for e in upserts} == {
+            (("key", "a"),),
+            (("key", "b"),),
+        }
+        assert all(e.model_label == "app.Submission" for e in upserts)
+
+    def test_last_event_wins(self):
+        effects = self._project(
+            [
+                _msg({"key": "a", "fields": {"v": 1}, "status": 0}, label="create"),
+                _msg({"key": "a", "fields": {"v": 2}, "status": 1}, label="update"),
+            ]
+        )
+        assert len(effects) == 1
+        assert effects[0].op == "update_or_create"
+        assert effects[0].lookup == {"key": "a"}
+        assert effects[0].defaults == {"fields": {"v": 2}, "status": 1}
+
+    def test_tombstone_emits_delete(self):
+        effects = self._project(
+            [
+                _msg({"key": "a", "fields": {"v": 1}, "status": 0}, label="create"),
+                _msg({"key": "a", "fields": {"v": 1}, "status": 0}, label="delete"),
+            ]
+        )
+        assert len(effects) == 1
+        assert effects[0].op == "delete"
+        assert effects[0].lookup == {"key": "a"}
+
+    def test_recreate_after_tombstone_upserts(self):
+        # create -> delete -> create: the latest event is live, so the row
+        # reappears with the newest snapshot.
+        effects = self._project(
+            [
+                _msg({"key": "a", "fields": {"v": 1}, "status": 0}, label="create"),
+                _msg({"key": "a", "fields": {"v": 1}, "status": 0}, label="delete"),
+                _msg({"key": "a", "fields": {"v": 3}, "status": 2}, label="create"),
+            ]
+        )
+        assert len(effects) == 1
+        assert effects[0].op == "update_or_create"
+        assert effects[0].defaults == {"fields": {"v": 3}, "status": 2}
+
+    def test_custom_tombstone_labels(self):
+        effects = project_latest(
+            [_msg({"key": "a", "fields": {}, "status": 0}, label="archived")],
+            "app.Submission",
+            subject_field="key",
+            subject_of=lambda e: e["key"],
+            defaults_of=lambda _msg, e: {"status": e["status"]},
+            tombstone_labels=("archived",),
+        )
+        assert len(effects) == 1
+        assert effects[0].op == "delete"
+
+    def test_only_subjects_present_get_effects(self):
+        # Incremental: a tail read with only 'a' touches only 'a' — an absent
+        # subject is not deleted (only an explicit tombstone is).
+        effects = self._project(
+            [_msg({"key": "a", "fields": {}, "status": 0}, label="update")]
+        )
+        assert len(effects) == 1
+        assert effects[0].lookup == {"key": "a"}
+        assert effects[0].op == "update_or_create"


### PR DESCRIPTION
## What

Promotes two primitives the `SubmissionEvent → Submission` spike (#29, a reference
draft) exercised **by hand** into core, so adopters of the RFC #22 Decision #13
model don't re-derive — or mis-test — them. Grounded in real friction from
building the spike (the review even caught a version off-by-one and a vacuous
test in the hand-rolled versions).

### 1. `rakaia.project_latest(...)` — the current-state read model behind an event log

```python
project_latest(messages, model_label, *, subject_of, defaults_of,
               subject_field="subject", tombstone_labels=("delete",)) -> list[Effect]
```

Folds a stream to the **latest** event per subject and returns one
`update_or_create` per live subject's full snapshot, plus a `delete` per
**tombstoned** subject (Decision #2). Unlike `reconcile_children` (parent→child
fan-out) this is subject→latest-row, keyed on the aggregate identity. It touches
only subjects **present in** `messages`, so it serves a full-stream rebuild *and*
an incremental tail read (`store.read(path, offset=…)`) — a subject's absence is
never a delete, only an explicit tombstone is.

### 2. `django_rakaia.materialize_history(...)` — one-call `/history` materialiser

Collapses the `store.read` → `history_effects` → `DjangoExecutor().apply` dance
— currently duplicated across **both** examples *and*
`test_history_materialization.py` — into a single call. Forwards `version_of`
(e.g. `lambda m: int(m.offset)` to key on the durable offset) and an optional
`executor`.

## Tests

- **6 pure** `project_latest` cases: one-upsert-per-subject, last-event-wins,
  tombstone→delete, recreate-after-tombstone (row reappears), custom tombstone
  labels, incremental-subset (absent subject not deleted).
- **4 django** `materialize_history` cases: one-call apply (marker/actor incl.
  owner fallback), idempotent re-run, `version_of=int(offset)` keys on the
  durable offset, custom executor honored (non-vacuous: ORM untouched).

Full suite **473 passed, 1 skipped**; `ruff check` + `ruff format --check` clean.

## Scope

Core only (`src/` + `tests/`). Wiring the examples/spike to use these is a
follow-up; #29 stays the worked reference.