### PR TITLE
fix(projections): guard reconcile_aggregate whole-table wipe (#50)

### DIFF
--- a/src/rakaia/projections.py
+++ b/src/rakaia/projections.py
@@ -256,6 +256,8 @@ def reconcile_aggregate(
     scope_lookup: dict[str, Any],
     group_key: str,
     groups: Mapping[Any, dict[str, Any]],
+    *,
+    allow_full_clear: bool = False,
 ) -> list[Effect]:
     """Materialise one recomputed aggregate row per group, without stale rows.
 
@@ -266,12 +268,14 @@ def reconcile_aggregate(
     per group plus a reconcile ``delete`` that removes aggregate rows for groups
     which no longer have any contributors.
 
-    .. warning::
-        The reconcile delete is scoped to ``scope_lookup``. With a global scope
-        (``scope_lookup={}``) **and** empty ``groups``, the delete matches every
-        row in the model and clears the whole table. Pass a non-empty
-        ``scope_lookup`` whenever the aggregate model holds more than this one
-        rollup, so an empty recompute clears only that scope.
+    **Whole-table-wipe guard.** The reconcile delete is scoped to
+    ``scope_lookup``. A global scope (``scope_lookup={}``) **with** empty
+    ``groups`` is a delete that matches *every* row in the model — a full-table
+    clear. That is correct for a full rebuild which legitimately found zero
+    facts, but is a footgun when run against an empty or half-migrated fact
+    table (it silently wipes the projection). So that exact combination raises
+    ``ValueError`` unless you opt in with ``allow_full_clear=True``. A non-empty
+    ``scope_lookup`` (a scoped clear) or non-empty ``groups`` is never gated.
 
     Args:
         model_label: 'app_label.ModelName' of the aggregate model.
@@ -283,12 +287,26 @@ def reconcile_aggregate(
             ``"district"``. (Single-field groups; composite groups are out of
             scope — a simple ``exclude`` cannot express "tuple not in set".)
         groups: mapping of group value to its recomputed ``defaults=`` values.
+        allow_full_clear: opt in to the whole-table clear (global scope + empty
+            groups). Required for that one combination; ignored otherwise.
 
     Returns:
         One ``update_or_create`` Effect per group (in mapping order), followed by
         one ``delete`` Effect removing rows under ``scope_lookup`` whose group is
         not present. Empty ``groups`` yields just the delete, clearing the set.
+
+    Raises:
+        ValueError: if ``scope_lookup`` and ``groups`` are both empty and
+            ``allow_full_clear`` is not set — the un-opted-in whole-table wipe.
     """
+    if not scope_lookup and not groups and not allow_full_clear:
+        raise ValueError(
+            f"reconcile_aggregate({model_label!r}) with a global scope "
+            "(scope_lookup={}) and empty groups would delete every row in the "
+            "model. Pass a non-empty scope_lookup to clear only that scope, or "
+            "allow_full_clear=True to confirm you intend a whole-table clear "
+            "(e.g. a full rebuild that found zero facts)."
+        )
     group_values = list(groups)
     effects: list[Effect] = [
         Effect(

--- a/tests/test_rakaia/test_projections.py
+++ b/tests/test_rakaia/test_projections.py
@@ -287,11 +287,39 @@ class TestReconcileAggregate:
         # groups that vanished (no contributors) get their aggregate removed
         assert deletes[0].exclude == {"suku__in": ["Fatuberliu", "Maubara"]}
 
-    def test_empty_groups_deletes_all(self):
-        effects = _agg({})
+    def test_empty_groups_with_scope_clears_only_that_scope(self):
+        # Empty groups under a *non-empty* scope is a safe scoped clear (removes
+        # every aggregate row in the scope) and needs no opt-in.
+        effects = _agg({}, scope={"report_id": 42})
         assert [e for e in effects if e.op == "update_or_create"] == []
         deletes = [e for e in effects if e.op == "delete"]
+        assert deletes[0].lookup == {"report_id": 42}
         assert deletes[0].exclude == {"suku__in": []}
+
+    def test_empty_global_scope_and_empty_groups_raises(self):
+        # The whole-table-wipe footgun (#50): global scope + no groups matches
+        # every row. Guarded — it must be an explicit opt-in, not a silent wipe.
+        with pytest.raises(ValueError, match="allow_full_clear"):
+            _agg({})
+
+    def test_empty_global_scope_and_empty_groups_allowed_with_flag(self):
+        # A legitimate full rebuild that found zero facts opts in explicitly.
+        effects = reconcile_aggregate(
+            model_label="app.Balance",
+            scope_lookup={},
+            group_key="suku",
+            groups={},
+            allow_full_clear=True,
+        )
+        assert [e for e in effects if e.op == "update_or_create"] == []
+        deletes = [e for e in effects if e.op == "delete"]
+        assert deletes[0].lookup == {}
+        assert deletes[0].exclude == {"suku__in": []}
+
+    def test_global_scope_with_groups_needs_no_flag(self):
+        # Global scope but non-empty groups is not a full clear — unaffected.
+        effects = _agg({"a": {"total": 1}})
+        assert [e.op for e in effects] == ["update_or_create", "delete"]
 
     def test_scope_included_in_lookup_and_delete(self):
         effects = _agg({"north": {"total": 5}}, scope={"report_id": 42})


### PR DESCRIPTION
Closes #50. Surfaced by the Partisipa generalization spike.

## Problem
`reconcile_aggregate` emits a reconcile-delete scoped to `scope_lookup`. With a **global scope (`scope_lookup={}`) and empty `groups`**, that delete matches every row and **clears the whole table** — a silent-wipe footgun when a batch reducer runs against an empty/half-migrated fact table. It was guarded only by a docstring warning.

## Change
- Add keyword-only `allow_full_clear: bool = False`.
- Raise `ValueError` for the exact `not scope_lookup and not groups and not allow_full_clear` combination.
- A scoped clear (non-empty scope) and any call with non-empty groups are never gated — backward-compatible for every correct caller.
- Docstring rewritten to describe the guard.

## Tests (TDD)
- `test_empty_global_scope_and_empty_groups_raises` — footgun raises.
- `test_empty_global_scope_and_empty_groups_allowed_with_flag` — full rebuild opts in, gets the whole-model delete.
- `test_empty_groups_with_scope_clears_only_that_scope` — scoped clear unchanged (replaces old `test_empty_groups_deletes_all`).
- `test_global_scope_with_groups_needs_no_flag` — non-empty groups unaffected.

Full suite: 578 passed / 1 skipped; `ruff check` + `ruff format --check` clean.