### PR TITLE
fix(upcaster): include match_field in dedup/conflict key

### DIFF
--- a/src/rakaia/registry.py
+++ b/src/rakaia/registry.py
@@ -528,7 +528,8 @@ class UpcasterVersion:
 
 class UpcasterRegistry:
     """
-    Registry of schema-version upcasters, keyed by (event_match, from_version).
+    Registry of schema-version upcasters, keyed by (event_match, from_version,
+    match_field).
 
     Each upcaster transforms an event dict from schema_version N to N+1. The
     registry composes them into a chain via `apply_chain`.
@@ -540,7 +541,7 @@ class UpcasterRegistry:
         *,
         stream_path: str = UPCASTERS_META_STREAM,
     ) -> None:
-        self._upcasters: dict[tuple[str, int], UpcasterVersion] = {}
+        self._upcasters: dict[tuple[str, int, str | None], UpcasterVersion] = {}
         self._store = store
         self._stream_path = stream_path
         self._persisted_ids: set[tuple[str, int, str, str, str | None]] = set()
@@ -561,6 +562,12 @@ class UpcasterRegistry:
         When `match_field` is set, the `event_match` pattern is tested against
         `event[match_field]` (content routing) instead of the stream/event-match
         string, so a per-form upcaster can route on a per-entity stream.
+
+        A stream-routed and a content-routed upcaster may share the same
+        `(event_match, from_version)` — `match_field` is part of the identity
+        key, so they are distinct registrations, not a conflict. A conflict
+        is only raised when `(event_match, from_version, match_field)` are
+        all identical but the function/hash differ.
         """
         if from_version < 1:
             raise ValueError(f"from_version must be >= 1, got {from_version}")
@@ -574,19 +581,16 @@ class UpcasterRegistry:
             match_field=match_field,
         )
 
-        key = (event_match, from_version)
+        key = (event_match, from_version, match_field)
         existing = self._upcasters.get(key)
         if existing is not None:
             if _u_identity(existing) == _u_identity(new):
                 return existing
             raise UpcasterConflictError(
                 f"Upcaster already registered for event_match={event_match!r}, "
-                f"from_version={from_version} (existing dotted_path="
-                f"{existing.dotted_path!r} match_field={existing.match_field!r}, "
-                f"new dotted_path={new.dotted_path!r} match_field={new.match_field!r})."
-                " The (event_match, from_version) key ignores match_field, so a "
-                "stream-routed and a content-routed upcaster cannot share it — "
-                "give them distinct event_match patterns."
+                f"from_version={from_version}, match_field={match_field!r} "
+                f"(existing dotted_path={existing.dotted_path!r}, "
+                f"new dotted_path={new.dotted_path!r})."
             )
 
         if self._store is not None:
