### PR TITLE
Multi-owner reconcile_aggregate: owns= null-clears only this owner's columns (#67)

### DIFF
--- a/docs/projections-and-fan-out.md
+++ b/docs/projections-and-fan-out.md
@@ -194,3 +194,43 @@ The disjoint-defaults invariant still holds across owners: two effects (whether
 `update` or `update_or_create`) that write the **same** column on the same row in
 one batch raise `EffectCollisionError`, so overlapping ownership surfaces as a
 loud error rather than a last-writer-wins race.
+
+### Reconciling a multi-owned aggregate: `reconcile_aggregate(owns=…)`
+
+The write side above is only half the story. `reconcile_aggregate` also emits a
+**reconcile pass** that removes rows for groups which lost their last
+contributor — and by default that pass is a whole-row `delete`. On a shared row
+that delete would clobber the *other* owners' columns when this reducer's group
+vanishes. Pass `owns=` (the columns this reducer owns) to switch to the
+multi-owner reconcile:
+
+```python
+# finance reducer recomputes its ksp_total per suku on a shared SukuProjection row
+reconcile_aggregate(
+    "ida.SukuProjection",
+    scope_lookup={},
+    group_key="suku",
+    groups={suku: {"ksp_total": total} for suku, total in recomputed.items()},
+    owns=["ksp_total"],            # <- multi-owner mode
+)
+```
+
+With `owns=` set, each group is an `op="update"` (never mints the row), and a
+vanished group's row is **not deleted** — its `ksp_total` is null-cleared via an
+`op="retire"` patch that spares the groups still present, leaving the status
+reducer's columns on that row untouched. The null-out needs no liveness guard: a
+column set to `None` converges on re-run, so it is idempotent as-is (unlike a
+soft-delete `retire`, which stamps a sentinel and must guard on it).
+
+Under an **incremental, touched-aware** reducer that recomputes only the touched
+subjects, bound the reconcile with `retire_filter=` so it does not reap groups
+elsewhere that still exist but were not recomputed this pass — it scopes only the
+reconcile, not the per-group upserts:
+
+```python
+reconcile_aggregate(
+    "ida.SukuProjection", scope_lookup={}, group_key="suku",
+    groups=recomputed, owns=["ksp_total"],
+    retire_filter={"report_id__in": touched_report_ids},
+)
+```

