### PR TITLE
feat(registry): resettable registries + test-isolation story (#38)

### DIFF
--- a/docs/versioned-handlers.md
+++ b/docs/versioned-handlers.md
@@ -268,6 +268,64 @@ The drift signal tells you that a function you'd promised to leave alone
 remedy is either to revert the change or to formalise it as a new
 version covering the appropriate seq range.
 
+## Registries: global vs injected, and test isolation
+
+The bare decorators (`@register_handler`, `@register_upcaster`,
+`@register_reducer`) register against **process-wide default registries** —
+convenient for an app that discovers its handlers at import time. But a global
+mutable registry is the seam most at odds with rakaia's otherwise pure design:
+registrations made in one test leak into the next, and long-running / hot-reload
+processes accumulate stale versions.
+
+Two supported patterns keep replay deterministic and tests isolated:
+
+**Preferred — construct and inject a fresh registry.** `replay()` and
+`merge_replay()` take `handler_registry=` / `upcaster_registry=`, so a test (or a
+per-tenant caller) can build its own and never touch the global:
+
+```python
+from rakaia import HandlerRegistry, UpcasterRegistry, replay
+
+handlers = HandlerRegistry()
+handlers.register("mogrify", "room:*", mogrify_v1, effective_from=0)
+replay(store, "room:1", executor, handler_registry=handlers)
+```
+
+This is also how you get **namespace / tenant scoping** today: key a separate
+registry instance per tenant and inject it — there is no built-in scoping on the
+default registry, and this is the escape hatch.
+
+**Default-registry tests — reset in teardown.** When the code under test uses the
+bare decorators, call `reset_default_registries()` between tests:
+
+```python
+import pytest
+from rakaia import reset_default_registries
+
+@pytest.fixture(autouse=True)
+def _isolate_registries():
+    reset_default_registries()
+    yield
+    reset_default_registries()
+```
+
+rakaia's own `tests/test_rakaia/conftest.py` ships exactly this fixture.
+`HandlerRegistry.reset()` / `UpcasterRegistry.reset()` clear **in-memory**
+registration state only; they do **not** delete the durable meta-streams
+(`__rakaia__:handlers`, `__rakaia__:upcasters`, `__rakaia__:reducers`). On a
+store-backed registry, resetting the dedup cache means the next `register()`
+re-appends an audit event even for an already-persisted registration — delete the
+meta-stream via the store if you need a truly clean slate.
+
+### Reducers replace last-write-wins
+
+A **reducer** (`register_reducer(name, stage, fn)`) is a single *current*
+definition keyed by `name` — not a seq-versioned series like a handler.
+Registering a different function under an existing name **replaces** it. This is
+deliberate: a reducer recomputes an aggregate *wholesale* from the committed
+projections on every replay, so there is no per-sequence window to version over.
+If you need two coexisting reduce steps, give them distinct names.
+
 ## Replacing `post_migration_tasks.py`
 
 Existing `PostMigrationTask` entries map naturally onto versioned handlers

--- a/src/rakaia/__init__.py
+++ b/src/rakaia/__init__.py
@@ -68,6 +68,7 @@ from .registry import (
     register_handler,
     register_reducer,
     register_upcaster,
+    reset_default_registries,
     upcast,
 )
 from .replay import ReplayResult, merge_replay, replay
@@ -167,6 +168,7 @@ __all__ = [
     "UpcasterChainError",
     "get_default_registry",
     "get_default_upcaster_registry",
+    "reset_default_registries",
     "upcast",
     "HANDLERS_META_STREAM",
     "UPCASTERS_META_STREAM",

--- a/src/rakaia/registry.py
+++ b/src/rakaia/registry.py
@@ -107,6 +107,16 @@ class ReducerVersion:
     accumulated projections (e.g. all contributing rows for a group) and
     returning the idempotent Effects that materialise the aggregate. It is the
     replay-time hook that `reconcile_aggregate` is designed to fill.
+
+    **Replacement semantics — last-write-wins by name, not seq-versioned.**
+    A reducer is a single *current* definition keyed by `name`, unlike a handler,
+    which is a series of `[from_seq, to_seq)`-bracketed versions. Registering a
+    different function under an existing name **replaces** the prior one. This is
+    intentional: a reducer recomputes an aggregate *wholesale* from the committed
+    projections on every replay, so there is no per-sequence window a reducer
+    could be versioned over — the only thing that matters is the definition in
+    force when replay runs. If you need two coexisting reduce steps, give them
+    distinct names.
     """
 
     name: str
@@ -266,6 +276,23 @@ class HandlerRegistry:
 
         self._reducers[name] = reducer
         return reducer
+
+    def reset(self) -> None:
+        """Clear all in-memory registrations (handlers, reducers, and the
+        persisted-id dedup caches) so a fresh set can be registered.
+
+        This resets **in-memory registration state only** — it is the seam for
+        per-test isolation (see `reset_default_registries()` and the test-isolation
+        section of ``docs/versioned-handlers.md``). It does **not** delete the
+        durable meta-streams (``__rakaia__:handlers`` / ``__rakaia__:reducers``);
+        to discard those, delete the streams via the store. On a store-backed
+        registry, clearing the dedup cache means the next `register()` re-appends
+        an audit event even for an already-persisted registration.
+        """
+        self._versions.clear()
+        self._reducers.clear()
+        self._persisted_ids.clear()
+        self._reducer_persisted_ids.clear()
 
     def reducers_for_stage(self, stage: int) -> list[ReducerVersion]:
         """Reducers registered for `stage`, in deterministic (name) order."""
@@ -719,6 +746,16 @@ class UpcasterRegistry:
     def all_upcasters(self) -> list[UpcasterVersion]:
         return list(self._upcasters.values())
 
+    def reset(self) -> None:
+        """Clear all in-memory upcaster registrations and the dedup cache.
+
+        In-memory state only — mirrors `HandlerRegistry.reset()`: the seam for
+        per-test isolation, not a delete of the durable ``__rakaia__:upcasters``
+        meta-stream (delete that via the store if you need to).
+        """
+        self._upcasters.clear()
+        self._persisted_ids.clear()
+
     def rehydrate(self) -> None:
         if self._store is None:
             return
@@ -846,6 +883,24 @@ def get_default_upcaster_registry() -> UpcasterRegistry:
     return _default_upcaster_registry
 
 
+def reset_default_registries() -> None:
+    """Reset both process-wide default registries (handlers + upcasters).
+
+    The one call a test's teardown needs to stop registrations leaking between
+    tests when they use the default registries (via the bare `@register_handler`
+    / `@register_upcaster` / `@register_reducer` decorators). Prefer constructing
+    fresh `HandlerRegistry()` / `UpcasterRegistry()` instances and injecting them
+    into `replay()` where you can; use this when the code under test registers
+    against the module-global default. See the test-isolation section of
+    ``docs/versioned-handlers.md``.
+
+    Resets in-memory registration state only — it does not touch any durable
+    meta-streams (see `HandlerRegistry.reset()`).
+    """
+    _default_registry.reset()
+    _default_upcaster_registry.reset()
+
+
 def upcast(
     event: dict[str, Any],
     event_match: str,
@@ -926,6 +981,9 @@ def register_reducer(
     The decorated function is called `fn(reader)` once during staged replay,
     after `stage`'s per-event handlers commit, and returns the Effects that
     materialise the aggregate (typically via `reconcile_aggregate`).
+
+    A reducer is a single current definition keyed by `name` (last-write-wins),
+    not a seq-versioned series like a handler — see `ReducerVersion`.
 
     Example:
         @register_reducer(name="balance", stage=1)

--- a/tests/test_rakaia/conftest.py
+++ b/tests/test_rakaia/conftest.py
@@ -1,0 +1,22 @@
+"""Shared fixtures for the framework-tier (`rakaia`) test suite.
+
+The autouse `_isolate_default_registries` fixture resets the process-wide default
+handler/upcaster registries around every test, so registrations made against the
+default (via a bare `@register_handler` / `@register_upcaster` / `@register_reducer`)
+cannot leak from one test into the next. This is the test-isolation tripwire #38
+asks for; tests that construct and inject their own `HandlerRegistry()` are
+unaffected. See the test-isolation section of ``docs/versioned-handlers.md``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from rakaia.registry import reset_default_registries
+
+
+@pytest.fixture(autouse=True)
+def _isolate_default_registries():
+    reset_default_registries()
+    yield
+    reset_default_registries()

--- a/tests/test_rakaia/test_registry_isolation.py
+++ b/tests/test_rakaia/test_registry_isolation.py
@@ -1,0 +1,120 @@
+"""Tests for registry reset / test-isolation (#38).
+
+Covers `HandlerRegistry.reset()`, `UpcasterRegistry.reset()`, and the
+`reset_default_registries()` teardown helper — the documented way to stop
+registrations leaking between tests.
+"""
+
+from __future__ import annotations
+
+from rakaia.registry import (
+    HANDLERS_META_STREAM,
+    HandlerRegistry,
+    UpcasterRegistry,
+    get_default_registry,
+    get_default_upcaster_registry,
+    register_handler,
+    register_upcaster,
+    reset_default_registries,
+)
+from rakaia.store import StreamStore
+
+
+def _fn(tag: str):
+    def handler(event):  # noqa: ARG001
+        return tag
+
+    handler.__qualname__ = f"_fn.<{tag}>"
+    return handler
+
+
+def _up(tag: str):
+    def upcaster(event):
+        return {**event, "tag": tag}
+
+    upcaster.__qualname__ = f"_up.<{tag}>"
+    return upcaster
+
+
+class TestHandlerRegistryReset:
+    def test_reset_clears_handlers_and_reducers(self):
+        reg = HandlerRegistry()
+        reg.register("mogrify", "room:*", _fn("v1"), 0, 10)
+        reg.register_reducer("balance", 1, _fn("b"))
+        assert reg.all_versions()
+        assert reg.all_reducers()
+
+        reg.reset()
+
+        assert reg.all_versions() == []
+        assert reg.all_reducers() == []
+        assert reg.stages() == []
+        assert reg.has_reducers() is False
+
+    def test_reset_allows_reregistering_a_conflicting_range(self):
+        # A range that would overlap the first registration is accepted again
+        # after reset, proving the in-memory series was cleared.
+        reg = HandlerRegistry()
+        reg.register("m", "e", _fn("v1"), 0, None)
+        reg.reset()
+        reg.register("m", "e", _fn("v2"), 0, None)  # would overlap pre-reset
+        assert [v.effective_from for v in reg.all_versions()] == [0]
+
+    def test_reset_reappends_audit_event_on_store_backed(self):
+        # Clearing the dedup cache means an identical re-registration appends a
+        # fresh audit event to the meta-stream (reset() is in-memory only; it
+        # does not delete the durable stream).
+        store = StreamStore()
+        reg = HandlerRegistry(store=store)
+        reg.register("mogrify", "room:*", _fn("v1"), 0, 10)
+        assert len(store.read(HANDLERS_META_STREAM)[0]) == 1
+
+        reg.reset()
+        assert store.has(HANDLERS_META_STREAM)  # durable stream survives reset
+
+        reg.register("mogrify", "room:*", _fn("v1"), 0, 10)
+        assert len(store.read(HANDLERS_META_STREAM)[0]) == 2
+
+
+class TestUpcasterRegistryReset:
+    def test_reset_clears_upcasters(self):
+        reg = UpcasterRegistry()
+        reg.register("room:*", 1, _up("v1"))
+        assert reg.all_upcasters()
+
+        reg.reset()
+
+        assert reg.all_upcasters() == []
+        # A different fn is now accepted at the same key (no conflict) — proof
+        # the in-memory map was cleared.
+        reg.register("room:*", 1, _up("v2"))
+        assert len(reg.all_upcasters()) == 1
+
+
+class TestResetDefaultRegistries:
+    def test_resets_both_default_registries(self):
+        register_handler("m", "room:*", 0, 10)(_fn("v1"))
+        register_upcaster("room:*", 1)(_up("v1"))
+        assert get_default_registry().all_versions()
+        assert get_default_upcaster_registry().all_upcasters()
+
+        reset_default_registries()
+
+        assert get_default_registry().all_versions() == []
+        assert get_default_upcaster_registry().all_upcasters() == []
+
+
+class TestAutouseIsolation:
+    """The autouse conftest fixture must leave each test a clean default
+    registry — these two tests register the same handler and neither sees the
+    other's registration (order-independent)."""
+
+    def test_first_registers_on_clean_default(self):
+        assert get_default_registry().all_versions() == []
+        register_handler("leaky", "room:*", 0, None)(_fn("v1"))
+        assert len(get_default_registry().all_versions()) == 1
+
+    def test_second_also_sees_clean_default(self):
+        assert get_default_registry().all_versions() == []
+        register_handler("leaky", "room:*", 0, None)(_fn("v1"))
+        assert len(get_default_registry().all_versions()) == 1


### PR DESCRIPTION
Closes #38. Refs ADR-0002 (item 4).

## Problem
The handler/upcaster/reducer registries were process-global mutable singletons with no `reset()` and no documented test-isolation story, so registrations leaked between tests and stale versions accumulated in long-running processes. Reducer replacement (last-write-wins) was also undocumented.

## Changes
- **`reset()`** on `HandlerRegistry` and `UpcasterRegistry`, plus exported **`reset_default_registries()`** — clear in-memory registration state and the dedup caches. Durable meta-streams (`__rakaia__:handlers` etc.) are left intact (documented).
- **Autouse fixture** in `tests/test_rakaia/conftest.py` resets the default registries around every test — the no-leak tripwire the issue asks for. Tests that inject their own `HandlerRegistry()` are unaffected.
- **Docs**: new "Registries: global vs injected, and test isolation" section in `versioned-handlers.md` (incl. per-tenant scoping via injection), and reducer **last-write-wins by name** documented in the `ReducerVersion`/`register_reducer` docstrings + docs.

## Testing
- New `tests/test_rakaia/test_registry_isolation.py`.
- Full `test_rakaia` suite green (414 passed); `ruff check` + `ruff format --check` clean on changed files.