### PR TITLE
fix(django): keep `channels` optional for framework-tier consumers (#41)

### DIFF
--- a/src/django_rakaia/apps.py
+++ b/src/django_rakaia/apps.py
@@ -1,4 +1,5 @@
 from django.apps import AppConfig
+from django.conf import settings
 
 
 class DjangoRakaiaConfig(AppConfig):
@@ -7,7 +8,35 @@ class DjangoRakaiaConfig(AppConfig):
     verbose_name = "Rakaia Streams"
 
     def ready(self) -> None:
-        import django_rakaia.channels_signals  # noqa: F401
+        # Framework tier: always wire handler/upcaster autodiscovery. This path
+        # has no `channels` dependency, so it must load for a projections-only
+        # consumer that never touches the protocol server (ADR-0002 / #41).
         from django_rakaia.handlers_autodiscover import autodiscover
 
         autodiscover()
+
+        # Protocol tier: SSE broadcasting via Django Channels. Wired only when
+        # wanted, so `channels`/`daphne` stay an optional extra for framework
+        # consumers (they are in `[project.optional-dependencies]`).
+        self._wire_sse_signals()
+
+    def _wire_sse_signals(self) -> None:
+        """Import the Channels SSE signal handlers unless opted out / absent.
+
+        Gate (issue #41 — keep `channels` optional for framework-tier use):
+
+        * ``RAKAIA_ENABLE_SSE = False`` — never wire.
+        * ``RAKAIA_ENABLE_SSE = True`` — wire; if `channels` is missing, let the
+          ``ImportError`` propagate (the consumer asked for SSE but didn't
+          install the extra — a real misconfiguration, surfaced loudly).
+        * unset — auto-detect: wire if `channels` imports, skip silently if not
+          (a framework-only consumer that never installed the extra).
+        """
+        enabled = getattr(settings, "RAKAIA_ENABLE_SSE", None)
+        if enabled is False:
+            return
+        try:
+            import django_rakaia.channels_signals  # noqa: F401
+        except ImportError:
+            if enabled:
+                raise

--- a/tests/test_django_rakaia/test_apps.py
+++ b/tests/test_django_rakaia/test_apps.py
@@ -1,0 +1,57 @@
+"""Tests for `DjangoRakaiaConfig.ready()` SSE-signal gating (issue #41).
+
+The framework tier (handler/upcaster autodiscovery) must load with no
+`channels` dependency; the protocol tier (SSE broadcast via `channels_signals`)
+must only be wired when it is actually wanted. These tests pin that boundary:
+
+* `RAKAIA_ENABLE_SSE=False` — never wire, even if `channels` is installed.
+* unset + `channels` importable — auto-wire (preserves today's behaviour).
+* unset + `channels` missing — skip silently (framework-only consumer).
+* `RAKAIA_ENABLE_SSE=True` + `channels` missing — fail loud (you asked for it).
+"""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+from django.apps import apps
+from django.test import override_settings
+
+_SIGNALS = "django_rakaia.channels_signals"
+
+
+def _config():
+    return apps.get_app_config("django_rakaia")
+
+
+class TestSseSignalGating:
+    def test_disabled_setting_never_wires_signals(self, monkeypatch):
+        # Explicit opt-out: channels_signals must not be (re)imported even though
+        # `channels` is installed in this environment.
+        monkeypatch.delitem(sys.modules, _SIGNALS, raising=False)
+        with override_settings(RAKAIA_ENABLE_SSE=False):
+            _config()._wire_sse_signals()
+        assert _SIGNALS not in sys.modules
+
+    def test_auto_detect_wires_when_channels_available(self, monkeypatch):
+        # Default (no setting) + channels present → signals wired.
+        monkeypatch.delitem(sys.modules, _SIGNALS, raising=False)
+        _config()._wire_sse_signals()
+        assert _SIGNALS in sys.modules
+
+    def test_auto_detect_skips_silently_when_channels_missing(self, monkeypatch):
+        # Framework-only consumer: no `channels`, no setting → skip, no raise.
+        monkeypatch.setitem(sys.modules, "channels", None)
+        monkeypatch.setitem(sys.modules, "channels.layers", None)
+        monkeypatch.delitem(sys.modules, _SIGNALS, raising=False)
+        _config()._wire_sse_signals()  # must not raise
+        assert _SIGNALS not in sys.modules
+
+    def test_explicit_enable_raises_when_channels_missing(self, monkeypatch):
+        # Opting in but forgetting the dependency is a real error, surfaced loudly.
+        monkeypatch.setitem(sys.modules, "channels", None)
+        monkeypatch.setitem(sys.modules, "channels.layers", None)
+        monkeypatch.delitem(sys.modules, _SIGNALS, raising=False)
+        with override_settings(RAKAIA_ENABLE_SSE=True), pytest.raises(ImportError):
+            _config()._wire_sse_signals()


### PR DESCRIPTION
Closes a concrete instance of the framework ↔ protocol-server boundary leak tracked by #41 (raised in [this comment](https://github.com/joshbrooks/rakaia/issues/41#issuecomment-5057075344) as "the cleanest single example of the boundary the ADR is drawing").

## The leak

`DjangoRakaiaConfig.ready()` unconditionally ran `import django_rakaia.channels_signals`, which does `from channels.layers import get_channel_layer`. But `channels`/`daphne` are in `[project.optional-dependencies]`. So a **framework-tier-only consumer** (durable store + `replay`/projections, no SSE/ASGI) that installs `rakaia` without the `[django]` extra crashes with `ModuleNotFoundError: channels` at app load — forced to ship an ASGI stack it never uses.

## The fix

Split `ready()` into its two tiers:

- **Framework tier** — `autodiscover()` (handlers/upcasters) has no `channels` dependency and always runs.
- **Protocol tier** — SSE broadcasting moves behind `_wire_sse_signals()`, gated by an optional `RAKAIA_ENABLE_SSE` setting (matching the existing `RAKAIA_STORE` convention in `django_store.py`):
  - `False` → never wire.
  - `True` → wire; let `ImportError` propagate if `channels` is missing (opted in but didn't install the extra — a real misconfig, surfaced loudly).
  - unset → auto-detect: wire if `channels` imports, skip silently if not.

**Backwards-compatible:** existing SSE consumers (channels installed, no setting) auto-wire exactly as before; framework-only consumers stop crashing. Verified the boundary is complete — the only two `channels` imports (`channels_signals`, `channels_views`) are both protocol-tier and no framework-tier module (`__init__`/models/`django_store`/replay) transitively pulls them in.

## Test plan

- New `tests/test_django_rakaia/test_apps.py::TestSseSignalGating` (written red first): the four gate branches — disabled-never-wires, auto-detect-wires-when-present, auto-detect-skips-when-missing (no raise), explicit-enable-raises-when-missing. Missing-`channels` is simulated via `sys.modules` stubbing.
- Full suite: 591 passed, 1 pre-existing skip. `ruff check` + `ruff format --check` clean.

## Related #41 housekeeping

The sibling #41 item — export `ReadableStore`/`ProjectionReader` in `rakaia.__all__` — is **already shipped** (present in `rakaia/__init__.py` since #36), so no code change was needed for it here.

Relates to #41 (ADR-0002 boundary epic).