--- a/src/rakaia/projections.py
+++ b/src/rakaia/projections.py
@@ -282,6 +282,8 @@ def reconcile_aggregate(
     group_key: str,
     groups: Mapping[Any, dict[str, Any]],
     *,
+    owns: Sequence[str] | None = None,
+    retire_filter: dict[str, Any] | None = None,
     allow_full_clear: bool = False,
 ) -> list[Effect]:
     """Materialise one recomputed aggregate row per group, without stale rows.
@@ -293,63 +295,124 @@ def reconcile_aggregate(
     per group plus a reconcile ``delete`` that removes aggregate rows for groups
     which no longer have any contributors.
 
-    **Whole-table-wipe guard.** The reconcile delete is scoped to
-    ``scope_lookup``. A global scope (``scope_lookup={}``) **with** empty
-    ``groups`` is a delete that matches *every* row in the model — a full-table
-    clear. That is correct for a full rebuild which legitimately found zero
-    facts, but is a footgun when run against an empty or half-migrated fact
-    table (it silently wipes the projection). So that exact combination raises
-    ``ValueError`` unless you opt in with ``allow_full_clear=True``. A non-empty
-    ``scope_lookup`` (a scoped clear) or non-empty ``groups`` is never gated.
+    **Multi-owner mode (`owns=`).** The default whole-row reconcile is wrong when
+    the aggregate row is *shared* — one row whose columns are written by several
+    independent reducers (e.g. a status reducer owns some columns, a finance
+    reducer owns others). Deleting the whole row when *this* reducer's group
+    vanishes would clobber the columns owned by the others. Pass ``owns=`` (the
+    column names this reducer owns) to switch to a mode that composes on a shared
+    row: each group is an ``op="update"`` (update-if-exists — never mints a row,
+    so the row's *existence* stays owned by whoever creates it), and a vanished
+    group's row is not deleted but **null-cleared on this owner's columns only**
+    via an ``op="retire"`` patch, leaving the other owners' columns intact. The
+    null-out needs no liveness/open-guard (unlike a soft-delete `retire`): setting
+    a column to ``None`` converges on re-run, so it is idempotent as-is.
+
+    **Touched-scoped replay (`retire_filter=`).** The reconcile pass (delete or
+    retire) narrows to ``scope_lookup`` (plus ``retire_filter``). Under an
+    incremental *touched-aware* reducer that recomputes only the touched
+    subjects, the un-narrowed pass would reap groups elsewhere that still exist
+    but were not recomputed this pass. Pass ``retire_filter=`` to bound the
+    reconcile to the touched scope (as `reconcile_by_key` does), e.g.
+    ``{"report_id__in": touched_report_ids}`` — it scopes *only* the reconcile,
+    not the per-group upserts.
+
+    **Whole-table-wipe guard.** The reconcile pass is scoped to ``scope_lookup``
+    (plus ``retire_filter``). A global scope with empty ``groups`` matches *every*
+    row in the model — a full-table clear (a whole-row delete in single-owner
+    mode, or a null-out of this owner's columns on every row in multi-owner mode).
+    That is correct for a full rebuild which legitimately found zero facts, but is
+    a footgun against an empty or half-migrated fact table. So that exact
+    combination raises ``ValueError`` unless you opt in with
+    ``allow_full_clear=True``. A non-empty ``scope_lookup``, ``retire_filter`` or
+    ``groups`` bounds the pass and is never gated.
 
     Args:
         model_label: 'app_label.ModelName' of the aggregate model.
         scope_lookup: lookup bounding the aggregate set, e.g. ``{}`` for a global
             rollup or ``{"report_id": r}`` for a scoped one. Each row is keyed by
-            this plus ``{group_key: value}``; the reconcile delete is scoped to
-            it.
+            this plus ``{group_key: value}``; the reconcile pass is scoped to it.
         group_key: the field identifying a group, e.g. ``"suku"`` or
             ``"district"``. (Single-field groups; composite groups are out of
             scope — a simple ``exclude`` cannot express "tuple not in set".)
         groups: mapping of group value to its recomputed ``defaults=`` values.
+        owns: the columns this reducer owns on a shared (multi-owned) row. When
+            given, per-group effects are ``op="update"`` and a vanished group's
+            row is null-cleared on these columns instead of deleted. Omit (the
+            default) for the single-owner whole-row reconcile. An empty sequence
+            is rejected — pass the columns, or omit.
+        retire_filter: extra filter scoping **only** the reconcile pass, distinct
+            from the per-group key. Use it to keep a touched-scoped reducer from
+            reaping groups outside the recomputed scope.
         allow_full_clear: opt in to the whole-table clear (global scope + empty
-            groups). Required for that one combination; ignored otherwise.
+            groups + empty retire_filter). Required for that one combination;
+            ignored otherwise.
 
     Returns:
-        One ``update_or_create`` Effect per group (in mapping order), followed by
-        one ``delete`` Effect removing rows under ``scope_lookup`` whose group is
-        not present. Empty ``groups`` yields just the delete, clearing the set.
+        One per-group Effect (``update_or_create``, or ``update`` in multi-owner
+        mode) in mapping order, followed by one reconcile Effect: a ``delete`` of
+        rows whose group is not present (single-owner), or a ``retire`` null-out
+        of this owner's columns on those rows (multi-owner). Empty ``groups``
+        yields just the reconcile effect, clearing the set.
 
     Raises:
-        ValueError: if ``scope_lookup`` and ``groups`` are both empty and
-            ``allow_full_clear`` is not set — the un-opted-in whole-table wipe.
+        ValueError: if ``owns`` is an empty sequence; or if ``scope_lookup``,
+            ``retire_filter`` and ``groups`` are all empty and ``allow_full_clear``
+            is not set — the un-opted-in whole-table wipe.
     """
