### PR TITLE
Hardening pass: test coverage, docs, cleanup, handler refactor

### DIFF
--- a/docs/producer-fencing.md
+++ b/docs/producer-fencing.md
@@ -1,0 +1,75 @@
+# Producer fencing & validation results
+
+Rakaia's protocol server implements Kafka-style **idempotent producers** for
+exactly-once append semantics: fire-and-forget writes with server-side
+deduplication and zombie fencing. This page is the reference for the Python
+result types that model that validation — the values `StreamStore.append()`
+returns on the `producer_result` field of its `AppendResult`.
+
+For the wire-level contract (the `Producer-Id` / `Producer-Epoch` /
+`Producer-Seq` headers and their response codes) see
+[Protocol specification §5.2.1 — Idempotent Producers](protocol.md#521-idempotent-producers).
+These types are a **protocol-server (Tier 2) concern** — see
+[Framework vs. protocol server](framework-vs-protocol-server.md). Framework-tier
+code that only reads/writes through the Store contract never needs them.
+
+## How it fits together
+
+A write carrying the three producer headers is validated against the stream's
+per-producer state before it is appended. `append()` returns an `AppendResult`
+whose `producer_result` is one of the variants below; the ASGI handler
+(`rakaia.handler`) maps each to an HTTP status. All three headers must be
+supplied together or none at all (partial → `400`).
+
+- **`ProducerState`** — the per-producer state the store tracks to make these
+  decisions: `epoch`, `last_seq`, and `last_updated`. One per `producer_id`,
+  held on the `Stream`.
+- **`ClosedBy`** — the `(producer_id, epoch, seq)` tuple that performed the
+  closing append, retained so a retried append-and-close is recognised as an
+  idempotent success rather than a "stream closed" rejection.
+- **`ProducerValidationResult`** — the union type aliasing the six result
+  variants; use it in annotations.
+
+## Result variants
+
+| Result type | `status` | When it is returned | HTTP mapping |
+| --- | --- | --- | --- |
+| `ProducerAccepted` | `"accepted"` | Append accepted — new data, or a new epoch established (`epoch > current`, `seq == 0`). Carries `is_new` and the `proposed_state`. | `200 OK` (or `204` when no `producer_id`); echoes `Producer-Epoch` / `Producer-Seq` |
+| `ProducerDuplicate` | `"duplicate"` | `seq <= last_seq` for the current epoch — a retried request already applied. Idempotent success, no re-append. Carries `last_seq`. | `204 No Content`; `Producer-Seq` = highest accepted seq |
+| `ProducerStaleEpoch` | `"stale_epoch"` | `epoch < current` — a zombie/old producer session, fenced off. Carries `current_epoch`. | `403 Forbidden`; `Producer-Epoch` = current server epoch |
+| `ProducerInvalidEpochSeq` | `"invalid_epoch_seq"` | A new epoch (`epoch > current`) that did not start at `seq == 0`. | `400 Bad Request` |
+| `ProducerSequenceGap` | `"sequence_gap"` | `seq > last_seq + 1` within an epoch — a message was skipped. Carries `expected_seq` and `received_seq`. | `409 Conflict`; `Producer-Expected-Seq` / `Producer-Received-Seq` |
+| `ProducerStreamClosed` | `"stream_closed"` | The target stream is already closed. | `409 Conflict`; `Stream-Closed: true` |
+
+Only `ProducerAccepted` results in data being written; every other variant is a
+no-op on the log. Match on the `status` string (a `Literal`) or `isinstance`
+against the dataclass — both are exported from the top-level `rakaia` package.
+
+## Example
+
+```python
+from rakaia import AppendOptions, ProducerAccepted, StreamStore
+
+store = StreamStore()
+store.create("orders")
+
+result = store.append(
+    "orders",
+    b'{"id": 1}',
+    AppendOptions(
+        content_type="application/json",
+        producer_id="worker-a",
+        producer_epoch=0,
+        producer_seq=0,
+    ),
+)
+
+match result.producer_result:
+    case ProducerAccepted():
+        ...  # appended
+    case None:
+        ...  # no producer headers supplied — a plain append
+    case rejected:
+        # ProducerDuplicate / StaleEpoch / SequenceGap / InvalidEpochSeq / StreamClosed
+        print("rejected:", rejected.status)
+```

--- a/src/django_rakaia/admin.py
+++ b/src/django_rakaia/admin.py
@@ -77,6 +77,7 @@ class StreamEventAdmin(admin.ModelAdmin):
             data_str = json.dumps(data, indent=2)
             if len(data_str) > 100:
                 return data_str[:97] + "..."
+            return data_str
         except (TypeError, ValueError):
             return str(obj.data)  # type: ignore[call-overload]
 
@@ -253,7 +254,7 @@ class TranslatableAdmin(admin.ModelAdmin):
 
     def msgstr_preview(self, obj):
         if not obj.msgstr:
-            return format_html(
+            return mark_safe(
                 '<span style="color: #999; font-style: italic;">Not translated</span>'
             )
 
@@ -285,10 +286,10 @@ class TranslatableAdmin(admin.ModelAdmin):
 
     def deleted_status(self, obj):
         if obj.deleted:
-            return format_html(
+            return mark_safe(
                 '<span style="color: #dc3545; font-weight: bold;">Deleted</span>'
             )
-        return format_html('<span style="color: #28a745;">Active</span>')
+        return mark_safe('<span style="color: #28a745;">Active</span>')
 
     deleted_status.short_description = "Status"
 

--- a/src/rakaia/handler.py
+++ b/src/rakaia/handler.py
@@ -392,6 +392,44 @@ async def _handle_head(
 # =============================================================================
 
 
+async def _validate_read_params(
+    send: Send,
+    qs: str,
+    offset: str | None,
+    live: str | None,
+    cors: dict[str, str],
+) -> bool:
+    """Validate the GET read query parameters.
+
+    On the first invalid parameter, send a ``400`` and return ``False`` — the
+    caller must then return. Returns ``True`` when the read may proceed.
+    """
+    if offset is not None:
+        if offset == "":
+            await _send_error(send, 400, b"Empty offset parameter", cors)
+            return False
+
+        if len(get_all_query_params(qs, "offset")) > 1:
+            await _send_error(
+                send, 400, b"Multiple offset parameters not allowed", cors
+            )
+            return False
+
+        if not VALID_OFFSET_PATTERN.match(offset):
+            await _send_error(send, 400, b"Invalid offset format", cors)
+            return False
+
+    # Long-poll and SSE both require an explicit offset.
+    if (live == "long-poll" or live == "sse") and not offset:
+        label = "SSE" if live == "sse" else "Long-poll"
+        await _send_error(
+            send, 400, f"{label} requires offset parameter".encode(), cors
+        )
+        return False
+
+    return True
+
+
 async def _handle_read(
     path: str,
     scope: Scope,
@@ -411,29 +449,7 @@ async def _handle_read(
     live = get_query_param(qs, "live")
     cursor = get_query_param(qs, "cursor")
 
-    # Validate offset
-    if offset is not None:
-        if offset == "":
-            await _send_error(send, 400, b"Empty offset parameter", cors)
-            return
-
-        all_offsets = get_all_query_params(qs, "offset")
-        if len(all_offsets) > 1:
-            await _send_error(
-                send, 400, b"Multiple offset parameters not allowed", cors
-            )
-            return
-
-        if not VALID_OFFSET_PATTERN.match(offset):
-            await _send_error(send, 400, b"Invalid offset format", cors)
-            return
-
-    # Require offset for long-poll and SSE
-    if (live == "long-poll" or live == "sse") and not offset:
-        label = "SSE" if live == "sse" else "Long-poll"
-        await _send_error(
-            send, 400, f"{label} requires offset parameter".encode(), cors
-        )
+    if not await _validate_read_params(send, qs, offset, live, cors):
         return
 
     # Determine base64 encoding for SSE binary streams
@@ -817,31 +833,37 @@ async def _handle_sse(
 # =============================================================================
 
 
-async def _handle_append(
-    path: str,
-    scope: Scope,
-    receive: Receive,
-    send: Send,
-    store: StreamStore,
-    cors: dict[str, str],
-) -> None:
-    content_type = get_header(scope, "content-type")
-    seq = get_header(scope, "stream-seq")
-    closed_header = get_header(scope, STREAM_CLOSED_HEADER)
-    close_stream = closed_header == "true"
+@dataclass
+class _ParsedProducer:
+    """Validated producer coordinates parsed from the append request headers."""
 
-    # Extract producer headers
+    producer_id: str | None
+    epoch: int | None
+    seq: int | None
+    has_all: bool
+    """Whether all three producer headers were supplied (idempotent-producer mode)."""
+
+
+async def _parse_producer_headers(
+    send: Send,
+    scope: Scope,
+    cors: dict[str, str],
+) -> _ParsedProducer | None:
+    """Extract and validate the idempotent-producer headers.
+
+    All three (`Producer-Id`, `Producer-Epoch`, `Producer-Seq`) must be present
+    together or absent together, and epoch/seq must be non-negative integers.
+    On any violation, send a ``400`` and return ``None`` — the caller must then
+    return. Otherwise return the parsed coordinates (epoch/seq are ``None`` when
+    no producer headers were supplied).
+    """
     producer_id = get_header(scope, PRODUCER_ID_HEADER)
     producer_epoch_str = get_header(scope, PRODUCER_EPOCH_HEADER)
     producer_seq_str = get_header(scope, PRODUCER_SEQ_HEADER)
 
-    # Validate producer headers - all three together or none
-    has_any = any(
-        h is not None for h in [producer_id, producer_epoch_str, producer_seq_str]
-    )
-    has_all = all(
-        h is not None for h in [producer_id, producer_epoch_str, producer_seq_str]
-    )
+    present = [producer_id, producer_epoch_str, producer_seq_str]
+    has_any = any(h is not None for h in present)
+    has_all = all(h is not None for h in present)
 
     if has_any and not has_all:
         await _send_error(
@@ -850,13 +872,12 @@ async def _handle_append(
             b"All producer headers (Producer-Id, Producer-Epoch, Producer-Seq) must be provided together",
             cors,
         )
-        return
+        return None
 
     if has_all and producer_id == "":
         await _send_error(send, 400, b"Invalid Producer-Id: must not be empty", cors)
-        return
+        return None
 
-    # Parse producer epoch/seq
     producer_epoch: int | None = None
     producer_seq: int | None = None
     if has_all:
@@ -870,7 +891,7 @@ async def _handle_append(
                 b"Invalid Producer-Epoch: must be a non-negative integer",
                 cors,
             )
-            return
+            return None
         producer_epoch = int(producer_epoch_str)
 
         if not STRICT_INTEGER_PATTERN.match(producer_seq_str):
@@ -880,8 +901,32 @@ async def _handle_append(
                 b"Invalid Producer-Seq: must be a non-negative integer",
                 cors,
             )
-            return
+            return None
         producer_seq = int(producer_seq_str)
+
+    return _ParsedProducer(producer_id, producer_epoch, producer_seq, has_all)
+
+
+async def _handle_append(
+    path: str,
+    scope: Scope,
+    receive: Receive,
+    send: Send,
+    store: StreamStore,
+    cors: dict[str, str],
+) -> None:
+    content_type = get_header(scope, "content-type")
+    seq = get_header(scope, "stream-seq")
+    closed_header = get_header(scope, STREAM_CLOSED_HEADER)
+    close_stream = closed_header == "true"
+
+    parsed = await _parse_producer_headers(send, scope, cors)
+    if parsed is None:
+        return
+    producer_id = parsed.producer_id
+    producer_epoch = parsed.epoch
+    producer_seq = parsed.seq
+    has_all = parsed.has_all
 
     body = await read_body(receive)
 

--- a/src/rakaia/handler.py
+++ b/src/rakaia/handler.py
@@ -68,6 +68,25 @@ STREAM_CLOSED_HEADER_RESP = "Stream-Closed"
 # Strict integer pattern for producer headers
 STRICT_INTEGER_PATTERN = re.compile(r"^\d+$")
 
+
+async def _send_error(
+    send: Send,
+    status: int,
+    message: bytes,
+    cors: dict[str, str],
+    extra_headers: dict[str, str] | None = None,
+) -> None:
+    """Send a plain-text error response carrying the CORS headers.
+
+    Collapses the repeated ``send_response(send, status, {**cors,
+    "content-type": "text/plain"}, msg)`` shape used throughout the handler.
+    """
+    headers = {**cors, "content-type": "text/plain"}
+    if extra_headers:
+        headers.update(extra_headers)
+    await send_response(send, status, headers, message)
+
+
 # Valid TTL pattern (non-negative integer, no leading zeros except for "0")
 VALID_TTL_PATTERN = re.compile(r"^(0|[1-9]\d*)$")
 
@@ -85,7 +104,6 @@ class InjectedFault:
     delay_ms: int | None = None
     drop_connection: bool = False
     truncate_body_bytes: int | None = None
-    probability: float | None = None
     method: str | None = None
     corrupt_body: bool = False
     jitter_ms: int | None = None
@@ -192,59 +210,31 @@ def create_app(
             elif method == "DELETE":
                 await _handle_delete(path, send, actual_store, cors_headers)
             else:
-                await send_response(
-                    send,
-                    405,
-                    {**cors_headers, "content-type": "text/plain"},
-                    b"Method not allowed",
-                )
+                await _send_error(send, 405, b"Method not allowed", cors_headers)
         except KeyError as e:
             msg = str(e)
             if "not found" in msg.lower():
-                await send_response(
-                    send,
-                    404,
-                    {**cors_headers, "content-type": "text/plain"},
-                    b"Stream not found",
-                )
+                await _send_error(send, 404, b"Stream not found", cors_headers)
             else:
                 raise
         except ValueError as e:
             msg = str(e)
             if "already exists with different configuration" in msg:
-                await send_response(
+                await _send_error(
                     send,
                     409,
-                    {**cors_headers, "content-type": "text/plain"},
                     b"Stream already exists with different configuration",
+                    cors_headers,
                 )
             elif "Sequence conflict" in msg:
-                await send_response(
-                    send,
-                    409,
-                    {**cors_headers, "content-type": "text/plain"},
-                    b"Sequence conflict",
-                )
+                await _send_error(send, 409, b"Sequence conflict", cors_headers)
             elif "Content-type mismatch" in msg:
-                await send_response(
-                    send,
-                    409,
-                    {**cors_headers, "content-type": "text/plain"},
-                    b"Content-type mismatch",
-                )
+                await _send_error(send, 409, b"Content-type mismatch", cors_headers)
             elif "Invalid JSON" in msg:
-                await send_response(
-                    send,
-                    400,
-                    {**cors_headers, "content-type": "text/plain"},
-                    b"Invalid JSON",
-                )
+                await _send_error(send, 400, b"Invalid JSON", cors_headers)
             elif "Empty arrays are not allowed" in msg:
-                await send_response(
-                    send,
-                    400,
-                    {**cors_headers, "content-type": "text/plain"},
-                    b"Empty arrays are not allowed",
+                await _send_error(
+                    send, 400, b"Empty arrays are not allowed", cors_headers
                 )
             else:
                 raise
@@ -282,23 +272,15 @@ async def _handle_create(
 
     # Validate TTL and Expires-At
     if ttl_header and expires_at_header:
-        await send_response(
-            send,
-            400,
-            {**cors, "content-type": "text/plain"},
-            b"Cannot specify both Stream-TTL and Stream-Expires-At",
+        await _send_error(
+            send, 400, b"Cannot specify both Stream-TTL and Stream-Expires-At", cors
         )
         return
 
     ttl_seconds: int | None = None
     if ttl_header:
         if not VALID_TTL_PATTERN.match(ttl_header):
-            await send_response(
-                send,
-                400,
-                {**cors, "content-type": "text/plain"},
-                b"Invalid Stream-TTL value",
-            )
+            await _send_error(send, 400, b"Invalid Stream-TTL value", cors)
             return
         ttl_seconds = int(ttl_header)
 
@@ -309,12 +291,7 @@ async def _handle_create(
 
             datetime.fromisoformat(expires_at_header.replace("Z", "+00:00"))
         except ValueError:
-            await send_response(
-                send,
-                400,
-                {**cors, "content-type": "text/plain"},
-                b"Invalid Stream-Expires-At timestamp",
-            )
+            await _send_error(send, 400, b"Invalid Stream-Expires-At timestamp", cors)
             return
 
     # Read body
@@ -381,7 +358,7 @@ async def _handle_head(
 ) -> None:
     stream = store.get(path)
     if stream is None:
-        await send_response(send, 404, {**cors, "content-type": "text/plain"}, b"")
+        await _send_error(send, 404, b"", cors)
         return
 
     headers: dict[str, str] = {
@@ -426,12 +403,7 @@ async def _handle_read(
 ) -> None:
     stream = store.get(path)
     if stream is None:
-        await send_response(
-            send,
-            404,
-            {**cors, "content-type": "text/plain"},
-            b"Stream not found",
-        )
+        await _send_error(send, 404, b"Stream not found", cors)
         return
 
     qs = get_query_string(scope)
@@ -442,41 +414,25 @@ async def _handle_read(
     # Validate offset
     if offset is not None:
         if offset == "":
-            await send_response(
-                send,
-                400,
-                {**cors, "content-type": "text/plain"},
-                b"Empty offset parameter",
-            )
+            await _send_error(send, 400, b"Empty offset parameter", cors)
             return
 
         all_offsets = get_all_query_params(qs, "offset")
         if len(all_offsets) > 1:
-            await send_response(
-                send,
-                400,
-                {**cors, "content-type": "text/plain"},
-                b"Multiple offset parameters not allowed",
+            await _send_error(
+                send, 400, b"Multiple offset parameters not allowed", cors
             )
             return
 
         if not VALID_OFFSET_PATTERN.match(offset):
-            await send_response(
-                send,
-                400,
-                {**cors, "content-type": "text/plain"},
-                b"Invalid offset format",
-            )
+            await _send_error(send, 400, b"Invalid offset format", cors)
             return
 
     # Require offset for long-poll and SSE
     if (live == "long-poll" or live == "sse") and not offset:
         label = "SSE" if live == "sse" else "Long-poll"
-        await send_response(
-            send,
-            400,
-            {**cors, "content-type": "text/plain"},
-            f"{label} requires offset parameter".encode(),
+        await _send_error(
+            send, 400, f"{label} requires offset parameter".encode(), cors
         )
         return
 
@@ -888,21 +844,16 @@ async def _handle_append(
     )
 
     if has_any and not has_all:
-        await send_response(
+        await _send_error(
             send,
             400,
-            {**cors, "content-type": "text/plain"},
             b"All producer headers (Producer-Id, Producer-Epoch, Producer-Seq) must be provided together",
+            cors,
         )
         return
 
     if has_all and producer_id == "":
-        await send_response(
-            send,
-            400,
-            {**cors, "content-type": "text/plain"},
-            b"Invalid Producer-Id: must not be empty",
-        )
+        await _send_error(send, 400, b"Invalid Producer-Id: must not be empty", cors)
         return
 
     # Parse producer epoch/seq
@@ -913,21 +864,21 @@ async def _handle_append(
         assert producer_seq_str is not None
 
         if not STRICT_INTEGER_PATTERN.match(producer_epoch_str):
-            await send_response(
+            await _send_error(
                 send,
                 400,
-                {**cors, "content-type": "text/plain"},
                 b"Invalid Producer-Epoch: must be a non-negative integer",
+                cors,
             )
             return
         producer_epoch = int(producer_epoch_str)
 
         if not STRICT_INTEGER_PATTERN.match(producer_seq_str):
-            await send_response(
+            await _send_error(
                 send,
                 400,
-                {**cors, "content-type": "text/plain"},
                 b"Invalid Producer-Seq: must be a non-negative integer",
+                cors,
             )
             return
         producer_seq = int(producer_seq_str)
@@ -944,12 +895,7 @@ async def _handle_append(
                 path, producer_id, producer_epoch, producer_seq
             )
             if close_result is None:
-                await send_response(
-                    send,
-                    404,
-                    {**cors, "content-type": "text/plain"},
-                    b"Stream not found",
-                )
+                await _send_error(send, 404, b"Stream not found", cors)
                 return
 
             pr = close_result.producer_result
@@ -967,50 +913,42 @@ async def _handle_append(
                 )
                 return
             if isinstance(pr, ProducerStaleEpoch):
-                await send_response(
+                await _send_error(
                     send,
                     403,
-                    {
-                        **cors,
-                        "content-type": "text/plain",
-                        PRODUCER_EPOCH_HEADER: str(pr.current_epoch),
-                    },
                     b"Stale producer epoch",
+                    cors,
+                    {PRODUCER_EPOCH_HEADER: str(pr.current_epoch)},
                 )
                 return
             if isinstance(pr, ProducerInvalidEpochSeq):
-                await send_response(
-                    send,
-                    400,
-                    {**cors, "content-type": "text/plain"},
-                    b"New epoch must start with sequence 0",
+                await _send_error(
+                    send, 400, b"New epoch must start with sequence 0", cors
                 )
                 return
             if isinstance(pr, ProducerSequenceGap):
-                await send_response(
+                await _send_error(
                     send,
                     409,
+                    b"Producer sequence gap",
+                    cors,
                     {
-                        **cors,
-                        "content-type": "text/plain",
                         PRODUCER_EXPECTED_SEQ_HEADER: str(pr.expected_seq),
                         PRODUCER_RECEIVED_SEQ_HEADER: str(pr.received_seq),
                     },
-                    b"Producer sequence gap",
                 )
                 return
             if isinstance(pr, ProducerStreamClosed):
                 s = store.get(path)
-                await send_response(
+                await _send_error(
                     send,
                     409,
+                    b"Stream is closed",
+                    cors,
                     {
-                        **cors,
-                        "content-type": "text/plain",
                         STREAM_CLOSED_HEADER_RESP: "true",
                         STREAM_OFFSET_HEADER_RESP: s.current_offset if s else "",
                     },
-                    b"Stream is closed",
                 )
                 return
 
@@ -1031,12 +969,7 @@ async def _handle_append(
             # Simple close without producer
             close_result = store.close_stream(path)
             if close_result is None:
-                await send_response(
-                    send,
-                    404,
-                    {**cors, "content-type": "text/plain"},
-                    b"Stream not found",
-                )
+                await _send_error(send, 404, b"Stream not found", cors)
                 return
             await send_response(
                 send,
@@ -1051,22 +984,12 @@ async def _handle_append(
 
     # Empty body without close is an error
     if len(body) == 0:
-        await send_response(
-            send,
-            400,
-            {**cors, "content-type": "text/plain"},
-            b"Empty body",
-        )
+        await _send_error(send, 400, b"Empty body", cors)
         return
 
     # Content-Type required for bodies
     if not content_type:
-        await send_response(
-            send,
-            400,
-            {**cors, "content-type": "text/plain"},
-            b"Content-Type header is required",
-        )
+        await _send_error(send, 400, b"Content-Type header is required", cors)
         return
 
     append_opts = AppendOptions(
@@ -1103,16 +1026,15 @@ async def _handle_append(
             return
 
         s = store.get(path)
-        await send_response(
+        await _send_error(
             send,
             409,
+            b"Stream is closed",
+            cors,
             {
-                **cors,
-                "content-type": "text/plain",
                 STREAM_CLOSED_HEADER_RESP: "true",
                 STREAM_OFFSET_HEADER_RESP: s.current_offset if s else "",
             },
-            b"Stream is closed",
         )
         return
 
@@ -1146,38 +1068,29 @@ async def _handle_append(
         return
 
     if isinstance(pr, ProducerStaleEpoch):
-        await send_response(
+        await _send_error(
             send,
             403,
-            {
-                **cors,
-                "content-type": "text/plain",
-                PRODUCER_EPOCH_HEADER: str(pr.current_epoch),
-            },
             b"Stale producer epoch",
+            cors,
+            {PRODUCER_EPOCH_HEADER: str(pr.current_epoch)},
         )
         return
 
     if isinstance(pr, ProducerInvalidEpochSeq):
-        await send_response(
-            send,
-            400,
-            {**cors, "content-type": "text/plain"},
-            b"New epoch must start with sequence 0",
-        )
+        await _send_error(send, 400, b"New epoch must start with sequence 0", cors)
         return
 
     if isinstance(pr, ProducerSequenceGap):
-        await send_response(
+        await _send_error(
             send,
             409,
+            b"Producer sequence gap",
+            cors,
             {
-                **cors,
-                "content-type": "text/plain",
                 PRODUCER_EXPECTED_SEQ_HEADER: str(pr.expected_seq),
                 PRODUCER_RECEIVED_SEQ_HEADER: str(pr.received_seq),
             },
-            b"Producer sequence gap",
         )
         return
 
@@ -1194,12 +1107,7 @@ async def _handle_delete(
     cors: dict[str, str],
 ) -> None:
     if not store.has(path):
-        await send_response(
-            send,
-            404,
-            {**cors, "content-type": "text/plain"},
-            b"Stream not found",
-        )
+        await _send_error(send, 404, b"Stream not found", cors)
         return
 
     store.delete(path)
@@ -1224,22 +1132,12 @@ async def _handle_test_inject(
         try:
             config = json.loads(body)
         except (json.JSONDecodeError, UnicodeDecodeError):
-            await send_response(
-                send,
-                400,
-                {**cors, "content-type": "text/plain"},
-                b"Invalid JSON body",
-            )
+            await _send_error(send, 400, b"Invalid JSON body", cors)
             return
 
         path = config.get("path")
         if not path:
-            await send_response(
-                send,
-                400,
-                {**cors, "content-type": "text/plain"},
-                b"Missing required field: path",
-            )
+            await _send_error(send, 400, b"Missing required field: path", cors)
             return
 
         injected_faults[path] = InjectedFault(
@@ -1249,7 +1147,6 @@ async def _handle_test_inject(
             delay_ms=config.get("delayMs"),
             drop_connection=config.get("dropConnection", False),
             truncate_body_bytes=config.get("truncateBodyBytes"),
-            probability=config.get("probability"),
             method=config.get("method"),
             corrupt_body=config.get("corruptBody", False),
             jitter_ms=config.get("jitterMs"),
@@ -1271,12 +1168,7 @@ async def _handle_test_inject(
             b'{"ok":true}',
         )
     else:
-        await send_response(
-            send,
-            405,
-            {**cors, "content-type": "text/plain"},
-            b"Method not allowed",
-        )
+        await _send_error(send, 405, b"Method not allowed", cors)
 
 
 def _consume_fault(

--- a/src/rakaia/store.py
+++ b/src/rakaia/store.py
@@ -8,6 +8,7 @@ producer validation, long-poll waiting, and TTL/expiry.
 from __future__ import annotations
 
 import asyncio
+import logging
 import time
 from datetime import datetime, timezone
 
@@ -39,6 +40,8 @@ from .types import (
 # *validates* them, so it deliberately does not import `VALID_OFFSET_PATTERN`.
 # Offset validation lives in the two protocol servers (`handler` /
 # `protocol_views`), which share the one pattern from `.types` (#41).
+
+_log = logging.getLogger("rakaia.store")
 
 
 class StreamStore:
@@ -83,7 +86,14 @@ class StreamStore:
                 if now > expires.replace(tzinfo=timezone.utc).timestamp():
                     return True
             except ValueError:
-                pass
+                # A malformed Stream-Expires-At can't be evaluated, so the
+                # stream is treated as non-expiring. Log it rather than
+                # swallowing silently so bad data is observable.
+                _log.debug(
+                    "Ignoring malformed expires_at %r on stream %r",
+                    stream.expires_at,
+                    stream.path,
+                )
 
         return False
 

--- a/tests/test_django_rakaia/test_admin.py
+++ b/tests/test_django_rakaia/test_admin.py
@@ -1,0 +1,142 @@
+"""Tests for the Django admin display helpers (``django_rakaia.admin``).
+
+Exercises the custom ``ModelAdmin`` display/formatter methods directly against
+model instances: counts, badges, data previews (including truncation and the
+short-data path), link builders, translation status, and the dynamic
+``register_stream_event_admin`` guard.
+"""
+
+import pytest
+from django.contrib import admin as django_admin
+
+from django_rakaia.admin import (
+    StreamAdmin,
+    StreamEntryAdmin,
+    StreamEventAdmin,
+    TranslatableAdmin,
+    register_stream_event_admin,
+)
+from django_rakaia.models import Stream, StreamEntry, StreamEvent, Translatable
+
+pytestmark = pytest.mark.django_db
+
+
+def _entry(stream_id: str, offset: int, event_type: str = "create", **data):
+    stream, _ = Stream.objects.get_or_create(stream_id=stream_id)
+    event = StreamEvent.objects.create(event_type=event_type, data=data or {"k": "v"})
+    entry = StreamEntry.objects.create(stream=stream, event=event, offset=offset)
+    return stream, event, entry
+
+
+class TestStreamAdmin:
+    def setup_method(self) -> None:
+        self.admin = StreamAdmin(Stream, django_admin.site)
+
+    def test_event_count_and_last_offset(self) -> None:
+        stream, _, _ = _entry("s:1", 1)
+        _entry("s:1", 7)
+        assert self.admin.event_count(stream) == 2
+        assert self.admin.last_entry_offset(stream) == 7
+
+    def test_last_offset_none_when_empty(self) -> None:
+        stream = Stream.objects.create(stream_id="empty")
+        assert self.admin.event_count(stream) == 0
+        assert self.admin.last_entry_offset(stream) is None
+
+
+class TestStreamEventAdmin:
+    def setup_method(self) -> None:
+        self.admin = StreamEventAdmin(StreamEvent, django_admin.site)
+
+    def test_badge_known_and_unknown_type(self) -> None:
+        create_evt = StreamEvent.objects.create(event_type="create", data={})
+        weird_evt = StreamEvent.objects.create(event_type="weird", data={})
+        assert "CREATE" in self.admin.event_type_badge(create_evt)
+        assert "#28a745" in self.admin.event_type_badge(create_evt)  # green
+        # Unknown type falls back to the neutral grey.
+        assert "#6c757d" in self.admin.event_type_badge(weird_evt)
+
+    def test_data_preview_short_returns_json(self) -> None:
+        evt = StreamEvent.objects.create(event_type="create", data={"a": 1})
+        preview = self.admin.data_preview(evt)
+        assert preview is not None
+        assert '"a": 1' in preview
+
+    def test_data_preview_truncates_long(self) -> None:
+        evt = StreamEvent.objects.create(event_type="create", data={"blob": "x" * 500})
+        preview = self.admin.data_preview(evt)
+        assert preview.endswith("...")
+        assert len(preview) == 100
+
+    def test_stream_count_and_streams_list(self) -> None:
+        _, event, _ = _entry("s:1", 1)
+        StreamEntry.objects.create(
+            stream=Stream.objects.get_or_create(stream_id="s:2")[0],
+            event=event,
+            offset=1,
+        )
+        assert self.admin.stream_count(event) == 2
+        listed = self.admin.streams_list(event)
+        assert "s:1" in listed and "s:2" in listed
+
+    def test_streams_list_empty(self) -> None:
+        event = StreamEvent.objects.create(event_type="create", data={})
+        assert self.admin.streams_list(event) == "-"
+
+
+class TestStreamEntryAdmin:
+    def setup_method(self) -> None:
+        self.admin = StreamEntryAdmin(StreamEntry, django_admin.site)
+
+    def test_links_and_badge(self) -> None:
+        _, _, entry = _entry("s:1", 3, event_type="delete")
+        stream_link = self.admin.stream_link(entry)
+        assert "s:1" in stream_link and "/admin/django_rakaia/stream/" in stream_link
+        event_link = self.admin.event_link(entry)
+        assert "/admin/django_rakaia/streamevent/" in event_link
+        badge = self.admin.event_type_badge(entry)
+        assert "DELETE" in badge and "#dc3545" in badge  # red
+
+
+class TestTranslatableAdmin:
+    def setup_method(self) -> None:
+        self.admin = TranslatableAdmin(Translatable, django_admin.site)
+
+    def test_msgstr_preview_variants(self) -> None:
+        empty = Translatable.objects.create(msgid="a", msgstr="", langcode="pt")
+        assert "Not translated" in self.admin.msgstr_preview(empty)
+
+        short = Translatable.objects.create(msgid="b", msgstr="hi", langcode="pt")
+        assert self.admin.msgstr_preview(short) == "hi"
+
+        longt = Translatable.objects.create(msgid="c", msgstr="y" * 80, langcode="pt")
+        assert self.admin.msgstr_preview(longt).endswith("...")
+
+    def test_langcode_badge_known_and_unknown(self) -> None:
+        known = Translatable.objects.create(msgid="a", msgstr="x", langcode="pt")
+        assert "#6f42c1" in self.admin.langcode_badge(known)  # purple
+        unknown = Translatable.objects.create(msgid="b", msgstr="x", langcode="zz")
+        assert "#6c757d" in self.admin.langcode_badge(unknown)  # grey fallback
+
+    def test_deleted_status(self) -> None:
+        from django.utils import timezone
+
+        active = Translatable.objects.create(msgid="a", msgstr="x", langcode="pt")
+        assert "Active" in self.admin.deleted_status(active)
+        gone = Translatable.objects.create(
+            msgid="b", msgstr="x", langcode="pt", deleted=timezone.now()
+        )
+        assert "Deleted" in self.admin.deleted_status(gone)
+
+    def test_get_queryset(self, rf) -> None:
+        Translatable.objects.create(msgid="a", msgstr="x", langcode="pt")
+        request = rf.get("/admin/")
+        assert self.admin.get_queryset(request).count() == 1
+
+
+class TestRegisterStreamEventAdmin:
+    def test_base_streamevent_is_noop(self) -> None:
+        before = set(django_admin.site._registry)
+        register_stream_event_admin(StreamEvent)
+        # Registering the base model must not touch the registry.
+        assert set(django_admin.site._registry) == before

--- a/tests/test_django_rakaia/test_views.py
+++ b/tests/test_django_rakaia/test_views.py
@@ -1,0 +1,258 @@
+"""Tests for the Django dashboard views (``django_rakaia.views``).
+
+Covers the login gate, the HTML dashboard pages (rendered via app templates),
+and the JSON API endpoints: happy paths, empty state, 404/absent streams, and
+input validation on pagination/offset parameters.
+"""
+
+import json
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.test import Client
+from django.urls import reverse
+
+from django_rakaia.models import Stream, StreamEntry, StreamEvent, Translatable
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def client() -> Client:
+    return Client()
+
+
+@pytest.fixture
+def user():
+    return get_user_model().objects.create_user(username="dash", password="pw")
+
+
+@pytest.fixture
+def auth_client(client: Client, user) -> Client:
+    client.force_login(user)
+    # The test app emits a stream event on every ``auth.User`` save (create +
+    # the last_login update from force_login), so start each test from a clean
+    # slate rather than counting those incidental rows.
+    StreamEntry.objects.all().delete()
+    StreamEvent.objects.all().delete()
+    Stream.objects.all().delete()
+    return client
+
+
+def _make_entry(stream_id: str, offset: int, event_type: str = "create", **data):
+    """Create a Stream + StreamEvent + StreamEntry triple at ``offset``."""
+    stream, _ = Stream.objects.get_or_create(stream_id=stream_id)
+    event = StreamEvent.objects.create(event_type=event_type, data=data or {"k": "v"})
+    StreamEntry.objects.create(stream=stream, event=event, offset=offset)
+    return stream, event
+
+
+# ---------------------------------------------------------------------------
+# Auth gate
+# ---------------------------------------------------------------------------
+
+
+class TestAuthGate:
+    def test_streams_index_redirects_when_anonymous(self, client: Client) -> None:
+        resp = client.get(reverse("django_rakaia:streams_index"))
+        assert resp.status_code == 302
+        assert "/accounts/login" in resp["Location"]
+
+    def test_streams_api_redirects_when_anonymous(self, client: Client) -> None:
+        resp = client.get(reverse("django_rakaia:streams_api"))
+        assert resp.status_code == 302
+
+
+# ---------------------------------------------------------------------------
+# HTML dashboard pages
+# ---------------------------------------------------------------------------
+
+
+class TestStreamsIndex:
+    def test_empty(self, auth_client: Client) -> None:
+        resp = auth_client.get(reverse("django_rakaia:streams_index"))
+        assert resp.status_code == 200
+        assert resp.context["total_streams"] == 0
+        assert resp.context["total_events"] == 0
+        assert resp.context["streams"] == []
+
+    def test_with_data(self, auth_client: Client) -> None:
+        _make_entry("s:1", 1)
+        _make_entry("s:1", 2)
+        _make_entry("s:2", 1)
+        resp = auth_client.get(reverse("django_rakaia:streams_index"))
+        assert resp.status_code == 200
+        # Two streams have entries; three events total.
+        assert resp.context["total_streams"] == 2
+        assert resp.context["total_events"] == 3
+        counts = {s["stream_id"]: s["event_count"] for s in resp.context["streams"]}
+        assert counts == {"s:1": 2, "s:2": 1}
+
+
+class TestStreamDetail:
+    def test_absent_stream_renders_exists_false(self, auth_client: Client) -> None:
+        resp = auth_client.get(reverse("django_rakaia:stream_detail", args=["nope"]))
+        assert resp.status_code == 200
+        assert resp.context["exists"] is False
+
+    def test_existing_stream_with_events(self, auth_client: Client) -> None:
+        _make_entry("s:1", 1)
+        _make_entry("s:1", 5)
+        resp = auth_client.get(reverse("django_rakaia:stream_detail", args=["s:1"]))
+        assert resp.status_code == 200
+        assert resp.context["exists"] is True
+        assert resp.context["stats"]["event_count"] == 2
+        assert resp.context["stats"]["min_offset"] == 1
+        assert resp.context["stats"]["max_offset"] == 5
+
+    def test_existing_stream_no_events(self, auth_client: Client) -> None:
+        Stream.objects.create(stream_id="empty:1")
+        resp = auth_client.get(reverse("django_rakaia:stream_detail", args=["empty:1"]))
+        assert resp.status_code == 200
+        assert resp.context["exists"] is True
+        assert resp.context["stats"]["event_count"] == 0
+
+
+# ---------------------------------------------------------------------------
+# JSON API endpoints
+# ---------------------------------------------------------------------------
+
+
+class TestStreamsApi:
+    def test_empty(self, auth_client: Client) -> None:
+        resp = auth_client.get(reverse("django_rakaia:streams_api"))
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body == {"streams": [], "total": 0}
+
+    def test_serialization(self, auth_client: Client) -> None:
+        _make_entry("s:1", 1)
+        _make_entry("s:1", 2)
+        resp = auth_client.get(reverse("django_rakaia:streams_api"))
+        body = resp.json()
+        assert body["total"] == 1
+        (stream,) = body["streams"]
+        assert stream["stream_id"] == "s:1"
+        assert stream["event_count"] == 2
+        assert stream["min_offset"] == 1
+        assert stream["max_offset"] == 2
+        assert stream["last_event"] is not None
+
+
+class TestStreamEventsApi:
+    def test_absent_stream_returns_empty(self, auth_client: Client) -> None:
+        resp = auth_client.get(
+            reverse("django_rakaia:stream_events_api", args=["nope"])
+        )
+        assert resp.status_code == 200
+        assert resp.json() == {"stream_id": "nope", "events": [], "count": 0}
+
+    def test_returns_events_ordered_by_offset(self, auth_client: Client) -> None:
+        _make_entry("s:1", 2, event_type="update", value=2)
+        _make_entry("s:1", 1, event_type="create", value=1)
+        resp = auth_client.get(reverse("django_rakaia:stream_events_api", args=["s:1"]))
+        body = resp.json()
+        assert body["count"] == 2
+        assert [e["offset"] for e in body["events"]] == [1, 2]
+        assert body["events"][0]["event_type"] == "create"
+
+    def test_after_offset_filter(self, auth_client: Client) -> None:
+        for off in (1, 2, 3):
+            _make_entry("s:1", off)
+        resp = auth_client.get(
+            reverse("django_rakaia:stream_events_api", args=["s:1"]),
+            {"after_offset": 1},
+        )
+        body = resp.json()
+        assert [e["offset"] for e in body["events"]] == [2, 3]
+
+    def test_limit_clamped_and_has_more(self, auth_client: Client) -> None:
+        for off in range(1, 6):
+            _make_entry("s:1", off)
+        resp = auth_client.get(
+            reverse("django_rakaia:stream_events_api", args=["s:1"]),
+            {"limit": 2},
+        )
+        body = resp.json()
+        assert body["count"] == 2
+        assert body["has_more"] is True
+
+    def test_invalid_limit_returns_400(self, auth_client: Client) -> None:
+        _make_entry("s:1", 1)
+        resp = auth_client.get(
+            reverse("django_rakaia:stream_events_api", args=["s:1"]),
+            {"limit": "abc"},
+        )
+        assert resp.status_code == 400
+
+    def test_invalid_after_offset_returns_400(self, auth_client: Client) -> None:
+        _make_entry("s:1", 1)
+        resp = auth_client.get(
+            reverse("django_rakaia:stream_events_api", args=["s:1"]),
+            {"after_offset": "abc"},
+        )
+        assert resp.status_code == 400
+
+
+class TestTranslationsApi:
+    def test_filter_by_langcode_and_msgid(self, auth_client: Client) -> None:
+        Translatable.objects.create(msgid="hello", msgstr="ola", langcode="pt")
+        Translatable.objects.create(msgid="hello", msgstr="halo", langcode="id")
+        Translatable.objects.create(msgid="bye", msgstr="tchau", langcode="pt")
+
+        resp = auth_client.get(
+            reverse("django_rakaia:translations_api"), {"langcode": "pt"}
+        )
+        body = resp.json()
+        assert body["total"] == 2
+        assert {t["langcode"] for t in body["translations"]} == {"pt"}
+
+        resp = auth_client.get(
+            reverse("django_rakaia:translations_api"), {"msgid": "hello"}
+        )
+        body = resp.json()
+        assert body["total"] == 2
+        assert {t["msgid"] for t in body["translations"]} == {"hello"}
+
+
+class TestTranslationCreateUpdateApi:
+    def _url(self) -> str:
+        return reverse("django_rakaia:translation_create_update_api")
+
+    def test_create(self, auth_client: Client) -> None:
+        resp = auth_client.post(
+            self._url(),
+            data=json.dumps({"msgid": "hi", "msgstr": "oi", "langcode": "pt"}),
+            content_type="application/json",
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["success"] is True
+        assert body["action"] == "create"
+        assert Translatable.objects.filter(msgid="hi", langcode="pt").exists()
+
+    def test_update_existing(self, auth_client: Client) -> None:
+        # msgctxt="" (not NULL) to match the view's ``msgctxt or ""`` lookup key.
+        Translatable.objects.create(msgid="hi", msgstr="old", langcode="pt", msgctxt="")
+        resp = auth_client.post(
+            self._url(),
+            data=json.dumps({"msgid": "hi", "msgstr": "new", "langcode": "pt"}),
+            content_type="application/json",
+        )
+        body = resp.json()
+        assert body["action"] == "update"
+        assert Translatable.objects.get(msgid="hi", langcode="pt").msgstr == "new"
+
+    def test_missing_msgid_returns_400(self, auth_client: Client) -> None:
+        resp = auth_client.post(
+            self._url(),
+            data=json.dumps({"msgstr": "oi"}),
+            content_type="application/json",
+        )
+        assert resp.status_code == 400
+
+    def test_invalid_json_returns_400(self, auth_client: Client) -> None:
+        resp = auth_client.post(
+            self._url(), data="{not json", content_type="application/json"
+        )
+        assert resp.status_code == 400

--- a/tests/test_rakaia/test_offset_patterns.py
+++ b/tests/test_rakaia/test_offset_patterns.py
@@ -1,0 +1,61 @@
+"""Tests for the shared offset/TTL/content-type validation patterns.
+
+``VALID_OFFSET_PATTERN`` is the single source of truth in ``rakaia.types`` and is
+imported by every protocol server (#41). ``VALID_TTL_PATTERN`` /
+``VALID_CONTENT_TYPE_PATTERN`` live in ``rakaia.handler``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from rakaia.handler import VALID_CONTENT_TYPE_PATTERN, VALID_TTL_PATTERN
+from rakaia.types import VALID_OFFSET_PATTERN
+
+
+class TestValidOffsetPattern:
+    @pytest.mark.parametrize("value", ["-1", "now", "0_0", "123_456", "999999_0"])
+    def test_accepts_canonical_and_sentinels(self, value: str) -> None:
+        assert VALID_OFFSET_PATTERN.match(value)
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "",
+            "1",  # bare seq without byte component
+            "1_",  # missing byte
+            "_1",  # missing seq
+            "1_2_3",  # too many components
+            "-2",  # only -1 is a valid sentinel
+            "NOW",  # case-sensitive
+            "1_-2",  # negative byte
+            "abc",
+            "1.2",
+            " 0_0",  # leading space
+            "0_0 ",  # trailing space
+        ],
+    )
+    def test_rejects_malformed(self, value: str) -> None:
+        assert VALID_OFFSET_PATTERN.match(value) is None
+
+
+class TestValidTtlPattern:
+    @pytest.mark.parametrize("value", ["0", "1", "60", "86400"])
+    def test_accepts_non_negative_ints(self, value: str) -> None:
+        assert VALID_TTL_PATTERN.match(value)
+
+    @pytest.mark.parametrize("value", ["", "-1", "01", "1.5", "abc", " 1"])
+    def test_rejects_malformed(self, value: str) -> None:
+        assert VALID_TTL_PATTERN.match(value) is None
+
+
+class TestValidContentTypePattern:
+    @pytest.mark.parametrize(
+        "value", ["text/plain", "application/json", "application/octet-stream"]
+    )
+    def test_accepts_typical(self, value: str) -> None:
+        assert VALID_CONTENT_TYPE_PATTERN.match(value)
+
+    @pytest.mark.parametrize("value", ["", "plain", "/json", "text"])
+    def test_rejects_malformed(self, value: str) -> None:
+        assert VALID_CONTENT_TYPE_PATTERN.match(value) is None

--- a/tests/test_rakaia/test_source_hash.py
+++ b/tests/test_rakaia/test_source_hash.py
@@ -1,0 +1,48 @@
+"""Tests for rakaia.source_hash.hash_function_source (drift-detection hashing)."""
+
+from __future__ import annotations
+
+import pytest
+
+from rakaia.source_hash import hash_function_source
+
+
+def sample_handler(event):
+    return {"value": event["v"]}
+
+
+def _nested_factory():
+    # Same body as the module-level ``sample_handler`` but indented one level.
+    # textwrap.dedent must normalise the indentation so both hash identically.
+    def sample_handler(event):
+        return {"value": event["v"]}
+
+    return sample_handler
+
+
+class TestHashFunctionSource:
+    def test_is_deterministic_sha256_hex(self) -> None:
+        h1 = hash_function_source(sample_handler)
+        h2 = hash_function_source(sample_handler)
+        assert h1 == h2
+        assert len(h1) == 64
+        assert all(c in "0123456789abcdef" for c in h1)
+
+    def test_indentation_normalised(self) -> None:
+        # The drift-detection contract: re-indenting a handler body (e.g. moving
+        # it inside a factory) must NOT change its hash.
+        assert hash_function_source(sample_handler) == hash_function_source(
+            _nested_factory()
+        )
+
+    def test_different_body_different_hash(self) -> None:
+        def other(event):
+            return {"value": event["w"]}
+
+        assert hash_function_source(sample_handler) != hash_function_source(other)
+
+    def test_builtin_without_source_raises_valueerror(self) -> None:
+        # Builtins have no retrievable source; inspect raises, which the helper
+        # surfaces as a clear ValueError.
+        with pytest.raises(ValueError, match="Cannot capture source"):
+            hash_function_source(len)

--- a/tests/test_rakaia/test_store.py
+++ b/tests/test_rakaia/test_store.py
@@ -617,3 +617,74 @@ class TestGloballyMonotonicOffsets:
         # Every recreation's tail is strictly greater than the last.
         assert tails == sorted(tails)
         assert len(set(tails)) == 4
+
+
+class TestReadEdgeCases:
+    """Boundary behaviour of read(): empty streams, sentinel offsets, and the
+    exclusive-offset contract (read returns messages strictly after `offset`)."""
+
+    def test_read_empty_stream(self, store: StreamStore):
+        store.create("s")
+        messages, up_to_date = store.read("s")
+        assert messages == []
+        assert up_to_date is True
+
+    def test_read_empty_stream_with_sentinel_offset(self, store: StreamStore):
+        store.create("s")
+        messages, up_to_date = store.read("s", "-1")
+        assert messages == []
+        assert up_to_date is True
+
+    def test_read_missing_stream_raises(self, store: StreamStore):
+        with pytest.raises(KeyError):
+            store.read("nope")
+
+    def test_read_from_offset_is_exclusive(self, store: StreamStore):
+        store.create("s")
+        offsets = [
+            store.append("s", b"a").message.offset,
+            store.append("s", b"b").message.offset,
+            store.append("s", b"c").message.offset,
+        ]
+        # Offsets are strictly increasing and lexicographically sortable.
+        assert offsets == sorted(offsets)
+        assert len(set(offsets)) == 3
+
+        # No offset (or "-1") returns the whole stream in order.
+        allmsgs, up = store.read("s")
+        assert [m.offset for m in allmsgs] == offsets
+        assert up is True
+
+        # Reading from an offset is exclusive: it returns messages after it.
+        after_first, _ = store.read("s", offsets[0])
+        assert [m.offset for m in after_first] == offsets[1:]
+
+        # Reading from the tail offset yields nothing — caught up.
+        after_last, up = store.read("s", offsets[-1])
+        assert after_last == []
+        assert up is True
+
+    def test_read_beyond_tail_returns_empty(self, store: StreamStore):
+        store.create("s")
+        store.append("s", b"a")
+        msgs, up = store.read("s", "9999999999999999_9999999999999999")
+        assert msgs == []
+        assert up is True
+
+
+class TestClosedStreamAppend:
+    """Appending to a closed stream is rejected without mutating the log, even
+    when a Stream-Seq is supplied."""
+
+    def test_append_to_closed_stream_with_seq_rejected(self, store: StreamStore):
+        store.create("s")
+        store.append("s", b"a")
+        store.close_stream("s")
+
+        result = store.append("s", b"b", AppendOptions(seq=5))
+        assert result.stream_closed is True
+        assert result.message is None
+
+        # The rejected append left the log untouched.
+        msgs, _ = store.read("s")
+        assert [m.data for m in msgs] == [b"a"]

--- a/zensical.toml
+++ b/zensical.toml
@@ -38,6 +38,7 @@ nav = [
     { "Deployment" = "deployment.md" },
     { Reference = [
         { "Protocol specification" = "protocol.md" },
+        { "Producer fencing & validation" = "producer-fencing.md" },
         { "Backend storage" = "streams-backend-storage.md" },
     ] },
     { "Decision records" = [


### PR DESCRIPTION
A self-directed polish/hardening pass across four independently-committable
workstreams. Every commit is behavior-preserving where it touches production
code; each was verified against `ruff check`/`ruff format --check` (scoped to
`src/ tests/`), the full pytest suite, and — for the handler changes — the
Durable Streams conformance suite.

## What's in it

| Commit | Workstream |
| --- | --- |
| `test:` | Coverage for the two untested Django modules (`views.py`, `admin.py`) plus `source_hash`, offset/TTL/content-type regex patterns, and store edge cases (empty reads, exclusive-offset contract, append-to-closed) |
| `docs:` | New `producer-fencing.md` reference for the `Producer*` validation result types (all in `__all__`, previously undocumented), wired into the Reference nav |
| `refactor:` | `_send_error` helper collapsing ~30 repeated plain-text error responses; removed dead `InjectedFault.probability`; logged a previously-silent `except` on malformed `expires_at` |
| `refactor:` | Extracted `_validate_read_params` and `_parse_producer_headers` (+`_ParsedProducer`) from the two largest ASGI handlers |

Net: +833 / −229 across 10 files, **+77 tests** (613 → 690 passing).

## Latent bugs fixed (surfaced by the first tests against `admin.py`)

- `StreamEventAdmin.data_preview` returned `None` for data ≤100 chars (missing `return`).
- `msgstr_preview` / `deleted_status` called `format_html()` with a constant and no args, which current Django rejects with `TypeError` — would crash the admin changelist. Switched to `mark_safe` for the static HTML.

## Verification

- `ruff check src/ tests/` — clean
- `ruff format --check src/ tests/` — clean
- `pytest` — **690 passed, 1 skipped**
- `zensical build` — no issues
- `just conformance` — **0 new failures**, 276 passed, 56 expected (the known stream-forking gap, #61)

## Deferred (documented, not built)

- The deeper `_handle_append` / `_handle_read` splits (`_do_append`, `_resolve_read_offset`, mode-dispatch) — entangled with per-request local state; real regression risk for modest gain, better done interactively.
- Bigger design calls left for maintainer sign-off: a `ReconcileRequest` dataclass for `reconcile_by_key`'s 10 params, a domain-exception hierarchy replacing `ValueError`, and an in-memory mock `WritableStore`.

## Notes

- The exploration's "missing return type hints" finding was inaccurate — the handler/store/projections public surfaces were already fully annotated, so no type-hint changes were needed.
