### PR TITLE
Subscriber cursors: incremental per-consumer stream reads (quick win #4, #11)

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -124,6 +124,8 @@ the channel layer.
   label, and no-op suppression on append.
 - [History read-model](history-read-model.md) — Latest-state vs a queryable
   audit trail, both derived from one log.
+- [Subscriber cursors](subscriber-cursors.md) — Incremental per-consumer reads
+  over a stream's offsets, with rewind detection and durable watermarks.
 - [Alerts projection](alerts-projection.md) — Human judgment and machine rules
   in one projection, without clobber.
 - [Dry-run & executors](dry-run-and-executors.md) — Preview a replay's writes

--- a/docs/subscriber-cursors.md
+++ b/docs/subscriber-cursors.md
@@ -52,16 +52,26 @@ already is).
 
 ## Rewind detection
 
-If the stored cursor sorts *after* the current head, the log shrank beneath it —
-a truncation, or a delete-and-recreate — so the consumer must reset and re-read
-from the start. Offsets are compared **numerically** (parsing the `_`-joined
-integer parts), so detection is correct even for the Django store's
-non-zero-padded offsets, where `"10"` is later than `"2"` despite sorting before
-it as a string.
+If the stored cursor sorts *after* the current head, the log shrank beneath it,
+so the consumer resets and re-reads from the start. Offsets are compared
+**numerically** (parsing the `_`-joined integer parts), so detection is correct
+even for the Django store's non-zero-padded offsets, where `"10"` is later than
+`"2"` despite sorting before it as a string.
 
