### PR TITLE
fix(offsets): single-source the offset-validation pattern across protocol servers (#41)

### DIFF
--- a/src/django_rakaia/protocol_views.py
+++ b/src/django_rakaia/protocol_views.py
@@ -24,7 +24,6 @@ Usage:
 
 import asyncio
 import json
-import re
 
 from django.db import transaction
 from django.db.models import Max
@@ -33,16 +32,27 @@ from django.urls import path
 from django.views.decorators.http import require_http_methods
 
 from django_rakaia.models import Stream, StreamEntry, StreamEvent
+from rakaia.types import VALID_OFFSET_PATTERN
 
 # =============================================================================
 # Constants and Type Aliases
 # =============================================================================
 
-# Offset format: {read_seq}_{byte_offset} (both zero-padded to 16 digits)
+# Offset format for this (Django ORM-backed) protocol server: a fixed `0`
+# generation sentinel, an underscore, then the entry's monotonic 1-indexed
+# **sequence number** (from `Stream.get_next_offset`) zero-padded to 16 digits —
+# e.g. `"0_0000000000000001"`. The low field is a sequence number, NOT a byte
+# offset: this server counts events, not bytes. The generation is a literal `0`
+# (it does not yet advance across delete+recreate — that is #34 Defect #2,
+# deferred). Padding keeps offsets lexicographically sortable per protocol §6.
+# The in-memory `handler` server emits a *different* format (`{seq}_{byte}`) for
+# the same protocol — permitted: the protocol mandates opacity, not one format
+# (§6; see #49). Only the *validation* pattern is shared (imported above, #41).
 OFFSET_FORMAT = "0_{:016d}"
 
-# Valid offset pattern per protocol spec
-VALID_OFFSET_PATTERN = re.compile(r"^(-1|now|\d+_\d+)$")
+# `VALID_OFFSET_PATTERN` is imported from `rakaia.types` (the single source of
+# truth, #41) so this server and the in-memory `handler` validate offsets
+# identically even though they format them differently.
 
 # Header names (protocol specification)
 STREAM_NEXT_OFFSET_HEADER = "Stream-Next-Offset"
@@ -59,26 +69,27 @@ CACHE_CONTROL_HEADER = "Cache-Control"
 
 def format_offset(offset: int) -> str:
     """
-    Format an integer offset as a protocol-compliant offset string.
+    Format an integer sequence number as a protocol-compliant offset string.
 
     Args:
-        offset: Integer offset value.
+        offset: The entry's monotonic 1-indexed sequence number.
 
     Returns:
-        Formatted offset string (e.g., "0_0000000000000001").
+        Formatted offset string (e.g., "0_0000000000000001"): the `0`
+        generation sentinel, then the zero-padded sequence number.
     """
     return OFFSET_FORMAT.format(offset)
 
 
 def parse_offset(offset_str: str) -> int:
     """
-    Parse a protocol offset string to an integer.
+    Parse a protocol offset string back to its integer sequence number.
 
     Args:
-        offset_str: Offset string in format "read_seq_byte_offset".
+        offset_str: Offset string in format "{generation}_{sequence}".
 
     Returns:
-        Integer byte offset.
+        The sequence number (the part after the underscore).
 
     Raises:
         ValueError: If offset format is invalid.

--- a/src/rakaia/handler.py
+++ b/src/rakaia/handler.py
@@ -47,6 +47,7 @@ from .types import (
     STREAM_EXPIRES_AT_HEADER,
     STREAM_SSE_DATA_ENCODING_HEADER,
     STREAM_TTL_HEADER,
+    VALID_OFFSET_PATTERN,
     AppendOptions,
     ProducerDuplicate,
     ProducerInvalidEpochSeq,
@@ -61,8 +62,8 @@ STREAM_CURSOR_HEADER_RESP = "Stream-Cursor"
 STREAM_UP_TO_DATE_HEADER_RESP = "Stream-Up-To-Date"
 STREAM_CLOSED_HEADER_RESP = "Stream-Closed"
 
-# Valid offset pattern
-VALID_OFFSET_PATTERN = re.compile(r"^(-1|now|\d+_\d+)$")
+# `VALID_OFFSET_PATTERN` is imported from `.types` (the single source of truth,
+# #41) so this server and the Django `protocol_views` validate offsets identically.
 
 # Strict integer pattern for producer headers
 STRICT_INTEGER_PATTERN = re.compile(r"^\d+$")

--- a/src/rakaia/store.py
+++ b/src/rakaia/store.py
@@ -8,7 +8,6 @@ producer validation, long-poll waiting, and TTL/expiry.
 from __future__ import annotations
 
 import asyncio
-import re
 import time
 from datetime import datetime, timezone
 
@@ -36,8 +35,10 @@ from .types import (
     StreamMessage,
 )
 
-# Valid offset pattern: exactly digits_digits, or sentinel -1, or now
-VALID_OFFSET_PATTERN = re.compile(r"^(-1|now|\d+_\d+)$")
+# NB: this module generates offsets (the `{seq}_{byte}` format) but never
+# *validates* them, so it deliberately does not import `VALID_OFFSET_PATTERN`.
+# Offset validation lives in the two protocol servers (`handler` /
+# `protocol_views`), which share the one pattern from `.types` (#41).
 
 
 class StreamStore:

--- a/src/rakaia/types.py
+++ b/src/rakaia/types.py
@@ -7,6 +7,7 @@ and protocol constants.
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass, field
 from typing import Literal
 
@@ -44,6 +45,16 @@ SSE_CLOSED_FIELD = "streamClosed"
 
 # Offset format: zero-padded 16-digit numbers separated by underscore
 INITIAL_OFFSET = "0000000000000000_0000000000000000"
+
+# Canonical offset-validation pattern: a `{digits}_{digits}` token, or the
+# sentinels `-1` (stream start) / `now` (current tail). This is the ONE source of
+# truth every offset producer/validator imports — the in-memory `StreamStore`,
+# the standalone `handler` ASGI server, and the Django `protocol_views`. Servers
+# may still emit *different* offset formats (the protocol mandates opacity, not
+# one format — §6; see #49 / `tests/store_contract.py`), but they must all agree
+# on what a syntactically valid offset looks like, so validation can't silently
+# drift apart via copy-paste (issue #41).
+VALID_OFFSET_PATTERN = re.compile(r"^(-1|now|\d+_\d+)$")
 
 # Default port for standalone servers
 DEFAULT_PORT = 4437

--- a/tests/test_django_rakaia/test_protocol.py
+++ b/tests/test_django_rakaia/test_protocol.py
@@ -494,3 +494,81 @@ class TestErrorHandling:
         Note: Content-type validation is a TODO item.
         """
         pytest.skip("Content-type validation is a TODO item")
+
+
+# =============================================================================
+# Offset Contract (issue #41 — the framework ↔ protocol-server boundary)
+# =============================================================================
+
+
+class TestOffsetContract:
+    """Pin the offset invariants the #41 finding exposed.
+
+    The two protocol servers (`rakaia.handler` over the in-memory store, and
+    `django_rakaia.protocol_views` over the ORM) are allowed to emit *different*
+    offset formats — the protocol mandates opacity, not one format (§6), and the
+    store-format divergence is deliberately pinned (see #49 / `tests/
+    store_contract.py`). What must NOT diverge is:
+
+    1. the *validation pattern* — one shared source of truth, so the servers
+       can't drift into accepting each other's offsets by silent copy-paste; and
+    2. the offset *behaviour* — strictly increasing, lexicographically sortable,
+       and usable as an opaque resume token — the same behaviour the store
+       contract asserts, now asserted at the protocol-server boundary too.
+    """
+
+    def test_offset_pattern_is_single_source(self):
+        # Both offset *validators* must reference ONE canonical pattern object, so
+        # a future edit can't relax one server's validation without the other.
+        from django_rakaia import protocol_views
+        from rakaia import handler
+        from rakaia import types as rakaia_types
+
+        canonical = rakaia_types.VALID_OFFSET_PATTERN
+        assert handler.VALID_OFFSET_PATTERN is canonical
+        assert protocol_views.VALID_OFFSET_PATTERN is canonical
+
+    @pytest.mark.django_db
+    def test_offsets_strictly_increase_lexicographically(
+        self, client: Client, stream_id: str
+    ):
+        # Successive appends yield offsets that strictly increase under plain
+        # string comparison — no numeric parsing — mirroring the store contract.
+        client.put(
+            f"/protocol/streams/{stream_id}/create", content_type="application/json"
+        )
+        offsets = []
+        for i in range(12):  # spans the 9→10 boundary that breaks naive int-as-str
+            response = client.post(
+                f"/protocol/streams/{stream_id}/append",
+                data=json.dumps({"i": i}).encode("utf-8"),
+                content_type="application/json",
+            )
+            offsets.append(response.headers["Stream-Next-Offset"])
+
+        assert offsets == sorted(offsets)  # lexicographic order matches append order
+        assert len(set(offsets)) == len(offsets)  # no duplicates
+        assert all(a < b for a, b in zip(offsets, offsets[1:], strict=False))
+
+    @pytest.mark.django_db
+    def test_offset_is_an_opaque_resume_token(self, client: Client, stream_id: str):
+        # Reading from a returned offset yields exactly the events after it, with
+        # no client-side parsing of the offset's internal structure.
+        client.put(
+            f"/protocol/streams/{stream_id}/create", content_type="application/json"
+        )
+        second_offset = None
+        for i in range(4):
+            response = client.post(
+                f"/protocol/streams/{stream_id}/append",
+                data=json.dumps({"i": i}).encode("utf-8"),
+                content_type="application/json",
+            )
+            if i == 1:
+                second_offset = response.headers["Stream-Next-Offset"]
+
+        response = client.get(
+            f"/protocol/streams/{stream_id}/read?offset={second_offset}"
+        )
+        rows = [json.loads(line) for line in response.content.decode().splitlines()]
+        assert rows == [{"i": 2}, {"i": 3}]


### PR DESCRIPTION
Resolves the confirmed offset-format finding on #41.

## What the finding was

The two protocol servers — `rakaia.handler` (over the in-memory store) and `django_rakaia.protocol_views` (over the ORM) — emit **different** offset formats, and each **re-defined `VALID_OFFSET_PATTERN` inline** (a third identical copy also sat unused in `store.py`). Because both copies were identical and permissive (`\d+_\d+`), each server silently *accepts the other's offsets as valid* — and with no shared definition, the two validators could drift apart without any test noticing.

## What this changes (and what it deliberately doesn't)

Format divergence between the servers is **intentional and stays** — the protocol mandates opacity, not one format (§6), and the store-format divergence is already pinned in #49 / `tests/store_contract.py`. This PR targets only the real defects:

- **One source of truth.** `VALID_OFFSET_PATTERN` moves to `rakaia.types`; `handler` and `protocol_views` import it. `store.py` never validated offsets (it only *generates* them), so its inline copy was dead code — removed, along with the now-unused `re` import in both `store.py` and `protocol_views.py`.
- **Honest docs.** `protocol_views` claimed its `"0_{seq}"` format was `{read_seq}_{byte_offset}` "both zero-padded to 16 digits". Corrected: the low field is a monotonic **sequence number**, not a byte offset, and the generation is a literal `0` (advancing it across delete+recreate is #34 Defect #2, deferred).
- **Conformance guard.** New `TestOffsetContract` asserts (1) the two validators share one pattern object, and (2) protocol-server offsets are strictly-increasing, lexicographically-sortable, and usable as opaque resume tokens — mirroring the store contract, now at the protocol boundary.

## Test plan

- `TestOffsetContract` was written red first (the single-source assertion failed with `AttributeError` before `rakaia.types` grew the pattern), then green.
- Full suite: 587 passed, 1 pre-existing skip.
- `ruff check` and `ruff format --check` both clean.

Relates to #41 (boundary epic), #34 (offset conformance), #36 (conformance suite).
