### PR TITLE
docs(store): pin the intentional Django/in-memory divergence

### DIFF
--- a/src/django_rakaia/django_store.py
+++ b/src/django_rakaia/django_store.py
@@ -50,7 +50,16 @@ class DjangoStreamStore:
 
     def create(self, path: str, **_kwargs: Any) -> Stream:
         """Ensure a stream row exists (idempotent). Extra kwargs are ignored —
-        the durable store does not model TTL/expiry/content-type."""
+        the durable store does not model TTL/expiry/content-type.
+
+        Unlike the in-memory `StreamStore`, a re-`create` with a *different*
+        `content_type`/`ttl_seconds`/`expires_at`/`closed` never raises
+        `ValueError`: the `Stream` model has no columns for those, so there is
+        no stored config to conflict with. This is a deliberate, permanent
+        divergence (not a gap to close) — see
+        `tests/test_django_rakaia/test_django_store.py::
+        test_create_ignores_conflicting_kwargs_instead_of_raising`.
+        """
         stream, _ = Stream.objects.get_or_create(stream_id=path)
         return stream
 
@@ -65,6 +74,16 @@ class DjangoStreamStore:
         concurrent appends serialize on offset allocation instead of racing to
         the same value and failing the ``unique_together(stream, offset)``
         constraint.
+
+        Unlike the in-memory `StreamStore`, this never raises `ValueError` for
+        a Stream-Seq conflict and never reports a closed stream (no raise, no
+        `stream_closed`-style signal): there is no `closed` column and
+        `options.seq` is not consulted. Stream closing and producer-seq
+        fencing are live-protocol-server concerns, out of scope for the
+        durable event-sourcing store (module docstring). This is a
+        deliberate, permanent divergence — see
+        `tests/test_django_rakaia/test_django_store.py::
+        test_append_has_no_closed_stream_concept`.
         """
         with transaction.atomic():
             try:

--- a/src/rakaia/protocols.py
+++ b/src/rakaia/protocols.py
@@ -73,12 +73,24 @@ class WritableStore(ReadableStore, Protocol):
     def append(self, path: str, data: bytes, options: Any = None) -> Any:
         """Append one (optionally enveloped) event to `path`.
 
-        Raises `KeyError` if the stream does not exist (create it first) — the one
-        guaranteed exception. Beyond that, backends may raise for their own
-        validation (the in-memory `StreamStore` raises `ValueError` on a
-        content-type or Stream-Seq conflict) or signal a closed stream without
-        raising; `DjangoStreamStore` has no such concept. Depend only on the
-        `KeyError` here; treat richer errors as backend-specific.
+        Three possible outcomes, only the first of which is guaranteed across
+        every backend:
+
+        - Raises `KeyError` if the stream does not exist (create it first) —
+          the one guaranteed exception every `WritableStore` must raise.
+        - May raise `ValueError` for a backend's own validation (the in-memory
+          `StreamStore` raises this on a content-type or Stream-Seq conflict);
+          `DjangoStreamStore` has no such concept and never raises it.
+        - May return normally with a closed-stream signal instead of raising
+          (the in-memory `StreamStore`'s `AppendResult.stream_closed=True`,
+          with `message=None`, when appending to a closed stream);
+          `DjangoStreamStore` has no closed-stream concept and never signals
+          this.
+
+        Depend only on the `KeyError` here; treat the `ValueError` and
+        `stream_closed=True` cases as backend-specific, not part of the
+        `WritableStore` contract (see `tests/store_contract.py` for what is and
+        isn't asserted across backends).
 
         The envelope — `label` and `metadata` on `options` (an `AppendOptions`) —
         is recorded and read back by `read`; ambient `provenance()` merges under

--- a/tests/store_contract.py
+++ b/tests/store_contract.py
@@ -12,11 +12,24 @@ directly; only the backend subclasses run it.
 Out of contract scope (backend-specific, deliberately not asserted here):
 `create()` conflict detection (the in-memory `StreamStore` raises `ValueError`
 on re-create with a different content_type/ttl; `DjangoStreamStore` has no such
-concept and ignores extra kwargs), stream close / Stream-Seq / producer fencing,
-and the exact offset *format* (compound `{seq}_{byte}` vs zero-padded int). Those
-are tested in each backend's own suite; asserting one behaviour for both here
-would contradict the point of a shared contract. Cross-backend offset/format
-unification is tracked in #39.
+concept — its `Stream` model has no content_type/ttl/closed columns at all —
+and permanently ignores extra kwargs instead of raising), stream close /
+Stream-Seq / producer fencing (same story: no `closed` concept on the durable
+side), and the exact offset *format* (compound `{seq}_{byte}` vs zero-padded
+int). These are genuine, permanent architectural divergences, not gaps to
+close — asserting one behaviour for both here would contradict the point of a
+shared contract, and a producer that depends on in-memory conflict-rejection
+or closed-stream signalling is relying on protocol-server behaviour ADR 0002
+explicitly excludes from `WritableStore` (see `src/rakaia/protocols.py`).
+Each divergence is pinned in that backend's own suite instead:
+- in-memory: `tests/test_rakaia/test_store.py::
+  test_create_conflicting_content_type_raises`,
+  `test_create_conflicting_ttl_raises`, `test_seq_conflict_raises`,
+  `test_append_to_closed_stream_returns_stream_closed`.
+- Django: `tests/test_django_rakaia/test_django_store.py::
+  test_create_ignores_conflicting_kwargs_instead_of_raising`,
+  `test_append_has_no_closed_stream_concept`.
+Cross-backend offset/format unification is tracked in #39.
 """
 
 from __future__ import annotations

