### PR TITLE
feat(upcaster): content-routing via match_field (#37)

### DIFF
--- a/src/rakaia/registry.py
+++ b/src/rakaia/registry.py
@@ -582,7 +582,11 @@ class UpcasterRegistry:
             raise UpcasterConflictError(
                 f"Upcaster already registered for event_match={event_match!r}, "
                 f"from_version={from_version} (existing dotted_path="
-                f"{existing.dotted_path!r}, new={new.dotted_path!r})"
+                f"{existing.dotted_path!r} match_field={existing.match_field!r}, "
+                f"new dotted_path={new.dotted_path!r} match_field={new.match_field!r})."
+                " The (event_match, from_version) key ignores match_field, so a "
+                "stream-routed and a content-routed upcaster cannot share it — "
+                "give them distinct event_match patterns."
             )
 
         if self._store is not None:
@@ -595,11 +599,23 @@ class UpcasterRegistry:
         up: UpcasterVersion, event: dict[str, Any] | None, event_match_str: str
     ) -> str:
         """The string an upcaster's pattern is matched against: a content field
-        when `match_field` is set (mirrors handler routing), else the stream/
-        event-match string. A content-routed upcaster with no event to read
-        yields "" (so it simply does not match)."""
+        when `match_field` is set (mirrors `HandlerRegistry._match_subject`), else
+        the stream/event-match string.
+
+        A content-routed upcaster matched with `event=None` raises — like handler
+        dispatch — to catch a caller who forgot to pass the event (which would
+        otherwise leave the event silently un-upcast). An event that is present
+        but lacks the field yields "" and simply does not match (a different
+        form_type on the stream is normal, not an error)."""
         if up.match_field is not None:
-            return str((event or {}).get(up.match_field, ""))
+            if event is None:
+                raise ValueError(
+                    f"Upcaster (event_match={up.event_match!r}) routes on "
+                    f"match_field={up.match_field!r} but was matched without an "
+                    "event; pass the decoded event to current_version()/"
+                    "apply_chain() (or use upcast_to_current)."
+                )
+            return str(event.get(up.match_field, ""))
         return event_match_str
 
     def current_version(
@@ -634,6 +650,13 @@ class UpcasterRegistry:
         (default 1). Each step finds the upcaster matching the event_match (or
         `event[match_field]` for content-routed upcasters) and the current
         version, then bumps schema_version on the result.
+
+        Content-routing note: each step is re-matched against the *progressively
+        upcasted* event, so a content-routed chain's `match_field` discriminator
+        must stay stable across the chain. An upcaster that renames or rewrites
+        the discriminator (e.g. v1→v2 renaming `form_type`) re-routes subsequent
+        steps off the new value — keep the discriminator field constant, or route
+        those steps on the stream path.
 
         If `drift_callback` is provided, it is called once per step with
         `(version, current_hash)` if the upcaster's source hash has changed

--- a/src/rakaia/registry.py
+++ b/src/rakaia/registry.py
@@ -519,6 +519,12 @@ class UpcasterVersion:
     dotted_path: str
     source_hash: str
 
+    match_field: str | None = None
+    """When set, the ``event_match`` pattern is tested against
+    ``event[match_field]`` (content routing) instead of the stream/event-match
+    string — mirrors ``register_handler``, so a per-form upcaster can route on a
+    per-entity stream (e.g. ``submissions:<uuid>``) whose path carries no type."""
+
 
 class UpcasterRegistry:
     """
@@ -537,7 +543,7 @@ class UpcasterRegistry:
         self._upcasters: dict[tuple[str, int], UpcasterVersion] = {}
         self._store = store
         self._stream_path = stream_path
-        self._persisted_ids: set[tuple[str, int, str, str]] = set()
+        self._persisted_ids: set[tuple[str, int, str, str, str | None]] = set()
         if store is not None:
             self._ensure_stream()
             self._load_persisted_ids()
@@ -547,8 +553,15 @@ class UpcasterRegistry:
         event_match: str,
         from_version: int,
         fn: Callable[[dict[str, Any]], dict[str, Any]],
+        *,
+        match_field: str | None = None,
     ) -> UpcasterVersion:
-        """Register an upcaster from `from_version` to `from_version + 1`."""
+        """Register an upcaster from `from_version` to `from_version + 1`.
+
+        When `match_field` is set, the `event_match` pattern is tested against
+        `event[match_field]` (content routing) instead of the stream/event-match
+        string, so a per-form upcaster can route on a per-entity stream.
+        """
         if from_version < 1:
             raise ValueError(f"from_version must be >= 1, got {from_version}")
 
@@ -558,6 +571,7 @@ class UpcasterRegistry:
             fn=fn,
             dotted_path=f"{fn.__module__}.{fn.__qualname__}",
             source_hash=hash_function_source(fn),
+            match_field=match_field,
         )
 
         key = (event_match, from_version)
@@ -576,12 +590,30 @@ class UpcasterRegistry:
         self._upcasters[key] = new
         return new
 
-    def current_version(self, event_match_str: str) -> int:
-        """Highest schema version reachable for an event matching this string."""
+    @staticmethod
+    def _subject(
+        up: UpcasterVersion, event: dict[str, Any] | None, event_match_str: str
+    ) -> str:
+        """The string an upcaster's pattern is matched against: a content field
+        when `match_field` is set (mirrors handler routing), else the stream/
+        event-match string. A content-routed upcaster with no event to read
+        yields "" (so it simply does not match)."""
+        if up.match_field is not None:
+            return str((event or {}).get(up.match_field, ""))
+        return event_match_str
+
+    def current_version(
+        self, event_match_str: str, event: dict[str, Any] | None = None
+    ) -> int:
+        """Highest schema version reachable for an event matching this string.
+
+        Pass `event` so content-routed upcasters (registered with `match_field`)
+        match against `event[match_field]`; without it they are skipped.
+        """
         matching_froms = [
             fv
-            for (pattern, fv) in self._upcasters
-            if fnmatch.fnmatchcase(event_match_str, pattern)
+            for (pattern, fv), up in self._upcasters.items()
+            if fnmatch.fnmatchcase(self._subject(up, event, event_match_str), pattern)
         ]
         if not matching_froms:
             return 1
@@ -599,8 +631,9 @@ class UpcasterRegistry:
         Upcast `event` from its current schema_version up to `target_version`.
 
         The event's current version is read from event["schema_version"]
-        (default 1). Each step finds the upcaster matching the event_match
-        and the current version, then bumps schema_version on the result.
+        (default 1). Each step finds the upcaster matching the event_match (or
+        `event[match_field]` for content-routed upcasters) and the current
+        version, then bumps schema_version on the result.
 
         If `drift_callback` is provided, it is called once per step with
         `(version, current_hash)` if the upcaster's source hash has changed
