### PR TITLE
ci(conformance): distinguish regressions from the known fork gap

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  # Keep the pinned Durable Streams conformance suite (and vitest) current so new
+  # protocol revisions surface as PRs instead of drifting silently. On such a PR,
+  # conformance/check-regressions.mjs shows any newly-added protocol tests as NEW
+  # failures — an immediate, readable picture of what the newer revision requires.
+  - package-ecosystem: npm
+    directory: /conformance
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "chore(conformance)"
+    labels:
+      - dependencies
+      - conformance

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -4,8 +4,13 @@ name: Conformance
 # live rakaia server. It is currently INFORMATIONAL (non-blocking): the suite
 # step uses `continue-on-error` so failures are reported without blocking
 # merges while rakaia's protocol coverage matures (stream forking is not yet
-# implemented). Flip `continue-on-error` off to make it a required check once
-# rakaia passes the full suite.
+# implemented).
+#
+# Results are diffed against conformance/expected-failures.txt so a genuine
+# regression is distinguished from the known gap: NEW failures surface as
+# `::error::` annotations and a step summary, while expected fork failures stay
+# quiet. To make regressions block merges later, either flip `continue-on-error`
+# off below or set CONFORMANCE_FAIL_ON_REGRESSION=1 for the run step.
 
 on:
   push:
@@ -42,27 +47,23 @@ jobs:
         working-directory: conformance
         run: npm ci
 
+      # Runs the suite and diffs the results against conformance/expected-failures.txt.
+      # check-regressions.mjs writes the GitHub step summary and emits `::error::`
+      # annotations for any NEW failure, so regressions are loud on the PR. The step
+      # stays informational (continue-on-error) — the check exits 0 unless
+      # CONFORMANCE_FAIL_ON_REGRESSION=1, which is the one-line switch to make
+      # regressions a required check later.
       - name: Run Durable Streams conformance suite (informational)
         id: conformance
         continue-on-error: true
         run: ./conformance/run.sh 4437 2>&1 | tee conformance-results.log
 
-      - name: Summarize results
-        if: always()
-        run: |
-          {
-            echo "### Durable Streams conformance results"
-            echo ""
-            echo '```'
-            grep -E "Test Files|Tests " conformance-results.log | tail -5 \
-              || echo "(no summary captured — see the uploaded log)"
-            echo '```'
-          } >> "$GITHUB_STEP_SUMMARY"
-
-      - name: Upload full log
+      - name: Upload logs and JSON report
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: conformance-log
-          path: conformance-results.log
+          path: |
+            conformance-results.log
+            conformance/conformance-results.json
           if-no-files-found: warn

--- a/.gitignore
+++ b/.gitignore
@@ -51,5 +51,6 @@ examples/chat/staticfiles/
 
 # Conformance harness (JS deps + run logs)
 conformance/node_modules/
+conformance/conformance-results.json
 conformance-results.log
 conformance-server.log

--- a/conformance/README.md
+++ b/conformance/README.md
@@ -29,11 +29,44 @@ npm ci
 CONFORMANCE_TEST_URL=http://127.0.0.1:4437 npm test
 ```
 
+## Regression detection (expected-failures baseline)
+
+Because rakaia doesn't yet pass the whole protocol surface, a raw pass/fail
+count can't tell a real regression apart from the known gap. So the run diffs
+results against a committed baseline of expected failures:
+
+- `expected-failures.txt` — one vitest `fullName` per line for every test rakaia
+  is known not to pass yet (currently the entire stream-forking family). `#`
+  comments and blank lines are ignored.
+- `check-regressions.mjs` — reads the suite's JSON report
+  (`conformance-results.json`, written by `npm run test:ci`) and the baseline,
+  then reports three sets:
+  - **NEW failures** (failed, not in the baseline) → regressions. In CI these
+    become `::error::` annotations and a step-summary section.
+  - **Newly passing** (in the baseline, now passing) → remove them from
+    `expected-failures.txt` to shrink the gap.
+  - **Expected** (failed, in the baseline) → the known gap; kept quiet.
+
+`conformance/run.sh` (and `just conformance`) runs the suite via `test:ci` and
+then `check-regressions.mjs` automatically. The check **exits 0** so the job
+stays informational; set `CONFORMANCE_FAIL_ON_REGRESSION=1` to make a regression
+exit non-zero.
+
+**Regenerating the baseline** (after fork lands, or a suite-version bump):
+
+```bash
+just conformance-baseline    # runs the suite, then rewrites expected-failures.txt
+git diff conformance/expected-failures.txt   # review before committing
+```
+
 ## Version pinning
 
 The suite version is pinned in `package.json` (and `package-lock.json`) for
