### PR TITLE
feat(alerts): machine-resolution transitions via executor retire-diff (#32)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,16 @@ is not yet tagged in a release.
 
 ### Added
 
+- **Machine-resolution transitions for `reconcile_by_key`** (#32). A retire that
+  soft-deletes stale rows can now notify. Opt in with
+  `reconcile_by_key(..., transition_kind="alert_transition")`: the executor
+  captures the identities of the rows the open-guarded retire actually flipped
+  (NULL→set) and returns them in `ApplyReport.retire_flips`, and the replay
+  orchestrator emits one `external` transition per real resolution — skipped and
+  counted on replay by default, delivered under `include_external=True`, so a
+  rebuild never re-spams. `Executor.apply` now returns an `ApplyReport` (was
+  `None`). → [`docs/alerts-projection.md`](docs/alerts-projection.md).
+
 - **Versioned event handlers, upcasters & replay** (#3). Register handlers
   against a sequence range so old events run through the business logic that was
   correct *when they happened*; replay is idempotent and detects handler drift.

--- a/docs/alerts-projection.md
+++ b/docs/alerts-projection.md
@@ -45,7 +45,7 @@ re-derivation must never clobber a human's judgment, and vice-versa.
 | Layer | Owner | rakaia mechanism | Status |
 |---|---|---|---|
 | **1. Authored / informational** (`alert`, `backfilled`, …) | an actor | appended `alert_raised` / `alert_dismissed` events → natural-key `update_or_create` (+ `external` transition) | **shipped (Phase 1)** |
-| **2. Machine-reconciled** (validator violations) | the rules | `reconcile_by_key(..., retire={"resolved_at": ts})`, scoped by `retire_filter` to machine types | **shipped (Phase 2)** |
+| **2. Machine-reconciled** (validator violations) | the rules | `reconcile_by_key(..., retire={"resolved_at": ts})`, scoped by `retire_filter` to machine types (+ opt-in `external` transition per real resolution) | **shipped (Phase 2 + #32)** |
 | **3. Dismissable warnings** (derived ⊕ authored) | rules *and* actor | staged replay: stage-1 reconcile reads stage-0 `alert_dismissed` via the `reader` — authored wins for user-resolvable types | **shipped (Phase 3)** |
 
 ## Phase 1 — authored alerts (shipped, zero core changes)
@@ -88,14 +88,22 @@ touch authored rows —
 retire="delete"`); it and `reconcile_by_key` share the executor. Unifying the
 two is a safe future cleanup, not required.
 
-### Known limitation carried into Phase 3
+### Machine-resolution transitions (shipped — the executor-diff, issue #32)
 
-`reconcile_by_key` emits **no** `external` transition. One retire Effect covers N
-rows, and a pure handler cannot see which rows actually flipped, so it cannot
-emit "one transition per real machine resolution" without either (a) an
-executor-level diff (return the rows a retire actually updated) or (b) the
-reader. Until then, machine resolutions are silent; only authored transitions
-notify. Phase 3 deferred this to a follow-up (see its "Remaining core gap").
+A pure handler cannot see which rows a single retire Effect actually flipped, so
+machine resolutions were originally silent. Closed via the **executor-diff**: the
+retire is already open-guarded (`resolved_at__isnull=True`), so the rows it
+matches are *exactly* the ones flipping NULL→set. Opt in with
+`reconcile_by_key(..., transition_kind="alert_transition")`; the executor then
+captures those rows' identities (a `SELECT` before the `UPDATE`, same txn — paid
+only when opted in) and returns them in `ApplyReport.retire_flips`. The replay
+orchestrator turns each into one `Effect(op="external", kind="alert_transition",
+payload={"key": <natural key>, "state": "resolved", ...})`. Because they're
+`external`, they ride the same replay gate as authored transitions — skipped and
+counted on replay by default, delivered only under `include_external=True` — so a
+rebuild never re-spams. Reference + tests:
+`tests/test_django_rakaia/test_alerts.py::TestRetireFlipReport` and
+`::TestMachineResolutionTransitions`.
 
 ## Phase 3 — composition (derived ⊕ authored), shipped
 
@@ -134,14 +142,11 @@ union. Authored-only types (`alert`) sit outside `RULE_TYPES`, so the reconcile
 never touches them — zero clobber, preserved. Reference + tests:
 `tests/test_django_rakaia/test_alerts.py::TestComposedAlerts`.
 
-### Remaining core gap (follow-up, optional)
+### Machine-resolution transitions — shipped (issue #32)
 
-`reconcile_by_key` emits **no** `external` transition — one retire Effect covers
-N rows and a pure handler cannot see which rows actually flipped. Accurate "one
-transition per real machine resolution" needs the executor to **return the rows a
-retire actually updated** so the orchestrator can emit transitions. Authored
-transitions already fire correctly (Phase 1). Tracked separately; not required
-for composition correctness.
+The one gap Phase 3 deferred — `reconcile_by_key` emitting no `external`
+transition for a machine resolution — is now closed via the executor-diff. See
+"Machine-resolution transitions (shipped)" under Phase 2 above.
 
 ### Acceptance — the spike oracle
 

--- a/src/django_rakaia/effect_executor.py
+++ b/src/django_rakaia/effect_executor.py
@@ -30,7 +30,7 @@ from django.apps import apps
 from django.db import transaction
 from django.db.models import Q
 
-from rakaia.effects import Effect, check_disjoint_defaults
+from rakaia.effects import ApplyReport, Effect, check_disjoint_defaults
 
 
 class DjangoExecutor:
@@ -39,9 +39,10 @@ class DjangoExecutor:
     def __init__(self, *, skip_unchanged: bool = False) -> None:
         self._skip_unchanged = skip_unchanged
 
-    def apply(self, effects: Iterable[Effect]) -> None:
+    def apply(self, effects: Iterable[Effect]) -> ApplyReport:
         effects_list = list(effects)
         check_disjoint_defaults(effects_list)
+        retire_flips: list[tuple[Effect, list[dict[str, Any]]]] = []
         with transaction.atomic():
             # Upserts first, then deletes, then retires: reconcile batches
             # (upsert current rows, prune/soft-delete the rest) converge
@@ -54,7 +55,10 @@ class DjangoExecutor:
                     self._delete(eff)
             for eff in effects_list:
                 if eff.op == "retire":
-                    self._retire(eff)
+                    flipped = self._retire(eff)
+                    if eff.transition_kind is not None:
+                        retire_flips.append((eff, flipped))
+        return ApplyReport(retire_flips=retire_flips)
 
     def _upsert(self, eff: Effect) -> None:
         if eff.model_label is None or eff.lookup is None:
@@ -107,11 +111,37 @@ class DjangoExecutor:
         cls._spare(qs, eff.spare_keys).delete()
 
     @classmethod
-    def _retire(cls, eff: Effect) -> None:
+    def _retire(cls, eff: Effect) -> list[dict[str, Any]]:
         if eff.model_label is None or eff.lookup is None:
             raise ValueError("retire effect requires model_label and lookup")
         if not eff.patch:
             raise ValueError("retire effect requires a non-empty patch")
         model = apps.get_model(eff.model_label)
         qs = model.objects.filter(**eff.lookup)
-        cls._spare(qs, eff.spare_keys).update(**eff.patch)
+        qs = cls._spare(qs, eff.spare_keys)
+        # The retire is open-guarded, so the rows it matches are exactly the ones
+        # that flip NULL->set. Capture their identities BEFORE the UPDATE (same
+        # atomic txn) only when the effect asked to notify — otherwise skip the
+        # SELECT entirely so a plain retire costs nothing extra.
+        flipped: list[dict[str, Any]] = []
+        if eff.transition_kind is not None:
+            cols = cls._identity_cols(eff)
+            flipped = list(qs.order_by(*cols).values(*cols))
+        qs.update(**eff.patch)
+        return flipped
+
+    @staticmethod
+    def _identity_cols(eff: Effect) -> list[str]:
+        """Columns identifying a flipped row in its transition payload: the
+        retire's scope-equality columns (lookup keys with no ``__`` lookup
+        modifier — the open-guard and retire_filter are excluded) plus the
+        natural-key columns the reconcile named, deduped in first-seen order for
+        a deterministic SELECT."""
+        cols: list[str] = []
+        for k in eff.lookup or {}:
+            if "__" not in k and k not in cols:
+                cols.append(k)
+        for k in eff.transition_key_fields or ():
+            if k not in cols:
+                cols.append(k)
+        return cols

--- a/src/rakaia/effects.py
+++ b/src/rakaia/effects.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import json
 from collections.abc import Callable, Iterable, Mapping
 from dataclasses import dataclass
+from dataclasses import field as dc_field
 from typing import Any, Literal, Protocol
 
 EffectOp = Literal["update_or_create", "delete", "external", "retire"]
@@ -72,6 +73,21 @@ class Effect:
     payload: dict[str, Any] | None = None
     """Opaque payload for external effects."""
 
+    # Fields for op="retire" — machine-resolution notifications
+    transition_kind: str | None = None
+    """When set on a retire, the orchestrator emits one ``external`` effect of
+    this ``kind`` per row the retire actually flipped (its liveness sentinel went
+    NULL->set) — the "one transition per real machine resolution" of a
+    ``reconcile_by_key`` soft-delete. Opt-in: a retire without it costs no extra
+    query. Only meaningful on op="retire" (a hard delete leaves no resolved row
+    to notify about)."""
+
+    transition_key_fields: tuple[str, ...] | None = None
+    """Natural-key column names identifying each flipped row in the transition
+    payload (the executor also folds in the retire's scope-equality columns).
+    Set by ``reconcile_by_key`` from its ``key_fields`` when ``transition_kind``
+    is requested. Only meaningful on op="retire"."""
+
     def __post_init__(self) -> None:
         # `exclude` and `spare_keys` are ALTERNATIVE row-sparing mechanisms.
         # Setting both silently ANDs them in the executor
@@ -90,6 +106,16 @@ class Effect:
             raise ValueError(
                 f"Effect sets `exclude` with op={self.op!r}; `exclude` only applies "
                 "to op='delete'. Use `spare_keys` to spare rows from a retire."
+            )
+        # `transition_kind`/`transition_key_fields` drive per-flip notifications,
+        # which only a retire produces (it flips rows silently). On any other op
+        # they would be dropped — fail loudly.
+        if (
+            self.transition_kind is not None or self.transition_key_fields is not None
+        ) and self.op != "retire":
+            raise ValueError(
+                f"Effect sets `transition_kind`/`transition_key_fields` with "
+                f"op={self.op!r}; it only applies to op='retire'."
             )
 
 
@@ -110,6 +136,22 @@ class EffectCollisionError(Exception):
 # =============================================================================
 
 
+@dataclass(frozen=True)
+class ApplyReport:
+    """What ``Executor.apply`` observed while applying a batch.
+
+    Currently carries ``retire_flips``: one ``(retire_effect, flipped_rows)``
+    entry per retire that opted into notifications (``transition_kind`` set),
+    where ``flipped_rows`` is the list of identity dicts for the rows whose
+    liveness sentinel actually went NULL->set. The orchestrator turns these into
+    one ``external`` transition each. Executors that don't observe flips (or
+    predate this) may return ``None``; the orchestrator treats that as empty."""
+
+    retire_flips: list[tuple[Effect, list[dict[str, Any]]]] = dc_field(
+        default_factory=list
+    )
+
+
 class Executor(Protocol):
     """
     Applies a batch of effects to durable storage.
@@ -119,7 +161,7 @@ class Executor(Protocol):
     before calling apply().
     """
 
-    def apply(self, effects: Iterable[Effect]) -> None: ...
+    def apply(self, effects: Iterable[Effect]) -> ApplyReport | None: ...
 
 
 # =============================================================================

--- a/src/rakaia/effects.py
+++ b/src/rakaia/effects.py
@@ -117,6 +117,22 @@ class Effect:
                 f"Effect sets `transition_kind`/`transition_key_fields` with "
                 f"op={self.op!r}; it only applies to op='retire'."
             )
+        # The two are a pair: `transition_key_fields` names the columns that
+        # identify each flipped row, and the executor's deterministic
+        # `ORDER BY`/identity SELECT relies on them being present whenever
+        # `transition_kind` asks for notifications. Enforce both-or-neither (and
+        # non-empty key fields) so a half-set retire can't silently degrade to a
+        # non-deterministic, identity-less transition.
+        if (self.transition_kind is None) != (self.transition_key_fields is None):
+            raise ValueError(
+                "Effect sets one of `transition_kind`/`transition_key_fields` "
+                "without the other; they must be set together."
+            )
+        if self.transition_key_fields is not None and not self.transition_key_fields:
+            raise ValueError(
+                "Effect sets an empty `transition_key_fields`; it must name at "
+                "least one column identifying each flipped row."
+            )
 
 
 # =============================================================================

--- a/src/rakaia/executors.py
+++ b/src/rakaia/executors.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 
-from .effects import Effect
+from .effects import ApplyReport, Effect
 
 
 class CollectingExecutor:
@@ -30,5 +30,7 @@ class CollectingExecutor:
     def __init__(self) -> None:
         self.effects: list[Effect] = []
 
-    def apply(self, effects: Iterable[Effect]) -> None:
+    def apply(self, effects: Iterable[Effect]) -> ApplyReport:
         self.effects.extend(effects)
+        # Records effects without applying them, so it observes no retire flips.
+        return ApplyReport()

--- a/src/rakaia/projections.py
+++ b/src/rakaia/projections.py
@@ -96,6 +96,7 @@ def reconcile_by_key(
     *,
     retire_filter: dict[str, Any] | None = None,
     retire: Literal["delete"] | dict[str, Any] = "delete",
+    transition_kind: str | None = None,
 ) -> list[Effect]:
     """Reconcile a set of rows keyed by a *composite natural key*.
 
@@ -129,6 +130,13 @@ def reconcile_by_key(
             field (e.g. a stale ``resolved_by``) is still retired correctly. The
             patch value must be the triggering event's timestamp, never
             ``timezone.now()``.
+        transition_kind: opt-in machine-resolution notifications. When set (only
+            valid with a soft-delete ``retire`` patch), the retire Effect is
+            marked so the replay orchestrator emits one ``external`` effect of
+            this ``kind`` per row the retire actually flipped (NULL->set) — the
+            real machine resolutions. Like all external effects it is skipped on
+            replay by default, so a rebuild never re-spams. Omit it (default) and
+            the retire stays silent, exactly as before.
 
     Returns:
         One ``update_or_create`` Effect per item, followed by one retire Effect
@@ -156,6 +164,11 @@ def reconcile_by_key(
     ]
 
     if retire == "delete":
+        if transition_kind is not None:
+            raise ValueError(
+                "transition_kind requires a soft-delete retire patch; a hard "
+                "delete leaves no resolved row to notify about."
+            )
         effects.append(
             Effect(
                 op="delete",
@@ -183,6 +196,10 @@ def reconcile_by_key(
                 lookup={**scope, **retire_filter, **open_guard},
                 spare_keys=keys,
                 patch=dict(retire),
+                transition_kind=transition_kind,
+                transition_key_fields=(
+                    tuple(key_fields) if transition_kind is not None else None
+                ),
             )
         )
     return effects

--- a/src/rakaia/replay.py
+++ b/src/rakaia/replay.py
@@ -168,6 +168,27 @@ def _record_touched(ctx: _ReplayCtx, effects: list[Effect]) -> None:
         )
 
 
+def _synth_transitions(report: object) -> list[Effect]:
+    # Turn the executor's retire-flip report into one external transition per
+    # row a retire actually flipped. `report` may be None (executors that don't
+    # observe flips) — treat that as nothing to synthesise.
+    flips = getattr(report, "retire_flips", None) or []
+    out: list[Effect] = []
+    for eff, rows in flips:
+        if eff.transition_kind is None:
+            continue
+        patch = eff.patch or {}
+        for identity in rows:
+            out.append(
+                Effect(
+                    op="external",
+                    kind=eff.transition_kind,
+                    payload={"key": dict(identity), "state": "resolved", **patch},
+                )
+            )
+    return out
+
+
 def _apply_effects(ctx: _ReplayCtx, effects: list[Effect]) -> None:
     external_count = sum(1 for e in effects if e.op == "external")
     if not ctx.include_external:
@@ -175,9 +196,17 @@ def _apply_effects(ctx: _ReplayCtx, effects: list[Effect]) -> None:
     to_apply = (
         effects if ctx.include_external else [e for e in effects if e.op != "external"]
     )
-    if to_apply:
-        ctx.executor.apply(to_apply)
-        ctx.result.effects_applied += len(to_apply)
+    if not to_apply:
+        return
+    report = ctx.executor.apply(to_apply)
+    ctx.result.effects_applied += len(to_apply)
+    # A retire that flipped rows (a real machine resolution) yields external
+    # transitions; feed them back through the same gate — so they're skipped-and-
+    # counted on replay by default, delivered only when include_external. They're
+    # all op="external", so this recurses at most once (no further flips).
+    synth = _synth_transitions(report)
+    if synth:
+        _apply_effects(ctx, synth)
 
 
 def _dispatch_event(

--- a/src/rakaia/replay.py
+++ b/src/rakaia/replay.py
@@ -183,7 +183,11 @@ def _synth_transitions(report: object) -> list[Effect]:
                 Effect(
                     op="external",
                     kind=eff.transition_kind,
-                    payload={"key": dict(identity), "state": "resolved", **patch},
+                    # Spread patch first so the orchestrator's own `key`/`state`
+                    # always win: reconcile_by_key is a generic primitive, and a
+                    # patch column named `key` or `state` must not clobber the
+                    # row identity or the transition state.
+                    payload={**patch, "key": dict(identity), "state": "resolved"},
                 )
             )
     return out

--- a/tests/test_django_rakaia/test_alerts.py
+++ b/tests/test_django_rakaia/test_alerts.py
@@ -29,6 +29,23 @@ from .models import Alert
 
 ALERT = "test_django_rakaia.Alert"
 
+
+class _CapturingDjangoExecutor(DjangoExecutor):
+    """DjangoExecutor that also records the ``external`` effects handed to it.
+
+    The base executor drops externals; this records them so a delivery test can
+    assert what the replay orchestrator synthesised from retire flips."""
+
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self.externals: list[Effect] = []
+
+    def apply(self, effects):
+        effects = list(effects)
+        self.externals.extend(e for e in effects if e.op == "external")
+        return super().apply(effects)
+
+
 # The machine-owned alert types (partisipa's NON_USER_RESOLVABLE_FLAG_TYPES) —
 # non-user-resolvable, so they ignore dismissals (machine wins).
 MACHINE_TYPES = ["ff4_operational_exceeds_ksp", "sf11_smt_exceeds_cap"]
@@ -188,7 +205,11 @@ def _seed(stream_key: str, alert_type: str, *, field_key: str = "", resolved_at=
 
 
 def _machine_reconcile(
-    stream_key: str, violations: list[dict], ts: str
+    stream_key: str,
+    violations: list[dict],
+    ts: str,
+    *,
+    transition_kind: str | None = None,
 ) -> list[Effect]:
     """One reconcile pass over the current machine violations for an entity."""
     return reconcile_by_key(
@@ -209,6 +230,7 @@ def _machine_reconcile(
         },
         retire_filter={"alert_type__in": MACHINE_TYPES},
         retire={"resolved_at": ts, "resolved_by": "system"},
+        transition_kind=transition_kind,
     )
 
 
@@ -301,6 +323,143 @@ class TestMachineReconciledAlerts:
         row = Alert.objects.get(stream_key="sub-1")
         assert not row.is_open  # correctly retired despite the reopen cycle
         assert row.resolved_at == "t4"
+
+
+@pytest.mark.django_db
+class TestRetireFlipReport:
+    """Issue #32 R3: the executor reports which rows a retire actually flipped
+    (NULL->set) so the orchestrator can emit one transition per real resolution.
+    Opt-in: only a retire carrying ``transition_kind`` pays for the extra SELECT.
+    """
+
+    def test_apply_reports_flipped_open_rows_only(self):
+        # b is open (will flip); c is already resolved (open-guard excludes it).
+        _seed("sub-1", "sf11_smt_exceeds_cap", field_key="b")
+        _seed(
+            "sub-1",
+            "sf11_smt_exceeds_cap",
+            field_key="c",
+            resolved_at="2026-01-01T00:00:00Z",
+        )
+        report = DjangoExecutor().apply(
+            _machine_reconcile(
+                "sub-1",
+                [],
+                ts="2026-07-20T09:00:00Z",
+                transition_kind="alert_transition",
+            )
+        )
+        assert len(report.retire_flips) == 1
+        eff, rows = report.retire_flips[0]
+        assert eff.transition_kind == "alert_transition"
+        # Only the open row flipped; identity is the full natural key.
+        assert rows == [
+            {
+                "stream_key": "sub-1",
+                "alert_type": "sf11_smt_exceeds_cap",
+                "field_key": "b",
+            }
+        ]
+
+    def test_flip_order_is_deterministic(self):
+        for fk in ("z", "a", "m"):
+            _seed("sub-1", "sf11_smt_exceeds_cap", field_key=fk)
+        report = DjangoExecutor().apply(
+            _machine_reconcile("sub-1", [], ts="t", transition_kind="alert_transition")
+        )
+        _, rows = report.retire_flips[0]
+        assert [r["field_key"] for r in rows] == ["a", "m", "z"]  # ordered by key
+
+    def test_no_report_and_no_extra_query_without_transition_kind(self):
+        _seed("sub-1", "sf11_smt_exceeds_cap", field_key="b")
+        report = DjangoExecutor().apply(
+            _machine_reconcile("sub-1", [], ts="t")  # no transition_kind
+        )
+        assert report.retire_flips == []
+
+
+@pytest.mark.django_db
+class TestMachineResolutionTransitions:
+    """Issue #32 R4 (headline): replaying machine reconciles emits exactly one
+    ``external`` ``alert_transition`` per *real* resolution — skipped on replay
+    by default, delivered when ``include_external=True``, never re-spammed."""
+
+    @staticmethod
+    def _seed_stream(events: list[dict]) -> StreamStore:
+        store = StreamStore()
+        store.create("sub:1")
+        for ev in events:
+            store.append("sub:1", json.dumps(ev).encode("utf-8"))
+        return store
+
+    @staticmethod
+    def _registry() -> HandlerRegistry:
+        reg = HandlerRegistry()
+
+        def reconcile_h(ev):
+            return _machine_reconcile(
+                ev["stream_key"],
+                ev["violations"],
+                ev["ts"],
+                transition_kind="alert_transition",
+            )
+
+        reg.register("reconcile_h", "sub:1", reconcile_h, 0, None)
+        return reg
+
+    # A = still violating on the 2nd pass; B = cleared -> the one real resolution.
+    A = {"alert_type": "ff4_operational_exceeds_ksp", "field_key": "a"}
+    B = {"alert_type": "sf11_smt_exceeds_cap", "field_key": "b"}
+
+    @property
+    def _events(self) -> list[dict]:
+        return [
+            {"stream_key": "sub-1", "ts": "t1", "violations": [self.A, self.B]},
+            {"stream_key": "sub-1", "ts": "t2", "violations": [self.A]},
+        ]
+
+    def test_one_transition_per_real_resolution(self):
+        store = self._seed_stream(self._events)
+        ex = _CapturingDjangoExecutor()
+        replay(
+            store, "sub:1", ex, handler_registry=self._registry(), include_external=True
+        )
+        assert len(ex.externals) == 1
+        t = ex.externals[0]
+        assert t.kind == "alert_transition"
+        assert t.payload["state"] == "resolved"
+        assert t.payload["key"] == {
+            "stream_key": "sub-1",
+            "alert_type": "sf11_smt_exceeds_cap",
+            "field_key": "b",
+        }
+        assert t.payload["resolved_by"] == "system"
+        assert t.payload["resolved_at"] == "t2"
+
+    def test_still_violating_key_emits_no_transition(self):
+        store = self._seed_stream(self._events)
+        ex = _CapturingDjangoExecutor()
+        replay(
+            store, "sub:1", ex, handler_registry=self._registry(), include_external=True
+        )
+        fired = {t.payload["key"]["alert_type"] for t in ex.externals}
+        assert "ff4_operational_exceeds_ksp" not in fired  # A stayed open
+
+    def test_transition_skipped_on_replay_by_default(self):
+        store = self._seed_stream(self._events)
+        ex = _CapturingDjangoExecutor()
+        result = replay(store, "sub:1", ex, handler_registry=self._registry())
+        assert ex.externals == []  # not delivered
+        assert result.external_effects_skipped == 1  # but counted
+
+    def test_rebuild_is_silent_by_default(self):
+        store = self._seed_stream(self._events)
+        reg = self._registry()
+        for _ in range(2):  # a rebuild replays from scratch at the default gate
+            ex = _CapturingDjangoExecutor()
+            result = replay(store, "sub:1", ex, handler_registry=reg)
+            assert ex.externals == []
+            assert result.external_effects_skipped == 1
 
 
 # ===========================================================================

--- a/tests/test_rakaia/test_effects.py
+++ b/tests/test_rakaia/test_effects.py
@@ -135,8 +135,43 @@ class TestEffectValidation:
             lookup={"s": 1},
             patch={"resolved_at": "t"},
             transition_kind="alert_transition",
+            transition_key_fields=("alert_type", "field_key"),
         )
         assert eff.transition_kind == "alert_transition"
+        assert eff.transition_key_fields == ("alert_type", "field_key")
+
+    def test_transition_kind_without_key_fields_rejected(self):
+        # The pair identifies each flipped row; a half-set retire would degrade
+        # the executor's deterministic identity SELECT — reject it.
+        with pytest.raises(ValueError, match="set together"):
+            Effect(
+                op="retire",
+                model_label="m.Alert",
+                lookup={"s": 1},
+                patch={"resolved_at": "t"},
+                transition_kind="alert_transition",
+            )
+
+    def test_key_fields_without_transition_kind_rejected(self):
+        with pytest.raises(ValueError, match="set together"):
+            Effect(
+                op="retire",
+                model_label="m.Alert",
+                lookup={"s": 1},
+                patch={"resolved_at": "t"},
+                transition_key_fields=("alert_type",),
+            )
+
+    def test_empty_transition_key_fields_rejected(self):
+        with pytest.raises(ValueError, match="at least one column"):
+            Effect(
+                op="retire",
+                model_label="m.Alert",
+                lookup={"s": 1},
+                patch={"resolved_at": "t"},
+                transition_kind="alert_transition",
+                transition_key_fields=(),
+            )
 
     def test_transition_kind_on_non_retire_rejected(self):
         # transition_kind means "emit one external per row this retire flipped".

--- a/tests/test_rakaia/test_effects.py
+++ b/tests/test_rakaia/test_effects.py
@@ -128,6 +128,34 @@ class TestEffectValidation:
             patch={"resolved_at": "t"},
         )
 
+    def test_transition_kind_on_retire_ok(self):
+        eff = Effect(
+            op="retire",
+            model_label="m.Alert",
+            lookup={"s": 1},
+            patch={"resolved_at": "t"},
+            transition_kind="alert_transition",
+        )
+        assert eff.transition_kind == "alert_transition"
+
+    def test_transition_kind_on_non_retire_rejected(self):
+        # transition_kind means "emit one external per row this retire flipped".
+        # Only a retire flips rows silently; on any other op the flag is
+        # meaningless and would be dropped — fail loudly instead.
+        with pytest.raises(ValueError, match="only applies to op='retire'"):
+            Effect(
+                op="update_or_create",
+                model_label="m.Alert",
+                lookup={"s": 1},
+                transition_kind="alert_transition",
+            )
+
+    def test_transition_kind_defaults_to_none(self):
+        eff = Effect(
+            op="retire", model_label="m.Alert", lookup={"s": 1}, patch={"r": 1}
+        )
+        assert eff.transition_kind is None
+
 
 class TestDispatchExternal:
     def test_routes_by_kind(self):

--- a/tests/test_rakaia/test_projections.py
+++ b/tests/test_rakaia/test_projections.py
@@ -81,7 +81,7 @@ class TestReconcileChildren:
         assert parent == {"parent_id": 7}
 
 
-def _by_key(items, *, retire="delete", retire_filter=None):
+def _by_key(items, *, retire="delete", retire_filter=None, transition_kind=None):
     return reconcile_by_key(
         model_label="app.Alert",
         scope={"stream_key": "sub-1"},
@@ -94,6 +94,7 @@ def _by_key(items, *, retire="delete", retire_filter=None):
         defaults_fn=lambda v: {"severity": v.get("severity", "info")},
         retire_filter=retire_filter,
         retire=retire,
+        transition_kind=transition_kind,
     )
 
 
@@ -143,6 +144,35 @@ class TestReconcileByKey:
         }
         assert r.patch == {"resolved_at": "t1", "resolved_by": "system"}
         assert r.spare_keys == [{"alert_type": "ff4", "field_key": "a"}]
+
+    def test_retire_carries_transition_kind_when_requested(self):
+        # R1: opt-in — a soft-delete retire asked to notify stamps the kind on
+        # the retire Effect so the orchestrator can emit one external transition
+        # per row the retire actually flipped.
+        effects = _by_key(
+            [{"alert_type": "ff4", "field_key": "a"}],
+            retire={"resolved_at": "t1", "resolved_by": "system"},
+            transition_kind="alert_transition",
+        )
+        retire = next(e for e in effects if e.op == "retire")
+        assert retire.transition_kind == "alert_transition"
+
+    def test_retire_has_no_transition_kind_by_default(self):
+        retire = next(
+            e for e in _by_key([], retire={"resolved_at": "t1"}) if e.op == "retire"
+        )
+        assert retire.transition_kind is None
+
+    def test_upserts_never_carry_transition_kind(self):
+        # Only the retire flips rows silently; the upserts are per-item and
+        # never a machine resolution, so they never carry the marker.
+        effects = _by_key(
+            [{"alert_type": "ff4", "field_key": "a"}],
+            retire={"resolved_at": "t1"},
+            transition_kind="alert_transition",
+        )
+        upserts = [e for e in effects if e.op == "update_or_create"]
+        assert upserts and all(e.transition_kind is None for e in upserts)
 
     def test_empty_items_retire_spares_nothing(self):
         effects = _by_key([], retire={"resolved_at": "t1"})

--- a/tests/test_rakaia/test_replay.py
+++ b/tests/test_rakaia/test_replay.py
@@ -6,14 +6,20 @@ import json
 
 import pytest
 
-from rakaia.effects import Effect
+from rakaia.effects import ApplyReport, Effect
 from rakaia.registry import (
     HandlerDriftError,
     HandlerGapError,
     HandlerRegistry,
     UpcasterRegistry,
 )
-from rakaia.replay import ENVELOPE_TS, TouchedSubject, merge_replay, replay
+from rakaia.replay import (
+    ENVELOPE_TS,
+    TouchedSubject,
+    _synth_transitions,
+    merge_replay,
+    replay,
+)
 from rakaia.store import StreamStore
 from rakaia.types import AppendOptions
 
@@ -1351,3 +1357,45 @@ class TestMergeReplay:
                 handler_registry=_touch_registry(),
                 upcaster_registry=UpcasterRegistry(),
             )
+
+
+class TestSynthTransitions:
+    """`_synth_transitions` turns an executor's retire-flip report into one
+    external transition per flipped row (issue #32)."""
+
+    @staticmethod
+    def _retire(patch):
+        return Effect(
+            op="retire",
+            model_label="app.Alert",
+            lookup={"stream_key": "s"},
+            patch=patch,
+            transition_kind="alert_transition",
+            transition_key_fields=("alert_type",),
+        )
+
+    def test_one_transition_per_flipped_row(self):
+        eff = self._retire({"resolved_at": "t2", "resolved_by": "system"})
+        rows = [
+            {"stream_key": "s", "alert_type": "a"},
+            {"stream_key": "s", "alert_type": "b"},
+        ]
+        out = _synth_transitions(ApplyReport(retire_flips=[(eff, rows)]))
+        assert [e.payload["key"]["alert_type"] for e in out] == ["a", "b"]
+        assert all(e.kind == "alert_transition" for e in out)
+        assert all(e.payload["state"] == "resolved" for e in out)
+        assert all(e.payload["resolved_by"] == "system" for e in out)
+
+    def test_patch_columns_never_clobber_identity_or_state(self):
+        # A generic reconcile whose soft-delete patch touches columns literally
+        # named `key`/`state` must not overwrite the transition's row identity
+        # or its resolved state.
+        eff = self._retire({"state": "archived", "key": "nope", "resolved_at": "t"})
+        rows = [{"stream_key": "s", "alert_type": "a"}]
+        (t,) = _synth_transitions(ApplyReport(retire_flips=[(eff, rows)]))
+        assert t.payload["key"] == {"stream_key": "s", "alert_type": "a"}
+        assert t.payload["state"] == "resolved"
+        assert t.payload["resolved_at"] == "t"  # non-colliding patch cols kept
+
+    def test_none_report_yields_nothing(self):
+        assert _synth_transitions(None) == []


### PR DESCRIPTION
Closes #32.

## The gap

`reconcile_by_key` soft-deletes stale rows in a **single** retire Effect covering N rows, so a pure handler can't see which rows actually flipped — machine (validator) resolutions were **silent**, while authored `alert_raised`/`alert_dismissed` transitions fired correctly (Phase 1).

## The fix — executor retire-diff

The retire is already **open-guarded** (`resolved_at IS NULL`), so the rows its WHERE clause matches are *exactly* the ones flipping NULL→set. No diff needed — just their identities.

- Opt in with `reconcile_by_key(..., transition_kind="alert_transition")`.
- The executor `SELECT`s the flipped rows' natural-key identities **before** the `UPDATE` (same atomic txn, paid **only** when opted in) and returns them in the new `ApplyReport.retire_flips`.
- The replay orchestrator emits **one `external` transition per real resolution**, routed through the **same gate** as authored transitions.

```
executor.apply(effects) → ApplyReport
  _retire (only when transition_kind set):
    rows = qs.order_by(*key).values(*key_fields)   ← capture flip set (same txn)
    qs.update(**patch)                             ← same WHERE ⇒ rows == flips
_synth_transitions(report): per flipped key →
  Effect(op="external", kind="alert_transition",
         payload={"key": k, "state": "resolved", **patch})
_apply_effects(synth):
  include_external=False (replay/rebuild) → counted skipped, NOT delivered ✓ never re-spams
  include_external=True  (live)           → ONE transition per real resolution ✓
```

## Design notes

- **Identity = natural key** (`{stream_key, alert_type, field_key}`), matching authored transitions, via the executor folding scope-equality columns + reconcile key-fields — not pk. Costs one extra Effect field (`transition_key_fields`) to keep the executor model-agnostic.
- **`Executor.apply` return type `None → ApplyReport | None`** (breaking protocol change, one prod impl + a couple test doubles). `_synth_transitions` tolerates `None`, so existing capture executors were untouched.
- **Determinism:** the pre-`UPDATE` `SELECT` uses `order_by(*key_fields)`, so transitions stay a pure function of the events.

## Tests (TDD, red→green)

- `TestReconcileByKey` — retire carries/omits `transition_kind`; upserts never carry it.
- `TestEffectValidation` — `transition_kind` rejected on non-retire ops.
- `TestRetireFlipReport` — reports only open rows that flipped (deterministic order; already-resolved excluded); no report/`SELECT` without opt-in.
- `TestMachineResolutionTransitions` — one transition per real resolution; still-violating spared key silent; skipped-but-counted on replay by default; rebuild silent.

## Verification

`just check` — **600 passed, 1 skipped**, ruff check + format clean, docs build clean.

Docs: `docs/alerts-projection.md` "Remaining core gap" → shipped; CHANGELOG entry added.