-    if not scope_lookup and not groups and not allow_full_clear:
+    if owns is not None and not owns:
+        raise ValueError(
+            f"reconcile_aggregate({model_label!r}) got owns=[]; pass the columns "
+            "this reducer owns on the shared row, or omit owns for single-owner "
+            "(whole-row) mode."
+        )
+    retire_filter = dict(retire_filter or {})
+    if not scope_lookup and not retire_filter and not groups and not allow_full_clear:
+        cleared = (
+            "null-clear this owner's columns on every row"
+            if owns is not None
+            else "delete every row"
+        )
         raise ValueError(
             f"reconcile_aggregate({model_label!r}) with a global scope "
-            "(scope_lookup={}) and empty groups would delete every row in the "
-            "model. Pass a non-empty scope_lookup to clear only that scope, or "
+            f"(scope_lookup={{}}) and empty groups would {cleared} in the model. "
+            "Pass a non-empty scope_lookup or retire_filter to bound it, or "
             "allow_full_clear=True to confirm you intend a whole-table clear "
             "(e.g. a full rebuild that found zero facts)."
         )
     group_values = list(groups)
+    per_group_op = "update" if owns is not None else "update_or_create"
     effects: list[Effect] = [
         Effect(
-            op="update_or_create",
+            op=per_group_op,
             model_label=model_label,
             lookup={**scope_lookup, group_key: value},
             defaults=dict(groups[value]),
         )
         for value in group_values
     ]
-    effects.append(
-        Effect(
-            op="delete",
-            model_label=model_label,
-            lookup=dict(scope_lookup),
-            exclude={f"{group_key}__in": group_values},
+    reconcile_lookup = {**scope_lookup, **retire_filter}
+    if owns is not None:
+        # Vanished group: null-clear only this owner's columns, sparing the
+        # groups still present, so the shared row survives for its other owners.
+        effects.append(
+            Effect(
+                op="retire",
+                model_label=model_label,
+                lookup=reconcile_lookup,
+                spare_keys=[{group_key: value} for value in group_values],
+                patch=dict.fromkeys(owns),
+            )
         )
-    )
+    else:
+        effects.append(
+            Effect(
+                op="delete",
+                model_label=model_label,
+                lookup=reconcile_lookup,
+                exclude={f"{group_key}__in": group_values},
+            )
+        )
     return effects
 
 

--- a/tests/test_django_rakaia/migrations/0006_sukuprojection.py
+++ b/tests/test_django_rakaia/migrations/0006_sukuprojection.py
@@ -1,0 +1,30 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("test_django_rakaia", "0005_measure"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="SukuProjection",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("suku", models.CharField(max_length=64, unique=True)),
+                (
+                    "status",
+                    models.CharField(default=None, max_length=16, null=True),
+                ),
+                ("ksp_total", models.IntegerField(default=None, null=True)),
+            ],
+        ),
+    ]

--- a/tests/test_django_rakaia/models.py
+++ b/tests/test_django_rakaia/models.py
@@ -279,6 +279,22 @@ class Balance(models.Model):
         app_label = "test_django_rakaia"
 
 
+class SukuProjection(models.Model):
+    """Multi-owned aggregate row for the `reconcile_aggregate(owns=...)` tests.
+
+    One row per ``suku`` whose columns are written by two independent reducers:
+    a status reducer owns ``status``, a finance reducer owns ``ksp_total``. When
+    one owner's group vanishes, its columns must be null-cleared without
+    disturbing the other owner's — the multi-owner reconcile invariant (#67)."""
+
+    suku = models.CharField(max_length=64, unique=True)
+    status = models.CharField(max_length=16, null=True, default=None)
+    ksp_total = models.IntegerField(null=True, default=None)
+
+    class Meta:
+        app_label = "test_django_rakaia"
+
+
 class Measure(models.Model):
     """Projection row with a UUID natural key and a Decimal column — the
     fixture for the ``diff_effects_against_rows`` verification helper, whose

--- a/tests/test_django_rakaia/test_projection_reader.py
+++ b/tests/test_django_rakaia/test_projection_reader.py
@@ -154,6 +154,60 @@ class TestReducerOverOrm:
 
 
 @pytest.mark.django_db
+class TestReconcileAggregateMultiOwner:
+    """The #67 invariant end-to-end: a vanished group null-clears only this
+    reducer's columns, leaving the shared row and its other owners intact."""
+
+    def test_vanished_group_spares_other_owners_columns(self):
+        from rakaia.projections import reconcile_aggregate
+
+        from .models import SukuProjection
+
+        # A shared row per suku: `status` owned by a status reducer, `ksp_total`
+        # owned by the finance reducer. Both suku A and B currently populated.
+        SukuProjection.objects.create(suku="A", status="approved", ksp_total=70)
+        SukuProjection.objects.create(suku="B", status="pending", ksp_total=50)
+
+        # The finance reducer recomputes and now only suku A has contributors —
+        # B's finance group vanished (but B's row still exists for its status).
+        effects = reconcile_aggregate(
+            "test_django_rakaia.SukuProjection",
+            {},
+            "suku",
+            {"A": {"ksp_total": 70}},
+            owns=["ksp_total"],
+        )
+        DjangoExecutor().apply(effects)
+
+        a = SukuProjection.objects.get(suku="A")
+        b = SukuProjection.objects.get(suku="B")
+        # A: present group, its finance column kept; status untouched.
+        assert (a.ksp_total, a.status) == (70, "approved")
+        # B: vanished group — finance column null-cleared, but the row SURVIVES
+        # and the status reducer's column is intact (not a whole-row delete).
+        assert (b.ksp_total, b.status) == (None, "pending")
+
+    def test_rerun_is_idempotent(self):
+        from rakaia.projections import reconcile_aggregate
+
+        from .models import SukuProjection
+
+        SukuProjection.objects.create(suku="B", status="pending", ksp_total=50)
+        effects = reconcile_aggregate(
+            "test_django_rakaia.SukuProjection",
+            {},
+            "suku",
+            {},  # no finance contributors anywhere
+            owns=["ksp_total"],
+            allow_full_clear=True,
+        )
+        DjangoExecutor().apply(effects)
+        DjangoExecutor().apply(effects)  # second pass converges, no error
+        b = SukuProjection.objects.get(suku="B")
+        assert (b.ksp_total, b.status) == (None, "pending")
+
+
+@pytest.mark.django_db
 class TestMergeReplayOverOrm:
     def test_merge_two_finance_streams_then_reduce(self):
         from .models import Balance