-reproducibility. Bump `@durable-streams/server-conformance-tests` there and
-re-run `npm install` to pick up a newer protocol revision.
+reproducibility. Dependabot (`.github/dependabot.yml`) opens PRs when a newer
+`@durable-streams/server-conformance-tests` is released; on such a PR the
+regression check shows any newly-added protocol tests as NEW failures, so you
+can see exactly what the newer revision requires. You can also bump it manually
+and re-run `npm install`.
 
 ## Status
 

--- a/conformance/check-regressions.mjs
+++ b/conformance/check-regressions.mjs
@@ -1,0 +1,188 @@
+#!/usr/bin/env node
+// Compare a vitest JSON run against the committed expected-failures baseline and
+// report regressions in a way that's loud on a PR but does NOT block by default.
+//
+// The Durable Streams conformance job is informational: rakaia does not yet pass
+// the full protocol surface (the stream-forking family is unimplemented). A plain
+// pass/fail count therefore can't tell a genuine regression apart from that known
+// gap. This script makes the distinction explicit:
+//
+//   NEW failures  — failed, and NOT in the baseline  → regressions (loud)
+//   Newly passing — in the baseline, but now passing → shrink the baseline
+//   Expected      — failed, and in the baseline      → the known gap (quiet)
+//
+// Output: a human summary on stdout, GitHub `::error::`/`::warning::` workflow
+// annotations, and (when $GITHUB_STEP_SUMMARY is set) a Markdown step summary.
+//
+// Exit code: 0 by default so the job stays non-blocking. Set
+// CONFORMANCE_FAIL_ON_REGRESSION=1 to exit non-zero when regressions are found
+// (one-line switch to make regressions a required check later).
+//
+// Usage:
+//   node check-regressions.mjs [results.json] [expected-failures.txt]
+
+import { readFileSync } from "node:fs"
+import { resolve, dirname } from "node:path"
+import { fileURLToPath } from "node:url"
+
+const here = dirname(fileURLToPath(import.meta.url))
+const resultsPath = resolve(process.argv[2] ?? resolve(here, "conformance-results.json"))
+const baselinePath = resolve(process.argv[3] ?? resolve(here, "expected-failures.txt"))
+
+function fail(msg) {
+  console.error(`check-regressions: ${msg}`)
+  process.exit(2)
+}
+
+let report
+try {
+  report = JSON.parse(readFileSync(resultsPath, "utf8"))
+} catch (err) {
+  fail(`could not read vitest JSON results at ${resultsPath}: ${err.message}`)
+}
+
+let baseline
+try {
+  baseline = new Set(
+    readFileSync(baselinePath, "utf8")
+      .split("\n")
+      .map((l) => l.trim())
+      .filter((l) => l && !l.startsWith("#")),
+  )
+} catch (err) {
+  fail(`could not read baseline at ${baselinePath}: ${err.message}`)
+}
+
+// Collect statuses keyed by the stable vitest `fullName`.
+const failed = new Set()
+const passed = new Set()
+for (const file of report.testResults ?? []) {
+  for (const a of file.assertionResults ?? []) {
+    if (a.status === "failed") failed.add(a.fullName)
+    else if (a.status === "passed") passed.add(a.fullName)
+  }
+}
+
+// `--write-baseline`: overwrite expected-failures.txt with the current failures.
+// Run after the suite when the accepted gap changes (e.g. fork lands, or the
+// suite version bumps). Review the diff before committing.
+if (process.argv.includes("--write-baseline")) {
+  const { writeFileSync } = await import("node:fs")
+  const header = [
+    "# Durable Streams conformance — expected failures (baseline)",
+    "#",
+    "# One vitest `fullName` (ancestorTitles + title) per line for each test that",
+    "# rakaia is KNOWN not to pass yet. check-regressions.mjs treats these as the",
+    "# accepted protocol gap: they do NOT count as regressions. Anything failing",
+    "# that is NOT listed here is a NEW regression; anything listed here that now",
+    "# PASSES should be removed to shrink the baseline.",
+    "#",
+    "# Current gap: the entire stream-forking family (not yet implemented).",
+    "# Regenerate with: just conformance-baseline   (see conformance/README.md)",
+    "# Lines starting with # and blank lines are ignored.",
+    "#",
+  ]
+  const body = [...failed].sort()
+  writeFileSync(baselinePath, header.concat(body).join("\n") + "\n")
+  console.log(`Wrote ${body.length} expected-failure entries to ${baselinePath}`)
+  process.exit(0)
+}
+
+const regressions = [...failed].filter((n) => !baseline.has(n)).sort()
+const nowPassing = [...baseline].filter((n) => passed.has(n)).sort()
+const stillExpected = [...failed].filter((n) => baseline.has(n)).sort()
+// Baseline entries that neither failed nor passed this run (renamed/removed upstream).
+const staleBaseline = [...baseline]
+  .filter((n) => !failed.has(n) && !passed.has(n))
+  .sort()
+
+// --- GitHub workflow annotations (show inline on the PR checks) ---
+const isCI = Boolean(process.env.GITHUB_ACTIONS)
+if (isCI) {
+  for (const n of regressions) {
+    console.log(`::error title=Conformance regression::${n}`)
+  }
+  for (const n of nowPassing) {
+    console.log(`::warning title=Conformance test now passing (shrink baseline)::${n}`)
+  }
+  if (staleBaseline.length) {
+    console.log(
+      `::warning title=Stale baseline entries (not in this run)::${staleBaseline.length} baselined test(s) were neither run nor found — the suite version may have changed`,
+    )
+  }
+}
+
+// --- Human-readable console summary ---
+const totals = {
+  total: report.numTotalTests ?? passed.size + failed.size,
+  passed: report.numPassedTests ?? passed.size,
+  failed: report.numFailedTests ?? failed.size,
+  skipped: report.numPendingTests ?? 0,
+}
+console.log("")
+console.log("Durable Streams conformance — regression check")
+console.log(
+  `  ${totals.passed} passed, ${totals.failed} failed, ${totals.skipped} skipped (of ${totals.total})`,
+)
+console.log(
+  `  ${regressions.length} NEW failure(s) · ${nowPassing.length} newly passing · ${stillExpected.length} expected (known gap)`,
+)
+if (regressions.length) {
+  console.log("\n  NEW failures (regressions):")
+  for (const n of regressions) console.log(`    ✗ ${n}`)
+}
+if (nowPassing.length) {
+  console.log("\n  Now passing — remove from expected-failures.txt:")
+  for (const n of nowPassing) console.log(`    ✓ ${n}`)
+}
+if (staleBaseline.length) {
+  console.log("\n  Stale baseline entries (not seen this run):")
+  for (const n of staleBaseline) console.log(`    ? ${n}`)
+}
+
+// --- GitHub step summary (Markdown) ---
+const summaryPath = process.env.GITHUB_STEP_SUMMARY
+if (summaryPath) {
+  const lines = []
+  const verdict = regressions.length
+    ? "🔴 **Regressions detected**"
+    : nowPassing.length
+      ? "🟡 **No regressions — baseline can shrink**"
+      : "🟢 **No regressions**"
+  lines.push("### Durable Streams conformance results", "")
+  lines.push(verdict, "")
+  lines.push(
+    `| Passed | Failed | Skipped | New failures | Newly passing | Expected gap |`,
+    `| ---: | ---: | ---: | ---: | ---: | ---: |`,
+    `| ${totals.passed} | ${totals.failed} | ${totals.skipped} | ${regressions.length} | ${nowPassing.length} | ${stillExpected.length} |`,
+    "",
+  )
+  const list = (title, items, mark) => {
+    if (!items.length) return
+    lines.push(`<details><summary>${title} (${items.length})</summary>`, "")
+    for (const n of items) lines.push(`- ${mark} \`${n}\``)
+    lines.push("", "</details>", "")
+  }
+  list("NEW failures (regressions)", regressions, "✗")
+  list("Now passing — shrink the baseline", nowPassing, "✓")
+  list("Stale baseline entries (not seen this run)", staleBaseline, "?")
+  lines.push(
+    "",
+    "_Informational check. Expected failures are the unimplemented stream-forking family; see `conformance/expected-failures.txt`._",
+  )
+  try {
+    // eslint-disable-next-line no-undef
+    ;(await import("node:fs")).appendFileSync(summaryPath, lines.join("\n") + "\n")
+  } catch (err) {
+    console.error(`check-regressions: could not write step summary: ${err.message}`)
+  }
+}
+
+const failOnRegression = process.env.CONFORMANCE_FAIL_ON_REGRESSION === "1"
+if (regressions.length && failOnRegression) {
+  console.log(
+    `\nExiting non-zero: ${regressions.length} regression(s) and CONFORMANCE_FAIL_ON_REGRESSION=1.`,
+  )
+  process.exit(1)
+}
+process.exit(0)

