### PR TITLE
Projection API ergonomics: verification helper, event_match sets, register_simple, replay_stream (#68)

### DIFF
--- a/src/django_rakaia/__init__.py
+++ b/src/django_rakaia/__init__.py
@@ -28,6 +28,9 @@ Public API:
     - stream_model: Decorator for automatically streaming model changes
     - create_stream_event: Helper function for manually creating stream events
     - register_stream_event_admin: Register stream event model with Django admin
+    - diff_effects_against_rows: Verify replayed effects reproduce the projection
+      (import from django_rakaia.verification — see that module; not eagerly
+      imported here because it pulls in the ORM before apps are ready)
 """
 
 # We intentionally do not eager import models here

--- a/src/django_rakaia/management/commands/replay.py
+++ b/src/django_rakaia/management/commands/replay.py
@@ -9,10 +9,8 @@ from typing import Any
 
 from django.core.management.base import BaseCommand, CommandParser
 
-from django_rakaia.effect_executor import DjangoExecutor
-from django_rakaia.store import get_store
+from django_rakaia.replay import replay_stream
 from rakaia.executors import CollectingExecutor
-from rakaia.replay import replay
 
 
 class Command(BaseCommand):
@@ -55,11 +53,12 @@ class Command(BaseCommand):
     def handle(self, *args: Any, **options: Any) -> None:  # noqa: ARG002
         dry_run = options["dry_run"]
         # On a dry run, collect the effects instead of applying them so we can
-        # both report the count and list exactly what *would* be written.
-        executor: Any = CollectingExecutor() if dry_run else DjangoExecutor()
-        result = replay(
-            store=get_store(),
-            stream_path=options["stream"],
+        # both report the count and list exactly what *would* be written. A real
+        # run defaults to the DjangoExecutor; either way replay_stream supplies
+        # the DjangoProjectionReader so staged handlers/reducers work.
+        executor: Any = CollectingExecutor() if dry_run else None
+        result = replay_stream(
+            options["stream"],
             executor=executor,
             start_seq=options["start_seq"],
             end_seq=options["end_seq"],

--- a/src/django_rakaia/replay.py
+++ b/src/django_rakaia/replay.py
@@ -1,0 +1,64 @@
+"""
+Django-side ``replay`` convenience.
+
+``rakaia.replay.replay()`` is framework-agnostic: it takes an executor and, for
+staged replays, a reader. From Django both of those are always the same pair —
+``DjangoExecutor`` writes the projections and ``DjangoProjectionReader`` reads
+them back for stage > 0 handlers and reducers. ``replay_stream`` fills those in
+so a staged replay does not fail with "stage > 0 but no reader" just because the
+caller didn't wire the Django reader by hand (see issue #68).
+
+    from django_rakaia.replay import replay_stream
+
+    replay_stream("submissions:42")                 # applies via the ORM
+    replay_stream("submissions:42", executor=CollectingExecutor())  # dry run
+
+Everything else is forwarded to ``rakaia.replay.replay`` unchanged.
+"""
+
+from __future__ import annotations
+
+from rakaia.effects import Executor
+from rakaia.protocols import ProjectionReader
+from rakaia.registry import HandlerRegistry, UpcasterRegistry
+from rakaia.replay import OnDriftPolicy, ReplayResult, replay
+
+from .effect_executor import DjangoExecutor
+from .projection_reader import DjangoProjectionReader
+from .store import get_store
+
+
+def replay_stream(
+    stream_path: str,
+    *,
+    executor: Executor | None = None,
+    reader: ProjectionReader | None = None,
+    handler_registry: HandlerRegistry | None = None,
+    upcaster_registry: UpcasterRegistry | None = None,
+    start_seq: int = 0,
+    end_seq: int | None = None,
+    event_match: str | None = None,
+    include_external: bool = False,
+    on_drift: OnDriftPolicy = "warn",
+    store: object | None = None,
+) -> ReplayResult:
+    """Replay ``stream_path`` through the Django executor + reader by default.
+
+    ``executor`` defaults to ``DjangoExecutor()`` (pass a ``CollectingExecutor``
+    for a dry run) and ``reader`` to ``DjangoProjectionReader()``, so a staged
+    replay works without the caller wiring the reader. ``store`` defaults to the
+    Django global store. All other arguments match ``rakaia.replay.replay``.
+    """
+    return replay(
+        store=store if store is not None else get_store(),
+        stream_path=stream_path,
+        executor=executor if executor is not None else DjangoExecutor(),
+        handler_registry=handler_registry,
+        upcaster_registry=upcaster_registry,
+        start_seq=start_seq,
+        end_seq=end_seq,
+        event_match=event_match,
+        include_external=include_external,
+        on_drift=on_drift,
+        reader=reader if reader is not None else DjangoProjectionReader(),
+    )

--- a/src/django_rakaia/verification.py
+++ b/src/django_rakaia/verification.py
@@ -1,0 +1,279 @@
+"""
+Verify that a batch of Effects reproduces the current Django projection rows.
+
+The canonical migration proof is: run ``replay()`` with a
+:class:`~rakaia.executors.CollectingExecutor`, then diff each write effect's
+``defaults`` against the live row it targets — "does replaying the log reproduce
+the projection we already have?" — without writing anything. Every port re-derives
+the same diff plus the same normalization (a UUID column read back as a
+``uuid.UUID`` vs a string in the effect; a JSON float vs the column's rounded
+``Decimal``). That normalization is universal, so it belongs here rather than in
+each consumer's ``replay_*`` proof.
+
+    from rakaia.executors import CollectingExecutor
+    from rakaia.replay import replay
+    from django_rakaia.verification import diff_effects_against_rows
+
+    ex = CollectingExecutor()
+    replay(store, "submissions", ex)
+    diff_effects_against_rows(ex.effects).raise_if_diff()
+
+By default only ``update_or_create`` and ``update`` effects are checked (the ops
+that carry ``defaults``); delete/retire/external effects have no target values to
+diff and are ignored.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable, Sequence
+from dataclasses import dataclass, field
+from decimal import Decimal
+from typing import Any
+from uuid import UUID
+
+from django.apps import apps
+from django.core.exceptions import FieldDoesNotExist
+from django.db.models import DecimalField
+
+from rakaia.effects import Effect
+
+from .projection_reader import DjangoProjectionReader
+
+# A normalizer coerces one value into a canonical, comparable form given the
+# model and the field name it belongs to. It is applied to BOTH the effect's
+# expected value and the row's stored value before they are compared, so a
+# normalizer that doesn't apply must return the value unchanged.
+Normalizer = Callable[[type, str, Any], Any]
+
+# Ops whose ``defaults`` describe row values worth verifying. delete/retire/
+# external carry no projected column values to diff.
+_WRITE_OPS = ("update_or_create", "update")
+
+
+class _Unset:
+    """Sentinel for "the row has no such attribute" (distinct from ``None``)."""
+
+    def __repr__(self) -> str:  # pragma: no cover - debug aid only
+        return "<unset>"
+
+
+_UNSET = _Unset()
+
+
+# =============================================================================
+# Report structures
+# =============================================================================
+
+
+@dataclass(frozen=True)
+class FieldDiff:
+    """One field whose stored value disagrees with the effect's ``defaults``."""
+
+    field: str
+    expected: Any
+    actual: Any
+
+    def __str__(self) -> str:
+        return f"{self.field}: expected {self.expected!r}, got {self.actual!r}"
+
+
+@dataclass(frozen=True)
+class RowDiff:
+    """The verification outcome for one write effect's target row."""
+
+    model_label: str
+    lookup: dict[str, Any]
+    missing: bool
+    field_diffs: list[FieldDiff] = field(default_factory=list)
+
+    @property
+    def ok(self) -> bool:
+        return not self.missing and not self.field_diffs
+
+    def __str__(self) -> str:
+        head = f"{self.model_label} {self.lookup!r}"
+        if self.missing:
+            return f"{head}: no matching row"
+        return f"{head}: " + "; ".join(str(d) for d in self.field_diffs)
+
+
+@dataclass(frozen=True)
+class DiffReport:
+    """Aggregate result of :func:`diff_effects_against_rows`.
+
+    ``rows`` holds one :class:`RowDiff` per write effect checked (in effect
+    order); ``problems`` is the subset that disagree. ``ok`` is the assertion a
+    migration proof cares about.
+    """
+
+    rows: list[RowDiff]
+
+    @property
+    def problems(self) -> list[RowDiff]:
+        return [r for r in self.rows if not r.ok]
+
+    @property
+    def ok(self) -> bool:
+        return not self.problems
+
+    def raise_if_diff(self) -> None:
+        """Raise :class:`VerificationError` if any checked row disagrees."""
+        if self.ok:
+            return
+        raise VerificationError(self)
+
+    def __str__(self) -> str:
+        problems = self.problems
+        if not problems:
+            return f"DiffReport: {len(self.rows)} row(s) verified, no differences"
+        lines = [
+            f"DiffReport: {len(problems)} of {len(self.rows)} row(s) differ:",
+            *(f"  - {p}" for p in problems),
+        ]
+        return "\n".join(lines)
+
+
+class VerificationError(AssertionError):
+    """Raised by :meth:`DiffReport.raise_if_diff` when a projection disagrees."""
+
+    def __init__(self, report: DiffReport) -> None:
+        self.report = report
+        super().__init__(str(report))
+
+
+# =============================================================================
+# Default normalizers
+# =============================================================================
+
+
+def normalize_uuid(_model: type, _field_name: str, value: Any) -> Any:
+    """Render a ``uuid.UUID`` as its canonical string.
+
+    A ``UUIDField`` reads back as a ``uuid.UUID`` while the effect (post JSON)
+    usually carries the string form; string-ifying both sides makes them agree.
+    """
+    if isinstance(value, UUID):
+        return str(value)
+    return value
+
+
+def normalize_decimal(model: type, field_name: str, value: Any) -> Any:
+    """Quantize a value bound for a ``DecimalField`` to the column's scale.
+
+    The log can carry more precision than the column stores — most commonly a
+    JSON number decoded as a ``float`` (``2.1``), which does not compare equal to
+    the column's ``Decimal("2.10")``. Coercing through ``str`` (to dodge binary
+    float noise) and quantizing to ``decimal_places`` puts both sides in the
+    column's representation. No-op for non-Decimal fields or ``None``.
+    """
+    if value is None:
+        return value
+    model_field = _resolve_field(model, field_name)
+    if not isinstance(model_field, DecimalField):
+        return value
+    if isinstance(value, float):
+        dec = Decimal(str(value))
+    elif isinstance(value, (int, str)):
+        dec = Decimal(value)
+    elif isinstance(value, Decimal):
+        dec = value
+    else:
+        return value
+    quantum = Decimal(1).scaleb(-model_field.decimal_places)
+    return dec.quantize(quantum)
+
+
+DEFAULT_NORMALIZERS: tuple[Normalizer, ...] = (normalize_uuid, normalize_decimal)
+
+
+# =============================================================================
+# Public entry point
+# =============================================================================
+
+
+def diff_effects_against_rows(
+    effects: Iterable[Effect],
+    *,
+    reader: DjangoProjectionReader | None = None,
+    normalizers: Sequence[Normalizer] | None = None,
+    ops: tuple[str, ...] = _WRITE_OPS,
+) -> DiffReport:
+    """Diff each write effect's ``defaults`` against its live projection row.
+
+    For every effect whose ``op`` is in ``ops`` (default: the write ops), the row
+    matching ``lookup`` is fetched via ``reader``. A missing row, or any field in
+    ``defaults`` whose stored value differs (after ``normalizers`` are applied to
+    both sides), is recorded in the returned :class:`DiffReport`.
+
+    ``normalizers`` defaults to :data:`DEFAULT_NORMALIZERS` (UUID + Decimal); pass
+    an explicit list to extend or replace them, or ``[]`` to compare raw values.
+    """
+    active_reader = reader if reader is not None else DjangoProjectionReader()
+    active_norms = DEFAULT_NORMALIZERS if normalizers is None else tuple(normalizers)
+
+    rows: list[RowDiff] = []
+    for eff in effects:
+        if eff.op not in ops:
+            continue
+        if eff.model_label is None or eff.lookup is None:
+            raise ValueError(
+                f"Effect with op={eff.op!r} requires model_label and lookup "
+                "to be verified"
+            )
+        model = apps.get_model(eff.model_label)
+        row = active_reader.get(eff.model_label, **eff.lookup)
+        if row is None:
+            rows.append(RowDiff(eff.model_label, eff.lookup, missing=True))
+            continue
+        field_diffs = _diff_row(model, row, eff.defaults or {}, active_norms)
+        rows.append(
+            RowDiff(eff.model_label, eff.lookup, missing=False, field_diffs=field_diffs)
+        )
+    return DiffReport(rows=rows)
+
+
+# =============================================================================
+# Internal
+# =============================================================================
+
+
+def _diff_row(
+    model: type,
+    row: Any,
+    defaults: dict[str, Any],
+    normalizers: tuple[Normalizer, ...],
+) -> list[FieldDiff]:
+    diffs: list[FieldDiff] = []
+    for name, expected in defaults.items():
+        actual = getattr(row, name, _UNSET)
+        exp_c = _canonical(model, name, expected, normalizers)
+        act_c = (
+            _UNSET if actual is _UNSET else _canonical(model, name, actual, normalizers)
+        )
+        if exp_c != act_c:
+            diffs.append(FieldDiff(field=name, expected=expected, actual=actual))
+    return diffs
+
+
+def _canonical(
+    model: type, field_name: str, value: Any, normalizers: tuple[Normalizer, ...]
+) -> Any:
+    for norm in normalizers:
+        value = norm(model, field_name, value)
+    return value
+
+
+def _resolve_field(model: type, name: str) -> Any | None:
+    """The model field named ``name``, resolving an FK's ``attname`` (``x_id``).
+
+    ``get_field`` knows the relation name (``project``) but not its column
+    (``project_id``); effects address the column, so fall back to a scan by
+    ``attname`` before giving up.
+    """
+    try:
+        return model._meta.get_field(name)
+    except FieldDoesNotExist:
+        for candidate in model._meta.get_fields():
+            if getattr(candidate, "attname", None) == name:
+                return candidate
+        return None

--- a/src/rakaia/__init__.py
+++ b/src/rakaia/__init__.py
@@ -67,6 +67,7 @@ from .registry import (
     get_default_upcaster_registry,
     register_handler,
     register_reducer,
+    register_simple,
     register_upcaster,
     reset_default_registries,
     upcast,
@@ -153,6 +154,7 @@ __all__ = [
     "project_latest",
     # Versioned handlers — registry
     "register_handler",
+    "register_simple",
     "register_reducer",
     "register_upcaster",
     "HandlerRegistry",

--- a/src/rakaia/registry.py
+++ b/src/rakaia/registry.py
@@ -983,6 +983,38 @@ def register_handler(
     return decorator
 
 
+def register_simple(
+    name: str,
+    event_match: str,
+    *,
+    match_field: str | None = None,
+    stage: int = 0,
+    registry: HandlerRegistry | None = None,
+) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    """Register an always-on handler — the common "just project" case.
+
+    Shorthand for ``register_handler(name, event_match, effective_from=0,
+    effective_to=None, ...)``: one open-ended version covering every sequence,
+    with no seq-range ceremony. Reach for `register_handler` only when you
+    actually need version brackets (a handler whose body changes at a known
+    sequence). `match_field` and `stage` pass straight through.
+
+    Example:
+        @register_simple("project_registry", "TF_6_1_1", match_field="form_type")
+        def project_registry(event):
+            return Effect(op="update_or_create", ...)
+    """
+    return register_handler(
+        name,
+        event_match,
+        effective_from=0,
+        effective_to=None,
+        match_field=match_field,
+        stage=stage,
+        registry=registry,
+    )
+
+
 def register_reducer(
     name: str,
     stage: int,

--- a/src/rakaia/registry.py
+++ b/src/rakaia/registry.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 import fnmatch
 import importlib
 import json
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
@@ -67,8 +67,12 @@ class HandlerVersion:
     name: str
     """Handler name, stable across versions (e.g. 'mogrify')."""
 
-    event_match: str
-    """Glob pattern matched against the event's stream/event-type."""
+    event_match: str | frozenset[str]
+    """Glob pattern(s) matched against the routing subject. A ``str`` is a single
+    glob (the common case); a ``frozenset`` matches the subject against **any**
+    of its element globs, so one registration covers several unrelated
+    form_types that share no glob prefix (e.g. ``{"TF_6_1_1", "SF_1_2"}``). Set
+    at registration from a str or any iterable of strings."""
 
     effective_from: int
     """Inclusive lower bound on stream sequence."""
@@ -168,7 +172,9 @@ class HandlerRegistry:
         stream_path: str = HANDLERS_META_STREAM,
     ) -> None:
         # (name, event_match) -> sorted list of HandlerVersion by effective_from
-        self._versions: dict[tuple[str, str], list[HandlerVersion]] = {}
+        self._versions: dict[
+            tuple[str, str | frozenset[str]], list[HandlerVersion]
+        ] = {}
         # reducer name -> ReducerVersion
         self._reducers: dict[str, ReducerVersion] = {}
         self._store = store
@@ -176,7 +182,7 @@ class HandlerRegistry:
         self._reducer_stream_path = REDUCERS_META_STREAM
         # Identity tuples already persisted to the stream — used for dedup.
         self._persisted_ids: set[
-            tuple[str, str, int, int | None, str, str, str | None, int]
+            tuple[str, str | frozenset[str], int, int | None, str, str, str | None, int]
         ] = set()
         self._reducer_persisted_ids: set[tuple[str, int, str, str]] = set()
         if store is not None:
@@ -188,7 +194,7 @@ class HandlerRegistry:
     def register(
         self,
         name: str,
-        event_match: str,
+        event_match: str | Iterable[str],
         fn: Callable[..., Any],
         effective_from: int,
         effective_to: int | None = None,
@@ -203,13 +209,18 @@ class HandlerRegistry:
         dotted_path, source_hash, match_field, stage) is a no-op that returns
         the existing version without re-appending to the meta-stream.
 
-        When `match_field` is set, `event_match` is matched against
+        `event_match` is a glob string or an iterable of glob strings; a
+        collection matches the subject against **any** of its members, so one
+        registration covers several unrelated form_types that share no glob
+        (canonicalised to a `frozenset`, so member order does not matter). When
+        `match_field` is set, the pattern(s) are matched against
         `event[match_field]` (e.g. 'form_type') instead of the stream path.
 
         `stage` (default 0) controls replay ordering: replay runs stages in
         ascending order, and a stage > 0 handler is invoked as `fn(event,
         reader)` so it can read earlier stages' projections.
         """
+        event_match = _canonical_event_match(event_match)
         if effective_from < 0:
             raise ValueError(
                 f"effective_from must be non-negative, got {effective_from}"
@@ -343,7 +354,7 @@ class HandlerRegistry:
         resolved: list[HandlerVersion] = []
         for (name, pattern), versions in self._versions.items():
             subject = self._match_subject(name, versions, event_match, event)
-            if not fnmatch.fnmatchcase(subject, pattern):
+            if not _pattern_matches(pattern, subject):
                 continue
             covering = [
                 v
@@ -463,7 +474,13 @@ class HandlerRegistry:
             return
         payload = {
             "name": version.name,
-            "event_match": version.event_match,
+            # A frozenset event_match serializes as a sorted list so the
+            # meta-stream is stable regardless of set iteration order.
+            "event_match": (
+                version.event_match
+                if isinstance(version.event_match, str)
+                else sorted(version.event_match)
+            ),
             "effective_from": version.effective_from,
             "effective_to": version.effective_to,
             "dotted_path": version.dotted_path,
@@ -817,13 +834,46 @@ class UpcasterRegistry:
 
 
 # =============================================================================
+# event_match helpers
+# =============================================================================
+
+
+def _canonical_event_match(event_match: str | Iterable[str]) -> str | frozenset[str]:
+    """Normalise an `event_match` argument to its stored form.
+
+    A plain string is kept as-is (the common single-glob case). Any other
+    iterable of strings becomes a ``frozenset`` — hashable (so it works as the
+    series key and in the identity tuple) and order-independent (so the same
+    members in a different order dedup). Raises on an empty collection or a
+    non-string member, which are always mistakes.
+    """
+    if isinstance(event_match, str):
+        return event_match
+    members = frozenset(event_match)
+    if not members:
+        raise ValueError(
+            "event_match collection must contain at least one pattern (got empty)"
+        )
+    if not all(isinstance(m, str) for m in members):
+        raise ValueError("event_match collection members must all be strings")
+    return members
+
+
+def _pattern_matches(pattern: str | frozenset[str], subject: str) -> bool:
+    """Whether `subject` matches `pattern` — a single glob, or any glob in a set."""
+    if isinstance(pattern, str):
+        return fnmatch.fnmatchcase(subject, pattern)
+    return any(fnmatch.fnmatchcase(subject, p) for p in pattern)
+
+
+# =============================================================================
 # Identity helpers
 # =============================================================================
 
 
 def _identity(
     v: HandlerVersion,
-) -> tuple[str, str, int, int | None, str, str, str | None, int]:
+) -> tuple[str, str | frozenset[str], int, int | None, str, str, str | None, int]:
     # match_field / stage are appended after dotted_path (index 4) and
     # source_hash (index 5) so rehydrate()'s ident[4] lookup stays valid.
     return (
@@ -840,10 +890,14 @@ def _identity(
 
 def _identity_from_payload(
     p: dict[str, Any],
-) -> tuple[str, str, int, int | None, str, str, str | None, int]:
+) -> tuple[str, str | frozenset[str], int, int | None, str, str, str | None, int]:
     return (
         p["name"],
-        p["event_match"],
+        # Reconstruct the same canonical (frozenset) identity a list-serialized
+        # set was persisted from, so a reload dedups against the live version.
+        p["event_match"]
+        if isinstance(p["event_match"], str)
+        else frozenset(p["event_match"]),
         int(p["effective_from"]),
         p["effective_to"] if p["effective_to"] is None else int(p["effective_to"]),
         p["dotted_path"],
@@ -936,7 +990,7 @@ def upcast(
 
 def register_handler(
     name: str,
-    event_match: str,
+    event_match: str | Iterable[str],
     effective_from: int,
     effective_to: int | None = None,
     *,
@@ -947,9 +1001,12 @@ def register_handler(
     """
     Decorator that registers a handler version with the default registry.
 
-    Pass `match_field` to route on a payload field (e.g. 'form_type') instead
-    of the stream path. Pass `stage` (default 0) to place the handler in a
-    replay stage; stage > 0 handlers are called `fn(event, reader)`.
+    `event_match` is a glob string or an iterable of glob strings; a collection
+    matches any of its members, so one registration covers several unrelated
+    form_types (e.g. `{"TF_6_1_1", "SF_1_2"}`) without a per-value loop. Pass
+    `match_field` to route on a payload field (e.g. 'form_type') instead of the
+    stream path. Pass `stage` (default 0) to place the handler in a replay stage;
+    stage > 0 handlers are called `fn(event, reader)`.
 
     Example:
         @register_handler(
@@ -965,6 +1022,15 @@ def register_handler(
                 lookup={"id": event["room_id"]},
                 defaults={"name": event["name"]},
             )
+
+        # One registration for several form_types that share no glob:
+        @register_handler(
+            name="sweep",
+            event_match={"TF_6_1_1", "SF_1_2", "POM_1"},
+            effective_from=0,
+            match_field="form_type",
+        )
+        def sweep(event): ...
     """
     target = registry if registry is not None else _default_registry
 
@@ -985,7 +1051,7 @@ def register_handler(
 
 def register_simple(
     name: str,
-    event_match: str,
+    event_match: str | Iterable[str],
     *,
     match_field: str | None = None,
     stage: int = 0,

--- a/tests/test_django_rakaia/migrations/0005_measure.py
+++ b/tests/test_django_rakaia/migrations/0005_measure.py
@@ -1,0 +1,29 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("test_django_rakaia", "0004_alert_dismissed_version"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="Measure",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("ref", models.UUIDField(unique=True)),
+                (
+                    "amount",
+                    models.DecimalField(decimal_places=2, default=0, max_digits=10),
+                ),
+            ],
+        ),
+    ]

--- a/tests/test_django_rakaia/models.py
+++ b/tests/test_django_rakaia/models.py
@@ -279,6 +279,19 @@ class Balance(models.Model):
         app_label = "test_django_rakaia"
 
 
+class Measure(models.Model):
+    """Projection row with a UUID natural key and a Decimal column — the
+    fixture for the ``diff_effects_against_rows`` verification helper, whose
+    default normalizers cover exactly these two "log carries a different
+    representation than the column" cases (UUID<->str, over-precise Decimal)."""
+
+    ref = models.UUIDField(unique=True)
+    amount = models.DecimalField(max_digits=10, decimal_places=2, default=0)
+
+    class Meta:
+        app_label = "test_django_rakaia"
+
+
 class History(models.Model):
     """Audit-log read-model for the history materializer tests."""
 

--- a/tests/test_django_rakaia/test_replay_helper.py
+++ b/tests/test_django_rakaia/test_replay_helper.py
@@ -1,0 +1,83 @@
+"""Tests for ``django_rakaia.replay.replay_stream`` — the Django-side replay
+convenience that defaults the executor AND the reader, so a staged replay does
+not fail with "stage > 0 but no reader" (#68 minor)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from django_rakaia.replay import replay_stream
+from django_rakaia.store import get_store
+from rakaia.effects import Effect
+from rakaia.registry import HandlerRegistry, UpcasterRegistry
+
+from .models import Area
+
+
+def _ref(event):
+    return Effect(
+        op="update_or_create",
+        model_label="test_django_rakaia.Area",
+        lookup={"name": event["name"]},
+        defaults={},
+    )
+
+
+def _dep(event, reader):
+    ref = reader.get("test_django_rakaia.Area", name=event["ref"])
+    tag = "FOUND" if ref is not None else "MISSING"
+    return Effect(
+        op="update_or_create",
+        model_label="test_django_rakaia.Area",
+        lookup={"name": f"{event['key']}->{tag}"},
+        defaults={},
+    )
+
+
+@pytest.mark.django_db
+class TestReplayStream:
+    def test_staged_replay_defaults_the_reader(self):
+        store = get_store()
+        store.delete("s")
+        store.create("s")
+        # Dependent arrives before the reference it needs — only a staged replay
+        # with a reader resolves it.
+        for event in (
+            {"schema_version": 1, "kind": "DEP", "key": "d1", "ref": "the-ref"},
+            {"schema_version": 1, "kind": "REF", "key": "r1", "name": "the-ref"},
+        ):
+            store.append("s", json.dumps(event).encode("utf-8"))
+
+        reg = HandlerRegistry()
+        reg.register("ref", "REF", _ref, 0, None, match_field="kind", stage=0)
+        reg.register("dep", "DEP", _dep, 0, None, match_field="kind", stage=1)
+
+        # No executor, no reader passed — both default to the Django ones.
+        replay_stream(
+            "s",
+            handler_registry=reg,
+            upcaster_registry=UpcasterRegistry(),
+        )
+
+        assert Area.objects.filter(name="d1->FOUND").exists()
+        assert not Area.objects.filter(name="d1->MISSING").exists()
+
+    def test_returns_replay_result(self):
+        store = get_store()
+        store.delete("s2")
+        store.create("s2")
+        store.append(
+            "s2",
+            json.dumps({"schema_version": 1, "kind": "REF", "name": "solo"}).encode(),
+        )
+
+        reg = HandlerRegistry()
+        reg.register("ref", "REF", _ref, 0, None, match_field="kind", stage=0)
+
+        result = replay_stream(
+            "s2", handler_registry=reg, upcaster_registry=UpcasterRegistry()
+        )
+        assert result.events_processed == 1
+        assert Area.objects.filter(name="solo").exists()

--- a/tests/test_django_rakaia/test_verification.py
+++ b/tests/test_django_rakaia/test_verification.py
@@ -1,0 +1,257 @@
+"""Tests for ``diff_effects_against_rows`` — the projection-verification helper.
+
+The migration pattern these back is: run ``replay()`` with a ``CollectingExecutor``
+and diff each write effect's ``defaults`` against the live row, so a port can prove
+"replaying the log reproduces the current projection" without touching the DB. See
+issue #68 item #1.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from decimal import Decimal
+
+import pytest
+
+from django_rakaia.store import get_store
+from django_rakaia.verification import (
+    VerificationError,
+    diff_effects_against_rows,
+)
+from rakaia.effects import Effect
+from rakaia.executors import CollectingExecutor
+from rakaia.registry import HandlerRegistry, UpcasterRegistry
+from rakaia.replay import replay
+
+from .models import FinanceLine, Measure
+
+
+@pytest.mark.django_db
+class TestDiffEffectsAgainstRows:
+    def test_all_effects_match_reports_ok(self):
+        FinanceLine.objects.create(submission_id="s1", suku="A", delta=100)
+        FinanceLine.objects.create(submission_id="s2", suku="B", delta=50)
+        effects = [
+            Effect(
+                op="update_or_create",
+                model_label="test_django_rakaia.FinanceLine",
+                lookup={"submission_id": "s1"},
+                defaults={"suku": "A", "delta": 100},
+            ),
+            Effect(
+                op="update_or_create",
+                model_label="test_django_rakaia.FinanceLine",
+                lookup={"submission_id": "s2"},
+                defaults={"suku": "B", "delta": 50},
+            ),
+        ]
+        report = diff_effects_against_rows(effects)
+        assert report.ok
+        assert not report.problems
+        assert len(report.rows) == 2
+
+    def test_field_mismatch_is_reported_with_expected_and_actual(self):
+        FinanceLine.objects.create(submission_id="s1", suku="A", delta=100)
+        effects = [
+            Effect(
+                op="update_or_create",
+                model_label="test_django_rakaia.FinanceLine",
+                lookup={"submission_id": "s1"},
+                defaults={"suku": "A", "delta": 999},
+            ),
+        ]
+        report = diff_effects_against_rows(effects)
+        assert not report.ok
+        (row,) = report.problems
+        assert not row.missing
+        (diff,) = row.field_diffs
+        assert diff.field == "delta"
+        assert diff.expected == 999
+        assert diff.actual == 100
+
+    def test_missing_row_is_reported(self):
+        effects = [
+            Effect(
+                op="update_or_create",
+                model_label="test_django_rakaia.FinanceLine",
+                lookup={"submission_id": "ghost"},
+                defaults={"suku": "A", "delta": 1},
+            ),
+        ]
+        report = diff_effects_against_rows(effects)
+        assert not report.ok
+        (row,) = report.problems
+        assert row.missing
+        assert row.field_diffs == []
+
+    def test_empty_defaults_only_checks_existence(self):
+        FinanceLine.objects.create(submission_id="s1", suku="A", delta=1)
+        present = Effect(
+            op="update_or_create",
+            model_label="test_django_rakaia.FinanceLine",
+            lookup={"submission_id": "s1"},
+            defaults={},
+        )
+        absent = Effect(
+            op="update_or_create",
+            model_label="test_django_rakaia.FinanceLine",
+            lookup={"submission_id": "ghost"},
+            defaults={},
+        )
+        assert diff_effects_against_rows([present]).ok
+        assert not diff_effects_against_rows([absent]).ok
+
+    def test_non_write_effects_are_ignored(self):
+        # A delete effect carries no defaults to verify; it must not be treated
+        # as a row to diff (and must not crash the helper).
+        effects = [
+            Effect(
+                op="delete",
+                model_label="test_django_rakaia.FinanceLine",
+                lookup={"submission_id": "whatever"},
+            ),
+        ]
+        report = diff_effects_against_rows(effects)
+        assert report.ok
+        assert report.rows == []
+
+
+@pytest.mark.django_db
+class TestDefaultNormalizers:
+    def test_uuid_object_matches_stored_uuid(self):
+        ref = uuid.uuid4()
+        Measure.objects.create(ref=ref, amount=Decimal("1.00"))
+        # Effect carries the UUID as a string (as it would after JSON round-trip);
+        # the stored column is a uuid.UUID. Without normalization these differ.
+        effect = Effect(
+            op="update_or_create",
+            model_label="test_django_rakaia.Measure",
+            lookup={"ref": str(ref)},
+            defaults={"amount": Decimal("1.00")},
+        )
+        assert diff_effects_against_rows([effect]).ok
+
+    def test_over_precise_float_matches_column_decimal(self):
+        ref = uuid.uuid4()
+        Measure.objects.create(ref=ref, amount=Decimal("2.10"))
+        # A JSON payload decodes 2.10 as the float 2.1, which does NOT compare
+        # equal to Decimal("2.10"). The decimal normalizer quantizes it to the
+        # column's decimal_places so the diff is clean.
+        effect = Effect(
+            op="update_or_create",
+            model_label="test_django_rakaia.Measure",
+            lookup={"ref": str(ref)},
+            defaults={"amount": 2.1},
+        )
+        report = diff_effects_against_rows([effect])
+        assert report.ok, str(report)
+
+    def test_normalization_can_be_disabled(self):
+        ref = uuid.uuid4()
+        Measure.objects.create(ref=ref, amount=Decimal("2.10"))
+        effect = Effect(
+            op="update_or_create",
+            model_label="test_django_rakaia.Measure",
+            lookup={"ref": str(ref)},
+            defaults={"amount": 2.1},
+        )
+        # With no normalizers, the float-vs-Decimal mismatch surfaces.
+        report = diff_effects_against_rows([effect], normalizers=[])
+        assert not report.ok
+
+    def test_custom_normalizer_is_applied(self):
+        FinanceLine.objects.create(submission_id="s1", suku="a", delta=1)
+        effect = Effect(
+            op="update_or_create",
+            model_label="test_django_rakaia.FinanceLine",
+            lookup={"submission_id": "s1"},
+            defaults={"suku": "A", "delta": 1},  # note upper-case
+        )
+        assert not diff_effects_against_rows([effect]).ok
+
+        def casefold_norm(_model, _field_name, value):
+            return value.casefold() if isinstance(value, str) else value
+
+        report = diff_effects_against_rows([effect], normalizers=[casefold_norm])
+        assert report.ok
+
+
+def _finance_line_handler(event):
+    return Effect(
+        op="update_or_create",
+        model_label="test_django_rakaia.FinanceLine",
+        lookup={"submission_id": event["key"]},
+        defaults={"suku": event["suku"], "delta": event["delta"]},
+    )
+
+
+@pytest.mark.django_db
+class TestEndToEndCollectingExecutorProof:
+    """The headline pattern: prove replay reproduces the projection, read-only."""
+
+    def test_replay_effects_match_current_rows(self):
+        FinanceLine.objects.create(submission_id="f1", suku="A", delta=100)
+        FinanceLine.objects.create(submission_id="f2", suku="B", delta=50)
+
+        store = get_store()
+        store.delete("s")
+        store.create("s")
+        for event in (
+            {
+                "schema_version": 1,
+                "kind": "FINANCE",
+                "key": "f1",
+                "suku": "A",
+                "delta": 100,
+            },
+            {
+                "schema_version": 1,
+                "kind": "FINANCE",
+                "key": "f2",
+                "suku": "B",
+                "delta": 50,
+            },
+        ):
+            store.append("s", json.dumps(event).encode("utf-8"))
+
+        reg = HandlerRegistry()
+        reg.register(
+            "finance",
+            "FINANCE",
+            _finance_line_handler,
+            0,
+            None,
+            match_field="kind",
+            stage=0,
+        )
+        ex = CollectingExecutor()
+        replay(
+            store,
+            "s",
+            ex,
+            handler_registry=reg,
+            upcaster_registry=UpcasterRegistry(),
+        )
+
+        report = diff_effects_against_rows(ex.effects)
+        assert report.ok, str(report)
+
+    def test_raise_if_diff_raises_on_mismatch_and_is_quiet_when_clean(self):
+        FinanceLine.objects.create(submission_id="f1", suku="A", delta=1)
+        good = Effect(
+            op="update_or_create",
+            model_label="test_django_rakaia.FinanceLine",
+            lookup={"submission_id": "f1"},
+            defaults={"suku": "A", "delta": 1},
+        )
+        diff_effects_against_rows([good]).raise_if_diff()  # no raise
+
+        bad = Effect(
+            op="update_or_create",
+            model_label="test_django_rakaia.FinanceLine",
+            lookup={"submission_id": "f1"},
+            defaults={"suku": "A", "delta": 2},
+        )
+        with pytest.raises(VerificationError):
+            diff_effects_against_rows([bad]).raise_if_diff()

--- a/tests/test_rakaia/test_registry.py
+++ b/tests/test_rakaia/test_registry.py
@@ -298,3 +298,54 @@ class TestDecorator:
         from rakaia.registry import get_default_registry
 
         assert get_default_registry() is get_default_registry()
+
+
+class TestRegisterSimple:
+    """`register_simple` = the always-on, single-stage projection case without
+    the `effective_from=0` ceremony (#68 minor)."""
+
+    def test_registers_open_range_from_zero(self):
+        from rakaia.registry import register_simple
+
+        reg = HandlerRegistry()
+
+        @register_simple("proj", "room:*", registry=reg)
+        def handler(event):
+            return event
+
+        (version,) = reg.all_versions()
+        assert version.effective_from == 0
+        assert version.effective_to is None
+        assert version.stage == 0
+        assert version.match_field is None
+        # Covers any sequence, since it is open-ended from 0.
+        assert reg.resolve("room:5", 0) == [version]
+        assert reg.resolve("room:5", 10_000) == [version]
+
+    def test_passes_through_match_field_and_stage(self):
+        from rakaia.registry import register_simple
+
+        reg = HandlerRegistry()
+
+        @register_simple(
+            "link", "SF_1_2", match_field="form_type", stage=1, registry=reg
+        )
+        def handler(event, reader):  # noqa: ARG001
+            return event
+
+        (version,) = reg.all_versions()
+        assert version.match_field == "form_type"
+        assert version.stage == 1
+        assert version.effective_from == 0
+        assert version.effective_to is None
+
+    def test_returns_original_function(self):
+        from rakaia.registry import register_simple
+
+        reg = HandlerRegistry()
+
+        @register_simple("m", "e", registry=reg)
+        def handler(event):
+            return event
+
+        assert handler({"x": 1}) == {"x": 1}

--- a/tests/test_rakaia/test_registry.py
+++ b/tests/test_rakaia/test_registry.py
@@ -179,6 +179,59 @@ class TestMatchField:
             reg.resolve("room:5", 0)
 
 
+class TestEventMatchSet:
+    """`event_match` may be a collection of patterns, so one registration covers
+    several unrelated form_types that share no glob (#68 item 4)."""
+
+    def test_set_matches_any_member(self, reg: HandlerRegistry):
+        v = reg.register(
+            "sweep",
+            {"TF_6_1_1", "SF_1_2", "POM_1"},
+            _fn("v1"),
+            0,
+            None,
+            match_field="form_type",
+        )
+        for ft in ("TF_6_1_1", "SF_1_2", "POM_1"):
+            assert reg.resolve("submissions", 0, event={"form_type": ft}) == [v]
+        assert reg.resolve("submissions", 0, event={"form_type": "CFM_2"}) == []
+
+    def test_set_elements_may_be_globs(self, reg: HandlerRegistry):
+        v = reg.register(
+            "sweep", {"SF_*", "TF_6_1_1"}, _fn("v1"), 0, None, match_field="form_type"
+        )
+        assert reg.resolve("submissions", 0, event={"form_type": "SF_9_9"}) == [v]
+        assert reg.resolve("submissions", 0, event={"form_type": "TF_6_1_1"}) == [v]
+        assert reg.resolve("submissions", 0, event={"form_type": "TF_1_3"}) == []
+
+    def test_set_without_match_field_routes_on_stream_path(self, reg: HandlerRegistry):
+        v = reg.register("sweep", {"room:*", "chat:*"}, _fn("v1"), 0, None)
+        assert reg.resolve("room:5", 0) == [v]
+        assert reg.resolve("chat:9", 0) == [v]
+        assert reg.resolve("dm:1", 0) == []
+
+    def test_list_and_tuple_accepted_and_order_independent(self, reg: HandlerRegistry):
+        # A list/tuple is accepted; the canonical form is order-independent, so
+        # re-registering the same members in a different order is a no-op.
+        fn = _fn("v1")
+        v1 = reg.register("sweep", ["A", "B"], fn, 0, None, match_field="form_type")
+        v2 = reg.register("sweep", ("B", "A"), fn, 0, None, match_field="form_type")
+        assert v1 is v2
+        assert len(reg.all_versions()) == 1
+
+    def test_empty_collection_raises(self, reg: HandlerRegistry):
+        with pytest.raises(ValueError, match="at least one"):
+            reg.register("sweep", set(), _fn("v1"), 0, None, match_field="form_type")
+
+    def test_gap_check_spans_a_set_series(self, reg: HandlerRegistry):
+        # A set series with a coverage gap still raises when a matching event
+        # lands in the gap (the coverage check is per series, not per element).
+        reg.register("sweep", {"A", "B"}, _fn("v1"), 0, 10, match_field="form_type")
+        reg.register("sweep", {"A", "B"}, _fn("v2"), 20, None, match_field="form_type")
+        with pytest.raises(HandlerGapError):
+            reg.resolve("submissions", 15, event={"form_type": "A"})
+
+
 class TestStage:
     def test_register_with_stage(self, reg: HandlerRegistry):
         v = reg.register("m", "e", _fn("v1"), 0, None, stage=1)

--- a/tests/test_rakaia/test_registry_persistence.py
+++ b/tests/test_rakaia/test_registry_persistence.py
@@ -84,6 +84,30 @@ class TestPersistence:
         messages2, _ = store.read(HANDLERS_META_STREAM)
         assert len(messages2) == 1
 
+    def test_event_match_set_persists_as_sorted_list_and_dedups(
+        self, store: StreamStore
+    ):
+        reg = HandlerRegistry(store=store)
+        reg.register(
+            "sweep", {"TF_6_1_1", "SF_1_2"}, _fn("v1"), 0, None, match_field="form_type"
+        )
+
+        messages, _ = store.read(HANDLERS_META_STREAM)
+        payload = json.loads(messages[0].data)
+        # Serialized deterministically as a sorted list so the meta-stream is
+        # stable regardless of set iteration order.
+        assert payload["event_match"] == ["SF_1_2", "TF_6_1_1"]
+
+        # A fresh registry over the same store reconstructs the same canonical
+        # (frozenset) identity, so the identical registration dedups — no
+        # re-append even though the members are passed in a different order.
+        reg2 = HandlerRegistry(store=store)
+        reg2.register(
+            "sweep", ["TF_6_1_1", "SF_1_2"], _fn("v1"), 0, None, match_field="form_type"
+        )
+        messages2, _ = store.read(HANDLERS_META_STREAM)
+        assert len(messages2) == 1
+
     def test_missing_match_field_defaults_to_none(self, store: StreamStore):
         reg = HandlerRegistry(store=store)
         reg.register("m", "e", _fn("v1"), 0, None)


### PR DESCRIPTION
Addresses the registry/verification tranche of #68 (projection API ergonomics
from the Partisipa port) — the items that don't change replay/executor core
semantics. The two invasive items (#2 overlay executor, #3 symbolic refs) and
the #5 cookbook follow as separate PRs.

## #68 item 1 — `diff_effects_against_rows` verification helper

`django_rakaia.verification.diff_effects_against_rows(effects, *, reader,
normalizers, ops)` ships the projection-verification pattern every `replay_*`
proof re-derives by hand: run `replay()` with a `CollectingExecutor`, then diff
each write effect's `defaults` against the live row — read-only, no DB writes.

- Returns a `DiffReport` (`.ok` / `.problems` / `.rows` / `.raise_if_diff()`),
  with `RowDiff` / `FieldDiff` carrying expected-vs-actual per field, plus a
  readable `__str__`.
- Default normalizers cover the two universal "log carries a different
  representation than the column" cases: **UUID ↔ str** and an over-precise /
  JSON-float value vs the column's **Decimal** scale (quantized to
  `decimal_places`). Normalizers are pluggable — pass `[]` for raw comparison or
  a list to extend.
- FK `attname` (`x_id`) is resolved when locating the model field.
- Adds a `Measure` test model (`UUIDField` + `DecimalField`) + migration as the
  normalizer fixture.

## #68 item 4 — `event_match` accepts a set of patterns

`register_handler` / `register_simple` now take `event_match` as a glob **string**
(unchanged) **or an iterable of glob strings**, so one registration covers several
unrelated form_types that share no glob (e.g. `{"TF_6_1_1", "SF_1_2", "POM_1"}`)
instead of a register-once-per-value loop. A collection matches the routing
subject against **any** member; elements may themselves be globs.

- Canonicalised to a `frozenset`: hashable (works as the series key and in the
  identity tuple) and order-independent (same members in any order dedup).
- Persisted as a **sorted list** in the meta-stream and reconstructed to the same
  frozenset identity on reload, so store-backed dedup/rehydrate is preserved.
- Empty collections and non-string members are rejected.
- **Predicates are out of scope** — a callable can't be rehydrated from the
  persisted meta-stream.

## #68 minors

- **`register_simple(name, event_match, *, match_field, stage)`** — the always-on,
  single-stage "just project" case without the `effective_from=0` /
  `effective_to=None` ceremony. Delegates to `register_handler`; exported from
  `rakaia`.
- **`django_rakaia.replay.replay_stream(...)`** — defaults **both** the executor
  (`DjangoExecutor`) and reader (`DjangoProjectionReader`), so a staged replay
  from Django no longer fails with *"stage > 0 but no reader"* when the caller
  didn't wire a reader by hand. `manage.py replay` now routes through it, fixing
  staged replay via the command.

## Tests

23 new tests (11 verification, 3 `register_simple`, 2 `replay_stream`, 7
`event_match` sets incl. a persistence round-trip); staged replay through
`manage.py replay` covered. Full suite: **727 passed, 1 skipped**. `ruff check` +
`ruff format --check` clean.
