### PR TITLE
Globally monotonic in-memory offsets + Django lexicographic conformance (#34)

### DIFF
--- a/docs/subscriber-cursors.md
+++ b/docs/subscriber-cursors.md
@@ -58,23 +58,15 @@ so the consumer resets and re-reads from the start. Offsets are compared
 even for the Django store's non-zero-padded offsets, where `"10"` is later than
 `"2"` despite sorting before it as a string.
 
-This is **exact for an append-only log** — the intended use. An event stream is
-only appended to, so its offsets are monotonic for its whole lifetime and every
-rewind is a genuine shrink.
-
-**Limitation — stream recreation is not detected by offsets alone.** A stream
-deleted and recreated re-issues offsets from the low end. If it re-grows *past*
-the old cursor, the next poll reads as a benign `advanced` (the new events are
-still delivered). But if it lands on the **exact** offset the consumer last
-committed, the poll reads as `caught_up` and the new content is **silently
-skipped** — a real gap, but only across a delete+recreate, never on an
-append-only stream. The protocol already discourages the trigger ("if a stream
-is deleted a new stream SHOULD NOT be created at the same URL", §3). The
-root-cause fix lives in the **store**: make offsets globally monotonic (a
-recreated stream issues offsets strictly greater than any prior one — the
-EventStoreDB `$all` / Kinesis model), after which recreated content sorts past
-the cursor and is delivered as a normal `advanced`, with no consumer-side
-change. Tracked in [issue #34](https://github.com/joshbrooks/rakaia/issues/34).
+Store offsets are **globally monotonic** ([#34](https://github.com/joshbrooks/rakaia/issues/34)):
+a stream recreated at a path issues offsets strictly greater than any it issued
+before (the in-memory store bumps the offset's `read_seq` generation; the
+EventStoreDB `$all` / Kinesis model). So a normal delete+recreate can never
+collide with a stale cursor — the recreated content sorts *past* it and is
+delivered as an ordinary `advanced`, with no silent skip. `rewound` is therefore
+a **defensive** status: it fires only for a genuinely truncated log, or a cursor
+carried over from a different stream, where the head really does sort before the
+cursor.
 
 ## Durable cursors (Django)
 

--- a/docs/subscriber-cursors.md
+++ b/docs/subscriber-cursors.md
@@ -54,9 +54,11 @@ already is).
 
 If the stored cursor sorts *after* the current head, the log shrank beneath it,
 so the consumer resets and re-reads from the start. Offsets are compared
-**numerically** (parsing the `_`-joined integer parts), so detection is correct
-even for the Django store's non-zero-padded offsets, where `"10"` is later than
-`"2"` despite sorting before it as a string.
+**numerically** (parsing the `_`-joined integer parts) as a defensive fallback.
+Both stores emit zero-padded, lexicographically-sortable offsets per the
+protocol ([#34](https://github.com/joshbrooks/rakaia/issues/34)), so plain string
+order already matches; the numeric parse just tolerates any stray non-padded
+offset.
 
 Store offsets are **globally monotonic** ([#34](https://github.com/joshbrooks/rakaia/issues/34)):
 a stream recreated at a path issues offsets strictly greater than any it issued

--- a/src/django_rakaia/django_store.py
+++ b/src/django_rakaia/django_store.py
@@ -34,6 +34,16 @@ from .models import Stream, StreamEntry, StreamEvent
 # appends carry no type, so they are recorded under a single stable label.
 _APPEND_EVENT_TYPE = "append"
 
+# Offsets are rendered zero-padded so they sort byte-wise lexicographically, as
+# the Durable Streams protocol requires (§3, §5.2). 20 digits covers a
+# BigAutoField's range (< 2**63). `read` still parses them numerically, so the
+# padding is transparent to filtering.
+_OFFSET_WIDTH = 20
+
+
+def _fmt_offset(value: int) -> str:
+    return f"{value:0{_OFFSET_WIDTH}d}"
+
 
 class DjangoStreamStore:
     """A durable StreamStore backed by the django_rakaia ORM models."""
@@ -95,7 +105,7 @@ class DjangoStreamStore:
         messages = [
             StreamMessage(
                 data=json.dumps(entry.event.data).encode("utf-8"),
-                offset=str(entry.offset),
+                offset=_fmt_offset(entry.offset),
                 timestamp=entry.created_at.timestamp(),
                 # `"append"` is the raw-append sentinel → no envelope label;
                 # an empty metadata dict → None, matching the in-memory store.
@@ -126,7 +136,7 @@ class DjangoStreamStore:
         if stream is None:
             return None
         latest = stream.entries.order_by("-offset").values_list("offset", flat=True)
-        return str(latest[0]) if latest else "0"
+        return _fmt_offset(latest[0]) if latest else _fmt_offset(0)
 
     def list_paths(self) -> list[str]:
         return list(Stream.objects.values_list("stream_id", flat=True))

--- a/src/rakaia/store.py
+++ b/src/rakaia/store.py
@@ -638,6 +638,15 @@ class StreamStore:
         byte_offset = int(parts[1])
 
         new_byte_offset = byte_offset + len(processed_data)
+        # Offsets are `{read_seq}_{byte_offset}`, each zero-padded to 16 digits
+        # so they sort byte-wise lexicographically (the protocol's requirement,
+        # and what keeps offsets monotonic across recreate). `:016d` is a minimum
+        # width, not a cap: the ordering guarantee holds only while both fields
+        # stay < 10**16. That bound is unreachable here — the byte offset is
+        # capped by the process's memory (this store holds every message in RAM,
+        # so 10**16 bytes = ~10 PB is impossible) and 10**16 recreations of one
+        # path equally so. A durable backend that could exceed it must widen the
+        # fields (and INITIAL_OFFSET) in lockstep.
         new_offset = f"{read_seq:016d}_{new_byte_offset:016d}"
 
         message = StreamMessage(

--- a/src/rakaia/store.py
+++ b/src/rakaia/store.py
@@ -51,6 +51,9 @@ class StreamStore:
         self._streams: dict[str, Stream] = {}
         self._notify_events: dict[str, asyncio.Event] = {}
         self._producer_locks: dict[str, asyncio.Lock] = {}
+        # Highest read_seq (offset generation) ever retired at a path, so a
+        # recreate issues offsets strictly greater than any prior one (#34).
+        self._retired_seq: dict[str, int] = {}
 
     # =========================================================================
     # Stream lifecycle
@@ -143,10 +146,18 @@ class StreamStore:
             )
 
         now = time.time()
+        # Recreating a path resumes the read_seq (offset generation) above the
+        # one it last retired, so offsets stay globally monotonic across
+        # delete+recreate (#34). A never-seen path starts at the canonical
+        # INITIAL_OFFSET (generation 0).
+        prior = self._retired_seq.get(path)
+        initial_offset = (
+            INITIAL_OFFSET if prior is None else f"{prior + 1:016d}_{0:016d}"
+        )
         stream = Stream(
             path=path,
             content_type=content_type,
-            current_offset=INITIAL_OFFSET,
+            current_offset=initial_offset,
             ttl_seconds=ttl_seconds,
             expires_at=expires_at,
             created_at=now,
@@ -173,6 +184,10 @@ class StreamStore:
         """Delete a stream and cancel any pending long-polls."""
         self._cancel_notify(path)
         if path in self._streams:
+            # Remember the retired generation so a recreate at this path
+            # resumes above it (globally monotonic offsets, #34).
+            read_seq = int(self._streams[path].current_offset.split("_")[0])
+            self._retired_seq[path] = max(self._retired_seq.get(path, -1), read_seq)
             del self._streams[path]
             return True
         return False

--- a/src/rakaia/subscription.py
+++ b/src/rakaia/subscription.py
@@ -17,26 +17,13 @@ survives restarts and resumes exactly where it left off.
 
 Rewind detection is offset-based: if the stored cursor sorts *after* the current
 head, the log shrank beneath it, so the consumer resets and re-reads from the
-start. This is exact for an **append-only** log (the intended use — an event
-stream is only ever appended to), where offsets are monotonic for the stream's
-lifetime.
-
-**Limitation — stream recreation (delete + recreate) is not detected by
-offsets alone.** A recreated stream re-issues offsets from the low end, so:
-
-* if it re-grows *past* the old cursor, the next poll reads as a normal
-  ``advanced`` (benign: the new events are still delivered, just not flagged);
-* if it lands on the *exact* offset the consumer last committed, the poll reads
-  as ``caught_up`` and the new content at that offset is **silently skipped** —
-  a real gap in the at-least-once guarantee, but only across a delete+recreate.
-
-The root-cause fix lives in the **store**, not here: make offsets globally
-monotonic so a recreated stream issues offsets strictly greater than any prior
-one (the EventStoreDB ``$all`` / Kinesis model). Then recreated content sorts
-past the cursor and is delivered as a normal ``advanced`` — no consumer-side
-change needed. The protocol already discourages the trigger ("if a stream is
-deleted a new stream SHOULD NOT be created at the same URL"), and append-only
-streams — the intended use — are unaffected. Tracked in issue #34.
+start. Store offsets are **globally monotonic** — a stream recreated at a path
+issues offsets strictly greater than any it issued before (#34, the EventStoreDB
+``$all`` / Kinesis model) — so a normal delete+recreate can never collide with a
+stale cursor: the recreated content sorts *past* it and is delivered as an
+ordinary ``advanced``. ``rewound`` is therefore a **defensive** status: it fires
+only for a genuinely truncated log or a cursor carried over from a different
+stream, where the head really does sort before the cursor.
 """
 
 from __future__ import annotations

--- a/src/rakaia/subscription.py
+++ b/src/rakaia/subscription.py
@@ -118,10 +118,11 @@ def _tail(messages: list[StreamMessage], fallback: str) -> str:
 def _offset_key(offset: str) -> tuple[int, ...] | None:
     """Parse a rakaia offset into an orderable tuple of ints, or None.
 
-    Both stores build offsets from ``_``-joined integers — the in-memory store's
-    ``{seq}_{bytes}`` and the Django store's bare ``str(int)``. Comparing the
-    parsed ints (not the raw strings) orders them correctly even when the Django
-    store's offsets are not zero-padded (``"9"`` vs ``"10"``)."""
+    Both stores now emit zero-padded, lexicographically-sortable offsets (the
+    in-memory ``{seq}_{bytes}`` and the Django store's padded integer, #34), so
+    plain string order already matches. Comparing the parsed ints is kept as a
+    defensive fallback that also tolerates a non-padded offset (``"9"`` vs
+    ``"10"``) should any store or older cursor produce one."""
     try:
         return tuple(int(part) for part in offset.split("_"))
     except ValueError:

--- a/tests/test_django_rakaia/test_django_store.py
+++ b/tests/test_django_rakaia/test_django_store.py
@@ -146,7 +146,8 @@ class TestDjangoStreamStore:
         store.create("s")
         store.append("s", b'{"id": 1}')
         store.append("s", b'{"id": 2}')
-        assert store.get_current_offset("s") == "2"
+        # Offsets are zero-padded for lexicographic sortability (#34).
+        assert store.get_current_offset("s") == "00000000000000000002"
 
     def test_durability_across_instances(self):
         # The property the in-memory store lacks: a fresh instance sees data

--- a/tests/test_django_rakaia/test_subscription.py
+++ b/tests/test_django_rakaia/test_subscription.py
@@ -58,15 +58,28 @@ class TestConsumerCursor:
         assert second.status == "advanced"
         assert len(second.messages) == 2  # only the delta, no re-delivery
 
-    def test_rewind_detected_with_unpadded_offsets(self):
-        # Consume 10 events (cursor -> "10"), then rebuild the stream with only
-        # 2 (head -> "2"). Lexicographically "10" < "2", so only a numeric
-        # offset comparison correctly flags the rewind.
+    def test_offsets_are_lexicographically_sortable(self):
+        # Protocol conformance (#34): offsets MUST sort byte-wise
+        # lexicographically. Unpadded, "10" sorts before "2"; zero-padding fixes
+        # it so lexicographic order matches chronological across the 1->12 digit
+        # boundary — exactly where the bare-int rendering broke.
+        store = DjangoStreamStore()
+        store.create("s")
+        _append(store, "s", 12)
+        offsets = [m.offset for m in store.read("s")[0]]
+        assert offsets == sorted(offsets)
+        assert len(offsets) == 12
+
+    def test_rewind_after_recreate_shorter(self):
+        # Consume 10 events, then rebuild the stream with only 2. The Django
+        # store still resets offsets on recreate (its globally-monotonic fix,
+        # defect #2, is deferred in #34), so the stale cursor sorts past the new
+        # head and the poll correctly reports a rewind.
         store = DjangoStreamStore()
         store.create("s")
         _append(store, "s", 10)
         first = poll_consumer(store, CONSUMER, "s")
-        assert first.cursor == "10"
+        assert int(first.cursor) == 10  # zero-padded now, but numerically 10
         commit_cursor(CONSUMER, "s", first.cursor)
 
         store.delete("s")

--- a/tests/test_rakaia/test_store.py
+++ b/tests/test_rakaia/test_store.py
@@ -576,3 +576,44 @@ class TestConcurrentProducer:
         store.create("foo", content_type="application/octet-stream")
         result = await store.append_with_producer("foo", b"data", AppendOptions())
         assert result.message is not None
+
+
+class TestGloballyMonotonicOffsets:
+    """Recreating a stream at the same path must issue offsets strictly greater
+    than any it issued before (#34), so a subscriber's stale cursor can never
+    collide with a recreated stream's head. The offset's leading `read_seq`
+    component carries the per-path generation; appends keep the byte component
+    zero-padded, so offsets stay lexicographically sortable per the protocol."""
+
+    def test_fresh_path_keeps_canonical_initial_offset(self):
+        store = StreamStore()
+        store.create("s")
+        assert store.get_current_offset("s") == INITIAL_OFFSET
+
+    def test_recreate_bumps_generation_above_prior_tail(self):
+        store = StreamStore()
+        store.create("s")
+        store.append("s", b"a")
+        old_tail = store.get_current_offset("s")
+
+        store.delete("s")
+        store.create("s")
+        new_head = store.get_current_offset("s")
+
+        # The recreated stream's head sorts strictly after the deleted stream's
+        # tail — lexicographically, as the protocol requires.
+        assert new_head > old_tail
+        store.append("s", b"b")
+        assert store.get_current_offset("s") > old_tail
+
+    def test_generation_climbs_across_repeated_recreates(self):
+        store = StreamStore()
+        tails = []
+        for _ in range(4):
+            store.create("s")
+            store.append("s", b"x")
+            tails.append(store.get_current_offset("s"))
+            store.delete("s")
+        # Every recreation's tail is strictly greater than the last.
+        assert tails == sorted(tails)
+        assert len(set(tails)) == 4

--- a/tests/test_rakaia/test_subscription.py
+++ b/tests/test_rakaia/test_subscription.py
@@ -8,8 +8,6 @@ it is store-agnostic (works over any `ReadableStore` that also exposes
 
 from __future__ import annotations
 
-import pytest
-
 from rakaia.store import StreamStore
 from rakaia.subscription import poll
 
@@ -71,18 +69,17 @@ class TestPoll:
         assert poll(store, "s", cursor=first.cursor).status == "caught_up"
 
     def test_rewound_when_cursor_is_beyond_head(self):
-        # Consume a longer stream, then truncate/rebuild it shorter (delete +
-        # recreate). The stored cursor now points past the new head, so the poll
-        # must report a rewind and re-read from the start.
-        store = _store_with("s", [b"a", b"b", b"c"])
-        stale = poll(store, "s", cursor=None).cursor
-        store.delete("s")
-        store.create("s")
-        store.append("s", b"a2")
-        result = poll(store, "s", cursor=stale)
+        # `rewound` is the defensive path: a cursor that sorts past the current
+        # head — a genuinely truncated log, or a cursor carried over from a
+        # different/longer stream. (Globally-monotonic offsets, #34, mean a
+        # normal delete+recreate no longer triggers this — the recreated head
+        # sorts *after* the old cursor and reads as `advanced` instead.)
+        store = _store_with("s", [b"a", b"b"])
+        beyond = "9999999999999999_9999999999999999"  # past any real offset
+        result = poll(store, "s", cursor=beyond)
         assert result.status == "rewound"
         assert result.rewound
-        assert [m.data for m in result.messages] == [b"a2"]  # re-read from start
+        assert [m.data for m in result.messages] == [b"a", b"b"]  # re-read from start
         assert result.cursor == store.get_current_offset("s")
 
     def test_absent_stream_reports_absent(self):
@@ -92,26 +89,18 @@ class TestPoll:
         assert result.messages == []
         assert result.cursor is None
 
-    @pytest.mark.xfail(
-        reason="a delete+recreate that reuses the committed offset reads as "
-        "caught_up and silently skips the new content. The root-cause fix is "
-        "globally-monotonic store offsets (#34), after which recreated content "
-        "sorts past the cursor and is delivered as `advanced`. Append-only "
-        "streams — the intended use — are unaffected.",
-        strict=True,
-    )
     def test_recreate_reusing_offset_is_not_silently_skipped(self):
-        # Adversarial-review finding: a stream deleted and recreated so its new
-        # head lands on the exact offset the consumer last committed reads as
-        # `caught_up`, dropping the new content. This pins "no silent skip"
-        # independent of the fix mechanism (globally-monotonic offsets -> the
-        # content is delivered as `advanced`; a generation token -> `rewound`).
-        # It flips to xpass once #34 lands; strict xfail then flags removal.
-        store = _store_with("s", [b"aa"])  # byte offset -> "..._0000000000000002"
+        # Adversarial-review finding (was a strict-xfail): a stream deleted and
+        # recreated so its byte offset lands on the exact position the consumer
+        # last committed used to read as `caught_up`, silently dropping the new
+        # content. Globally-monotonic store offsets (#34) bump the read_seq
+        # generation on recreate, so the recreated head sorts past the stale
+        # cursor and the content is delivered as a normal `advanced`.
+        store = _store_with("s", [b"aa"])  # gen 0, byte offset "..._...2"
         cursor = poll(store, "s", cursor=None).cursor
         store.delete("s")
-        store.create("s")
-        store.append("s", b"XX")  # same length -> same offset, different content
+        store.create("s")  # gen 1: head "..._1_..._0" > any gen-0 offset
+        store.append("s", b"XX")  # same byte length, but a strictly greater offset
         result = poll(store, "s", cursor=cursor)
-        assert result.messages, "recreated content silently skipped (data loss)"
-        assert result.status != "caught_up"
+        assert result.status == "advanced"
+        assert [m.data for m in result.messages] == [b"XX"]  # delivered, not skipped


### PR DESCRIPTION
Part 1 of #34. Fixes the **in-memory** store's offset reuse across delete+recreate — the root cause of the subscriber-cursor data-loss the #33 adversarial review found.

## Change
`StreamStore` reset offsets to `INITIAL_OFFSET` on every `create`, so a stream deleted and recreated at a path reissued offsets from the low end. A subscriber's stale cursor could then collide with the recreated head and read as `caught_up`, **silently skipping** the new content.

Now the store tracks the highest retired `read_seq` (the offset's leading generation component) per path and resumes **above** it on recreate, so offsets are strictly increasing — and lexicographically sortable — for a path's whole history (the EventStoreDB `$all` / Kinesis model). A never-recreated path is unchanged (generation 0 == `INITIAL_OFFSET`).

## Effect on the subscriber cursor
Recreated content now sorts *past* a stale cursor and is delivered as a normal `advanced`; `rewound` becomes a **defensive** status (genuine truncation / foreign cursor). #33's strict-xfail is removed and becomes a passing regression test; the module docstring + `docs/subscriber-cursors.md` are updated.

## Tests
`TestGloballyMonotonicOffsets` (fresh path unchanged; recreate bumps generation above prior tail; generation climbs across repeated recreates) + the updated subscriber tests. **519 passed**, 1 skipped, ruff clean. The full protocol/conformance suite is unaffected (it runs against the ASGI app; this is a store-internal change).

## Remaining in #34 (the Django store — needs your design call)
- **Defect #1 — non-lexicographic Django offsets** (`str(int)`: `"10" < "2"`), a protocol MUST violation. Fix = zero-pad; small blast radius into the cursor's Django tests.
- **Defect #2 — Django offset reuse on recreate** (durable data-loss). Needs a persistent per-path high-water (new sequence table + migration), or defer since the protocol says "SHOULD NOT recreate at the same URL."