### PR TITLE
docs(registry): guard the touched-aware reducer example against empty touched

### DIFF
--- a/src/rakaia/registry.py
+++ b/src/rakaia/registry.py
@@ -1013,6 +1013,8 @@ def register_reducer(
         @register_reducer(name="balance", stage=1)
         def balance(reader, touched):
             sukus = {r.lookup["suku"] for r in touched if r.model_label == "ida.Line"}
+            if not sukus:
+                return []  # nothing changed this pass — a no-op, not a clear
             groups = _recompute_totals(reader, only=sukus)
             return reconcile_aggregate("ida.Balance", {}, "suku", groups)
     """


### PR DESCRIPTION
Follow-up to #52 (whole-table-wipe guard).

The touched-aware reducer example in `register_reducer`'s docstring called `reconcile_aggregate("ida.Balance", {}, "suku", groups)` with a global scope. When a replay pass touches nothing relevant, `sukus` is empty → `groups` is empty → the call now hits the #50/#52 guard and raises `ValueError`. Anyone copying the canonical incremental pattern inherited that latent crash.

Add the `if not sukus: return []` early-return so the empty-touched case is a no-op, matching the reducer contract.

Docstring-only; `ruff check`/`ruff format --check` clean, projections + replay suites pass.