--- a/tests/test_rakaia/test_projections.py
+++ b/tests/test_rakaia/test_projections.py
@@ -369,6 +369,101 @@ class TestReconcileAggregate:
         assert scope == {"report_id": 42}
 
 
+class TestReconcileAggregateMultiOwner:
+    """`owns=` — reconcile a group set that shares a row with other reducers."""
+
+    def _agg(self, groups, *, owns=("ksp_total",), scope=None, retire_filter=None):
+        return reconcile_aggregate(
+            model_label="app.Project",
+            scope_lookup=scope if scope is not None else {"report_id": 7},
+            group_key="suku",
+            groups=groups,
+            owns=owns,
+            retire_filter=retire_filter,
+        )
+
+    def test_per_group_effects_are_update_not_upsert(self):
+        # Multi-owner never mints the shared row — the row's existence is owned
+        # by whoever creates it, so each group is an update-if-exists.
+        effects = self._agg({"north": {"ksp_total": 5}})
+        assert [e.op for e in effects] == ["update", "retire"]
+        upd = effects[0]
+        assert upd.lookup == {"report_id": 7, "suku": "north"}
+        assert upd.defaults == {"ksp_total": 5}
+
+    def test_reconcile_is_retire_nulling_only_owned_columns(self):
+        effects = self._agg(
+            {"north": {"ksp_total": 5}}, owns=("ksp_total", "ksp_count")
+        )
+        retire = effects[-1]
+        assert retire.op == "retire"
+        assert retire.lookup == {"report_id": 7}
+        # only this owner's columns are cleared; other owners' columns untouched
+        assert retire.patch == {"ksp_total": None, "ksp_count": None}
+        # present groups are spared from the null-out
+        assert retire.spare_keys == [{"suku": "north"}]
+        # a pure null-out needs no liveness/open-guard and fires no transition
+        assert retire.transition_kind is None
+
+    def test_retire_spares_every_present_group(self):
+        effects = self._agg({"north": {"ksp_total": 1}, "south": {"ksp_total": 2}})
+        assert effects[-1].spare_keys == [{"suku": "north"}, {"suku": "south"}]
+
+    def test_empty_groups_clears_owner_columns_in_scope(self):
+        # This owner has no contributors anywhere in the (bounded) scope: clear
+        # its columns on every row in scope, sparing nothing.
+        effects = self._agg({})
+        assert [e.op for e in effects] == ["retire"]
+        assert effects[0].spare_keys == []
+        assert effects[0].patch == {"ksp_total": None}
+
+    def test_retire_filter_narrows_only_the_reconcile_pass(self):
+        # Touched-scoped replay: bound the reconcile to the recomputed subjects
+        # so groups elsewhere that still exist are not reaped.
+        effects = self._agg(
+            {"north": {"ksp_total": 5}},
+            scope={},
+            retire_filter={"report_id__in": [7, 8]},
+        )
+        upd, retire = effects
+        # retire_filter scopes the reconcile, not the per-group upsert
+        assert upd.lookup == {"suku": "north"}
+        assert retire.lookup == {"report_id__in": [7, 8]}
+
+    def test_empty_owns_raises(self):
+        with pytest.raises(ValueError, match="owns"):
+            self._agg({"north": {"ksp_total": 1}}, owns=[])
+
+    def test_global_scope_empty_groups_raises_mentioning_columns(self):
+        with pytest.raises(ValueError, match="null-clear this owner's columns"):
+            self._agg({}, scope={})
+
+    def test_retire_filter_alone_bounds_the_pass_no_flag(self):
+        # A non-empty retire_filter bounds the reconcile, so the wipe guard does
+        # not fire even under a global scope with empty groups.
+        effects = self._agg({}, scope={}, retire_filter={"report_id__in": [7]})
+        assert [e.op for e in effects] == ["retire"]
+        assert effects[0].lookup == {"report_id__in": [7]}
+
+    def test_global_scope_empty_groups_allowed_with_flag(self):
+        effects = reconcile_aggregate(
+            model_label="app.Project",
+            scope_lookup={},
+            group_key="suku",
+            groups={},
+            owns=("ksp_total",),
+            allow_full_clear=True,
+        )
+        assert [e.op for e in effects] == ["retire"]
+        assert effects[0].lookup == {}
+        assert effects[0].spare_keys == []
+
+    def test_scope_lookup_not_mutated(self):
+        scope = {"report_id": 7}
+        self._agg({"north": {"ksp_total": 1}}, scope=scope)
+        assert scope == {"report_id": 7}
+
+
 class TestProjectLatest:
     def _project(self, messages):
         return project_latest(


### PR DESCRIPTION
Closes #67 (#54 part b).

## Problem
`reconcile_aggregate` always appended a **whole-row** `delete` for vanished groups. On a row whose columns are written by several independent reducers (Partisipa's `ProjectProjection`: a status reducer owns some columns, a finance reducer owns others), that delete wipes the *other* owners' columns when this reducer's group loses its last contributor — so a multi-owned projection couldn't use `reconcile_aggregate` at all.

## Change
Opt-in **`owns=`** (the columns this reducer owns) switches to a multi-owner reconcile:
- per group → `op="update"` (update-if-exists — never mints the shared row; existence stays owned by whoever creates it);
- vanished group → `op="retire"` with `patch=dict.fromkeys(owns)`, sparing the groups still present — **null-clears only this owner's columns**, leaving the row and its other owners intact.

The null-out needs **no liveness/open-guard** (unlike a soft-delete `retire`): setting a column to `None` converges on re-run, so it's idempotent as-is, and it fires no transition.

Also adds **`retire_filter=`** (mirroring `reconcile_by_key`) to bound the reconcile pass to the recomputed scope under a **touched-aware** incremental reducer — without it, a touched-scoped recompute would reap groups elsewhere that still exist but weren't recomputed this pass. The wipe guard now treats a non-empty `retire_filter` as bounding the pass, and its message is mode-aware (delete vs null-out).

Default behaviour (`owns=None`) is unchanged.

## Design notes
- Pure composition of #66's `op="update"` and the existing `retire`/`spare_keys` primitive — **no executor changes**.
- Backward-compatible: both new params are keyword-only with `None` defaults.

## Tests / verification
- Unit (`test_rakaia/test_projections.py::TestReconcileAggregateMultiOwner`): op shape, null-out patch, spare_keys, `retire_filter` scoping, empty-`owns` rejection, mode-aware wipe guard, `allow_full_clear`.
- Django integration (`test_django_rakaia/test_projection_reader.py::TestReconcileAggregateMultiOwner`) on a new shared-row `SukuProjection` model (migration `0006`): proves a vanished group **null-clears finance columns while the status reducer's column survives** on the same row, and that a re-run is idempotent.
- Docs: new "Reconciling a multi-owned aggregate" section in `docs/projections-and-fan-out.md`.
- Full suite **757 passed, 1 skipped**; `ruff check` + `ruff format --check` clean; `zensical build` clean.