-**One blind spot:** a stream deleted and then re-grown *past* the old cursor
-before the next poll reads as a normal `advanced`. Offsets alone cannot see that;
-a stream-generation token would close it, and is a deliberate future extension.
+This is **exact for an append-only log** — the intended use. An event stream is
+only appended to, so its offsets are monotonic for its whole lifetime and every
+rewind is a genuine shrink.
+
+**Limitation — stream recreation is not detected by offsets alone.** A stream
+deleted and recreated re-issues offsets from the low end. If it re-grows *past*
+the old cursor, the next poll reads as a benign `advanced` (the new events are
+still delivered). But if it lands on the **exact** offset the consumer last
+committed, the poll reads as `caught_up` and the new content is **silently
+skipped** — a real gap, but only across a delete+recreate, never on an
+append-only stream. Closing it needs a **stream-generation token** (a per-stream
+identity that changes on recreate — e.g. the Django `Stream` row's pk) threaded
+through the cursor; that is the tracked follow-up (issue #11 / PR #33) before
+this is relied on across stream recreation.
 
 ## Durable cursors (Django)
 

--- a/docs/subscriber-cursors.md
+++ b/docs/subscriber-cursors.md
@@ -68,10 +68,13 @@ the old cursor, the next poll reads as a benign `advanced` (the new events are
 still delivered). But if it lands on the **exact** offset the consumer last
 committed, the poll reads as `caught_up` and the new content is **silently
 skipped** — a real gap, but only across a delete+recreate, never on an
-append-only stream. Closing it needs a **stream-generation token** (a per-stream
-identity that changes on recreate — e.g. the Django `Stream` row's pk) threaded
-through the cursor; that is the tracked follow-up (issue #11 / PR #33) before
-this is relied on across stream recreation.
+append-only stream. The protocol already discourages the trigger ("if a stream
+is deleted a new stream SHOULD NOT be created at the same URL", §3). The
+root-cause fix lives in the **store**: make offsets globally monotonic (a
+recreated stream issues offsets strictly greater than any prior one — the
+EventStoreDB `$all` / Kinesis model), after which recreated content sorts past
+the cursor and is delivered as a normal `advanced`, with no consumer-side
+change. Tracked in [issue #34](https://github.com/joshbrooks/rakaia/issues/34).
 
 ## Durable cursors (Django)
 

--- a/docs/subscriber-cursors.md
+++ b/docs/subscriber-cursors.md
@@ -1,0 +1,95 @@
+# Subscriber cursors
+
+A durable stream already assigns every event a **monotonic offset**, so "give me
+everything that changed since I last looked" needs nothing more than *remember
+the last offset, read after it*. `rakaia.subscription` packages that into a small
+per-consumer cursor with **rewind detection** — the streams-native replacement
+for a hand-rolled `last_change_id` sync endpoint (a per-consumer watermark plus a
+"the log was rebuilt, resync" signal).
+
+This is the read side of the log. Where [versioned handlers](versioned-handlers.md)
+and [projections](projections-and-fan-out.md) rebuild *server* state from a
+stream, a subscriber cursor lets an *external* consumer — a reporting job, a
+search indexer, a browser syncing into IndexedDB — pull the delta incrementally
+and resume exactly where it left off.
+
+## The core: `poll`
+
+`poll(store, path, cursor)` is store-agnostic and pure with respect to the store:
+it reads `path` forward from `cursor` and reports what happened. It works over
+any store that can `read` and expose its head offset — the in-memory
+`StreamStore` and the Django `DjangoStreamStore` both qualify.
+
+```python
+from rakaia import poll
+
+result = poll(store, "submissions", cursor=None)   # first poll: everything
+for msg in result.messages:
+    apply(msg)
+cursor = result.cursor                              # persist this watermark
+
+# later — only the delta since `cursor`
+result = poll(store, "submissions", cursor)
+```
+
+`result.status` is one of:
+
+| status | meaning |
+|---|---|
+| `fresh` | first poll (no prior cursor) — every message returned |
+| `advanced` | new messages since the cursor — the delta returned |
+| `caught_up` | cursor is at the head — nothing new (`result.caught_up`) |
+| `rewound` | cursor sorts **past** the head — the log was rebuilt beneath it; re-read from the start and reset derived state (`result.rewound`) |
+| `absent` | the stream does not exist |
+
+## At-least-once: poll, apply, *then* commit
+
+`poll` never advances anything itself — it returns the *new* watermark in
+`result.cursor`, and you persist it only **after** the messages are applied. A
+crash between applying and committing re-delivers the batch rather than skipping
+it, so downstream apply logic should be idempotent (which, for a projection, it
+already is).
+
+## Rewind detection
+
+If the stored cursor sorts *after* the current head, the log shrank beneath it —
+a truncation, or a delete-and-recreate — so the consumer must reset and re-read
+from the start. Offsets are compared **numerically** (parsing the `_`-joined
+integer parts), so detection is correct even for the Django store's
+non-zero-padded offsets, where `"10"` is later than `"2"` despite sorting before
+it as a string.
+
+**One blind spot:** a stream deleted and then re-grown *past* the old cursor
+before the next poll reads as a normal `advanced`. Offsets alone cannot see that;
+a stream-generation token would close it, and is a deliberate future extension.
+
+## Durable cursors (Django)
+
+`django_rakaia.subscription` persists the watermark in a `ConsumerCursor` row
+(`(consumer_id, stream_path) → offset`) so a consumer survives restarts:
+
+```python
+from django_rakaia.django_store import DjangoStreamStore
+from django_rakaia.subscription import poll_consumer, commit_cursor
+
+store = DjangoStreamStore()
+result = poll_consumer(store, consumer_id="reporting", stream_path="submissions")
+for msg in result.messages:
+    apply(msg)
+commit_cursor("reporting", "submissions", result.cursor)   # after applying
+```
+
+`poll_consumer` loads the stored cursor and calls `poll`; `commit_cursor` upserts
+the new watermark. Splitting them preserves the at-least-once guarantee above.
+
+## Why this matters for the Partisipa migration
+
+Partisipa's `sync_identity/watermarks.py` + `list_options(last_change_id)`
+hand-roll exactly this: monotonic change-ids, per-consumer cursors, and
+DB-rewind detection. Once `Submission` is a rakaia stream, that machinery *is* a
+subscriber cursor — the stream's offsets are the change-ids, `ConsumerCursor` is
+the per-consumer watermark, and `rewound` is the rewind signal the frontend needs
+to trigger a full IndexedDB resync. This is quick-win **#4** of the
+[streams-migration issue (#11)](https://github.com/joshbrooks/rakaia/issues/11):
+the rakaia primitive is shipped here; wiring the client sync protocol onto it is
+the Partisipa-side follow-on.

--- a/src/django_rakaia/migrations/0003_consumercursor.py
+++ b/src/django_rakaia/migrations/0003_consumercursor.py
@@ -1,0 +1,32 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("django_rakaia", "0002_streamevent_metadata"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="ConsumerCursor",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("consumer_id", models.CharField(max_length=128)),
+                ("stream_path", models.CharField(max_length=255)),
+                ("offset", models.CharField(max_length=64)),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+            ],
+            options={
+                "db_table": "rakaia_consumercursor",
+                "unique_together": {("consumer_id", "stream_path")},
+            },
+        ),
+    ]

--- a/src/django_rakaia/models.py
+++ b/src/django_rakaia/models.py
@@ -273,3 +273,26 @@ class Translatable(models.Model):
         """Restore a soft-deleted translation."""
         self.deleted = None
         self.save()
+
+
+class ConsumerCursor(models.Model):
+    """A durable per-consumer watermark over a stream.
+
+    One row per ``(consumer_id, stream_path)`` holding the last offset that
+    consumer applied. It is the streams-native replacement for a hand-rolled
+    ``last_change_id`` sync table: a consumer resumes exactly where it left off
+    across restarts. See ``rakaia.subscription.poll`` for the read semantics and
+    ``django_rakaia.subscription`` for the load/commit helpers.
+    """
+
+    consumer_id = models.CharField(max_length=128)
+    stream_path = models.CharField(max_length=255)
+    offset = models.CharField(max_length=64)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        db_table = "rakaia_consumercursor"
+        unique_together = [["consumer_id", "stream_path"]]
+
+    def __str__(self) -> str:
+        return f"{self.consumer_id}@{self.stream_path}={self.offset}"

--- a/src/django_rakaia/subscription.py
+++ b/src/django_rakaia/subscription.py
@@ -1,0 +1,46 @@
+"""Durable per-consumer cursors backed by the ``ConsumerCursor`` model.
+
+Thin persistence layer over `rakaia.subscription.poll`: load a consumer's stored
+watermark, poll the stream for the delta, and — after the caller has applied the
+messages — commit the new watermark. Splitting poll from commit keeps delivery
+**at-least-once**: a crash between applying and committing re-delivers the batch
+rather than skipping it.
+"""
+
+from __future__ import annotations
+
+from rakaia.subscription import CursorStore, Poll, poll
+
+from .models import ConsumerCursor
+
+
+def load_cursor(consumer_id: str, stream_path: str) -> str | None:
+    """The consumer's last committed offset for `stream_path`, or None."""
+    row = ConsumerCursor.objects.filter(
+        consumer_id=consumer_id, stream_path=stream_path
+    ).first()
+    return row.offset if row else None
+
+
+def commit_cursor(consumer_id: str, stream_path: str, offset: str) -> None:
+    """Persist `offset` as the consumer's watermark for `stream_path`.
+
+    Call this only **after** the polled messages have been applied.
+    """
+    ConsumerCursor.objects.update_or_create(
+        consumer_id=consumer_id,
+        stream_path=stream_path,
+        defaults={"offset": offset},
+    )
+
+
+def poll_consumer(store: CursorStore, consumer_id: str, stream_path: str) -> Poll:
+    """Load this consumer's cursor and poll `stream_path` for the delta.
+
+    Does **not** advance the cursor — apply ``result.messages``, then call
+    `commit_cursor(consumer_id, stream_path, result.cursor)`. A ``rewound``
+    result means the log was rebuilt beneath the cursor; reset derived state
+    before applying, exactly as with the core `poll`.
+    """
+    cursor = load_cursor(consumer_id, stream_path)
+    return poll(store, stream_path, cursor)

--- a/src/rakaia/__init__.py
+++ b/src/rakaia/__init__.py
@@ -65,6 +65,7 @@ from .registry import (
 )
 from .replay import ReplayResult, merge_replay, replay
 from .store import StreamStore
+from .subscription import Poll, PollStatus, poll
 from .types import (
     AppendOptions,
     AppendResult,
@@ -160,6 +161,10 @@ __all__ = [
     "replay",
     "merge_replay",
     "ReplayResult",
+    # Subscriber cursors
+    "poll",
+    "Poll",
+    "PollStatus",
     # Version
     "__version__",
 ]

--- a/src/rakaia/subscription.py
+++ b/src/rakaia/subscription.py
@@ -30,11 +30,13 @@ offsets alone.** A recreated stream re-issues offsets from the low end, so:
   as ``caught_up`` and the new content at that offset is **silently skipped** —
   a real gap in the at-least-once guarantee, but only across a delete+recreate.
 
-Closing this needs a **stream-generation token** (a per-stream identity that
-changes on recreate — e.g. the Django ``Stream`` row's pk) threaded through the
-cursor, so a generation change forces a resync regardless of offset. That is the
-tracked follow-up before this is relied on across stream recreation; it does not
-affect append-only streams, which are correct as-is. See issue #11 / PR #33.
+The root-cause fix lives in the **store**, not here: make offsets globally
+monotonic so a recreated stream issues offsets strictly greater than any prior
+one (the EventStoreDB ``$all`` / Kinesis model). Then recreated content sorts
+past the cursor and is delivered as a normal ``advanced`` — no consumer-side
+change needed. The protocol already discourages the trigger ("if a stream is
+deleted a new stream SHOULD NOT be created at the same URL"), and append-only
+streams — the intended use — are unaffected. Tracked in issue #34.
 """
 
 from __future__ import annotations

--- a/src/rakaia/subscription.py
+++ b/src/rakaia/subscription.py
@@ -1,0 +1,133 @@
+"""Per-consumer stream cursors: read a stream incrementally with rewind detection.
+
+A durable stream already carries monotonic offsets, so "give me what changed
+since I last looked" is just *remember the last offset, read after it*. This is
+the streams-native form of a hand-rolled ``last_change_id`` sync API (a
+per-consumer watermark + a "the log was rebuilt, resync" signal).
+
+`poll` is store-agnostic and pure with respect to the store: it derives its
+status entirely from the stored cursor versus the current head, so replaying the
+same reads yields the same result. It works over any `ReadableStore` that also
+exposes ``get_current_offset`` — both the in-memory `StreamStore` and the Django
+`DjangoStreamStore` qualify.
+
+The consumer holds the cursor; `django_rakaia` provides a durable place to keep
+it (`ConsumerCursor`) plus `load_cursor`/`commit_cursor` helpers, so a consumer
+survives restarts and resumes exactly where it left off.
+
+Rewind detection is offset-based: if the stored cursor sorts *after* the current
+head, the log shrank beneath it (a truncation or a delete+recreate), so the
+consumer must reset and re-read from the start. Its one blind spot: a stream
+deleted and then re-grown *past* the old cursor before the next poll reads as a
+normal advance — offsets alone can't see that. A stream-generation token would
+close it; that is a deliberate future extension, not part of this primitive.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal, Protocol
+
+from .protocols import ReadableStore
+from .types import StreamMessage
+
+PollStatus = Literal["fresh", "advanced", "caught_up", "rewound", "absent"]
+"""Outcome of a `poll`:
+
+* ``fresh`` — first poll (no prior cursor); every message returned.
+* ``advanced`` — new messages since the cursor; the delta returned.
+* ``caught_up`` — cursor is at the head; nothing new.
+* ``rewound`` — cursor sorts past the head (log truncated/rebuilt); re-read from
+  the start. The consumer should reset any derived state before applying.
+* ``absent`` — the stream does not exist; nothing returned.
+"""
+
+
+class CursorStore(ReadableStore, Protocol):
+    """A `ReadableStore` that also exposes its current head offset."""
+
+    def get_current_offset(self, path: str) -> str | None: ...
+
+
+@dataclass(frozen=True)
+class Poll:
+    """The result of polling a stream from a cursor."""
+
+    messages: list[StreamMessage]
+    """The messages to apply, oldest-first (empty when caught up or absent)."""
+
+    cursor: str | None
+    """The new watermark to persist — the last consumed offset. Unchanged when
+    caught up; ``None`` when the stream is absent."""
+
+    status: PollStatus
+
+    @property
+    def rewound(self) -> bool:
+        """The log was rebuilt beneath the cursor; reset before applying."""
+        return self.status == "rewound"
+
+    @property
+    def caught_up(self) -> bool:
+        """No new messages since the cursor."""
+        return self.status == "caught_up"
+
+
+def poll(store: CursorStore, path: str, cursor: str | None) -> Poll:
+    """Read `path` forward from `cursor`, detecting a rewound log.
+
+    Args:
+        store: a `ReadableStore` that also exposes ``get_current_offset``.
+        path: the stream to poll.
+        cursor: the last offset this consumer applied, or ``None`` on first poll.
+
+    Returns:
+        A `Poll`. Persist ``.cursor`` only after the messages are applied, so a
+        crash mid-apply re-delivers rather than skips (at-least-once). A
+        ``rewound`` result re-reads from the start; reset derived state first.
+    """
+    head = store.get_current_offset(path)
+    if head is None:
+        return Poll(messages=[], cursor=None, status="absent")
+
+    if cursor is None:
+        messages, _ = store.read(path)
+        return Poll(messages=messages, cursor=_tail(messages, head), status="fresh")
+
+    if _after(cursor, head):
+        # The cursor points beyond the current head: the log was truncated or
+        # rebuilt shorter. Re-read from the start and signal the reset.
+        messages, _ = store.read(path)
+        return Poll(messages=messages, cursor=_tail(messages, head), status="rewound")
+
+    if cursor == head:
+        return Poll(messages=[], cursor=cursor, status="caught_up")
+
+    messages, _ = store.read(path, cursor)
+    return Poll(messages=messages, cursor=_tail(messages, cursor), status="advanced")
+
+
+def _tail(messages: list[StreamMessage], fallback: str) -> str:
+    """The last message's offset, or `fallback` when there are no messages."""
+    return messages[-1].offset if messages else fallback
+
+
+def _offset_key(offset: str) -> tuple[int, ...] | None:
+    """Parse a rakaia offset into an orderable tuple of ints, or None.
+
+    Both stores build offsets from ``_``-joined integers — the in-memory store's
+    ``{seq}_{bytes}`` and the Django store's bare ``str(int)``. Comparing the
+    parsed ints (not the raw strings) orders them correctly even when the Django
+    store's offsets are not zero-padded (``"9"`` vs ``"10"``)."""
+    try:
+        return tuple(int(part) for part in offset.split("_"))
+    except ValueError:
+        return None
+
+
+def _after(a: str, b: str) -> bool:
+    """True if offset `a` sorts strictly after `b` (chronologically later)."""
+    ka, kb = _offset_key(a), _offset_key(b)
+    if ka is None or kb is None or len(ka) != len(kb):
+        return a > b  # unparseable/mismatched shape: fall back to lexicographic
+    return ka > kb

--- a/src/rakaia/subscription.py
+++ b/src/rakaia/subscription.py
@@ -16,11 +16,25 @@ it (`ConsumerCursor`) plus `load_cursor`/`commit_cursor` helpers, so a consumer
 survives restarts and resumes exactly where it left off.
 
 Rewind detection is offset-based: if the stored cursor sorts *after* the current
-head, the log shrank beneath it (a truncation or a delete+recreate), so the
-consumer must reset and re-read from the start. Its one blind spot: a stream
-deleted and then re-grown *past* the old cursor before the next poll reads as a
-normal advance — offsets alone can't see that. A stream-generation token would
-close it; that is a deliberate future extension, not part of this primitive.
+head, the log shrank beneath it, so the consumer resets and re-reads from the
+start. This is exact for an **append-only** log (the intended use — an event
+stream is only ever appended to), where offsets are monotonic for the stream's
+lifetime.
+
+**Limitation — stream recreation (delete + recreate) is not detected by
+offsets alone.** A recreated stream re-issues offsets from the low end, so:
+
+* if it re-grows *past* the old cursor, the next poll reads as a normal
+  ``advanced`` (benign: the new events are still delivered, just not flagged);
+* if it lands on the *exact* offset the consumer last committed, the poll reads
+  as ``caught_up`` and the new content at that offset is **silently skipped** —
+  a real gap in the at-least-once guarantee, but only across a delete+recreate.
+
+Closing this needs a **stream-generation token** (a per-stream identity that
+changes on recreate — e.g. the Django ``Stream`` row's pk) threaded through the
+cursor, so a generation change forces a resync regardless of offset. That is the
+tracked follow-up before this is relied on across stream recreation; it does not
+affect append-only streams, which are correct as-is. See issue #11 / PR #33.
 """
 
 from __future__ import annotations

--- a/tests/test_django_rakaia/test_subscription.py
+++ b/tests/test_django_rakaia/test_subscription.py
@@ -1,0 +1,78 @@
+"""Durable consumer-cursor tests over the Django store.
+
+Exercises `django_rakaia.subscription` (load/commit/poll_consumer) end-to-end
+against `DjangoStreamStore`, including resume-across-restart and rewind detection
+with the Django store's non-zero-padded integer offsets.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from django_rakaia.django_store import DjangoStreamStore
+from django_rakaia.subscription import commit_cursor, load_cursor, poll_consumer
+
+CONSUMER = "reporting"
+
+
+def _append(store: DjangoStreamStore, path: str, n: int) -> None:
+    for i in range(n):
+        store.append(path, json.dumps({"i": i}).encode())
+
+
+@pytest.mark.django_db
+class TestConsumerCursor:
+    def test_commit_then_load_round_trips(self):
+        assert load_cursor(CONSUMER, "s") is None
+        commit_cursor(CONSUMER, "s", "7")
+        assert load_cursor(CONSUMER, "s") == "7"
+        commit_cursor(CONSUMER, "s", "9")  # upsert, not duplicate
+        assert load_cursor(CONSUMER, "s") == "9"
+
+    def test_fresh_then_caught_up(self):
+        store = DjangoStreamStore()
+        store.create("s")
+        _append(store, "s", 3)
+
+        first = poll_consumer(store, CONSUMER, "s")
+        assert first.status == "fresh"
+        assert len(first.messages) == 3
+        commit_cursor(CONSUMER, "s", first.cursor)
+
+        again = poll_consumer(store, CONSUMER, "s")
+        assert again.caught_up
+        assert again.messages == []
+
+    def test_incremental_resume_across_restart(self):
+        store = DjangoStreamStore()
+        store.create("s")
+        _append(store, "s", 2)
+        first = poll_consumer(store, CONSUMER, "s")
+        commit_cursor(CONSUMER, "s", first.cursor)
+
+        _append(store, "s", 2)  # two more events arrive
+        # A "restart": a brand-new store handle, cursor read from the DB.
+        second = poll_consumer(DjangoStreamStore(), CONSUMER, "s")
+        assert second.status == "advanced"
+        assert len(second.messages) == 2  # only the delta, no re-delivery
+
+    def test_rewind_detected_with_unpadded_offsets(self):
+        # Consume 10 events (cursor -> "10"), then rebuild the stream with only
+        # 2 (head -> "2"). Lexicographically "10" < "2", so only a numeric
+        # offset comparison correctly flags the rewind.
+        store = DjangoStreamStore()
+        store.create("s")
+        _append(store, "s", 10)
+        first = poll_consumer(store, CONSUMER, "s")
+        assert first.cursor == "10"
+        commit_cursor(CONSUMER, "s", first.cursor)
+
+        store.delete("s")
+        store.create("s")
+        _append(store, "s", 2)
+
+        result = poll_consumer(store, CONSUMER, "s")
+        assert result.status == "rewound"
+        assert len(result.messages) == 2  # re-read from the start

--- a/tests/test_rakaia/test_subscription.py
+++ b/tests/test_rakaia/test_subscription.py
@@ -8,6 +8,8 @@ it is store-agnostic (works over any `ReadableStore` that also exposes
 
 from __future__ import annotations
 
+import pytest
+
 from rakaia.store import StreamStore
 from rakaia.subscription import poll
 
@@ -89,3 +91,24 @@ class TestPoll:
         assert result.status == "absent"
         assert result.messages == []
         assert result.cursor is None
+
+    @pytest.mark.xfail(
+        reason="offset-only rewind detection can't see a delete+recreate that "
+        "reuses the committed offset; needs a stream-generation token "
+        "(issue #11 / PR #33). Append-only streams are unaffected.",
+        strict=True,
+    )
+    def test_recreate_reusing_offset_should_rewind_not_silently_skip(self):
+        # Adversarial-review finding: a stream deleted and recreated so that its
+        # new head lands on the exact offset the consumer last committed reads as
+        # `caught_up`, silently dropping the new content. This pins the DESIRED
+        # behavior (rewound + redeliver); it flips green when the generation
+        # token lands, and strict xfail then flags the marker for removal.
+        store = _store_with("s", [b"aa"])  # byte offset -> "..._0000000000000002"
+        cursor = poll(store, "s", cursor=None).cursor
+        store.delete("s")
+        store.create("s")
+        store.append("s", b"XX")  # same length -> same offset, different content
+        result = poll(store, "s", cursor=cursor)
+        assert result.status == "rewound"
+        assert [m.data for m in result.messages] == [b"XX"]

--- a/tests/test_rakaia/test_subscription.py
+++ b/tests/test_rakaia/test_subscription.py
@@ -93,22 +93,25 @@ class TestPoll:
         assert result.cursor is None
 
     @pytest.mark.xfail(
-        reason="offset-only rewind detection can't see a delete+recreate that "
-        "reuses the committed offset; needs a stream-generation token "
-        "(issue #11 / PR #33). Append-only streams are unaffected.",
+        reason="a delete+recreate that reuses the committed offset reads as "
+        "caught_up and silently skips the new content. The root-cause fix is "
+        "globally-monotonic store offsets (#34), after which recreated content "
+        "sorts past the cursor and is delivered as `advanced`. Append-only "
+        "streams — the intended use — are unaffected.",
         strict=True,
     )
-    def test_recreate_reusing_offset_should_rewind_not_silently_skip(self):
-        # Adversarial-review finding: a stream deleted and recreated so that its
-        # new head lands on the exact offset the consumer last committed reads as
-        # `caught_up`, silently dropping the new content. This pins the DESIRED
-        # behavior (rewound + redeliver); it flips green when the generation
-        # token lands, and strict xfail then flags the marker for removal.
+    def test_recreate_reusing_offset_is_not_silently_skipped(self):
+        # Adversarial-review finding: a stream deleted and recreated so its new
+        # head lands on the exact offset the consumer last committed reads as
+        # `caught_up`, dropping the new content. This pins "no silent skip"
+        # independent of the fix mechanism (globally-monotonic offsets -> the
+        # content is delivered as `advanced`; a generation token -> `rewound`).
+        # It flips to xpass once #34 lands; strict xfail then flags removal.
         store = _store_with("s", [b"aa"])  # byte offset -> "..._0000000000000002"
         cursor = poll(store, "s", cursor=None).cursor
         store.delete("s")
         store.create("s")
         store.append("s", b"XX")  # same length -> same offset, different content
         result = poll(store, "s", cursor=cursor)
-        assert result.status == "rewound"
-        assert [m.data for m in result.messages] == [b"XX"]
+        assert result.messages, "recreated content silently skipped (data loss)"
+        assert result.status != "caught_up"

--- a/tests/test_rakaia/test_subscription.py
+++ b/tests/test_rakaia/test_subscription.py
@@ -1,0 +1,91 @@
+"""Tests for rakaia.subscription: the per-consumer stream cursor / watermark.
+
+A subscriber tracks the last offset it consumed and polls for the delta since.
+`poll` derives its status purely from the stored cursor vs the stream head, so
+it is store-agnostic (works over any `ReadableStore` that also exposes
+`get_current_offset`) and — like everything else in rakaia — deterministic.
+"""
+
+from __future__ import annotations
+
+from rakaia.store import StreamStore
+from rakaia.subscription import poll
+
+
+def _store_with(path: str, payloads: list[bytes]) -> StreamStore:
+    store = StreamStore()
+    store.create(path)
+    for p in payloads:
+        store.append(path, p)
+    return store
+
+
+class TestPoll:
+    def test_fresh_subscriber_gets_everything(self):
+        store = _store_with("s", [b"a", b"b", b"c"])
+        result = poll(store, "s", cursor=None)
+        assert result.status == "fresh"
+        assert [m.data for m in result.messages] == [b"a", b"b", b"c"]
+        # Cursor advances to the tail so the next poll resumes after it.
+        assert result.cursor == store.get_current_offset("s")
+
+    def test_incremental_poll_returns_only_the_delta(self):
+        store = _store_with("s", [b"a", b"b"])
+        first = poll(store, "s", cursor=None)
+        store.append("s", b"c")
+        store.append("s", b"d")
+        second = poll(store, "s", cursor=first.cursor)
+        assert second.status == "advanced"
+        assert [m.data for m in second.messages] == [b"c", b"d"]
+        assert second.cursor == store.get_current_offset("s")
+
+    def test_caught_up_returns_no_messages(self):
+        store = _store_with("s", [b"a"])
+        first = poll(store, "s", cursor=None)
+        again = poll(store, "s", cursor=first.cursor)
+        assert again.status == "caught_up"
+        assert again.caught_up
+        assert again.messages == []
+        assert again.cursor == first.cursor  # unchanged
+
+    def test_no_gaps_or_dupes_across_repeated_polls(self):
+        store = _store_with("s", [])
+        seen: list[bytes] = []
+        cursor = None
+        for i in range(5):
+            store.append("s", f"e{i}".encode())
+            result = poll(store, "s", cursor=cursor)
+            seen.extend(m.data for m in result.messages)
+            cursor = result.cursor
+        assert seen == [b"e0", b"e1", b"e2", b"e3", b"e4"]
+
+    def test_empty_stream_is_fresh_then_caught_up(self):
+        store = StreamStore()
+        store.create("s")
+        first = poll(store, "s", cursor=None)
+        assert first.status == "fresh"
+        assert first.messages == []
+        assert first.cursor == store.get_current_offset("s")
+        assert poll(store, "s", cursor=first.cursor).status == "caught_up"
+
+    def test_rewound_when_cursor_is_beyond_head(self):
+        # Consume a longer stream, then truncate/rebuild it shorter (delete +
+        # recreate). The stored cursor now points past the new head, so the poll
+        # must report a rewind and re-read from the start.
+        store = _store_with("s", [b"a", b"b", b"c"])
+        stale = poll(store, "s", cursor=None).cursor
+        store.delete("s")
+        store.create("s")
+        store.append("s", b"a2")
+        result = poll(store, "s", cursor=stale)
+        assert result.status == "rewound"
+        assert result.rewound
+        assert [m.data for m in result.messages] == [b"a2"]  # re-read from start
+        assert result.cursor == store.get_current_offset("s")
+
+    def test_absent_stream_reports_absent(self):
+        store = StreamStore()
+        result = poll(store, "missing", cursor="0000000000000000_0000000000000009")
+        assert result.status == "absent"
+        assert result.messages == []
+        assert result.cursor is None

--- a/zensical.toml
+++ b/zensical.toml
@@ -26,6 +26,7 @@ nav = [
     { "Event envelope & provenance" = "event-envelope.md" },
     { "History read-model" = "history-read-model.md" },
     { "Alerts projection" = "alerts-projection.md" },
+    { "Subscriber cursors" = "subscriber-cursors.md" },
     { "Dry-run & executors" = "dry-run-and-executors.md" },
     { "pghistory retirement (spike)" = "pghistory-retirement.md" },
     { "Staged replay (spike)" = "staged-replay.md" },


### PR DESCRIPTION
Draft — the rakaia-side of **quick win #4** from #11 (Partisipa streams migration). Autonomous session; **not** for merge without review.

## Why
Most of #11's "unlock" already shipped (event envelope, history read-model + `recover_peak_snapshot`, the pghistory-retirement design doc; quick wins #1–#3 map to shipped primitives/examples). The one genuinely-unbuilt rakaia-side piece was **#4**: Partisipa's `sync_identity/watermarks.py` + `list_options(last_change_id)` hand-roll a per-consumer watermark + DB-rewind detection. Once `Submission` is a stream, that machinery *is* a subscriber cursor over stream offsets. This ships that primitive.

## What
**Core** — `rakaia.subscription.poll(store, path, cursor) -> Poll` (store-agnostic, pure over the store):
- `status ∈ {fresh, advanced, caught_up, rewound, absent}`; `Poll.messages` + `Poll.cursor` (new watermark).
- **Rewind detection**: cursor sorts past the head (truncation / delete+recreate) → re-read from start. Offsets compared **numerically** (parse the `_`-joined int parts), so it's correct even for the Django store's non-zero-padded offsets — `"10"` is later than `"2"` despite sorting before it lexicographically (a test pins exactly this).
- `poll` never advances; caller applies **then** commits → **at-least-once**.

**Durable (Django)** — `ConsumerCursor` model (`(consumer_id, stream_path) → offset`, migration `0003`) + `django_rakaia.subscription`: `load_cursor` / `commit_cursor` / `poll_consumer`.

**Docs** — `docs/subscriber-cursors.md` (+ nav/index), incl. the Partisipa `last_change_id` mapping.

## Tests (TDD)
7 core + 4 durable (`tests/test_rakaia/test_subscription.py`, `tests/test_django_rakaia/test_subscription.py`) — fresh/advance/caught-up/rewound/absent, no-gaps-no-dupes, resume-across-restart, and the unpadded-offset rewind case. **515 passed**, ruff check + format clean, migration graph clean.

## Known limitation (documented)
A stream deleted and re-grown *past* the old cursor before the next poll reads as a normal `advanced` — offsets alone can't see it; a stream-generation token would close it (future extension).

## Scope
rakaia repo only (primitive + docs + tests). Wiring the client sync protocol (frontend IndexedDB) onto this stays the Partisipa-side follow-on, as #11 notes.