@@ -628,7 +632,7 @@ class UpcasterRegistry:
         """
         matching_froms = [
             fv
-            for (pattern, fv), up in self._upcasters.items()
+            for (pattern, fv, _match_field), up in self._upcasters.items()
             if fnmatch.fnmatchcase(self._subject(up, event, event_match_str), pattern)
         ]
         if not matching_froms:
@@ -671,7 +675,7 @@ class UpcasterRegistry:
         while current < target_version:
             matching = [
                 up
-                for (pattern, fv), up in self._upcasters.items()
+                for (pattern, fv, _match_field), up in self._upcasters.items()
                 if fv == current
                 and fnmatch.fnmatchcase(
                     self._subject(up, event, event_match_str), pattern

--- a/tests/test_rakaia/test_upcasters.py
+++ b/tests/test_rakaia/test_upcasters.py
@@ -276,14 +276,37 @@ class TestContentRouting:
         assert out["schema_version"] == 3
         assert out["quantized"] is True and out["v3"] is True
 
-    def test_stream_and_content_routed_same_key_conflicts(self, reg: UpcasterRegistry):
-        # (event_match, from_version) ignores match_field, so a stream-routed and
-        # a content-routed upcaster can't share it — converting one to the other
-        # under the same identifiers is a migration foot-gun that must fail loudly,
-        # naming match_field as the differentiator.
+    def test_stream_and_content_routed_same_key_do_not_conflict(
+        self, reg: UpcasterRegistry
+    ):
+        # match_field is part of the identity key, so a stream-routed and a
+        # content-routed upcaster sharing (event_match, from_version) are
+        # distinct registrations, not a conflict — they route on different
+        # subjects (the stream path vs. event[match_field]) so there is no
+        # actual ambiguity.
         reg.register("TF_13_2_1", 1, _tf_v1_to_v2)  # stream-routed
+        reg.register(
+            "TF_13_2_1", 1, _sf_v1_to_v2, match_field="form_type"
+        )  # content-routed
+        assert len(reg.all_upcasters()) == 2
+
+        # stream-routed: matches when event_match_str == "TF_13_2_1"
+        stream_out = reg.upcast_to_current({"schema_version": 1}, "TF_13_2_1")
+        assert stream_out.get("quantized") is True
+
+        # content-routed: matches when event["form_type"] == "TF_13_2_1"
+        content_out = reg.upcast_to_current(
+            {"schema_version": 1, "form_type": "TF_13_2_1"}, "submissions:abc"
+        )
+        assert content_out.get("sf_touched") is True
+
+    def test_genuine_conflict_same_match_field_raises(self, reg: UpcasterRegistry):
+        # Same (event_match, from_version, match_field) with a different
+        # function is a real conflict and must still raise, naming
+        # match_field as part of the identifying key.
+        reg.register("TF_13_2_1", 1, _tf_v1_to_v2, match_field="form_type")
         with pytest.raises(UpcasterConflictError, match="match_field"):
-            reg.register("TF_13_2_1", 1, _tf_v1_to_v2, match_field="form_type")
+            reg.register("TF_13_2_1", 1, _sf_v1_to_v2, match_field="form_type")
 
     def test_content_routed_ambiguous_match_raises(self, reg: UpcasterRegistry):
         # two content-routed patterns that both match one event → ambiguous chain.
@@ -335,7 +358,7 @@ class TestModuleLevelUpcast:
             assert out["normalised"] is True
             assert out["schema_version"] == 2
         finally:
-            reg._upcasters.pop(("module_upcast_stream", 1), None)
+            reg._upcasters.pop(("module_upcast_stream", 1, None), None)
 
     def test_explicit_registry(self, reg: UpcasterRegistry):
         from rakaia import upcast


### PR DESCRIPTION
## Summary

PR #42 (content-routing via `match_field`) merged with one finding from its post-merge adversarial review left unaddressed: the upcaster registration/conflict key `(event_match, from_version)` excludes `match_field`, so a stream-routed upcaster and a content-routed one sharing that key spuriously collide with `UpcasterConflictError`, even though they route on different subjects (the stream path vs. `event[match_field]`) and aren't actually ambiguous.

Reproduced directly against `origin/main` before writing this fix:

```python
reg.register('TF_13_2_1', 1, stream_up)
reg.register('TF_13_2_1', 1, content_up, match_field='form_type')
# -> UpcasterConflictError on unmodified main
```

`main`'s error message already documented this as a known limitation ("The (event_match, from_version) key ignores match_field...") without fixing it — this PR closes the gap instead of just describing it.

## Changes

- Fold `match_field` into the registration/conflict key so a stream-routed and content-routed upcaster sharing `(event_match, from_version)` are correctly treated as distinct registrations.
- Update the two iteration sites that unpack the key.
- Tighten the conflict error message.
- Invert/extend the test that had encoded the buggy behavior as expected.

## Test plan
- [x] Full suite passes (556 passed, 1 skipped)
- [x] `ruff check` / `ruff format --check` clean
- [x] Manually reproduced the bug against unmodified `main`, confirmed this fix resolves it