### PR TITLE
feat(replay): pass touched subjects to opt-in reducers (#51)

### DIFF
--- a/docs/versioned-handlers.md
+++ b/docs/versioned-handlers.md
@@ -349,6 +349,37 @@ deliberate: a reducer recomputes an aggregate *wholesale* from the committed
 projections on every replay, so there is no per-sequence window to version over.
 If you need two coexisting reduce steps, give them distinct names.
 
+### Reducers: recompute everything, or just what changed
+
+By default a reducer is called `fn(reader)` and recomputes its aggregate
+*wholesale* — correct, and the right thing for a full rebuild. But recomputing
+every group on every incremental save is wasteful when a single submission
+touched two of them.
+
+A reducer that declares a **second parameter** — `fn(reader, touched)` — is
+handed the tuple of `TouchedSubject`s the pass's per-event handlers wrote (each
+carries the effect's `model_label` and `lookup`). It is deterministic and
+deduplicated, in event order, and — crucially — is a function of *this pass*:
+on a full replay it is every subject; on a tail/incremental replay it is only
+the ones the tail touched. So one reducer serves both paths — scope the
+recompute (and the `reconcile_aggregate` scope) to `touched` when it is small,
+recompute everything when it is the whole stream:
+
+```python
+from rakaia import register_reducer, reconcile_aggregate
+
+@register_reducer(name="balance", stage=1)
+def balance(reader, touched):
+    sukus = {t.lookup["suku"] for t in touched if t.model_label == "ida.Line"}
+    groups = _recompute_totals(reader, only=sukus)      # only the touched groups
+    return reconcile_aggregate("ida.Balance", {}, "suku", groups)
+```
+
+The signal is opt-in and detected by signature (the same way a stage > 0 handler
+opts in to the reader): a plain `fn(reader)` reducer is called exactly as before.
+Note it reflects **handler** writes only — a reducer's own output Effects are not
+recorded as touched, so reducers at the same stage don't feed each other.
+
 ## Replacing `post_migration_tasks.py`
 
 Existing `PostMigrationTask` entries map naturally onto versioned handlers

--- a/src/rakaia/__init__.py
+++ b/src/rakaia/__init__.py
@@ -71,7 +71,7 @@ from .registry import (
     reset_default_registries,
     upcast,
 )
-from .replay import ENVELOPE_TS, ReplayResult, merge_replay, replay
+from .replay import ENVELOPE_TS, ReplayResult, TouchedSubject, merge_replay, replay
 from .store import StreamStore
 from .subscription import Poll, PollStatus, poll
 from .types import (
@@ -177,6 +177,7 @@ __all__ = [
     "merge_replay",
     "ENVELOPE_TS",
     "ReplayResult",
+    "TouchedSubject",
     # Subscriber cursors
     "poll",
     "Poll",

--- a/src/rakaia/projections.py
+++ b/src/rakaia/projections.py
@@ -256,6 +256,8 @@ def reconcile_aggregate(
     scope_lookup: dict[str, Any],
     group_key: str,
     groups: Mapping[Any, dict[str, Any]],
+    *,
+    allow_full_clear: bool = False,
 ) -> list[Effect]:
     """Materialise one recomputed aggregate row per group, without stale rows.
 
@@ -266,12 +268,14 @@ def reconcile_aggregate(
     per group plus a reconcile ``delete`` that removes aggregate rows for groups
     which no longer have any contributors.
 
-    .. warning::
-        The reconcile delete is scoped to ``scope_lookup``. With a global scope
-        (``scope_lookup={}``) **and** empty ``groups``, the delete matches every
-        row in the model and clears the whole table. Pass a non-empty
-        ``scope_lookup`` whenever the aggregate model holds more than this one
-        rollup, so an empty recompute clears only that scope.
+    **Whole-table-wipe guard.** The reconcile delete is scoped to
+    ``scope_lookup``. A global scope (``scope_lookup={}``) **with** empty
+    ``groups`` is a delete that matches *every* row in the model — a full-table
+    clear. That is correct for a full rebuild which legitimately found zero
+    facts, but is a footgun when run against an empty or half-migrated fact
+    table (it silently wipes the projection). So that exact combination raises
+    ``ValueError`` unless you opt in with ``allow_full_clear=True``. A non-empty
+    ``scope_lookup`` (a scoped clear) or non-empty ``groups`` is never gated.
 
     Args:
         model_label: 'app_label.ModelName' of the aggregate model.
@@ -283,12 +287,26 @@ def reconcile_aggregate(
             ``"district"``. (Single-field groups; composite groups are out of
             scope — a simple ``exclude`` cannot express "tuple not in set".)
         groups: mapping of group value to its recomputed ``defaults=`` values.
+        allow_full_clear: opt in to the whole-table clear (global scope + empty
+            groups). Required for that one combination; ignored otherwise.
 
     Returns:
         One ``update_or_create`` Effect per group (in mapping order), followed by
         one ``delete`` Effect removing rows under ``scope_lookup`` whose group is
         not present. Empty ``groups`` yields just the delete, clearing the set.
+
+    Raises:
+        ValueError: if ``scope_lookup`` and ``groups`` are both empty and
+            ``allow_full_clear`` is not set — the un-opted-in whole-table wipe.
     """
+    if not scope_lookup and not groups and not allow_full_clear:
+        raise ValueError(
+            f"reconcile_aggregate({model_label!r}) with a global scope "
+            "(scope_lookup={}) and empty groups would delete every row in the "
+            "model. Pass a non-empty scope_lookup to clear only that scope, or "
+            "allow_full_clear=True to confirm you intend a whole-table clear "
+            "(e.g. a full rebuild that found zero facts)."
+        )
     group_values = list(groups)
     effects: list[Effect] = [
         Effect(

--- a/src/rakaia/registry.py
+++ b/src/rakaia/registry.py
@@ -108,6 +108,15 @@ class ReducerVersion:
     returning the idempotent Effects that materialise the aggregate. It is the
     replay-time hook that `reconcile_aggregate` is designed to fill.
 
+    **Optional touched-subjects arg.** A reducer that declares a second
+    parameter is invoked as `fn(reader, touched)`, where ``touched`` is the
+    deterministic, deduplicated tuple of `rakaia.TouchedSubject`s the pass's
+    per-event handlers wrote (their effects' ``(model_label, lookup)``). This
+    lets one reducer serve both paths: scope the recompute to ``touched`` on an
+    incremental forward replay, or ignore it and recompute everything on a full
+    rebuild. A plain ``fn(reader)`` reducer is unaffected (the arg is detected by
+    signature, mirroring how a stage > 0 handler opts in to the reader).
+
     **Replacement semantics — last-write-wins by name, not seq-versioned.**
     A reducer is a single *current* definition keyed by `name`, unlike a handler,
     which is a series of `[from_seq, to_seq)`-bracketed versions. Registering a
@@ -126,7 +135,8 @@ class ReducerVersion:
     """The stage this reducer runs in (after that stage's event handlers)."""
 
     fn: Callable[..., Any]
-    """The reducer callable. reader -> Effect | list[Effect] | None."""
+    """The reducer callable: ``reader -> ...`` or ``reader, touched -> ...``,
+    returning ``Effect | list[Effect] | None``."""
 
     dotted_path: str
     source_hash: str
@@ -984,7 +994,11 @@ def register_reducer(
 
     The decorated function is called `fn(reader)` once during staged replay,
     after `stage`'s per-event handlers commit, and returns the Effects that
-    materialise the aggregate (typically via `reconcile_aggregate`).
+    materialise the aggregate (typically via `reconcile_aggregate`). Declare a
+    second parameter — `fn(reader, touched)` — to also receive the tuple of
+    `rakaia.TouchedSubject`s the pass's handlers wrote, so the same reducer can
+    scope its recompute to what changed (incremental) or recompute everything
+    (full rebuild). The arg is detected by signature; `fn(reader)` is unchanged.
 
     A reducer is a single current definition keyed by `name` (last-write-wins),
     not a seq-versioned series like a handler — see `ReducerVersion`.
@@ -993,6 +1007,13 @@ def register_reducer(
         @register_reducer(name="balance", stage=1)
         def balance(reader):
             groups = _recompute_totals(reader)
+            return reconcile_aggregate("ida.Balance", {}, "suku", groups)
+
+        # touched-aware: only the groups this pass changed
+        @register_reducer(name="balance", stage=1)
+        def balance(reader, touched):
+            sukus = {r.lookup["suku"] for r in touched if r.model_label == "ida.Line"}
+            groups = _recompute_totals(reader, only=sukus)
             return reconcile_aggregate("ida.Balance", {}, "suku", groups)
     """
     target = registry if registry is not None else _default_registry

--- a/src/rakaia/replay.py
+++ b/src/rakaia/replay.py
@@ -18,7 +18,10 @@ pass per stage in ascending order: the whole range through stage 0, then stage
 projections earlier stages committed. A stage may also declare **reducers**
 (`register_reducer(name, stage, fn)`) that run once, after that stage's per-event
 handlers, to recompute an aggregate from the committed projections via the
-reader. See `register_handler(stage=...)` and `register_reducer(...)`.
+reader. A reducer declaring a second parameter (`fn(reader, touched)`) also
+receives the `TouchedSubject`s the pass's handlers wrote, so one reducer can
+scope its recompute to what changed (incremental) or to everything (full
+rebuild). See `register_handler(stage=...)` and `register_reducer(...)`.
 
 Re-running the same range twice produces identical materialized state because
 all Effects use update_or_create (idempotent).
@@ -26,6 +29,7 @@ all Effects use update_or_create (idempotent).
 
 from __future__ import annotations
 
+import inspect
 import json
 import logging
 from collections.abc import Iterable
@@ -79,6 +83,23 @@ class ReplayResult:
     drift_detected: list[str] = field(default_factory=list)
 
 
+@dataclass(frozen=True)
+class TouchedSubject:
+    """One subject a replay pass's per-event handlers wrote: the target model
+    and the ``lookup`` identifying the affected row(s), taken straight from the
+    applied Effect.
+
+    A staged-replay reducer that declares a second parameter receives the
+    deterministic, deduplicated tuple of these — the subjects changed *in this
+    pass* — so it can scope its recompute (e.g. only the touched groups on an
+    incremental forward replay, everything on a full rebuild). A one-argument
+    ``fn(reader)`` reducer is unaffected. See `register_reducer`.
+    """
+
+    model_label: str
+    lookup: dict[str, Any]
+
+
 @dataclass
 class _ReplayCtx:
     """Bundle of the invariants the pipeline helpers need, shared by `replay()`
@@ -90,6 +111,61 @@ class _ReplayCtx:
     include_external: bool
     on_drift: OnDriftPolicy
     result: ReplayResult
+    # Only accumulate touched subjects when a reducer actually opts in (a second
+    # parameter), so the common path pays nothing.
+    track_touched: bool = False
+    touched: list[TouchedSubject] = field(default_factory=list)
+    _touched_seen: set = field(default_factory=set)
+
+
+def _reducer_wants_touched(fn: Any) -> bool:
+    """Whether a reducer opts in to the touched-subjects arg by declaring a
+    second positional parameter — mirroring how a stage > 0 handler opts in to
+    the reader. A plain ``fn(reader)`` returns False and is called with one arg,
+    so existing reducers are unchanged.
+    """
+    try:
+        sig = inspect.signature(fn)
+    except (TypeError, ValueError):
+        return False
+    positional = 0
+    for p in sig.parameters.values():
+        if p.kind is inspect.Parameter.VAR_POSITIONAL:
+            return True
+        if p.kind in (
+            inspect.Parameter.POSITIONAL_ONLY,
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+        ):
+            positional += 1
+    return positional >= 2
+
+
+def _wants_touched_reducer(handlers: HandlerRegistry) -> bool:
+    """Whether any registered reducer opts in — decides if we bother tracking."""
+    return handlers.has_reducers() and any(
+        _reducer_wants_touched(r.fn) for r in handlers.all_reducers()
+    )
+
+
+def _record_touched(ctx: _ReplayCtx, effects: list[Effect]) -> None:
+    # A subject is a subject-bearing effect's (model_label, lookup). Skip
+    # external effects (no subject) and dedup in first-seen (event) order so the
+    # set is a pure function of the events. A non-hashable lookup value is rare
+    # and simply skips dedup — order still deterministic.
+    for e in effects:
+        if e.op == "external" or e.model_label is None or e.lookup is None:
+            continue
+        try:
+            key = (e.model_label, tuple(sorted(e.lookup.items())))
+        except TypeError:
+            key = None
+        if key is not None:
+            if key in ctx._touched_seen:
+                continue
+            ctx._touched_seen.add(key)
+        ctx.touched.append(
+            TouchedSubject(model_label=e.model_label, lookup=dict(e.lookup))
+        )
 
 
 def _apply_effects(ctx: _ReplayCtx, effects: list[Effect]) -> None:
@@ -112,16 +188,25 @@ def _dispatch_event(
     for version in versions:
         _check_handler_drift(version, ctx.on_drift, ctx.result)
         all_effects.extend(_call_handler(version, upcasted, ctx.reader))
+    if ctx.track_touched:
+        _record_touched(ctx, all_effects)
     _apply_effects(ctx, all_effects)
 
 
 def _run_stage_reducers(ctx: _ReplayCtx, stage: int | None) -> None:
     # Reducers run once per stage, after that stage's per-event handlers have
     # committed, reading the accumulated projections via the reader. A None
-    # stage (single, non-staged pass) has no reducers.
+    # stage (single, non-staged pass) has no reducers. A reducer declaring a
+    # second parameter also receives the subjects the pass's handlers touched so
+    # far (cumulative across stages already run this pass); reducer *outputs* are
+    # not themselves recorded as touched.
     for reducer in ctx.handlers.reducers_for_stage(stage):
         _check_reducer_drift(reducer, ctx.on_drift, ctx.result)
-        _apply_effects(ctx, _normalize_effects(reducer.fn(ctx.reader)))
+        if _reducer_wants_touched(reducer.fn):
+            out = reducer.fn(ctx.reader, tuple(ctx.touched))
+        else:
+            out = reducer.fn(ctx.reader)
+        _apply_effects(ctx, _normalize_effects(out))
 
 
 def replay(
@@ -171,9 +256,11 @@ def replay(
     stage > 0 handlers are called `fn(event, reader)` so they can resolve facts
     earlier stages materialised (a form linking to a reference entity another
     form created, regardless of arrival order). After a stage's per-event
-    handlers, its reducers (`register_reducer`) run once as `fn(reader)` to
-    recompute aggregates. With only stage 0 handlers and no reducers, replay is a
-    single pass, exactly as before.
+    handlers, its reducers (`register_reducer`) run once as `fn(reader)` — or
+    `fn(reader, touched)` for a reducer that opts in to the tuple of
+    `TouchedSubject`s the pass's handlers wrote — to recompute aggregates. With
+    only stage 0 handlers and no reducers, replay is a single pass, exactly as
+    before.
     """
     handlers = handler_registry or get_default_registry()
     upcasters = upcaster_registry or get_default_upcaster_registry()
@@ -212,6 +299,7 @@ def replay(
         include_external=include_external,
         on_drift=on_drift,
         result=result,
+        track_touched=_wants_touched_reducer(handlers),
     )
     stage_numbers = handlers.stages()
     staged = any(s > 0 for s in stage_numbers) or handlers.has_reducers()
@@ -373,6 +461,7 @@ def merge_replay(
         include_external=include_external,
         on_drift=on_drift,
         result=result,
+        track_touched=_wants_touched_reducer(handlers),
     )
     stage_numbers = handlers.stages()
     staged = any(s > 0 for s in stage_numbers) or handlers.has_reducers()

--- a/tests/test_rakaia/test_projections.py
+++ b/tests/test_rakaia/test_projections.py
@@ -287,11 +287,39 @@ class TestReconcileAggregate:
         # groups that vanished (no contributors) get their aggregate removed
         assert deletes[0].exclude == {"suku__in": ["Fatuberliu", "Maubara"]}
 
-    def test_empty_groups_deletes_all(self):
-        effects = _agg({})
+    def test_empty_groups_with_scope_clears_only_that_scope(self):
+        # Empty groups under a *non-empty* scope is a safe scoped clear (removes
+        # every aggregate row in the scope) and needs no opt-in.
+        effects = _agg({}, scope={"report_id": 42})
         assert [e for e in effects if e.op == "update_or_create"] == []
         deletes = [e for e in effects if e.op == "delete"]
+        assert deletes[0].lookup == {"report_id": 42}
         assert deletes[0].exclude == {"suku__in": []}
+
+    def test_empty_global_scope_and_empty_groups_raises(self):
+        # The whole-table-wipe footgun (#50): global scope + no groups matches
+        # every row. Guarded — it must be an explicit opt-in, not a silent wipe.
+        with pytest.raises(ValueError, match="allow_full_clear"):
+            _agg({})
+
+    def test_empty_global_scope_and_empty_groups_allowed_with_flag(self):
+        # A legitimate full rebuild that found zero facts opts in explicitly.
+        effects = reconcile_aggregate(
+            model_label="app.Balance",
+            scope_lookup={},
+            group_key="suku",
+            groups={},
+            allow_full_clear=True,
+        )
+        assert [e for e in effects if e.op == "update_or_create"] == []
+        deletes = [e for e in effects if e.op == "delete"]
+        assert deletes[0].lookup == {}
+        assert deletes[0].exclude == {"suku__in": []}
+
+    def test_global_scope_with_groups_needs_no_flag(self):
+        # Global scope but non-empty groups is not a full clear — unaffected.
+        effects = _agg({"a": {"total": 1}})
+        assert [e.op for e in effects] == ["update_or_create", "delete"]
 
     def test_scope_included_in_lookup_and_delete(self):
         effects = _agg({"north": {"total": 5}}, scope={"report_id": 42})

--- a/tests/test_rakaia/test_replay.py
+++ b/tests/test_rakaia/test_replay.py
@@ -13,7 +13,7 @@ from rakaia.registry import (
     HandlerRegistry,
     UpcasterRegistry,
 )
-from rakaia.replay import ENVELOPE_TS, merge_replay, replay
+from rakaia.replay import ENVELOPE_TS, TouchedSubject, merge_replay, replay
 from rakaia.store import StreamStore
 from rakaia.types import AppendOptions
 
@@ -896,6 +896,176 @@ class TestReducers:
         )
         assert len(proj.query("app.FinanceLine")) == 3
         assert {b.suku for b in proj.query("app.Balance")} == {"A", "B"}
+
+
+def _capturing_reducer(sink: list):
+    # A two-argument reducer opts in to the touched-subjects signal.
+    def reducer(reader, touched):  # noqa: ARG001
+        sink.append(touched)
+        return []
+
+    return reducer
+
+
+class TestReducerTouchedSubjects:
+    """A reducer that declares a second parameter receives the deterministic set
+    of subjects the pass's per-event handlers wrote (#51)."""
+
+    def test_two_arg_reducer_receives_touched_subjects(self, store: StreamStore):
+        _seed_stream(store, "s", _FINANCE_EVENTS)  # keys f1, f2, f3
+        sink: list = []
+        proj = DictProjections()
+        replay(
+            store,
+            "s",
+            proj,
+            handler_registry=_finance_registry(_capturing_reducer(sink)),
+            upcaster_registry=UpcasterRegistry(),
+            reader=proj,
+        )
+        (touched,) = sink
+        # In event order, one subject per FinanceLine write, each identified by
+        # the effect's (model_label, lookup).
+        assert [(t.model_label, t.lookup) for t in touched] == [
+            ("app.FinanceLine", {"submission_id": "f1"}),
+            ("app.FinanceLine", {"submission_id": "f2"}),
+            ("app.FinanceLine", {"submission_id": "f3"}),
+        ]
+        assert all(isinstance(t, TouchedSubject) for t in touched)
+
+    def test_one_arg_reducer_is_called_unchanged(self, store: StreamStore):
+        # A legacy fn(reader) reducer keeps working — no touched arg is forced.
+        _seed_stream(store, "s", _FINANCE_EVENTS)
+        proj = DictProjections()
+        replay(
+            store,
+            "s",
+            proj,
+            handler_registry=_finance_registry(_balance_reducer),
+            upcaster_registry=UpcasterRegistry(),
+            reader=proj,
+        )
+        assert proj.get("app.Balance", suku="A").total == 70
+
+    def test_touched_is_incremental_on_a_tail_replay(self, store: StreamStore):
+        # Replaying only the tail touches only the tail's subjects — the same
+        # reducer scopes to what the pass changed, no code change at the reducer.
+        _seed_stream(store, "s", _FINANCE_EVENTS)
+        sink: list = []
+        proj = DictProjections()
+        replay(
+            store,
+            "s",
+            proj,
+            handler_registry=_finance_registry(_capturing_reducer(sink)),
+            upcaster_registry=UpcasterRegistry(),
+            reader=proj,
+            start_seq=2,  # only f3
+        )
+        (touched,) = sink
+        assert [t.lookup for t in touched] == [{"submission_id": "f3"}]
+
+    def test_touched_excludes_reducer_outputs(self, store: StreamStore):
+        # touched reflects per-event *handler* writes, not what an earlier
+        # reducer at the same stage emitted. Two stage-1 reducers, name-ordered:
+        # "a_writes" recomputes app.Balance; "b_captures" runs after and must not
+        # see app.Balance in its touched set.
+        _seed_stream(store, "s", _FINANCE_EVENTS)
+        sink: list = []
+        reg = HandlerRegistry()
+        reg.register(
+            "finance", "FINANCE", _finance_line, 0, None, match_field="form_type"
+        )
+        reg.register_reducer("a_writes", 1, _balance_reducer)
+        reg.register_reducer("b_captures", 1, _capturing_reducer(sink))
+        proj = DictProjections()
+        replay(
+            store,
+            "s",
+            proj,
+            handler_registry=reg,
+            upcaster_registry=UpcasterRegistry(),
+            reader=proj,
+        )
+        (touched,) = sink
+        assert proj.get("app.Balance", suku="A").total == 70  # a_writes ran first
+        assert {t.model_label for t in touched} == {"app.FinanceLine"}
+
+    def test_touched_deduplicates_repeated_subjects(self, store: StreamStore):
+        # Two events writing the same subject appear once in touched.
+        events = [
+            {
+                "schema_version": 1,
+                "form_type": "FINANCE",
+                "key": "f1",
+                "suku": "A",
+                "delta": 100,
+            },
+            {
+                "schema_version": 1,
+                "form_type": "FINANCE",
+                "key": "f1",
+                "suku": "A",
+                "delta": 5,
+            },
+        ]
+        _seed_stream(store, "s", events)
+        sink: list = []
+        proj = DictProjections()
+        replay(
+            store,
+            "s",
+            proj,
+            handler_registry=_finance_registry(_capturing_reducer(sink)),
+            upcaster_registry=UpcasterRegistry(),
+            reader=proj,
+        )
+        (touched,) = sink
+        assert [t.lookup for t in touched] == [{"submission_id": "f1"}]
+
+    def test_touched_flows_through_merge_replay(self, store: StreamStore):
+        # merge_replay shares the same pipeline; a two-arg reducer gets the
+        # touched subjects merged across streams, in merged order.
+        _seed_stream(
+            store,
+            "fin/a",
+            [
+                {
+                    "schema_version": 1,
+                    "form_type": "FINANCE",
+                    "key": "f1",
+                    "suku": "A",
+                    "delta": 100,
+                    "ts": "2026-01-01T00:00:00Z",
+                }
+            ],
+        )
+        _seed_stream(
+            store,
+            "fin/b",
+            [
+                {
+                    "schema_version": 1,
+                    "form_type": "FINANCE",
+                    "key": "f2",
+                    "suku": "A",
+                    "delta": -30,
+                    "ts": "2026-01-01T01:00:00Z",
+                }
+            ],
+        )
+        sink: list = []
+        proj = DictProjections()
+        merge_replay(
+            store,
+            ["fin/a", "fin/b"],
+            proj,
+            handler_registry=_finance_registry(_capturing_reducer(sink)),
+            upcaster_registry=UpcasterRegistry(),
+            reader=proj,
+        )
+        (touched,) = sink
+        assert {t.lookup["submission_id"] for t in touched} == {"f1", "f2"}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #51. Surfaced by the Partisipa generalization spike.

## Problem
A staged-replay reducer was **batch-only**: it is called `fn(reader)` (`replay.py` `_run_stage_reducers`) with no signal of what the pass changed, so an aggregate can only be recomputed *wholesale*. In the spike that forced a separate `batch_registry` to keep the incremental forward path reducer-free, plus a duplicated fold (incremental vs batch — the same math twice).

## Change
A reducer that declares a **second parameter** — `fn(reader, touched)` — receives the deterministic, deduplicated tuple of `TouchedSubject` the pass's per-event handlers wrote (each an effect's `(model_label, lookup)`).

- One reducer serves both paths: scope the recompute (and `reconcile_aggregate` scope) to `touched` on an incremental/tail replay; recompute everything on a full rebuild (where `touched` is every subject).
- **Opt-in by signature**, mirroring how a stage > 0 handler opts in to the reader — existing `fn(reader)` reducers are called exactly as before.
- `touched` reflects **handler** writes only; reducer outputs are not recorded, so two reducers at the same stage don't feed each other.
- Deterministic: first-seen order across the pass, deduped; a pure function of the events. Accumulation is skipped entirely unless a reducer opts in (no cost on the common path).
- New public `rakaia.TouchedSubject`.

## Tests (TDD)
New `TestReducerTouchedSubjects`: receives touched; legacy one-arg reducer unchanged; incremental tail touches only the tail; excludes reducer outputs (two name-ordered stage-1 reducers); dedups repeated subjects; flows through `merge_replay`.

Full suite: 584 passed / 1 skipped; `ruff check` + `ruff format --check` clean. Docs: reducers section in `versioned-handlers.md`; `register_reducer`/`ReducerVersion` docstrings.

Relates to #50 (a touched-scoped reducer pairs with the `reconcile_aggregate` guard).