--- a/conformance/expected-failures.txt
+++ b/conformance/expected-failures.txt
@@ -1,0 +1,68 @@
+# Durable Streams conformance — expected failures (baseline)
+#
+# One vitest `fullName` (ancestorTitles + title) per line for each test that
+# rakaia is KNOWN not to pass yet. check-regressions.mjs treats these as the
+# accepted protocol gap: they do NOT count as regressions. Anything failing
+# that is NOT listed here is a NEW regression; anything listed here that now
+# PASSES should be removed to shrink the baseline.
+#
+# Current gap: the entire stream-forking family (not yet implemented).
+# Regenerate with: just conformance-baseline   (see conformance/README.md)
+# Lines starting with # and blank lines are ignored.
+#
+Fork - Appending should append to a fork
+Fork - Appending should append to source after fork — source independent
+Fork - Appending should support idempotent producer on fork
+Fork - Creation should accept JSON sub-offset equal to flattened message count
+Fork - Creation should accept binary sub-offset equal to message length
+Fork - Creation should allow sub-offset fork creation from a closed source stream
+Fork - Creation should append initial body after the materialized sub-offset prefix
+Fork - Creation should fork at a JSON sub-offset within a flattened batch
+Fork - Creation should fork at a binary sub-offset anchored mid-stream
+Fork - Creation should fork at a binary sub-offset within an append
+Fork - Creation should fork at a specific offset
+Fork - Creation should fork at head offset (all source data inherited)
+Fork - Creation should fork inheriting content-type when header omitted
+Fork - Creation should inherit content-type when sub-offset is supplied without explicit Content-Type
+Fork - Creation should not inherit producer state across binary sub-offset fork boundary
+Fork - Creation should not inherit producer state across sub-offset fork boundary
+Fork - Creation should return 400 for malformed sub-offset values
+Fork - Creation should return 400 when JSON sub-offset overshoots message count
+Fork - Creation should return 400 when Stream-Fork-Sub-Offset is supplied without Stream-Forked-From (even when value is 0)
+Fork - Creation should return 400 when binary sub-offset overshoots message length
+Fork - Creation should return 400 when forking at offset beyond stream length
+Fork - Creation should return 400 when sub-offset > 0 is supplied without Stream-Fork-Offset
+Fork - Creation should return 400 when sub-offset is supplied on an empty source stream
+Fork - Creation should return 404 when forking a nonexistent stream
+Fork - Creation should return 409 when re-creating a JSON fork with mismatched sub-offset
+Fork - Creation should return 409 when re-creating with mismatched sub-offset
+Fork - Creation should support appending to fork after sub-offset boundary
+Fork - Deletion and Lifecycle rejected fork (content-type mismatch) does not leak a source reference
+Fork - Deletion and Lifecycle should block re-creation of soft-deleted source (PUT returns 409)
+Fork - Deletion and Lifecycle should cascade GC through three levels
+Fork - Deletion and Lifecycle should cascade GC when last fork is deleted
+Fork - Deletion and Lifecycle should preserve data when deleting middle of chain
+Fork - Deletion and Lifecycle should return 409 for fork from soft-deleted source
+Fork - Deletion and Lifecycle should return 409 for fork with content-type mismatch
+Fork - Deletion and Lifecycle should return 410 for DELETE on soft-deleted source
+Fork - Deletion and Lifecycle should return 410 for GET on soft-deleted source
+Fork - Deletion and Lifecycle should return 410 for POST on soft-deleted source
+Fork - Deletion and Lifecycle should soft-delete source while fork exists — fork still reads
+Fork - Edge Cases should fork at every offset position
+Fork - Edge Cases should handle fork then immediately delete source
+Fork - Edge Cases should handle many forks of same stream (10 forks)
+Fork - JSON Mode should fork a JSON stream
+Fork - JSON Mode should read forked JSON across boundary
+Fork - Live Modes should handle long-poll handover at fork offset
+Fork - Live Modes should return inherited data immediately on long-poll
+Fork - Live Modes should stream fork data via SSE
+Fork - Reading should not show source appends after fork
+Fork - Reading should read across fork boundary
+Fork - Reading should read entire fork (source + fork data)
+Fork - Reading should read only inherited portion
+Fork - Recursive should append at each level independently
+Fork - Recursive should compose sub-offsets across chained forks
+Fork - Recursive should fork at mid-point of inherited data
+Fork - Recursive should read correctly across three levels
+Fork - TTL and Expiry should expire source with living forks (source goes 410)
+Fork - TTL and Expiry should inherit source TTL value when none specified

