### PR TITLE
using= connection seam: re-land #68 item 2 onto main (supersedes stranded #71)

### DIFF
--- a/docs/dry-run-and-executors.md
+++ b/docs/dry-run-and-executors.md
@@ -102,6 +102,47 @@ Drop `--dry-run` to apply the same effects via the `DjangoExecutor`. See
 [Versioned handlers](versioned-handlers.md) for the full command reference
 (`--from`, `--to`, `--strict-drift`, `--include-external`).
 
+## Verifying a from-scratch rebuild: the `using=` seam
+
+A `CollectingExecutor` answers a **regression** question: *"does replaying the log
+reproduce the rows I already have?"* It writes nothing, so it leans on the target
+rows already existing. It cannot answer the **rebuild** question — *"can I build
+the whole projection from the log into an empty schema, correctly?"* — because a
+stage-1 handler that resolves a reference another form created would find nothing
+(the reference was recorded, never applied), so the link can't be verified.
+
+The honest answer is not a bespoke in-memory shadow that imitates the ORM, but the
+**real** executor and reader pointed at a **disposable database**. Both
+`DjangoExecutor` and `DjangoProjectionReader` take a `using=` database alias:
+
+```python
+# settings: a throwaway alias — in-memory sqlite for fast/CI proofs,
+# or a scratch Postgres for a full-fidelity cut-over rehearsal.
+DATABASES["rebuild"] = {"ENGINE": "django.db.backends.sqlite3", "NAME": ":memory:"}
+
+replay(
+    store, "submissions",
+    DjangoExecutor(using="rebuild"),                 # writes land in the scratch DB
+    reader=DjangoProjectionReader(using="rebuild"),  # stage-1 reads them back
+    handler_registry=reg,
+)
+# ...then diff the rebuilt rows against production and throw the scratch DB away.
+```
+
+Because it is the real ORM, you get full fidelity — constraints, defaults, joins,
+`__gte` — for free, with no query engine to write and nothing written to
+production.
+
+Two caveats worth stating plainly:
+
+- **Diff on natural keys, not pks.** A from-scratch rebuild assigns fresh primary
+  keys (and a symbolic `Ref` resolves FKs to *those* pks), so
+  correctness is structural — *"the same submission binds to the same Project by
+  natural key"* — never *"row 42 → row 42."*
+- **sqlite `:memory:` is full *ORM* fidelity, not full *Postgres* fidelity.** Use
+  it for fast, CI-able iteration; replay into a throwaway Postgres alias (same
+  code, different `using=`) for the final cut-over proof.
+
 ## See it run
 
 Both worked examples exercise the dry run before writing:

--- a/src/django_rakaia/effect_executor.py
+++ b/src/django_rakaia/effect_executor.py
@@ -47,10 +47,25 @@ def _row_accessor(obj: Any) -> Any:
 
 
 class DjangoExecutor:
-    """Apply Effects via Django's ORM."""
+    """Apply Effects via Django's ORM.
 
-    def __init__(self, *, skip_unchanged: bool = False) -> None:
+    Pass `using` to apply against a named database alias instead of the default
+    — so a full from-scratch rebuild can be replayed into a *disposable*
+    database (an in-memory sqlite, or a throwaway Postgres) and verified without
+    touching production, at full ORM fidelity. `using=None` targets the default
+    alias, exactly as before. Pair with `DjangoProjectionReader(using=...)`.
+    """
+
+    def __init__(
+        self, *, skip_unchanged: bool = False, using: str | None = None
+    ) -> None:
         self._skip_unchanged = skip_unchanged
+        self._using = using
+
+    def _manager(self, model: type) -> Any:
+        # `.using(None)` keeps default routing, so this is uniform whether or
+        # not an alias was given.
+        return model.objects.using(self._using)
 
     def apply(self, effects: Iterable[Effect]) -> ApplyReport:
         effects_list = list(effects)
@@ -59,7 +74,7 @@ class DjangoExecutor:
         # and a sibling's Ref values are substituted before that sibling applies.
         resolver = RefResolver()
         retire_flips: list[tuple[Effect, list[dict[str, Any]]]] = []
-        with transaction.atomic():
+        with transaction.atomic(using=self._using):
             # Writes first, then deletes, then retires: reconcile batches
             # (upsert current rows, prune/soft-delete the rest) converge
             # regardless of handler order. Writes apply before deletes/retires,
@@ -89,12 +104,13 @@ class DjangoExecutor:
         model = apps.get_model(eff.model_label)
         defaults = eff.defaults or {}
         if not self._skip_unchanged:
-            obj, _ = model.objects.update_or_create(**eff.lookup, defaults=defaults)
+            obj, _ = self._manager(model).update_or_create(
+                **eff.lookup, defaults=defaults
+            )
             return obj
         return self._upsert_skip_unchanged(model, eff.lookup, defaults)
 
-    @staticmethod
-    def _update(eff: Effect) -> None:
+    def _update(self, eff: Effect) -> None:
         """Update-if-exists: update the rows matching `lookup` in place, never
         insert. A no-op when nothing matches or when `defaults` is empty.
 
@@ -107,24 +123,23 @@ class DjangoExecutor:
         if not defaults:
             return  # nothing to write — a pure no-op
         model = apps.get_model(eff.model_label)
-        model.objects.filter(**eff.lookup).update(**defaults)
+        self._manager(model).filter(**eff.lookup).update(**defaults)
 
-    @staticmethod
-    def _upsert_skip_unchanged(model: type, lookup: dict, defaults: dict) -> Any:
+    def _upsert_skip_unchanged(self, model: type, lookup: dict, defaults: dict) -> Any:
         try:
-            row = model.objects.get(**lookup)
+            row = self._manager(model).get(**lookup)
         except model.DoesNotExist:
             # Mirror update_or_create's create path: lookup fields + defaults,
             # dropping any lookup that isn't a concrete field assignment.
             params = {k: v for k, v in lookup.items() if "__" not in k}
             params.update(defaults)
-            return model.objects.create(**params)
+            return self._manager(model).create(**params)
         changed = {k: v for k, v in defaults.items() if getattr(row, k) != v}
         if not changed:
             return row  # nothing to write — skip the UPDATE entirely
         for field, value in changed.items():
             setattr(row, field, value)
-        row.save(update_fields=list(changed))
+        row.save(using=self._using, update_fields=list(changed))
         return row
 
     @staticmethod
@@ -141,23 +156,21 @@ class DjangoExecutor:
             spared |= Q(**key)
         return qs.exclude(spared)
 
-    @classmethod
-    def _delete(cls, eff: Effect) -> None:
+    def _delete(self, eff: Effect) -> None:
         if eff.model_label is None or eff.lookup is None:
             raise ValueError("delete effect requires model_label and lookup")
         model = apps.get_model(eff.model_label)
-        qs = model.objects.filter(**eff.lookup).exclude(**(eff.exclude or {}))
-        cls._spare(qs, eff.spare_keys).delete()
+        qs = self._manager(model).filter(**eff.lookup).exclude(**(eff.exclude or {}))
+        self._spare(qs, eff.spare_keys).delete()
 
-    @classmethod
-    def _retire(cls, eff: Effect) -> list[dict[str, Any]]:
+    def _retire(self, eff: Effect) -> list[dict[str, Any]]:
         if eff.model_label is None or eff.lookup is None:
             raise ValueError("retire effect requires model_label and lookup")
         if not eff.patch:
             raise ValueError("retire effect requires a non-empty patch")
         model = apps.get_model(eff.model_label)
-        qs = model.objects.filter(**eff.lookup)
-        qs = cls._spare(qs, eff.spare_keys)
+        qs = self._manager(model).filter(**eff.lookup)
+        qs = self._spare(qs, eff.spare_keys)
         # The retire is open-guarded, so the rows it matches are exactly the ones
         # that flip NULL->set. Capture their identities BEFORE the UPDATE (same
         # atomic txn) only when the effect asked to notify — otherwise skip the
@@ -171,7 +184,7 @@ class DjangoExecutor:
         # which serialises writers anyway.
         flipped: list[dict[str, Any]] = []
         if eff.transition_kind is not None:
-            cols = cls._identity_cols(eff)
+            cols = self._identity_cols(eff)
             flipped = list(qs.select_for_update().order_by(*cols).values(*cols))
         qs.update(**eff.patch)
         return flipped

--- a/src/django_rakaia/projection_reader.py
+++ b/src/django_rakaia/projection_reader.py
@@ -24,16 +24,30 @@ from django.db.models import QuerySet
 
 
 class DjangoProjectionReader:
-    """Read-only projection accessor over `apps.get_model(...).objects`."""
+    """Read-only projection accessor over `apps.get_model(...).objects`.
+
+    Pass `using` to read from a named database alias instead of the default —
+    the read half of the "replay a from-scratch rebuild into a disposable
+    database and verify it" pattern (#68). `using=None` reads the default alias,
+    exactly as before.
+    """
+
+    def __init__(self, *, using: str | None = None) -> None:
+        self._using = using
 
     def get(self, model_label: str, /, **lookup: Any) -> Any | None:
         """The single row matching `lookup`, or None (never raises on absence)."""
-        return apps.get_model(model_label).objects.filter(**lookup).first()
+        return self._manager(model_label).filter(**lookup).first()
 
     def filter(self, model_label: str, /, **lookup: Any) -> QuerySet:
         """A queryset of the rows matching `lookup`."""
-        return apps.get_model(model_label).objects.filter(**lookup)
+        return self._manager(model_label).filter(**lookup)
 
     def query(self, model_label: str, /) -> QuerySet:
         """A queryset of every row of the model."""
-        return apps.get_model(model_label).objects.all()
+        return self._manager(model_label).all()
+
+    def _manager(self, model_label: str) -> QuerySet:
+        # `.using(None)` is a no-op that keeps default routing, so this is
+        # uniform whether or not an alias was given.
+        return apps.get_model(model_label).objects.using(self._using)

--- a/tests/test_django_rakaia/settings.py
+++ b/tests/test_django_rakaia/settings.py
@@ -1,4 +1,10 @@
-DATABASES = {"default": {"ENGINE": "django.db.backends.sqlite3", "NAME": ":memory:"}}
+DATABASES = {
+    "default": {"ENGINE": "django.db.backends.sqlite3", "NAME": ":memory:"},
+    # A second in-memory alias used by the `using=` seam tests — a disposable
+    # database a from-scratch rebuild can be replayed into without touching
+    # `default` (see test_using_seam.py; #68 item 2).
+    "overlay": {"ENGINE": "django.db.backends.sqlite3", "NAME": ":memory:"},
+}
 INSTALLED_APPS = [
     "daphne",
     "channels",

--- a/tests/test_django_rakaia/test_using_seam.py
+++ b/tests/test_django_rakaia/test_using_seam.py
@@ -1,0 +1,162 @@
+"""The `using=` connection-alias seam (#68 item 2).
+
+`DjangoExecutor` and `DjangoProjectionReader` can target a named database alias,
+so a full from-scratch rebuild can be replayed into a *disposable* database and
+verified without touching production — the honest, full-ORM-fidelity answer to
+"an in-memory shadow the reader can see", reusing the real executor + reader
+instead of a bespoke in-memory engine.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from django_rakaia.effect_executor import DjangoExecutor
+from django_rakaia.projection_reader import DjangoProjectionReader
+from django_rakaia.store import get_store
+from rakaia.effects import Effect, Ref
+from rakaia.registry import HandlerRegistry, UpcasterRegistry
+from rakaia.replay import replay
+
+from .models import Area, FinanceLine
+
+pytestmark = pytest.mark.django_db(databases=["default", "overlay"])
+
+
+class TestExecutorUsing:
+    def test_writes_go_to_the_named_alias_only(self):
+        DjangoExecutor(using="overlay").apply(
+            [
+                Effect(
+                    op="update_or_create",
+                    model_label="test_django_rakaia.Area",
+                    lookup={"name": "OverlayOnly"},
+                    defaults={},
+                )
+            ]
+        )
+        assert Area.objects.using("overlay").filter(name="OverlayOnly").exists()
+        assert not Area.objects.using("default").filter(name="OverlayOnly").exists()
+
+    def test_default_alias_unchanged_when_using_none(self):
+        DjangoExecutor().apply(
+            [
+                Effect(
+                    op="update_or_create",
+                    model_label="test_django_rakaia.Area",
+                    lookup={"name": "DefaultRow"},
+                    defaults={},
+                )
+            ]
+        )
+        assert Area.objects.using("default").filter(name="DefaultRow").exists()
+        assert not Area.objects.using("overlay").filter(name="DefaultRow").exists()
+
+
+class TestReaderUsing:
+    def test_reader_reads_from_the_named_alias(self):
+        Area.objects.using("overlay").create(name="Only")
+        assert (
+            DjangoProjectionReader(using="overlay").get(
+                "test_django_rakaia.Area", name="Only"
+            )
+            is not None
+        )
+        # The default-alias reader does not see the overlay row.
+        assert (
+            DjangoProjectionReader(using="default").get(
+                "test_django_rakaia.Area", name="Only"
+            )
+            is None
+        )
+
+    def test_filter_and_query_route_to_alias(self):
+        Area.objects.using("overlay").create(name="a")
+        Area.objects.using("overlay").create(name="b")
+        reader = DjangoProjectionReader(using="overlay")
+        assert reader.filter("test_django_rakaia.Area", name="a").count() == 1
+        assert reader.query("test_django_rakaia.Area").count() == 2
+        assert DjangoProjectionReader().query("test_django_rakaia.Area").count() == 0
+
+
+def _ref_handler(event):
+    return Effect(
+        op="update_or_create",
+        model_label="test_django_rakaia.Area",
+        lookup={"name": event["name"]},
+        defaults={},
+    )
+
+
+def _dep_handler(event, reader):
+    ref = reader.get("test_django_rakaia.Area", name=event["ref"])
+    tag = "FOUND" if ref is not None else "MISSING"
+    return Effect(
+        op="update_or_create",
+        model_label="test_django_rakaia.Area",
+        lookup={"name": f"{event['key']}->{tag}"},
+        defaults={},
+    )
+
+
+_EVENTS = [
+    {"schema_version": 1, "kind": "DEP", "key": "d1", "ref": "the-ref"},
+    {"schema_version": 1, "kind": "REF", "key": "r1", "name": "the-ref"},
+]
+
+
+class TestFromScratchRebuildProof:
+    """Replay the whole log into the disposable `overlay` DB; `default` — standing
+    in for production — is never written."""
+
+    def test_staged_rebuild_links_in_overlay_leaving_default_empty(self):
+        store = get_store()
+        store.delete("s")
+        store.create("s")
+        for event in _EVENTS:
+            store.append("s", json.dumps(event).encode("utf-8"))
+
+        reg = HandlerRegistry()
+        reg.register("ref", "REF", _ref_handler, 0, None, match_field="kind", stage=0)
+        reg.register("dep", "DEP", _dep_handler, 0, None, match_field="kind", stage=1)
+
+        replay(
+            store,
+            "s",
+            DjangoExecutor(using="overlay"),
+            handler_registry=reg,
+            upcaster_registry=UpcasterRegistry(),
+            reader=DjangoProjectionReader(using="overlay"),
+        )
+
+        # The dependent — which arrives before its reference — links in the
+        # overlay, from an empty start.
+        assert Area.objects.using("overlay").filter(name="d1->FOUND").exists()
+        # Production (default) was never touched.
+        assert Area.objects.using("default").count() == 0
+
+    def test_refs_resolve_under_the_alias(self):
+        # A produces=/Ref pair also resolves against the overlay connection.
+        DjangoExecutor(using="overlay").apply(
+            [
+                Effect(
+                    op="update_or_create",
+                    model_label="test_django_rakaia.Area",
+                    lookup={"name": "Zone"},
+                    defaults={},
+                    produces="area",
+                ),
+                Effect(
+                    op="update_or_create",
+                    model_label="test_django_rakaia.FinanceLine",
+                    lookup={"submission_id": "s1"},
+                    defaults={"suku": "x", "delta": Ref("area")},
+                ),
+            ]
+        )
+        area = Area.objects.using("overlay").get(name="Zone")
+        line = FinanceLine.objects.using("overlay").get(submission_id="s1")
+        assert line.delta == area.pk
+        assert FinanceLine.objects.using("default").count() == 0


### PR DESCRIPTION
Re-lands **#68 item 2** (the `using=` connection-alias seam). #71 was marked
MERGED but never reached `main`: it merged into its base branch
`feat/symbolic-effect-refs`, which was then orphaned when #70 was **squash**-merged
to `main`. So the seam's merge commit lives only on that dead branch — `main` has
no `using=` parameter on `DjangoExecutor` / `DjangoProjectionReader`.

This PR is the single `using=` commit cherry-picked cleanly onto `main` (on top of
#70's refs, which are now in `main`). No behaviour change from the original #71 —
same diff, correct base.

## The change (unchanged from #71)

- **`DjangoExecutor(using=alias)`** routes every ORM call and the
  `transaction.atomic()` block to a named connection alias (helpers moved to
  instance methods sharing a `_manager(model)`).
- **`DjangoProjectionReader(using=alias)`** reads from the alias.
- `using=None` keeps default routing (`.using(None)` / `atomic(using=None)` are
  no-ops), so single-DB behaviour is unchanged.
- A from-scratch rebuild can be replayed into a disposable DB (`:memory:` sqlite
  for CI, scratch Postgres for cut-over) at full ORM fidelity. Refs (#70) resolve
  under the alias too.
- Docs: `docs/dry-run-and-executors.md` "Verifying a from-scratch rebuild".

## Verified on top of `main`

- `test_using_seam.py` (6 tests) green; full suite **751 passed, 1 skipped**.
- `ruff check` + `ruff format --check` + `zensical build` all clean.

Supersedes the stranded #71. After this merges, the cookbook PR (#72) can retarget
to `main`.