--- a/tests/test_django_rakaia/test_django_store.py
+++ b/tests/test_django_rakaia/test_django_store.py
@@ -15,6 +15,7 @@ from rakaia.effects import Effect
 from rakaia.registry import HandlerRegistry
 from rakaia.replay import replay
 from rakaia.store import StreamStore
+from rakaia.types import AppendOptions
 
 
 @pytest.mark.django_db
@@ -88,6 +89,38 @@ class TestDjangoStreamStore:
         store.create("t")
         assert store.has("s") is True
         assert set(store.list_paths()) == {"s", "t"}
+
+    def test_create_ignores_conflicting_kwargs_instead_of_raising(self):
+        # Deliberate divergence from the in-memory StreamStore (see its
+        # test_create_conflicting_content_type_raises /
+        # test_create_conflicting_ttl_raises): the Django Stream model has no
+        # content_type/ttl/closed columns at all, so there is no config to
+        # conflict on. `create()` re-`create`d with different kwargs silently
+        # ignores them rather than raising ValueError — this pins that
+        # behaviour so a future caller relying on in-memory-style
+        # conflict-rejection sees a failing test instead of a silent no-op.
+        store = DjangoStreamStore()
+        store.create("s", content_type="application/json")
+        # No ValueError, and the extra kwargs leave no trace to conflict on.
+        again = store.create("s", content_type="text/plain")
+        assert Stream.objects.filter(stream_id="s").count() == 1
+        assert again.stream_id == "s"
+
+    def test_append_has_no_closed_stream_concept(self):
+        # Deliberate divergence from the in-memory StreamStore (see its
+        # test_append_to_closed_stream_returns_stream_closed /
+        # test_seq_conflict_raises): DjangoStreamStore does not model stream
+        # closing or Stream-Seq/producer fencing (module docstring — those are
+        # live-protocol-server concerns, out of scope for the durable
+        # event-sourcing store). There is nothing to close and no seq option
+        # honoured, so repeated appends never raise ValueError and never
+        # report stream_closed — appends just keep succeeding.
+        store = DjangoStreamStore()
+        store.create("s")
+        first = store.append("s", b'{"id": 1}', AppendOptions(seq="5"))
+        second = store.append("s", b'{"id": 2}', AppendOptions(seq="5"))
+        assert first.event.data == {"id": 1}
+        assert second.event.data == {"id": 2}
 
     def test_get_current_offset(self):
         store = DjangoStreamStore()


### PR DESCRIPTION
## Summary

Post-merge adversarial review of PR #45 (WritableStore protocol + shared conformance suite) flagged that the shared conformance suite doesn't exercise `create()` conflict-rejection or closed-stream/`ValueError` paths that the in-memory `StreamStore` implements. Investigation found this is **not a gap to close** — it's an intentional, permanent architectural divergence:

- `DjangoStreamStore`'s `Stream` model has no `content_type`/`ttl`/`closed` columns, so there's no stored config to conflict on `create()`.
- Stream closing and producer-seq fencing are live-protocol-server concerns, explicitly out of scope for the durable event-sourcing store (per the module's own docstring / ADR 0002).

Rather than leave this implicit, this PR pins it:

- Two new tests lock in `DjangoStreamStore`'s actual behavior (silently ignores conflicting `create()` kwargs; has no closed-stream concept).
- `WritableStore.append()`'s docstring now spells out all three possible outcomes instead of one guaranteed exception plus a vague "backend-specific" wave.
- `store_contract.py`'s module docstring cross-references exactly where each divergence is pinned per backend.

This prevents a future refactor from silently drifting into a real cross-backend bug where none exists today.

## Test plan
- [x] Full suite passes (557 passed, 1 skipped)
- [x] `ruff check` / `ruff format --check` clean