--- a/conformance/package.json
+++ b/conformance/package.json
@@ -5,7 +5,9 @@
   "type": "module",
   "description": "Runs the upstream @durable-streams/server-conformance-tests suite against a running rakaia server.",
   "scripts": {
-    "test": "vitest run --no-coverage --reporter=default"
+    "test": "vitest run --no-coverage --reporter=default",
+    "test:ci": "vitest run --no-coverage --reporter=default --reporter=json --outputFile.json=./conformance-results.json",
+    "check-regressions": "node check-regressions.mjs"
   },
   "devDependencies": {
     "@durable-streams/server-conformance-tests": "0.3.6",

--- a/conformance/run.sh
+++ b/conformance/run.sh
@@ -59,7 +59,14 @@ if [ -z "${ready}" ]; then
   exit 1
 fi
 
-# Run the conformance suite.
+# Run the conformance suite. It emits a machine-readable JSON report
+# (conformance/conformance-results.json) alongside the human output. Expected
+# failures (the unimplemented stream-forking family) make vitest exit non-zero,
+# so we tolerate that here and let check-regressions.mjs decide the real verdict:
+# it distinguishes NEW regressions from the known gap.
 echo "==> Running Durable Streams conformance suite against ${BASE_URL}"
-CONFORMANCE_TEST_URL="${BASE_URL}" npm --prefix "${HERE}" test
+CONFORMANCE_TEST_URL="${BASE_URL}" npm --prefix "${HERE}" run test:ci || true
+
+echo "==> Checking results against the expected-failures baseline"
+node "${HERE}/check-regressions.mjs"
 exit $?

--- a/justfile
+++ b/justfile
@@ -289,6 +289,13 @@ rakaia port="4437":
 conformance port="4437":
     ./conformance/run.sh {{port}}
 
+# Regenerate conformance/expected-failures.txt from a fresh run. Use when the
+# accepted protocol gap changes (fork lands, or the suite version bumps); review
+# the diff before committing.
+conformance-baseline port="4437":
+    ./conformance/run.sh {{port}}
+    node conformance/check-regressions.mjs --write-baseline
+
 # ---------------------------------------------------------------------------
 # Quality gates
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Context

We run the upstream Durable Streams protocol conformance suite (`@durable-streams/server-conformance-tests@0.3.6`, ~338 vitest tests) against a live rakaia server in CI. The job is **informational** (`continue-on-error: true`) while protocol coverage matures — rakaia passes everything except the **stream-forking family** (56 tests, not yet implemented).

**Problem:** because the job never fails and its only output was a `grep` of two vitest summary lines, a regression in a *currently-passing* behavior was invisible — it looked identical to the known fork gap. A green (informational) check told you nothing about whether your change just broke a protocol behavior we used to satisfy. Separately, the pinned suite version had no update mechanism.

**Goal (unchanged):** keep the check **informational** (does not block merges), but make it easy to see when a change introduces a regression, and get notified when the suite version moves.

## What this does

**Regression visibility**
- `conformance/expected-failures.txt` — committed baseline of the 56 known-failing tests (verified against a live run: the entire stream-forking family; nothing else fails).
- `conformance/check-regressions.mjs` — diffs the vitest JSON report against the baseline and splits results into **NEW failures (regressions)**, **newly passing (shrink baseline)**, and **expected gap**. In CI it emits `::error::` annotations and a Markdown step summary. Exits 0 by default (stays informational); `CONFORMANCE_FAIL_ON_REGRESSION=1` flips it to blocking — a one-line switch for later.
- `conformance/package.json` — `test:ci` (emits `conformance-results.json`) + `check-regressions`.
- `conformance/run.sh` — runs `test:ci` then the diff check, tolerating the expected fork failures.
- `.github/workflows/conformance.yml` — drops the brittle `grep` summary (the script writes a richer one) and uploads the JSON report alongside the log.
- `justfile` — `just conformance-baseline` regenerates the baseline.

**Dependency monitoring**
- `.github/dependabot.yml` — weekly npm updates scoped to `/conformance`. When a newer suite lands, the regression check shows exactly which newly-added protocol tests it requires.

## Verification

- **Happy path:** `./conformance/run.sh` → `0 NEW failure(s) · 0 newly passing · 56 expected`, exit 0.
- **Regression** (drop a baseline line): flagged as NEW failure with `::error::` annotation + red step summary; exit 0 by default, exit 1 with `CONFORMANCE_FAIL_ON_REGRESSION=1`.
- **Newly passing** and **stale-baseline** cases both reported correctly.
- Both YAML files parse.

## Deferred (not in this PR)

- Flipping to a required/blocking check (toggle is in place).
- Uploading `conformance-server.log` + bumping uvicorn log level for easier debugging.
- Enabling the suite's `subscriptions` tests (needs a product decision).
- `run.sh` teardown can leak a reparented uvicorn worker locally (harmless in CI); candidate fast-follow.