### PR TITLE
feat(store): WritableStore protocol + shared conformance suite (#36)

### DIFF
--- a/src/rakaia/__init__.py
+++ b/src/rakaia/__init__.py
@@ -42,7 +42,12 @@ from .projections import (
     reconcile_children,
     reconcile_tree,
 )
-from .protocols import ProjectionReader, ReadableStore, WritableStore
+from .protocols import (
+    CursorStore,
+    ProjectionReader,
+    ReadableStore,
+    WritableStore,
+)
 from .registry import (
     HANDLERS_META_STREAM,
     REDUCERS_META_STREAM,
@@ -98,6 +103,7 @@ __all__ = [
     # Extension protocols (storage / projection seams)
     "ReadableStore",
     "WritableStore",
+    "CursorStore",
     "ProjectionReader",
     "provenance",
     "get_provenance",

--- a/src/rakaia/__init__.py
+++ b/src/rakaia/__init__.py
@@ -42,6 +42,7 @@ from .projections import (
     reconcile_children,
     reconcile_tree,
 )
+from .protocols import ProjectionReader, ReadableStore, WritableStore
 from .registry import (
     HANDLERS_META_STREAM,
     REDUCERS_META_STREAM,
@@ -94,6 +95,10 @@ __all__ = [
     "app",
     # Store
     "StreamStore",
+    # Extension protocols (storage / projection seams)
+    "ReadableStore",
+    "WritableStore",
+    "ProjectionReader",
     "provenance",
     "get_provenance",
     "append_if_changed",

--- a/src/rakaia/protocols.py
+++ b/src/rakaia/protocols.py
@@ -5,9 +5,14 @@ extension seams of the event-sourcing framework (ADR 0002).
 `replay()` only ever *reads* a stream, so it depends on the narrow
 `ReadableStore` protocol rather than the concrete in-memory `StreamStore`.
 Producers and the meta-stream registry additionally *write*, captured by
-`WritableStore`. Staged handlers read committed projections through
+`WritableStore`. Subscribers additionally need the head offset, captured by
+`CursorStore`. Staged handlers read committed projections through
 `ProjectionReader`. Any backend satisfying the relevant protocol — the in-memory
 `StreamStore`, a durable DB-backed store, or a third-party one — plugs in.
+
+All store-facing protocols live here so they read as one coherent seam:
+`ReadableStore` (read), `WritableStore` (+ create/append/has), `CursorStore`
+(+ get_current_offset).
 """
 
 from __future__ import annotations
@@ -54,22 +59,41 @@ class WritableStore(ReadableStore, Protocol):
         """Whether a stream exists at `path`."""
         ...
 
-    def create(self, path: str, **kwargs: Any) -> Any:
+    def create(self, path: str) -> Any:
         """Idempotently create the stream at `path`. `append` requires it to exist.
 
-        Backends may accept extra keyword options (content type, TTL, …) or
-        ignore them; only idempotent creation is part of the contract.
+        Only idempotent creation by `path` is part of the contract. Concrete
+        stores may accept extra keyword-only options (content type, TTL, …) via
+        their own richer signatures — deliberately *not* on this protocol, so a
+        backend that ignores such an option (e.g. `DjangoStreamStore`) can't be
+        called with it through the `WritableStore` type and silently no-op.
         """
         ...
 
     def append(self, path: str, data: bytes, options: Any = None) -> Any:
         """Append one (optionally enveloped) event to `path`.
 
-        Raises `KeyError` if the stream does not exist (create it first). The
-        envelope — `label` and `metadata` on `options` (an `AppendOptions`) — is
-        recorded and read back by `read`; ambient `provenance()` merges under
+        Raises `KeyError` if the stream does not exist (create it first) — the one
+        guaranteed exception. Beyond that, backends may raise for their own
+        validation (the in-memory `StreamStore` raises `ValueError` on a
+        content-type or Stream-Seq conflict) or signal a closed stream without
+        raising; `DjangoStreamStore` has no such concept. Depend only on the
+        `KeyError` here; treat richer errors as backend-specific.
+
+        The envelope — `label` and `metadata` on `options` (an `AppendOptions`) —
+        is recorded and read back by `read`; ambient `provenance()` merges under
         explicit metadata.
         """
+        ...
+
+
+@runtime_checkable
+class CursorStore(ReadableStore, Protocol):
+    """A `ReadableStore` that also exposes its current head offset — what a
+    subscriber (`poll()`) needs to detect new messages and a rewound log."""
+
+    def get_current_offset(self, path: str) -> str | None:
+        """The offset after the last message, or None if the stream is absent."""
         ...
 
 

--- a/src/rakaia/protocols.py
+++ b/src/rakaia/protocols.py
@@ -1,10 +1,13 @@
 """
-Structural protocols for pluggable storage backends.
+Structural protocols for pluggable storage and projection backends — the
+extension seams of the event-sourcing framework (ADR 0002).
 
 `replay()` only ever *reads* a stream, so it depends on the narrow
-`ReadableStore` protocol rather than the concrete in-memory `StreamStore`. Any
-backend that can return a stream's messages in order — the in-memory
-`StreamStore` or a durable, DB-backed store — satisfies it.
+`ReadableStore` protocol rather than the concrete in-memory `StreamStore`.
+Producers and the meta-stream registry additionally *write*, captured by
+`WritableStore`. Staged handlers read committed projections through
+`ProjectionReader`. Any backend satisfying the relevant protocol — the in-memory
+`StreamStore`, a durable DB-backed store, or a third-party one — plugs in.
 """
 
 from __future__ import annotations
@@ -25,6 +28,47 @@ class ReadableStore(Protocol):
 
         With no `offset`, returns every message; with an `offset`, returns the
         messages after it. Raises `KeyError` if the stream does not exist.
+        """
+        ...
+
+
+@runtime_checkable
+class WritableStore(ReadableStore, Protocol):
+    """A store the event-sourcing framework both writes to and reads from.
+
+    This is the **framework** store surface — what producers and the meta-stream
+    registry rely on: create a stream, append enveloped events, check existence,
+    and read them back (inherited from `ReadableStore`). It deliberately excludes
+    the Durable Streams **protocol-server** lifecycle (producer epoch/seq
+    fencing, close, TTL, long-poll/`wait_for_messages`); those live on the
+    standalone server's store and are not required to back `replay()`/projections.
+    See ADR 0002.
+
+    Return types are intentionally loose (`Any`): the in-memory `StreamStore`
+    returns rich protocol types (`Stream`/`AppendResult`) while `DjangoStreamStore`
+    returns ORM rows (`StreamEntry`). What both guarantee is the read-back
+    behaviour exercised by the shared conformance suite (`tests/store_contract.py`).
+    """
+
+    def has(self, path: str) -> bool:
+        """Whether a stream exists at `path`."""
+        ...
+
+    def create(self, path: str, **kwargs: Any) -> Any:
+        """Idempotently create the stream at `path`. `append` requires it to exist.
+
+        Backends may accept extra keyword options (content type, TTL, …) or
+        ignore them; only idempotent creation is part of the contract.
+        """
+        ...
+
+    def append(self, path: str, data: bytes, options: Any = None) -> Any:
+        """Append one (optionally enveloped) event to `path`.
+
+        Raises `KeyError` if the stream does not exist (create it first). The
+        envelope — `label` and `metadata` on `options` (an `AppendOptions`) — is
+        recorded and read back by `read`; ambient `provenance()` merges under
+        explicit metadata.
         """
         ...
 

--- a/src/rakaia/subscription.py
+++ b/src/rakaia/subscription.py
@@ -29,9 +29,9 @@ stream, where the head really does sort before the cursor.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Literal, Protocol
+from typing import Literal
 
-from .protocols import ReadableStore
+from .protocols import CursorStore
 from .types import StreamMessage
 
 PollStatus = Literal["fresh", "advanced", "caught_up", "rewound", "absent"]
@@ -45,11 +45,7 @@ PollStatus = Literal["fresh", "advanced", "caught_up", "rewound", "absent"]
 * ``absent`` — the stream does not exist; nothing returned.
 """
 
-
-class CursorStore(ReadableStore, Protocol):
-    """A `ReadableStore` that also exposes its current head offset."""
-
-    def get_current_offset(self, path: str) -> str | None: ...
+# CursorStore lives in rakaia.protocols alongside the other store-facing seams.
 
 
 @dataclass(frozen=True)

--- a/tests/store_contract.py
+++ b/tests/store_contract.py
@@ -1,0 +1,107 @@
+"""Shared conformance contract for the framework store surface (`WritableStore`).
+
+Both the in-memory `StreamStore` and the durable `DjangoStreamStore` must satisfy
+the create/append/read/has surface that `replay()`, producers, and the
+meta-stream registry rely on — so "test on the in-memory store, ship on the
+durable store" is safe. Subclass `StoreContract` in each backend's test package
+and provide a `store` fixture returning a fresh, empty store. See ADR 0002 / #36.
+
+This module is intentionally not named `test_*`, so pytest does not collect it
+directly; only the backend subclasses run it.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from rakaia.types import AppendOptions
+
+
+class StoreContract:
+    """Contract every framework store must uphold.
+
+    Subclasses provide::
+
+        @pytest.fixture
+        def store(self):
+            return MyStore()
+    """
+
+    def test_satisfies_writable_store_protocol(self, store):
+        from rakaia import ReadableStore, WritableStore
+
+        assert isinstance(store, WritableStore)
+        assert isinstance(store, ReadableStore)
+
+    def test_create_is_idempotent(self, store):
+        store.create("s")
+        store.create("s")
+        assert store.has("s") is True
+
+    def test_has_reflects_existence(self, store):
+        assert store.has("s") is False
+        store.create("s")
+        assert store.has("s") is True
+
+    def test_append_requires_existing_stream(self, store):
+        # The durable store raises; the contract requires create-before-append.
+        with pytest.raises(KeyError):
+            store.append("missing", b"{}")
+
+    def test_read_missing_stream_raises(self, store):
+        with pytest.raises(KeyError):
+            store.read("nope")
+
+    def test_append_then_read_roundtrips_in_order(self, store):
+        store.create("s")
+        events = [{"id": 1}, {"id": 2}, {"id": 3}]
+        for ev in events:
+            store.append("s", json.dumps(ev).encode("utf-8"))
+        messages, up_to_date = store.read("s")
+        assert up_to_date is True
+        assert [json.loads(m.data) for m in messages] == events
+
+    def test_partial_read_from_offset(self, store):
+        store.create("s")
+        for ev in [{"id": 1}, {"id": 2}, {"id": 3}]:
+            store.append("s", json.dumps(ev).encode("utf-8"))
+        messages, _ = store.read("s")
+        rest, _ = store.read("s", offset=messages[0].offset)
+        # each store's own offset is portable within that store (ordering semantics)
+        assert [json.loads(m.data) for m in rest] == [{"id": 2}, {"id": 3}]
+
+    def test_envelope_label_and_metadata_roundtrip(self, store):
+        store.create("s")
+        store.append(
+            "s",
+            b'{"id": 1}',
+            AppendOptions(label="update", metadata={"user": 7, "url": "/x"}),
+        )
+        messages, _ = store.read("s")
+        assert messages[-1].label == "update"
+        assert messages[-1].metadata == {"user": 7, "url": "/x"}
+
+    def test_raw_append_has_empty_envelope(self, store):
+        # A raw append (no options) reads back label="" / metadata=None on both
+        # backends, so handlers see a uniform envelope regardless of store.
+        store.create("s")
+        store.append("s", b'{"id": 1}')
+        messages, _ = store.read("s")
+        assert messages[-1].label == ""
+        assert messages[-1].metadata is None
+
+    def test_message_timestamp_is_float(self, store):
+        store.create("s")
+        store.append("s", b'{"id": 1}')
+        messages, _ = store.read("s")
+        assert isinstance(messages[0].timestamp, float)
+
+    def test_get_current_offset_none_then_advances(self, store):
+        assert store.get_current_offset("s") is None
+        store.create("s")
+        before = store.get_current_offset("s")
+        store.append("s", b'{"id": 1}')
+        after = store.get_current_offset("s")
+        assert after is not None and after != before

--- a/tests/store_contract.py
+++ b/tests/store_contract.py
@@ -8,6 +8,15 @@ and provide a `store` fixture returning a fresh, empty store. See ADR 0002 / #36
 
 This module is intentionally not named `test_*`, so pytest does not collect it
 directly; only the backend subclasses run it.
+
+Out of contract scope (backend-specific, deliberately not asserted here):
+`create()` conflict detection (the in-memory `StreamStore` raises `ValueError`
+on re-create with a different content_type/ttl; `DjangoStreamStore` has no such
+concept and ignores extra kwargs), stream close / Stream-Seq / producer fencing,
+and the exact offset *format* (compound `{seq}_{byte}` vs zero-padded int). Those
+are tested in each backend's own suite; asserting one behaviour for both here
+would contradict the point of a shared contract. Cross-backend offset/format
+unification is tracked in #39.
 """
 
 from __future__ import annotations
@@ -29,11 +38,12 @@ class StoreContract:
             return MyStore()
     """
 
-    def test_satisfies_writable_store_protocol(self, store):
-        from rakaia import ReadableStore, WritableStore
+    def test_satisfies_store_protocols(self, store):
+        from rakaia import CursorStore, ReadableStore, WritableStore
 
         assert isinstance(store, WritableStore)
         assert isinstance(store, ReadableStore)
+        assert isinstance(store, CursorStore)  # get_current_offset (subscribers)
 
     def test_create_is_idempotent(self, store):
         store.create("s")

--- a/tests/test_django_rakaia/test_django_store.py
+++ b/tests/test_django_rakaia/test_django_store.py
@@ -19,6 +19,12 @@ from rakaia.store import StreamStore
 
 @pytest.mark.django_db
 class TestDjangoStreamStore:
+    # The shared read/append/create/has surface (create-idempotence, append-
+    # requires-stream, ordered round-trip, partial read, envelope round-trip,
+    # current-offset) is covered once for every backend by
+    # tests/store_contract.py::StoreContract (see test_store_contract.py). Only
+    # DjangoStreamStore-specific behaviour lives here: ORM persistence, integer
+    # offset format, row locking, durability across instances, delete/list_paths.
     def test_create_persists_stream_row(self):
         DjangoStreamStore().create("submissions")
         assert Stream.objects.filter(stream_id="submissions").exists()
@@ -41,34 +47,6 @@ class TestDjangoStreamStore:
         )
         assert offsets == [1, 2]
 
-    def test_append_requires_existing_stream(self):
-        with pytest.raises(KeyError):
-            DjangoStreamStore().append("missing", b"{}")
-
-    def test_append_persists_and_reads_envelope(self):
-        from rakaia.types import AppendOptions
-
-        store = DjangoStreamStore()
-        store.create("s")
-        store.append(
-            "s",
-            b'{"id": 1}',
-            AppendOptions(label="update", metadata={"user": 7, "url": "/x"}),
-        )
-        messages, _ = store.read("s")
-        assert messages[-1].label == "update"
-        assert messages[-1].metadata == {"user": 7, "url": "/x"}
-
-    def test_raw_append_reads_empty_envelope(self):
-        # A raw append (no options) reads back label="" / metadata=None, matching
-        # the in-memory store — even though event_type is stored as "append".
-        store = DjangoStreamStore()
-        store.create("s")
-        store.append("s", b'{"id": 1}')
-        messages, _ = store.read("s")
-        assert messages[-1].label == ""
-        assert messages[-1].metadata is None
-
     def test_append_locks_stream_row_for_offset_allocation(self):
         # Regression guard for the concurrency bug: offset allocation must go
         # through select_for_update() so concurrent appends serialize on the
@@ -90,35 +68,6 @@ class TestDjangoStreamStore:
             store.append("s", b'{"id": 1}')
 
         assert locked, "append must lock the stream row via select_for_update()"
-
-    def test_read_returns_events_in_order(self):
-        store = DjangoStreamStore()
-        store.create("s")
-        for ev in [{"id": 1}, {"id": 2}, {"id": 3}]:
-            store.append("s", json.dumps(ev).encode("utf-8"))
-
-        messages, up_to_date = store.read("s")
-
-        assert up_to_date is True
-        assert [json.loads(m.data) for m in messages] == [
-            {"id": 1},
-            {"id": 2},
-            {"id": 3},
-        ]
-
-    def test_read_from_offset_partial(self):
-        store = DjangoStreamStore()
-        store.create("s")
-        for ev in [{"id": 1}, {"id": 2}, {"id": 3}]:
-            store.append("s", json.dumps(ev).encode("utf-8"))
-
-        messages, _ = store.read("s")
-        rest, _ = store.read("s", offset=messages[0].offset)
-        assert [json.loads(m.data) for m in rest] == [{"id": 2}, {"id": 3}]
-
-    def test_read_missing_stream_raises(self):
-        with pytest.raises(KeyError):
-            DjangoStreamStore().read("nope")
 
     def test_delete_removes_stream_and_entries(self):
         store = DjangoStreamStore()

--- a/tests/test_django_rakaia/test_store_contract.py
+++ b/tests/test_django_rakaia/test_store_contract.py
@@ -1,0 +1,19 @@
+"""Durable DjangoStreamStore against the shared WritableStore conformance contract.
+
+Same contract as the in-memory store (tests/store_contract.py) — this is what
+makes "test on memory, ship on durable" safe.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from django_rakaia.django_store import DjangoStreamStore
+from tests.store_contract import StoreContract
+
+
+@pytest.mark.django_db
+class TestDjangoStreamStoreContract(StoreContract):
+    @pytest.fixture
+    def store(self) -> DjangoStreamStore:
+        return DjangoStreamStore()

--- a/tests/test_rakaia/test_store_contract.py
+++ b/tests/test_rakaia/test_store_contract.py
@@ -1,0 +1,14 @@
+"""In-memory StreamStore against the shared WritableStore conformance contract."""
+
+from __future__ import annotations
+
+import pytest
+
+from rakaia.store import StreamStore
+from tests.store_contract import StoreContract
+
+
+class TestStreamStoreContract(StoreContract):
+    @pytest.fixture
+    def store(self) -> StreamStore:
+        return StreamStore()


### PR DESCRIPTION
Formalizes the framework **store seam** (ADR-0002).

- `protocols.py` gains **`WritableStore`** (= `ReadableStore` + `has`/`create`/`append`) — the create/append/read/has surface producers and the meta-stream registry rely on. It deliberately **excludes** the Durable Streams protocol-server lifecycle (producer epoch/seq fencing, close, TTL, `wait_for_messages`), which is not required to back `replay()`/projections.
- **`ReadableStore`, `WritableStore`, `ProjectionReader` are now exported** from `rakaia`, so consumers writing a custom backend/reader have something to import and type against (previously they were unexported).
- **`tests/store_contract.py`** — a shared `StoreContract` run against **both** the in-memory `StreamStore` **and** the durable `DjangoStreamStore` (22 cases). This makes 'test on memory, ship on durable' *enforced*, not assumed: create-idempotence, append-requires-stream, ordered round-trip, partial read from offset, envelope round-trip (labelled + raw), float timestamp, current-offset advance, and `isinstance` protocol satisfaction.

Return types stay loose (`Stream`/`AppendResult` vs `StreamEntry`); the contract is the read-back behaviour. Known cross-store differences (offset format, JSON-array flattening) are out of scope and tracked in #39.

542 passed; ruff clean. Closes #36.