### PR TITLE
feat(effects): validate exclude/spare_keys; add dispatch_external seam (#40)

### DIFF
--- a/src/rakaia/__init__.py
+++ b/src/rakaia/__init__.py
@@ -26,6 +26,7 @@ from .effects import (
     EffectOp,
     Executor,
     check_disjoint_defaults,
+    dispatch_external,
 )
 from .executors import CollectingExecutor
 from .handler import ServerOptions, create_app
@@ -130,6 +131,7 @@ __all__ = [
     "Executor",
     "EffectCollisionError",
     "check_disjoint_defaults",
+    "dispatch_external",
     "CollectingExecutor",
     # Versioned handlers — projections
     "reconcile_by_key",

--- a/src/rakaia/effects.py
+++ b/src/rakaia/effects.py
@@ -10,7 +10,7 @@ state) and keeps handlers trivially testable without a database.
 from __future__ import annotations
 
 import json
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable, Mapping
 from dataclasses import dataclass
 from typing import Any, Literal, Protocol
 
@@ -71,6 +71,26 @@ class Effect:
 
     payload: dict[str, Any] | None = None
     """Opaque payload for external effects."""
+
+    def __post_init__(self) -> None:
+        # `exclude` and `spare_keys` are ALTERNATIVE row-sparing mechanisms.
+        # Setting both silently ANDs them in the executor
+        # (`.exclude(**exclude).exclude(Q(...))`), which is never intended —
+        # reject it at construction so the mistake surfaces in the handler.
+        if self.exclude is not None and self.spare_keys is not None:
+            raise ValueError(
+                "Effect sets both `exclude` and `spare_keys`; they are alternative "
+                "row-sparing mechanisms — use one. `exclude` is the flat "
+                "reconcile_children (positional) case; `spare_keys` is the composite "
+                "natural-key case."
+            )
+        # `exclude` only applies to op="delete"; the retire path ignores it, so an
+        # `exclude` on a retire would be silently dropped. Fail loudly instead.
+        if self.exclude is not None and self.op != "delete":
+            raise ValueError(
+                f"Effect sets `exclude` with op={self.op!r}; `exclude` only applies "
+                "to op='delete'. Use `spare_keys` to spare rows from a retire."
+            )
 
 
 # =============================================================================
@@ -137,3 +157,41 @@ def check_disjoint_defaults(effects: Iterable[Effect]) -> None:
                     f"{field!r} on {eff.model_label} {eff.lookup!r}"
                 )
             existing[field] = idx
+
+
+# =============================================================================
+# External effect dispatch
+# =============================================================================
+
+
+def dispatch_external(
+    effects: Iterable[Effect],
+    handlers: Mapping[str, Callable[[Effect], Any]],
+    *,
+    on_unknown: Literal["raise", "ignore"] = "raise",
+) -> int:
+    """Route ``op="external"`` effects to per-``kind`` handlers.
+
+    rakaia never applies external effects itself: `replay()` filters them out
+    (unless ``include_external=True``) and executors drop them. This is the seam
+    for the *application* to act on them — email, webhooks, an alert transition —
+    without every consumer re-implementing ``for e in effects: if e.op ==
+    "external" and e.kind == ...``.
+
+    Pass a ``{kind: fn}`` map; each external effect is routed to
+    ``handlers[effect.kind]`` (non-external effects are skipped). Returns the
+    number dispatched. An effect whose ``kind`` has no handler raises ``KeyError``
+    by default, or is skipped with ``on_unknown="ignore"``.
+    """
+    dispatched = 0
+    for eff in effects:
+        if eff.op != "external":
+            continue
+        handler = handlers.get(eff.kind) if eff.kind is not None else None
+        if handler is None:
+            if on_unknown == "ignore":
+                continue
+            raise KeyError(f"No handler for external effect kind={eff.kind!r}")
+        handler(eff)
+        dispatched += 1
+    return dispatched

--- a/tests/test_rakaia/test_effects.py
+++ b/tests/test_rakaia/test_effects.py
@@ -169,6 +169,24 @@ class TestDispatchExternal:
         )
         assert n == 0
 
