### PR TITLE
fix(subscription): report caught_up for an empty delta above a lagging cursor

### DIFF
--- a/src/rakaia/subscription.py
+++ b/src/rakaia/subscription.py
@@ -39,7 +39,9 @@ PollStatus = Literal["fresh", "advanced", "caught_up", "rewound", "absent"]
 
 * ``fresh`` — first poll (no prior cursor); every message returned.
 * ``advanced`` — new messages since the cursor; the delta returned.
-* ``caught_up`` — cursor is at the head; nothing new.
+* ``caught_up`` — no messages live above the cursor; nothing new. Covers both
+  a cursor at the head and a cursor below a head that only reflects a persisted
+  high-water (a stream recreated but not yet re-appended, #34).
 * ``rewound`` — cursor sorts past the head (log truncated/rebuilt); re-read from
   the start. The consumer should reset any derived state before applying.
 * ``absent`` — the stream does not exist; nothing returned.
@@ -103,6 +105,13 @@ def poll(store: CursorStore, path: str, cursor: str | None) -> Poll:
         return Poll(messages=[], cursor=cursor, status="caught_up")
 
     messages, _ = store.read(path, cursor)
+    if not messages:
+        # The head sorts after the cursor, yet nothing lives above it: the head
+        # reflects a persisted high-water for a stream recreated but not yet
+        # re-appended (globally-monotonic offsets, #34). There is no delta to
+        # apply, so this is `caught_up` — not an `advanced` with an empty delta,
+        # which would falsely signal new content to a status-branching consumer.
+        return Poll(messages=[], cursor=cursor, status="caught_up")
     return Poll(messages=messages, cursor=_tail(messages, cursor), status="advanced")
 
 

--- a/tests/test_django_rakaia/test_subscription.py
+++ b/tests/test_django_rakaia/test_subscription.py
@@ -113,3 +113,23 @@ class TestConsumerCursor:
         result = poll_consumer(store, CONSUMER, "s")
         assert result.status == "caught_up"
         assert result.messages == []
+
+    def test_empty_recreate_with_lagging_cursor_reports_caught_up(self):
+        # #34 Defect #2, read side: the sibling test above commits a cursor AT the
+        # head. This covers a cursor BELOW the retired high-water — a consumer that
+        # was still behind when the stream was deleted. After an empty recreate the
+        # head reflects the watermark while no entries exist above the cursor, so
+        # the poll must report `caught_up`, not `advanced` with an empty delta.
+        store = DjangoStreamStore()
+        store.create("s")
+        _append(store, "s", 10)
+        poll_consumer(store, CONSUMER, "s")
+        # Commit a cursor below the head (10): this consumer is still catching up.
+        commit_cursor(CONSUMER, "s", "00000000000000000005")
+
+        store.delete("s")
+        store.create("s")  # recreated, no append yet
+
+        result = poll_consumer(store, CONSUMER, "s")
+        assert result.status == "caught_up"
+        assert result.messages == []

--- a/tests/test_rakaia/test_subscription.py
+++ b/tests/test_rakaia/test_subscription.py
@@ -104,3 +104,20 @@ class TestPoll:
         result = poll(store, "s", cursor=cursor)
         assert result.status == "advanced"
         assert [m.data for m in result.messages] == [b"XX"]  # delivered, not skipped
+
+    def test_empty_recreate_with_lagging_cursor_reports_caught_up(self):
+        # Read-side companion to the globally-monotonic fix (#34): after a stream
+        # is deleted and recreated but BEFORE any re-append, the head reflects the
+        # retired high-water while the stream holds no messages. A consumer whose
+        # cursor sorts below that head has nothing to apply yet, so the poll must
+        # report `caught_up` — not `advanced` with an empty delta, which would
+        # falsely signal "new content" to a consumer that branches on the status
+        # rather than iterating the (empty) message list.
+        store = _store_with("s", [b"a", b"b"])  # gen 0
+        cursor = poll(store, "s", cursor=None).cursor
+        store.delete("s")
+        store.create("s")  # gen 1, recreated, no append yet — head sorts > cursor
+        result = poll(store, "s", cursor=cursor)
+        assert result.status == "caught_up"
+        assert result.messages == []
+        assert result.cursor == cursor  # unchanged; nothing consumed


### PR DESCRIPTION
Follow-up to #59 — closes the read-side gap that the review of that PR surfaced (#34, Defect #2).

## The bug

`poll()` reaches its `advanced` branch whenever the head sorts strictly after the cursor. The globally-monotonic-offsets fix in #59/#35 means the head can now sit *above* the cursor while **no messages live above it**: a stream that was deleted and recreated reports a head at its retired high-water *before* the first re-append.

So a consumer whose cursor was still below the head at delete time, polling that empty recreate, got:

```python
Poll(messages=[], cursor=<unchanged>, status="advanced")
```

That contradicts the `advanced` contract ("new messages since the cursor; the delta returned") and falsely signals new content to any consumer that branches on `status == "advanced"` rather than iterating the (empty) message list. No data loss — the cursor stays put and picks up real appends — but the status is wrong.

`#59` added a read-side test (`test_empty_recreate_does_not_spuriously_rewind`) that covered a cursor **at** the head (→ `caught_up`); it missed the cursor-**below**-head sub-case, which fell through to `advanced`.

## The fix

Guard the `advanced` branch: when `read()` after the cursor yields no messages, return `caught_up` with the cursor unchanged. This only changes the empty-recreate case — in normal operation a head above the cursor always implies entries above it, so `read()` is non-empty and the branch is untouched.

## Tests (TDD, red→green)

- `tests/test_rakaia/test_subscription.py::test_empty_recreate_with_lagging_cursor_reports_caught_up` — store-agnostic core `poll()` test over the in-memory store.
- `tests/test_django_rakaia/test_subscription.py::test_empty_recreate_with_lagging_cursor_reports_caught_up` — end-to-end over `DjangoStreamStore`, the surface where the finding was reported.
- Both fail on `main` (`advanced` != `caught_up`) and pass with the fix.
- Full suite: 615 passed, 1 pre-existing skip. `ruff check` + `ruff format --check` clean.

Also aligns the `caught_up` entry in the `PollStatus` docstring with the broadened definition.