@@ -616,7 +649,10 @@ class UpcasterRegistry:
             matching = [
                 up
                 for (pattern, fv), up in self._upcasters.items()
-                if fv == current and fnmatch.fnmatchcase(event_match_str, pattern)
+                if fv == current
+                and fnmatch.fnmatchcase(
+                    self._subject(up, event, event_match_str), pattern
+                )
             ]
             if not matching:
                 raise UpcasterChainError(
@@ -652,7 +688,7 @@ class UpcasterRegistry:
         step every consumer outside `replay()` needs. Returns the event unchanged
         when no upcasters apply or it is already current.
         """
-        target = self.current_version(event_match_str)
+        target = self.current_version(event_match_str, event)
         return self.apply_chain(
             event, event_match_str, target, drift_callback=drift_callback
         )
@@ -697,6 +733,7 @@ class UpcasterRegistry:
             "from_version": version.from_version,
             "dotted_path": version.dotted_path,
             "source_hash": version.source_hash,
+            "match_field": version.match_field,
         }
         self._store.append(
             self._stream_path,
@@ -750,16 +787,20 @@ def _reducer_identity_from_payload(p: dict[str, Any]) -> tuple[str, int, str, st
     return (p["name"], int(p["stage"]), p["dotted_path"], p["source_hash"])
 
 
-def _u_identity(v: UpcasterVersion) -> tuple[str, int, str, str]:
-    return (v.event_match, v.from_version, v.dotted_path, v.source_hash)
+def _u_identity(v: UpcasterVersion) -> tuple[str, int, str, str, str | None]:
+    # match_field appended last so rehydrate()'s ident[2] (dotted_path) stays valid.
+    return (v.event_match, v.from_version, v.dotted_path, v.source_hash, v.match_field)
 
 
-def _u_identity_from_payload(p: dict[str, Any]) -> tuple[str, int, str, str]:
+def _u_identity_from_payload(
+    p: dict[str, Any],
+) -> tuple[str, int, str, str, str | None]:
     return (
         p["event_match"],
         int(p["from_version"]),
         p["dotted_path"],
         p["source_hash"],
+        p.get("match_field"),  # tolerate pre-match_field persisted payloads
     )
 
 
@@ -882,6 +923,7 @@ def register_upcaster(
     event_match: str,
     from_version: int,
     *,
+    match_field: str | None = None,
     registry: UpcasterRegistry | None = None,
 ) -> Callable[
     [Callable[[dict[str, Any]], dict[str, Any]]],
@@ -890,17 +932,32 @@ def register_upcaster(
     """
     Decorator that registers an upcaster from `from_version` to `from_version+1`.
 
+    By default `event_match` is matched against the stream/event-match string.
+    Set `match_field` to match it against `event[match_field]` instead (content
+    routing, mirroring `register_handler`) — so a per-form upcaster can route on
+    a per-entity stream (e.g. `submissions:<uuid>`) whose path carries no type.
+
     Example:
         @register_upcaster(event_match="room:*:messages", from_version=1)
         def upcast_room_v1_to_v2(event: dict) -> dict:
             return {**event, "currency": "USD"}
+
+        @register_upcaster(event_match="TF_13_2_1", from_version=1,
+                           match_field="form_type")
+        def upcast_tf1321_v1_to_v2(event: dict) -> dict:
+            return {**event, ...}
     """
     target = registry if registry is not None else _default_upcaster_registry
 
     def decorator(
         fn: Callable[[dict[str, Any]], dict[str, Any]],
     ) -> Callable[[dict[str, Any]], dict[str, Any]]:
-        target.register(event_match=event_match, from_version=from_version, fn=fn)
+        target.register(
+            event_match=event_match,
+            from_version=from_version,
+            fn=fn,
+            match_field=match_field,
+        )
         return fn
 
     return decorator

--- a/src/rakaia/replay.py
+++ b/src/rakaia/replay.py
@@ -163,7 +163,6 @@ def replay(
     match_str = event_match if event_match is not None else stream_path
 
     messages, _ = store.read(stream_path)
-    target_version = upcasters.current_version(match_str)
 
     result = ReplayResult()
 
@@ -178,10 +177,11 @@ def replay(
         )
 
     def _decode_upcast(seq: int, data: bytes) -> dict:
-        return upcasters.apply_chain(
+        # Target version is resolved per event so content-routed upcasters
+        # (match_field) can key off the event body, not just the stream path.
+        return upcasters.upcast_to_current(
             _decode_event(data, stream_path, seq),
             match_str,
-            target_version,
             drift_callback=_upcaster_drift,
         )
 
@@ -304,13 +304,12 @@ def merge_replay(
     tagged: list[tuple[tuple[Any, str, int], str, dict]] = []
     for path in stream_paths:
         match_str = event_match if event_match is not None else path
-        target_version = upcasters.current_version(match_str)
         messages, _ = store.read(path)
         for offset, msg in enumerate(messages):
-            upcasted = upcasters.apply_chain(
+            # per-event target so content-routed (match_field) upcasters resolve
+            upcasted = upcasters.upcast_to_current(
                 _decode_event(msg.data, path, offset),
                 match_str,
-                target_version,
                 drift_callback=_upcaster_drift,
             )
             if order_key not in upcasted:

--- a/tests/test_rakaia/test_upcasters.py
+++ b/tests/test_rakaia/test_upcasters.py
@@ -197,6 +197,11 @@ def _sf_v1_to_v2(event: dict) -> dict:
     return {**event, "sf_touched": True}
 
 
+def _tf_v2_to_v3(event: dict) -> dict:
+    # preserves form_type (the discriminator) so content-routing survives the chain
+    return {**event, "v3": True}
+
+
 class TestContentRouting:
     """match_field: route the pattern against event[match_field] (e.g. form_type)
     instead of the stream/event-match string — so per-form upcasters work on a
@@ -204,11 +209,19 @@ class TestContentRouting:
 
     def test_current_version_matches_on_content_field(self, reg: UpcasterRegistry):
         reg.register("TF_13_2_1", 1, _tf_v1_to_v2, match_field="form_type")
-        # path string alone can't resolve a content-routed upcaster
-        assert reg.current_version("submissions:abc") == 1
         # with the event, it routes on form_type
         assert reg.current_version("submissions:abc", {"form_type": "TF_13_2_1"}) == 2
+        # present-but-non-matching form_type is a normal no-match, not an error
         assert reg.current_version("submissions:abc", {"form_type": "SF_1_1"}) == 1
+
+    def test_content_routed_without_event_raises(self, reg: UpcasterRegistry):
+        # mirrors HandlerRegistry: a content-routed registration matched without
+        # an event is a caller bug (the event would silently stay un-upcast).
+        # The framework always passes the event (upcast_to_current), so this only
+        # bites callers of current_version()/apply_chain() who omit it.
+        reg.register("TF_13_2_1", 1, _tf_v1_to_v2, match_field="form_type")
+        with pytest.raises(ValueError, match="match_field='form_type'"):
+            reg.current_version("submissions:abc")
 
     def test_apply_chain_content_routed(self, reg: UpcasterRegistry):
         reg.register("TF_13_2_1", 1, _tf_v1_to_v2, match_field="form_type")
@@ -251,6 +264,35 @@ class TestContentRouting:
             return {**event, "hit": True}
 
         assert reg.all_upcasters()[0].match_field == "form_type"
+
+    def test_multi_step_content_routed_chain(self, reg: UpcasterRegistry):
+        # v1->v2->v3, both steps content-routed; discriminator preserved so
+        # routing survives the whole chain.
+        reg.register("TF_13_2_1", 1, _tf_v1_to_v2, match_field="form_type")
+        reg.register("TF_13_2_1", 2, _tf_v2_to_v3, match_field="form_type")
+        out = reg.upcast_to_current(
+            {"schema_version": 1, "form_type": "TF_13_2_1"}, "submissions:abc"
+        )
+        assert out["schema_version"] == 3
+        assert out["quantized"] is True and out["v3"] is True
+
+    def test_stream_and_content_routed_same_key_conflicts(self, reg: UpcasterRegistry):
+        # (event_match, from_version) ignores match_field, so a stream-routed and
+        # a content-routed upcaster can't share it — converting one to the other
+        # under the same identifiers is a migration foot-gun that must fail loudly,
+        # naming match_field as the differentiator.
+        reg.register("TF_13_2_1", 1, _tf_v1_to_v2)  # stream-routed
+        with pytest.raises(UpcasterConflictError, match="match_field"):
+            reg.register("TF_13_2_1", 1, _tf_v1_to_v2, match_field="form_type")
+
+    def test_content_routed_ambiguous_match_raises(self, reg: UpcasterRegistry):
+        # two content-routed patterns that both match one event → ambiguous chain.
+        reg.register("TF_*", 1, _tf_v1_to_v2, match_field="form_type")
+        reg.register("TF_13_*", 1, _sf_v1_to_v2, match_field="form_type")
+        with pytest.raises(UpcasterChainError, match="Multiple upcasters match"):
+            reg.upcast_to_current(
+                {"schema_version": 1, "form_type": "TF_13_2_1"}, "submissions:abc"
+            )
 
 
 class TestUpcastToCurrent:

--- a/tests/test_rakaia/test_upcasters.py
+++ b/tests/test_rakaia/test_upcasters.py
@@ -189,6 +189,70 @@ class TestDecorator:
         assert my_upcaster({"a": 1}) == {"a": 1, "tag": "x"}
 
 
+def _tf_v1_to_v2(event: dict) -> dict:
+    return {**event, "quantized": True}
+
+
+def _sf_v1_to_v2(event: dict) -> dict:
+    return {**event, "sf_touched": True}
+
+
+class TestContentRouting:
+    """match_field: route the pattern against event[match_field] (e.g. form_type)
+    instead of the stream/event-match string — so per-form upcasters work on a
+    per-entity stream (submissions:<uuid>) whose path carries no type."""
+
+    def test_current_version_matches_on_content_field(self, reg: UpcasterRegistry):
+        reg.register("TF_13_2_1", 1, _tf_v1_to_v2, match_field="form_type")
+        # path string alone can't resolve a content-routed upcaster
+        assert reg.current_version("submissions:abc") == 1
+        # with the event, it routes on form_type
+        assert reg.current_version("submissions:abc", {"form_type": "TF_13_2_1"}) == 2
+        assert reg.current_version("submissions:abc", {"form_type": "SF_1_1"}) == 1
+
+    def test_apply_chain_content_routed(self, reg: UpcasterRegistry):
+        reg.register("TF_13_2_1", 1, _tf_v1_to_v2, match_field="form_type")
+        event = {"schema_version": 1, "form_type": "TF_13_2_1", "x": 1}
+        out = reg.upcast_to_current(event, "submissions:abc")
+        assert out["schema_version"] == 2
+        assert out["quantized"] is True
+
+    def test_non_matching_form_type_is_untouched(self, reg: UpcasterRegistry):
+        reg.register("TF_13_2_1", 1, _tf_v1_to_v2, match_field="form_type")
+        event = {"form_type": "SF_1_1", "x": 1}
+        out = reg.upcast_to_current(event, "submissions:abc")
+        assert out == event  # no upcaster matched → unchanged, no schema bump
+
+    def test_two_form_types_route_independently(self, reg: UpcasterRegistry):
+        # Both keyed on the same per-entity path family, discriminated by form_type.
+        reg.register("TF_13_2_1", 1, _tf_v1_to_v2, match_field="form_type")
+        reg.register("SF_1_1", 1, _sf_v1_to_v2, match_field="form_type")
+        tf = reg.upcast_to_current({"form_type": "TF_13_2_1"}, "submissions:abc")
+        sf = reg.upcast_to_current({"form_type": "SF_1_1"}, "submissions:def")
+        assert tf.get("quantized") and "sf_touched" not in tf
+        assert sf.get("sf_touched") and "quantized" not in sf
+
+    def test_persistence_round_trips_match_field(self):
+        store = StreamStore()
+        reg1 = UpcasterRegistry(store=store)
+        reg1.register("TF_13_2_1", 1, _tf_v1_to_v2, match_field="form_type")
+        payload = json.loads(store.read(UPCASTERS_META_STREAM)[0][0].data)
+        assert payload["match_field"] == "form_type"
+        # a fresh registry over the same store dedups the identical registration
+        reg2 = UpcasterRegistry(store=store)
+        reg2.register("TF_13_2_1", 1, _tf_v1_to_v2, match_field="form_type")
+        assert len(store.read(UPCASTERS_META_STREAM)[0]) == 1
+
+    def test_decorator_passes_match_field(self):
+        reg = UpcasterRegistry()
+
+        @register_upcaster("TF_13_2_1", 1, match_field="form_type", registry=reg)
+        def up(event):
+            return {**event, "hit": True}
+
+        assert reg.all_upcasters()[0].match_field == "form_type"
+
+
 class TestUpcastToCurrent:
     def test_applies_full_chain(self, reg: UpcasterRegistry):
         reg.register("orders", 1, _up_v1_to_v2)


### PR DESCRIPTION
Adds `match_field` to `register_upcaster`, mirroring `register_handler`: the `event_match` pattern is tested against `event[match_field]` (e.g. `form_type`) instead of the stream/event-match string. This lets per-form upcasters route on a per-entity stream (`submissions:<uuid>`) whose path carries no type — previously structurally impossible, so such upcasters were silently dormant.

- Threaded through `UpcasterVersion`, `register()`, the decorator, both matching sites (`current_version`/`apply_chain` via a shared `_subject` helper), and the persisted identity.
- `replay`/`merge_replay` now resolve the target version **per event** (`upcast_to_current`) instead of once-per-stream from the path.
- +6 content-routing tests; full suite + ruff green.

See ADR-0002. Closes #37.