+    def test_kind_none_treated_as_unknown(self):
+        # A kind=None external effect has no handler; pins the behavior so a
+        # future refactor (e.g. handlers.get(eff.kind, default)) can't silently
+        # change it. Raises by default, skipped under on_unknown="ignore".
+        with pytest.raises(KeyError, match="kind=None"):
+            dispatch_external(
+                [Effect(op="external", kind=None, payload={})],
+                {"email": lambda _e: None},
+            )
+        assert (
+            dispatch_external(
+                [Effect(op="external", kind=None, payload={})],
+                {"email": lambda _e: None},
+                on_unknown="ignore",
+            )
+            == 0
+        )
+
 
 class TestCheckDisjointDefaults:
     def test_no_effects(self):

--- a/tests/test_rakaia/test_effects.py
+++ b/tests/test_rakaia/test_effects.py
@@ -10,6 +10,7 @@ from rakaia.effects import (
     Effect,
     EffectCollisionError,
     check_disjoint_defaults,
+    dispatch_external,
 )
 
 
@@ -88,6 +89,85 @@ class TestEffect:
         eff = Effect(op="external", kind="email")
         with pytest.raises(FrozenInstanceError):
             eff.kind = "stripe"  # type: ignore[misc]
+
+
+class TestEffectValidation:
+    def test_exclude_and_spare_keys_together_rejected(self):
+        # they are alternative row-sparing mechanisms; both would silently AND.
+        with pytest.raises(ValueError, match="both `exclude` and `spare_keys`"):
+            Effect(
+                op="delete",
+                model_label="m.M",
+                lookup={"parent": 1},
+                exclude={"idx__in": [0]},
+                spare_keys=[{"k": "v"}],
+            )
+
+    def test_exclude_on_retire_rejected(self):
+        # retire ignores exclude in the executor — fail loudly instead.
+        with pytest.raises(ValueError, match="only applies to op='delete'"):
+            Effect(
+                op="retire",
+                model_label="m.Alert",
+                lookup={"s": 1},
+                exclude={"idx__in": [0]},
+                patch={"resolved_at": "t"},
+            )
+
+    def test_exclude_on_delete_ok(self):
+        Effect(
+            op="delete", model_label="m.M", lookup={"p": 1}, exclude={"idx__in": [0]}
+        )
+
+    def test_spare_keys_on_retire_ok(self):
+        Effect(
+            op="retire",
+            model_label="m.Alert",
+            lookup={"s": 1},
+            spare_keys=[{"k": "v"}],
+            patch={"resolved_at": "t"},
+        )
+
+
+class TestDispatchExternal:
+    def test_routes_by_kind(self):
+        seen = []
+        effects = [
+            Effect(op="update_or_create", model_label="m.M", lookup={"id": 1}),
+            Effect(op="external", kind="email", payload={"to": "a"}),
+            Effect(op="external", kind="webhook", payload={"url": "u"}),
+        ]
+        n = dispatch_external(
+            effects,
+            {
+                "email": lambda e: seen.append(("email", e.payload)),
+                "webhook": lambda e: seen.append(("webhook", e.payload)),
+            },
+        )
+        assert n == 2
+        assert seen == [("email", {"to": "a"}), ("webhook", {"url": "u"})]
+
+    def test_non_external_effects_skipped(self):
+        n = dispatch_external(
+            [Effect(op="delete", model_label="m.M", lookup={"p": 1})],
+            {"email": lambda _e: None},
+        )
+        assert n == 0
+
+    def test_unknown_kind_raises_by_default(self):
+        with pytest.raises(KeyError, match="stripe"):
+            dispatch_external(
+                [Effect(op="external", kind="stripe", payload={})],
+                {"email": lambda _e: None},
+            )
+
+    def test_unknown_kind_ignored_when_configured(self):
+        n = dispatch_external(
+            [Effect(op="external", kind="stripe", payload={})],
+            {"email": lambda _e: None},
+            on_unknown="ignore",
+        )
+        assert n == 0
 
 
 class TestCheckDisjointDefaults:


### PR DESCRIPTION
Two Effect-model hygiene fixes from the seams review:

1. `Effect.__post_init__` rejects (a) setting both `exclude` and `spare_keys` (alternative row-sparing mechanisms the executor would silently AND), and (b) `exclude` on a non-`delete` op (the retire path ignored it). Fails fast in the handler.
2. `dispatch_external(effects, {kind: fn})` — a documented, exported seam for routing `op="external"` effects to per-`kind` handlers, so consumers stop re-implementing the `kind` switch.

+9 tests; full suite + ruff green. See ADR-0002. Closes #40.