### PR TITLE
Repair demos post-refactor + add protocol/multi-owner examples + docs (human + OKF)

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,18 +117,23 @@ pipeline.
 
 ## Sample applications
 
-Each example is a standalone Django project that demonstrates one feature area
-end-to-end. The two headless demos print their results; the two web demos are
-live in the browser. Run them all with `just demo`, or individually:
+Each example demonstrates one feature area end-to-end. Most are standalone Django
+projects; two are zero-dependency scripts (no Django). Run them all with
+`just demo`, or individually:
 
 | Example | Demonstrates | Run |
 |---|---|---|
 | [`examples/orders/`](examples/orders/) | Versioned handlers, upcasters, replay, dry-run | `just orders-demo` |
 | [`examples/formkit_submissions/`](examples/formkit_submissions/) | Projections/fan-out, `reconcile_children`, migration parity | `just formkit-demo` |
+| [`examples/protocol_streams/`](examples/protocol_streams/) | Protocol layer (no Django): producer fencing, close, `poll` cursors | `just protocol-demo` |
+| [`examples/multi_owner/`](examples/multi_owner/) | Effect primitives (no Django): `Ref`, `reconcile_aggregate(owns=)` | `just multi-owner-demo` |
 | [`examples/chat/`](examples/chat/) | `@stream_model`, multi-stream events, live SSE | `just dev` |
 | [`examples/polyglot/`](examples/polyglot/) | Language-scoped streams, live-editable translations | `just polyglot-dev` |
 
-For a narrated walkthrough of what each proves, see
+For the full catalog with a concept-coverage matrix, see
+[`docs/examples.md`](docs/examples.md) (human) or the machine-readable
+[Open Knowledge Format](https://github.com/GoogleCloudPlatform/knowledge-catalog)
+bundle in [`okf/`](okf/) (agents/tools). For a narrated walkthrough, see
 [`docs/whats-new.md`](docs/whats-new.md).
 
 ## Running it

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -19,6 +19,13 @@ Every demo is **assertion-backed**: it prints what it proves and fails loudly if
 the behaviour regresses. Running them is the fastest way to confirm the library
 works after a change.
 
+!!! note "Machine-readable companion"
+    A structured, cross-linked version of this page lives as an
+    [Open Knowledge Format](https://github.com/GoogleCloudPlatform/knowledge-catalog)
+    bundle at [`okf/`](https://github.com/joshbrooks/rakaia/tree/main/okf) in the
+    repo — one concept document per example and per concept group, for agents and
+    tools to consume.
+
 ## The mental model
 
 Rakaia is two layers, and the examples split along that line.

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,0 +1,203 @@
+---
+icon: lucide/layout-grid
+---
+
+# Examples & concept coverage
+
+This page is the **map of the `examples/` directory**: what each runnable demo
+proves, the one command that runs it, and a matrix of which rakaia concept each
+one exercises. It's written for two readers:
+
+- **Humans** evaluating or learning rakaia — start at the [mental model](#the-mental-model),
+  then run the demo closest to your problem.
+- **AI agents / contributors** navigating the repo — jump to the
+  [concept → example matrix](#concept-example-coverage-matrix) to find a working
+  reference for any public API, and to the [orientation](#orientation-for-contributors)
+  for where things live and the conventions every example follows.
+
+Every demo is **assertion-backed**: it prints what it proves and fails loudly if
+the behaviour regresses. Running them is the fastest way to confirm the library
+works after a change.
+
+## The mental model
+
+Rakaia is two layers, and the examples split along that line.
+
+1. **The protocol layer** — a [Durable Streams](protocol.md) server: an
+   append-only, ordered, offset-addressed log (`StreamStore`) with producer
+   fencing, close semantics, and subscriber cursors. Zero dependencies, no
+   Django. See [`protocol_streams`](#standalone-no-django).
+2. **The event-sourcing layer** (`django_rakaia`) — your database tables
+   (*projections*) are *derived* from the log by pure,
+   [versioned handlers](glossary.md#versioned-handler), so you can
+   [replay](glossary.md#replay) history and get time-correct results:
+
+```mermaid
+flowchart LR
+  W["Your model<br/>.save()"] -->|emit| S[("Stream<br/>append-only log")]
+  S -->|replay| U["Upcasters<br/>normalise old events"]
+  U --> H["Versioned handlers<br/>pure: event → Effect"]
+  H --> X{Executor}
+  X -->|"update_or_create / delete"| P[("Projection<br/>your tables")]
+  X -.->|dry-run| C["CollectingExecutor<br/>records, zero writes"]
+```
+
+New to the vocabulary (*projection*, *handler*, *upcaster*, *replay*, *effect*)?
+The [glossary](glossary.md) defines every term linked above.
+
+## Run everything
+
+```bash
+just install     # sync all dependency groups (dev + django + docs + prod)
+just demo        # the scripted headless tour, with narration
+```
+
+Individual demos are listed in the tables below. Every Django demo migrates
+first; the recipe and the command inside it are both idempotent and re-runnable.
+
+## The examples
+
+### Live SSE (Django, browser)
+
+Real-time demos — run the server, open the URL, watch events stream in.
+
+| Example | Proves | Run |
+|---|---|---|
+| [`chat`](https://github.com/joshbrooks/rakaia/tree/main/examples/chat) | `@stream_model`, multi-stream events per save, live SSE fan-out | `just dev` → `http://localhost:8000` |
+| [`polyglot`](https://github.com/joshbrooks/rakaia/tree/main/examples/polyglot) | Language-scoped streams, live-editable translations over SSE | `just polyglot-dev` → `http://localhost:8001` |
+
+### Headless event-sourcing (Django, scripted)
+
+One command each: seed a stream, replay it, assert the projection.
+
+| Example | Proves | Run |
+|---|---|---|
+| [`orders`](https://github.com/joshbrooks/rakaia/tree/main/examples/orders) | Versioned handlers, `effective_from/to`, upcasters, dry-run, `op="external"`, `op="update"` | `just orders-demo` |
+| [`formkit_submissions`](https://github.com/joshbrooks/rakaia/tree/main/examples/formkit_submissions) | Projections/fan-out, `reconcile_children`, migration parity vs a direct `to_model()` | `just formkit-demo` |
+| `formkit_submissions` (stream) | Arrow-flip: append log = source of truth → latest-version projection (`project_latest`) | `just formkit-stream-demo` |
+| [`projection_cookbook`](https://github.com/joshbrooks/rakaia/tree/main/examples/projection_cookbook) | Staged replay, `ProjectionReader`, `register_simple`, `diff_effects_against_rows` verification | `just cookbook-demo` |
+| [`partisipa_history`](https://github.com/joshbrooks/rakaia/tree/main/examples/partisipa_history) | pghistory-parity audit log + `recover_peak_snapshot` from an enveloped stream | `just partisipa-history-demo` |
+| [`partisipa_staged`](https://github.com/joshbrooks/rakaia/tree/main/examples/partisipa_staged) | Staged replay resolving late-arriving cross-form links | `just partisipa-demo` |
+| [`partisipa_close`](https://github.com/joshbrooks/rakaia/tree/main/examples/partisipa_close) | Close-precondition state machine decided purely from projected state; stage reducers | `just partisipa-close-demo` |
+| [`partisipa_merge`](https://github.com/joshbrooks/rakaia/tree/main/examples/partisipa_merge) | `merge_replay` of N streams into one deterministic order; cross-stream rollup | `just partisipa-merge-demo` |
+| [`partisipa_repeaters`](https://github.com/joshbrooks/rakaia/tree/main/examples/partisipa_repeaters) | Nested-repeater tree reconcile — no deep orphans, no double-count | `just partisipa-tree-demo` |
+
+### Standalone (no Django)
+
+Zero-dependency scripts — no database, no server. These cover the half of rakaia
+that isn't Django at all.
+
+| Example | Proves | Run |
+|---|---|---|
+| [`protocol_streams`](https://github.com/joshbrooks/rakaia/tree/main/examples/protocol_streams) | `StreamStore` append/read, `append_if_changed`, producer fencing, `close`, `poll` subscriber cursors, CDN cursors | `just protocol-demo` |
+| [`multi_owner`](https://github.com/joshbrooks/rakaia/tree/main/examples/multi_owner) | `Ref`/`RefResolver`, `reconcile_aggregate(owns=)`, `reconcile_by_key(retire=)`, `check_disjoint_defaults`, `dispatch_external` | `just multi-owner-demo` |
+
+## Concept → example coverage matrix
+
+Which example to read for a working reference to each public API. `—` means no
+example exercises it yet (see [known gaps](#known-gaps)).
+
+### Protocol layer
+
+| Concept | Demonstrated by |
+|---|---|
+| `StreamStore` append / read / offsets | `protocol_streams`, and every Django demo indirectly |
+| `append_if_changed` / `snapshots_equal` (no-op suppression) | `protocol_streams` |
+| Producer fencing (`ProducerAccepted`/`Duplicate`/`SequenceGap`/`StaleEpoch`/`InvalidEpochSeq`) | `protocol_streams` |
+| Stream `close_stream` / `CloseResult` | `protocol_streams` |
+| Subscriber cursors — `poll`, `Poll`, `PollStatus` | `protocol_streams` |
+| CDN cursors — `calculate_cursor`, `generate_response_cursor`, `CursorOptions` | `protocol_streams` |
+
+### Event envelope & provenance
+
+| Concept | Demonstrated by |
+|---|---|
+| `AppendOptions(label=…, metadata=…)`, `provenance()` | `formkit_submissions`, `formkit_submissions` (stream) |
+| History read-model — `history_effects`, materialized audit rows | `formkit_submissions`, `partisipa_history` |
+| `recover_peak_snapshot` (blank-save recovery) | `partisipa_history` |
+
+### Versioned handlers, upcasters, replay
+
+| Concept | Demonstrated by |
+|---|---|
+| `register_handler`, `effective_from`/`effective_to` (time-correctness) | `orders`, `formkit_submissions` |
+| `register_simple`, `match_field` routing | `projection_cookbook` |
+| Upcasters — `register_upcaster` (schema evolution) | `orders`, `formkit_submissions` |
+| Drift detection — `on_drift="raise"` | `orders` |
+| `replay`, single-stage | most Django demos |
+| Staged replay (`stage=`) + `ProjectionReader` | `projection_cookbook`, `partisipa_staged`, `partisipa_close`, `partisipa_merge` |
+| `merge_replay` (multi-stream deterministic order) | `partisipa_merge` |
+| Stage reducers (via `{"reduce": […]}` stage config) | `partisipa_close`, `partisipa_merge` |
+
+### Effects & executors
+
+| Concept | Demonstrated by |
+|---|---|
+| `Effect` ops: `update_or_create`, `update`, `delete`+`exclude`, `external` | `orders`, `partisipa_repeaters`, `multi_owner` |
+| `CollectingExecutor` (dry-run) | `orders`, `projection_cookbook` |
+| `DjangoExecutor` | every Django demo |
+| `Ref` / `RefResolver` (bind FK to a sibling's generated key) | `multi_owner` |
+| `check_disjoint_defaults` (multi-owner guard) | `multi_owner` |
+| `dispatch_external` (route `op="external"`) | `multi_owner` |
+| `diff_effects_against_rows` (replay-vs-rows verification) | `projection_cookbook` |
+
+### Projections & fan-out
+
+| Concept | Demonstrated by |
+|---|---|
+| `reconcile_children` (positional fan-out, orphan-safe) | `formkit_submissions`, `partisipa_close`, `partisipa_repeaters` |
+| `project_latest` (subject → latest snapshot) | `formkit_submissions` (stream) |
+| `reconcile_aggregate` (grouped rollup) + multi-owner `owns=` | `multi_owner` |
+| `reconcile_by_key` (composite natural key) + soft-delete `retire=` | `multi_owner` |
+
+### Django integration
+
+| Concept | Demonstrated by |
+|---|---|
+| `@stream_model`, `create_stream_event`, multi-stream events | `chat`, `polyglot` |
+| Live SSE broadcast (Channels) | `chat`, `polyglot` |
+| Durable `DjangoStreamStore` (log persisted in the DB) | `formkit_submissions` (stream) |
+
+### Known gaps
+
+No example exercises these yet — a good place to contribute a demo:
+
+- `register_reducer` as the *public API* (the partisipa demos wire reducers via
+  raw `{"reduce": […]}` stage config instead).
+- `reconcile_tree` (the `partisipa_repeaters` spike hand-rolls the equivalent
+  with `delete`+`exclude`).
+- `replay_stream` (the Django convenience wrapper).
+- `DjangoExecutor(skip_unchanged=True)`.
+
+## Orientation for contributors
+
+**Anatomy of an example.** A Django example (`examples/<name>/`) is a minimal
+Django project:
+
+- `<name>_project/settings.py` — `INSTALLED_APPS` includes `django_rakaia` and
+  the example app; `RAKAIA_STORE` selects the in-memory or durable store.
+- `<app>/models.py` — the projection tables (the *derived* state).
+- `<app>/handlers.py` — the pure `event → Effect` handlers, registered with
+  `@register_handler` / `@register_simple` / `@register_reducer`.
+- `<app>/seed.py` — the sample events the demo replays.
+- `<app>/management/commands/demo_<name>.py` — the runnable walkthrough.
+
+A standalone example (`examples/protocol_streams/`, `examples/multi_owner/`) is
+just a `demo.py` script that imports `rakaia` and the stdlib — no Django, no DB.
+
+**Conventions every example follows:**
+
+- **Migrate-first.** Each `demo_*` management command calls `migrate` itself, so
+  it works run directly *or* via `just`. The `db.sqlite3` files are gitignored
+  scratch state — never a committed fixture.
+- **Assertion-backed.** A demo ends with `All … checks passed ✓` or a traceback;
+  there is no "looks right" path. Re-running is idempotent (many take `--twice`).
+- **Deterministic.** Replays produce the same projection every time — no
+  `timezone.now()` inside a handler; event timestamps come from the envelope.
+
+**Adding an example:** copy the closest existing project, add a `just <name>-demo`
+recipe (migrate-first), a `README.md`, and — if it demonstrates a headline
+feature — a row in the [what's-new tour](whats-new.md) and this page's matrix.
+
+Run `just install && just demo` before pushing; CI runs `ruff check`,
+`ruff format --check`, `pytest`, and `zensical build`.

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -46,6 +46,7 @@ SSE demos. To jump straight to one, use its command from the table.
 |---|---|---|
 | [`orders`](../examples/orders/) | Versioned handlers, upcasters, replay, dry-run | `just orders-demo` |
 | [`formkit_submissions`](../examples/formkit_submissions/) | Projections/fan-out, `reconcile_children`, migration parity | `just formkit-demo` |
+| [`formkit_submissions` (stream)](../examples/formkit_submissions/) | Arrow-flip: append log = source of truth → projection | `just formkit-stream-demo` |
 | [`chat`](../examples/chat/) | `@stream_model`, multi-stream events, live SSE | `just dev` → http://localhost:8000 |
 | [`polyglot`](../examples/polyglot/) | Language-scoped streams, live-editable translations | `just polyglot-dev` → http://localhost:8001 |
 
@@ -54,6 +55,13 @@ a real (Partisipa) form pipeline — staged replay (`just partisipa-demo`),
 multi-stream merge (`just partisipa-merge-demo`), and nested-repeater
 tree-reconcile (`just partisipa-tree-demo`). They're linked from the sections
 below.
+
+Two **zero-dependency demos** cover the layers underneath Django, with no
+database at all: [`protocol_streams`](../examples/protocol_streams/) drives the
+raw protocol — append/read, producer fencing, close, subscriber cursors
+(`just protocol-demo`) — and [`multi_owner`](../examples/multi_owner/) drives the
+effect primitives for a row with several writers — symbolic `Ref`s,
+`reconcile_aggregate(owns=)`, `reconcile_by_key` (`just multi-owner-demo`).
 
 ---
 

--- a/examples/chat/chat_project/settings.py
+++ b/examples/chat/chat_project/settings.py
@@ -21,13 +21,23 @@ INSTALLED_APPS = [
     "chat",
 ]
 
+import importlib.util  # noqa: E402
+
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
     # WhiteNoise must come right after SecurityMiddleware so static-file
     # requests bypass the rest of the stack. With DEBUG=True the runserver
     # staticfiles handler still takes precedence; with DEBUG=False (e.g.
     # under `just serve`/hypercorn) WhiteNoise is what serves /static/.
-    "whitenoise.middleware.WhiteNoiseMiddleware",
+    #
+    # It ships in the `prod` extra, so it is inserted only when installed:
+    # `just dev` (dev extras only) serves static via the runserver handler and
+    # does not need it, while `just install` / `just serve` pull it in.
+    *(
+        ["whitenoise.middleware.WhiteNoiseMiddleware"]
+        if importlib.util.find_spec("whitenoise")
+        else []
+    ),
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",

--- a/examples/formkit_submissions/submission_stream/management/commands/demo_submission_stream.py
+++ b/examples/formkit_submissions/submission_stream/management/commands/demo_submission_stream.py
@@ -16,6 +16,7 @@ import contextlib
 import json
 from typing import Any
 
+from django.core.management import call_command
 from django.core.management.base import BaseCommand
 
 from submission_stream import stream
@@ -37,6 +38,10 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args: Any, **opts: Any) -> None:  # noqa: ARG002
+        # Self-contained: ensure this demo's tables exist so `manage.py
+        # demo_*` works when run directly, not only via the migrate-first
+        # `just` recipe. Idempotent — a no-op once migrations are applied.
+        call_command("migrate", verbosity=0, interactive=False)
         store = stream.get_store()
 
         if opts["reproject_only"]:

--- a/examples/formkit_submissions/submissions/management/commands/demo_submissions.py
+++ b/examples/formkit_submissions/submissions/management/commands/demo_submissions.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 import json
 from typing import Any
 
+from django.core.management import call_command
 from django.core.management.base import BaseCommand, CommandParser
 
 from django_rakaia.effect_executor import DjangoExecutor
@@ -98,6 +99,10 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args: Any, **opts: Any) -> None:  # noqa: ARG002
+        # Self-contained: ensure this demo's tables exist so `manage.py
+        # demo_*` works when run directly, not only via the migrate-first
+        # `just` recipe. Idempotent — a no-op once migrations are applied.
+        call_command("migrate", verbosity=0, interactive=False)
         store = get_store()
 
         # Reset so the command is re-runnable: fresh stream (seq restarts at 0).

--- a/examples/multi_owner/README.md
+++ b/examples/multi_owner/README.md
@@ -1,0 +1,37 @@
+# multi_owner — one row, many writers (no Django)
+
+The projection helpers most examples use (`reconcile_children`, `project_latest`)
+own a **whole** row. This example is for the harder case: a single projection row
+composed by **several independent owners**, or a child FK that must point at a
+sibling row whose primary key doesn't exist until apply time. Those primitives —
+the newest additions to rakaia — weren't exercised by any other example.
+
+It runs the scenarios end to end through a tiny in-memory executor
+([`executor.py`](./executor.py), a ~90-line stand-in for `DjangoExecutor`), so
+`Ref` resolution and the reconcile passes are *applied to real rows*, not just
+printed. No Django, no database.
+
+Companion docs: [`docs/dry-run-and-executors.md`](../../docs/dry-run-and-executors.md),
+[`docs/projections-and-fan-out.md`](../../docs/projections-and-fan-out.md),
+[`docs/alerts-projection.md`](../../docs/alerts-projection.md).
+
+## Run
+
+```sh
+just multi-owner-demo
+# or: cd examples/multi_owner && uv run python demo.py
+```
+
+## What it proves
+
+| Section | Primitive | Point |
+|---|---|---|
+| 1 | `Ref` / `RefResolver` | An effect binds an FK to a **sibling** effect's generated pk — no staging split, no reader lookup. A dangling `Ref` raises `UnresolvedRefError`, never a silent `NULL`. |
+| 2 | `reconcile_aggregate(owns=…)` | Two reducers share one row, each owning disjoint columns; when a group vanishes in one owner, only *that owner's* columns are null-cleared — the row and the other owner survive. |
+| 3 | `reconcile_by_key(retire=…)` | Reconcile rows on a composite natural key, **soft-deleting** stale rows (stamp `resolved_at`) instead of dropping them, scoped off authored rows via `retire_filter`. |
+| 4 | `check_disjoint_defaults` | The invariant that makes multi-owner rows safe: two owners writing the same column is caught as an `EffectCollisionError`. |
+| 5 | `dispatch_external` | Route the `op="external"` effects rakaia deliberately never applies (email, webhooks) to per-`kind` handlers. |
+
+`executor.py` is intentionally minimal — it supports only the lookup operators
+these demos need (`__in`, `__isnull`). For the production executor see
+`django_rakaia/effect_executor.py`.

--- a/examples/multi_owner/demo.py
+++ b/examples/multi_owner/demo.py
@@ -1,0 +1,282 @@
+#!/usr/bin/env python3
+"""`multi_owner` — one row, many writers: Refs, shared aggregates, natural keys.
+
+The projection helpers most examples use (`reconcile_children`, `project_latest`)
+own a *whole* row. The primitives here are for the harder case where a single
+projection row is composed by **several independent owners**, or where a child
+FK must point at a sibling row whose primary key doesn't exist until apply time.
+None of the other examples exercise them, so this one does — end to end, through a
+tiny in-memory executor (`executor.py`, standing in for `DjangoExecutor`):
+
+  * `Ref` / `RefResolver`     — an effect binds an FK to a *sibling* effect's
+                                generated primary key, no staging split.
+  * `reconcile_aggregate(owns=)` — two reducers share one row; each owns disjoint
+                                columns; a vanished group clears only its own.
+  * `reconcile_by_key(retire=)`  — reconcile rows on a composite natural key,
+                                soft-deleting (not hard-deleting) stale rows.
+  * `check_disjoint_defaults`    — the guard that makes multi-owner rows safe.
+  * `dispatch_external`          — route the `op="external"` effects rakaia won't.
+
+Runs as a plain script (no Django):
+
+    just multi-owner-demo
+    # or: uv run python examples/multi_owner/demo.py
+"""
+
+from __future__ import annotations
+
+from executor import DictExecutor
+
+from rakaia import (
+    Effect,
+    EffectCollisionError,
+    Ref,
+    check_disjoint_defaults,
+    dispatch_external,
+    reconcile_aggregate,
+    reconcile_by_key,
+)
+
+AREA = "geo.Area"
+PROJECT = "geo.Project"
+BALANCE = "fin.Balance"
+ALERT = "qa.Alert"
+
+
+def _hdr(title: str) -> None:
+    print(f"\n{title}")
+    print("-" * 62)
+
+
+def section_refs() -> None:
+    _hdr("[1] Ref / RefResolver: bind an FK to a sibling's generated pk")
+    ex = DictExecutor()
+    # One batch: create an Area, then a Project whose area_id must point at the
+    # Area's primary key — which does not exist until the first effect applies.
+    # `produces=`/`Ref` wires them without a natural-key reader lookup.
+    ex.apply(
+        [
+            Effect(
+                op="update_or_create",
+                model_label=AREA,
+                lookup={"name": "Zone-North"},
+                defaults={},
+                produces="north",
+            ),
+            Effect(
+                op="update_or_create",
+                model_label=PROJECT,
+                lookup={"name": "Irrigation-7"},
+                defaults={"area_id": Ref("north")},  # resolves to the Area pk
+            ),
+        ]
+    )
+    area = ex.rows(AREA)[0]
+    project = ex.rows(PROJECT)[0]
+    assert project["area_id"] == area["pk"]
+    print(
+        f"    Area pk={area['pk']}; Project.area_id={project['area_id']} — FK wired ✓"
+    )
+
+    # A dry run (CollectingExecutor) keeps the literal Ref; only an *applying*
+    # executor resolves it. So a forward/typo Ref is caught, not silently NULL.
+    from rakaia import RefResolver, UnresolvedRefError
+
+    try:
+        RefResolver().resolve_value(Ref("does-not-exist"))
+    except UnresolvedRefError:
+        print(
+            "    a Ref to an unproduced id raises UnresolvedRefError (never silent NULL) ✓"
+        )
+    else:  # pragma: no cover
+        raise AssertionError("expected UnresolvedRefError")
+
+
+def section_multi_owner_aggregate() -> None:
+    _hdr("[2] reconcile_aggregate(owns=): two reducers, one shared row")
+    ex = DictExecutor()
+
+    # A per-suku Balance row is co-owned. Because owns= per-group effects are
+    # update-if-exists (they never mint a row), one owner owns the row's
+    # *existence*: a ROSTER that upserts a row per active suku. Two more owners
+    # each recompute *their own columns only* — a STATUS reducer owns `status`,
+    # a FINANCE reducer owns `ksp_total`. Single-owner mode would DELETE the
+    # whole row when one reducer's group vanished, clobbering the others; owns=
+    # null-clears only its own columns instead.
+    def roster_pass(sukus: list[str]) -> list[Effect]:
+        return [
+            Effect(
+                op="update_or_create",
+                model_label=BALANCE,
+                lookup={"report_id": 1, "suku": s},
+                defaults={},
+            )
+            for s in sukus
+        ]
+
+    def status_pass(groups: dict[str, dict]) -> list[Effect]:
+        return reconcile_aggregate(
+            BALANCE, {"report_id": 1}, "suku", groups, owns=("status",)
+        )
+
+    def finance_pass(groups: dict[str, dict]) -> list[Effect]:
+        return reconcile_aggregate(
+            BALANCE, {"report_id": 1}, "suku", groups, owns=("ksp_total",)
+        )
+
+    # First replay: roster mints both rows; both owners fill their column.
+    ex.apply(roster_pass(["north", "south"]))
+    ex.apply(status_pass({"north": {"status": "open"}, "south": {"status": "open"}}))
+    ex.apply(finance_pass({"north": {"ksp_total": 500}, "south": {"ksp_total": 300}}))
+    north = next(r for r in ex.rows(BALANCE) if r["suku"] == "north")
+    assert north["status"] == "open" and north["ksp_total"] == 500
+    print("    north: status=open ksp_total=500  (written by two owners) ✓")
+
+    # Second replay: finance no longer has a 'north' contributor; roster and
+    # status still do. owns= null-clears ONLY finance's column on north; the
+    # row and the status owner's column both survive.
+    ex.apply(roster_pass(["north", "south"]))
+    ex.apply(status_pass({"north": {"status": "closed"}, "south": {"status": "open"}}))
+    ex.apply(finance_pass({"south": {"ksp_total": 300}}))  # north vanished here
+    north = next(r for r in ex.rows(BALANCE) if r["suku"] == "north")
+    assert north["ksp_total"] is None  # finance's column cleared
+    assert north["status"] == "closed"  # status owner untouched
+    print("    north: ksp_total->None (finance's col) but status='closed' kept ✓")
+    print("    the shared row survived a vanished group in one owner ✓")
+
+
+def section_reconcile_by_key() -> None:
+    _hdr("[3] reconcile_by_key(retire=patch): soft-delete on a natural key")
+    ex = DictExecutor()
+
+    # QA alerts keyed by (alert_type, field_key). A re-derivation should stamp
+    # `resolved_at` on alerts that no longer fire — NOT hard-delete them, so the
+    # audit trail survives — and leave authored rows alone via retire_filter.
+    def alerts(items: list[dict], event_ts: str) -> list[Effect]:
+        return reconcile_by_key(
+            ALERT,
+            scope={"submission_id": "sub-1"},
+            key_fields=("alert_type", "field_key"),
+            items=items,
+            key_fn=lambda v: {
+                "alert_type": v["alert_type"],
+                "field_key": v["field_key"],
+            },
+            defaults_fn=lambda v: {"severity": v["severity"], "resolved_at": None},
+            retire_filter={"alert_type__in": ["ff4", "sf11"]},  # machine types only
+            retire={"resolved_at": event_ts},  # soft-delete: stamp, don't drop
+        )
+
+    ex.apply(
+        alerts(
+            [
+                {"alert_type": "ff4", "field_key": "budget", "severity": "high"},
+                {"alert_type": "sf11", "field_key": "date", "severity": "low"},
+            ],
+            event_ts="t1",
+        )
+    )
+    assert len({r["pk"] for r in ex.rows(ALERT)}) == 2
+    print("    2 alerts raised (ff4/budget, sf11/date), both live ✓")
+
+    # Re-derive: the ff4 violation is fixed and no longer present.
+    ex.apply(
+        alerts(
+            [
+                {"alert_type": "sf11", "field_key": "date", "severity": "low"},
+            ],
+            event_ts="t2",
+        )
+    )
+    ff4 = next(r for r in ex.rows(ALERT) if r["alert_type"] == "ff4")
+    sf11 = next(r for r in ex.rows(ALERT) if r["alert_type"] == "sf11")
+    assert ff4["resolved_at"] == "t2"  # soft-deleted, row retained
+    assert sf11["resolved_at"] is None  # still firing, untouched
+    print("    ff4 stamped resolved_at=t2 (row kept); sf11 still open ✓")
+
+
+def section_disjoint_guard() -> None:
+    _hdr("[4] check_disjoint_defaults: the invariant that keeps owners honest")
+    # Two owners writing DISJOINT columns of the same row is fine...
+    ok = [
+        Effect(
+            op="update",
+            model_label=BALANCE,
+            lookup={"suku": "north"},
+            defaults={"status": "open"},
+        ),
+        Effect(
+            op="update",
+            model_label=BALANCE,
+            lookup={"suku": "north"},
+            defaults={"ksp_total": 5},
+        ),
+    ]
+    check_disjoint_defaults(ok)  # no raise
+    print("    disjoint columns on a shared row: allowed ✓")
+
+    # ...but two owners writing the SAME column is a collision — caught early.
+    clash = [
+        Effect(
+            op="update",
+            model_label=BALANCE,
+            lookup={"suku": "north"},
+            defaults={"status": "open"},
+        ),
+        Effect(
+            op="update",
+            model_label=BALANCE,
+            lookup={"suku": "north"},
+            defaults={"status": "closed"},
+        ),
+    ]
+    try:
+        check_disjoint_defaults(clash)
+    except EffectCollisionError as exc:
+        print(f"    same column from two owners: EffectCollisionError ✓\n      ({exc})")
+    else:  # pragma: no cover
+        raise AssertionError("expected EffectCollisionError")
+
+
+def section_dispatch_external() -> None:
+    _hdr("[5] dispatch_external: route the effects rakaia deliberately won't apply")
+    sent: list[str] = []
+    effects = [
+        Effect(
+            op="update_or_create",
+            model_label=BALANCE,
+            lookup={"suku": "north"},
+            defaults={"status": "closed"},
+        ),
+        Effect(
+            op="external",
+            kind="email",
+            payload={"to": "pm@example.org", "re": "north closed"},
+        ),
+        Effect(op="external", kind="webhook", payload={"url": "/hooks/closed"}),
+    ]
+    count = dispatch_external(
+        effects,
+        {
+            "email": lambda e: sent.append(f"email->{e.payload['to']}"),
+            "webhook": lambda e: sent.append(f"webhook->{e.payload['url']}"),
+        },
+    )
+    assert count == 2 and len(sent) == 2  # the write effect is ignored
+    print(f"    dispatched {count} external effects: {sent} ✓")
+
+
+def main() -> None:
+    print("=" * 62)
+    print("  Rakaia effect/projection primitives — one row, many writers")
+    print("=" * 62)
+    section_refs()
+    section_multi_owner_aggregate()
+    section_reconcile_by_key()
+    section_disjoint_guard()
+    section_dispatch_external()
+    print("\nAll multi-owner effect checks passed ✓")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/multi_owner/executor.py
+++ b/examples/multi_owner/executor.py
@@ -1,0 +1,115 @@
+"""A tiny in-memory Executor — the `DjangoExecutor` contract, over dicts.
+
+The point of this example is to exercise rakaia's effect/projection primitives
+(`Ref`/`RefResolver`, `reconcile_aggregate(owns=)`, `reconcile_by_key`) *without*
+Django, so this module stands in for `django_rakaia.effect_executor.DjangoExecutor`:
+it applies a batch of `Effect`s to dict-backed "tables", assigns primary keys,
+and resolves `Ref` placeholders through the real `rakaia.RefResolver` exactly the
+way the Django executor does. It is deliberately small — it supports only the
+lookup operators these demos use (`__in`, `__isnull`) — not a general ORM.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any
+
+from rakaia import Effect, RefResolver
+
+
+class DictExecutor:
+    """Applies effects to in-memory tables; resolves Refs against the batch."""
+
+    def __init__(self) -> None:
+        # model_label -> {pk: row_dict}. Every row carries a synthetic "pk".
+        self.tables: dict[str, dict[int, dict[str, Any]]] = {}
+        self._next_pk = 1
+
+    # -- row helpers --------------------------------------------------------
+
+    def rows(self, model_label: str) -> list[dict[str, Any]]:
+        """Every live row of a model, pk order — for asserting/printing state."""
+        return [
+            self.tables.get(model_label, {})[pk]
+            for pk in sorted(self.tables.get(model_label, {}))
+        ]
+
+    def _table(self, model_label: str) -> dict[int, dict[str, Any]]:
+        return self.tables.setdefault(model_label, {})
+
+    @staticmethod
+    def _matches(row: dict[str, Any], lookup: dict[str, Any]) -> bool:
+        """Django-style filter matching for the operators these demos need."""
+        for key, expected in lookup.items():
+            if key.endswith("__in"):
+                if row.get(key[:-4]) not in expected:
+                    return False
+            elif key.endswith("__isnull"):
+                if (row.get(key[:-8]) is None) is not expected:
+                    return False
+            elif row.get(key) != expected:
+                return False
+        return True
+
+    def _find(self, model_label: str, lookup: dict[str, Any]) -> list[dict[str, Any]]:
+        return [
+            r for r in self._table(model_label).values() if self._matches(r, lookup)
+        ]
+
+    @staticmethod
+    def _spared(row: dict[str, Any], spare_keys: list[dict[str, Any]]) -> bool:
+        return any(all(row.get(k) == v for k, v in key.items()) for key in spare_keys)
+
+    # -- the Executor protocol ---------------------------------------------
+
+    def apply(self, effects: Iterable[Effect]) -> None:
+        resolver = RefResolver()
+        for raw in effects:
+            eff = resolver.resolve_effect(raw)  # substitute any Ref values
+            table = self._table(eff.model_label or "")
+            lookup = eff.lookup or {}
+
+            if eff.op == "update_or_create":
+                existing = self._find(eff.model_label, lookup)
+                if existing:
+                    row = existing[0]
+                    row.update(eff.defaults or {})
+                else:
+                    row = {"pk": self._next_pk, **lookup, **(eff.defaults or {})}
+                    table[self._next_pk] = row
+                    self._next_pk += 1
+                if eff.produces is not None:
+                    # Let a sibling Ref bind to this row's pk (or any column).
+                    resolver.record(
+                        eff.produces,
+                        lambda field, row=row: (
+                            row["pk"] if field in ("pk", "id") else row.get(field)
+                        ),
+                    )
+
+            elif eff.op == "update":
+                # Update-if-exists: never mints a row (the multi-owner primitive).
+                for row in self._find(eff.model_label, lookup):
+                    row.update(eff.defaults or {})
+
+            elif eff.op == "delete":
+                doomed = self._find(eff.model_label, lookup)
+                if eff.exclude:
+                    doomed = [r for r in doomed if not self._matches(r, eff.exclude)]
+                if eff.spare_keys is not None:
+                    doomed = [r for r in doomed if not self._spared(r, eff.spare_keys)]
+                for row in doomed:
+                    del table[row["pk"]]
+
+            elif eff.op == "retire":
+                targets = self._find(eff.model_label, lookup)
+                if eff.spare_keys is not None:
+                    targets = [
+                        r for r in targets if not self._spared(r, eff.spare_keys)
+                    ]
+                for row in targets:
+                    row.update(eff.patch or {})
+
+            elif eff.op == "external":
+                # rakaia never applies external effects; replay filters them.
+                continue

--- a/examples/orders/orders/management/commands/demo_orders.py
+++ b/examples/orders/orders/management/commands/demo_orders.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import json
 from typing import Any
 
+from django.core.management import call_command
 from django.core.management.base import BaseCommand, CommandError, CommandParser
 
 from django_rakaia.effect_executor import DjangoExecutor
@@ -50,6 +51,10 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args: Any, **opts: Any) -> None:  # noqa: ARG002
+        # Self-contained: ensure this demo's tables exist so `manage.py
+        # demo_*` works when run directly, not only via the migrate-first
+        # `just` recipe. Idempotent — a no-op once migrations are applied.
+        call_command("migrate", verbosity=0, interactive=False)
         store = get_store()
 
         # Reset so the command is re-runnable: fresh stream (seq restarts at 0)

--- a/examples/partisipa_close/lifecycle/management/commands/demo_close.py
+++ b/examples/partisipa_close/lifecycle/management/commands/demo_close.py
@@ -27,6 +27,7 @@ import json
 from decimal import Decimal
 from typing import Any
 
+from django.core.management import call_command
 from django.core.management.base import BaseCommand, CommandError
 
 from django_rakaia.store import get_store
@@ -68,6 +69,10 @@ class Command(BaseCommand):
     help = "Decide a POM_1 cycle close from cross-form preconditions via replay."
 
     def handle(self, *args: Any, **opts: Any) -> None:  # noqa: ARG002
+        # Self-contained: ensure this demo's tables exist so `manage.py
+        # demo_*` works when run directly, not only via the migrate-first
+        # `just` recipe. Idempotent — a no-op once migrations are applied.
+        call_command("migrate", verbosity=0, interactive=False)
         store = get_store()
         store.delete(STREAM)
         store.create(STREAM)

--- a/examples/partisipa_history/history/management/commands/demo_history.py
+++ b/examples/partisipa_history/history/management/commands/demo_history.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from django.core.management import call_command
 from django.core.management.base import BaseCommand, CommandError
 
 from django_rakaia.store import get_store
@@ -64,6 +65,10 @@ class Command(BaseCommand):
     help = "Reproduce django-pghistory's audit + recovery from a rakaia stream."
 
     def handle(self, *args: Any, **opts: Any) -> None:  # noqa: ARG002
+        # Self-contained: ensure this demo's tables exist so `manage.py
+        # demo_*` works when run directly, not only via the migrate-first
+        # `just` recipe. Idempotent — a no-op once migrations are applied.
+        call_command("migrate", verbosity=0, interactive=False)
         store = get_store()
         for path in (STREAM, NAIVE_STREAM):
             store.delete(path)

--- a/examples/partisipa_merge/subproject/management/commands/demo_merge.py
+++ b/examples/partisipa_merge/subproject/management/commands/demo_merge.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 import json
 from typing import Any
 
+from django.core.management import call_command
 from django.core.management.base import BaseCommand, CommandError
 
 from django_rakaia.store import get_store
@@ -93,6 +94,10 @@ class Command(BaseCommand):
     help = "Merge several form streams into one deterministic subproject replay."
 
     def handle(self, *args: Any, **opts: Any) -> None:  # noqa: ARG002
+        # Self-contained: ensure this demo's tables exist so `manage.py
+        # demo_*` works when run directly, not only via the migrate-first
+        # `just` recipe. Idempotent — a no-op once migrations are applied.
+        call_command("migrate", verbosity=0, interactive=False)
         store = get_store()
         self._build_single(store, INITIAL_EVENTS)
         self._build_three(store, INITIAL_EVENTS)

--- a/examples/partisipa_repeaters/repeaters/management/commands/demo_repeaters.py
+++ b/examples/partisipa_repeaters/repeaters/management/commands/demo_repeaters.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import json
 from typing import Any
 
+from django.core.management import call_command
 from django.core.management.base import BaseCommand, CommandError
 
 from django_rakaia.store import get_store
@@ -72,6 +73,10 @@ class Command(BaseCommand):
     help = "Reconcile an unbounded nested-repeater tree on replay (no orphans)."
 
     def handle(self, *args: Any, **opts: Any) -> None:  # noqa: ARG002
+        # Self-contained: ensure this demo's tables exist so `manage.py
+        # demo_*` works when run directly, not only via the migrate-first
+        # `just` recipe. Idempotent — a no-op once migrations are applied.
+        call_command("migrate", verbosity=0, interactive=False)
         store = get_store()
         store.delete(STREAM)
         store.create(STREAM)

--- a/examples/partisipa_staged/partisipa/management/commands/demo_staged.py
+++ b/examples/partisipa_staged/partisipa/management/commands/demo_staged.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import json
 from typing import Any
 
+from django.core.management import call_command
 from django.core.management.base import BaseCommand, CommandError
 
 from django_rakaia.store import get_store
@@ -55,6 +56,10 @@ class Command(BaseCommand):
     help = "Demonstrate staged replay resolving late-arriving cross-form links."
 
     def handle(self, *args: Any, **opts: Any) -> None:  # noqa: ARG002
+        # Self-contained: ensure this demo's tables exist so `manage.py
+        # demo_*` works when run directly, not only via the migrate-first
+        # `just` recipe. Idempotent — a no-op once migrations are applied.
+        call_command("migrate", verbosity=0, interactive=False)
         store = get_store()
         store.delete(STREAM)
         store.create(STREAM)

--- a/examples/polyglot/polyglot_project/settings.py
+++ b/examples/polyglot/polyglot_project/settings.py
@@ -21,9 +21,18 @@ INSTALLED_APPS = [
     "polyglot",
 ]
 
+import importlib.util  # noqa: E402
+
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
-    "whitenoise.middleware.WhiteNoiseMiddleware",
+    # WhiteNoise ships in the `prod` extra and serves /static/ under
+    # `just serve`/hypercorn. It is inserted only when installed so that
+    # `just dev` (dev extras only) works — runserver serves static itself.
+    *(
+        ["whitenoise.middleware.WhiteNoiseMiddleware"]
+        if importlib.util.find_spec("whitenoise")
+        else []
+    ),
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",

--- a/examples/projection_cookbook/cookbook/management/commands/demo_cookbook.py
+++ b/examples/projection_cookbook/cookbook/management/commands/demo_cookbook.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import json
 from typing import Any
 
+from django.core.management import call_command
 from django.core.management.base import BaseCommand, CommandError
 
 from cookbook.models import Project, Task
@@ -32,6 +33,10 @@ class Command(BaseCommand):
     help = "Seed a two-form stream and replay it into a staged projection."
 
     def handle(self, *args: Any, **opts: Any) -> None:  # noqa: ARG002
+        # Self-contained: ensure this demo's tables exist so `manage.py
+        # demo_*` works when run directly, not only via the migrate-first
+        # `just` recipe. Idempotent — a no-op once migrations are applied.
+        call_command("migrate", verbosity=0, interactive=False)
         store = get_store()
 
         # 1. Seed. Reset first so the command is re-runnable (fresh stream, empty

--- a/examples/protocol_streams/README.md
+++ b/examples/protocol_streams/README.md
@@ -1,0 +1,32 @@
+# protocol_streams — the raw Durable Streams protocol (no Django)
+
+Every other example mounts rakaia in Django and drives the **event-sourcing
+layer** (versioned handlers, projections, replay). This one exercises the *other
+half*: the zero-dependency `StreamStore` and the pure-protocol primitives that
+sit underneath all of that. It imports nothing but `rakaia` and the stdlib.
+
+It is the runnable companion to [`docs/protocol.md`](../../docs/protocol.md),
+[`docs/producer-fencing.md`](../../docs/producer-fencing.md) and
+[`docs/subscriber-cursors.md`](../../docs/subscriber-cursors.md).
+
+## Run
+
+```sh
+just protocol-demo
+# or: uv run python examples/protocol_streams/demo.py
+```
+
+No database, no migrations, no server — it runs in-process and asserts each
+outcome, so a protocol-layer regression turns the final
+`All protocol checks passed ✓` into a stack trace.
+
+## What it proves
+
+| Section | Primitive | Point |
+|---|---|---|
+| 1 | `StreamStore.append` / `read` | An ordered, offset-addressed log; reads resume from an offset. |
+| 2 | `append_if_changed` / `snapshots_equal` | No-op saves are suppressed (write-side pghistory parity). |
+| 3 | `AppendOptions(producer_id, epoch, seq)` → `ProducerAccepted`/`Duplicate`/`SequenceGap`/`StaleEpoch`/`InvalidEpochSeq` | Idempotent retries, gap detection, and zombie fencing across an epoch change. |
+| 4 | `close_stream` → `CloseResult` | A closed stream is sealed; later appends are refused, idempotent re-close. |
+| 5 | `poll` → `Poll` / `PollStatus` | Incremental subscriber cursors: `fresh` → `caught_up` → `advanced` (delta only) → `rewound`. |
+| 6 | `calculate_cursor` / `generate_response_cursor` | CDN cache-collapsing interval cursors with monotonic progression (protocol §8.1). |

--- a/examples/protocol_streams/demo.py
+++ b/examples/protocol_streams/demo.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+"""`protocol_streams` — the raw Durable Streams protocol, no Django in sight.
+
+Every other example mounts rakaia in Django and drives the event-sourcing layer
+(handlers, projections, replay). This one exercises the *other half* of rakaia:
+the zero-dependency `StreamStore` and the pure-protocol primitives that sit
+underneath all of that — append/read, no-op suppression, **producer fencing**,
+**stream close**, **subscriber cursors** (`poll`), and the CDN cursor helpers.
+
+It imports nothing but `rakaia` and the stdlib, and runs as a plain script:
+
+    just protocol-demo
+    # or: uv run python examples/protocol_streams/demo.py
+
+Each section prints what it proves and asserts the outcome, so a regression in
+the protocol layer turns this from "All protocol checks passed ✓" into a stack
+trace.
+"""
+
+from __future__ import annotations
+
+import json
+
+from rakaia import (
+    AppendOptions,
+    CursorOptions,
+    ProducerAccepted,
+    ProducerDuplicate,
+    ProducerInvalidEpochSeq,
+    ProducerSequenceGap,
+    ProducerStaleEpoch,
+    StreamStore,
+    append_if_changed,
+    calculate_cursor,
+    generate_response_cursor,
+    poll,
+    snapshots_equal,
+)
+
+STREAM = "sensors/rack-4"
+
+
+def _hdr(title: str) -> None:
+    print(f"\n{title}")
+    print("-" * 60)
+
+
+def _json(**fields: object) -> bytes:
+    return json.dumps(fields).encode()
+
+
+def section_append_and_read(store: StreamStore) -> None:
+    _hdr("[1] APPEND -> READ: the store is an ordered, offset-addressed log")
+    store.create(STREAM)
+    first = store.append(STREAM, _json(temp=20.0)).message
+    second = store.append(STREAM, _json(temp=21.5)).message
+    assert first is not None and second is not None
+
+    messages, up_to_date = store.read(STREAM)
+    assert [json.loads(m.data)["temp"] for m in messages] == [20.0, 21.5]
+    assert up_to_date
+    # Offsets are opaque but strictly increasing, so a reader can resume.
+    assert second.offset > first.offset
+    # A partial read from an offset returns only what came after it.
+    tail, _ = store.read(STREAM, first.offset)
+    assert [json.loads(m.data)["temp"] for m in tail] == [21.5]
+    print(f"    2 messages, offsets {first.offset} < {second.offset}")
+    print("    read(offset=first) returns only the tail — resumable reads ✓")
+
+
+def section_append_if_changed(store: StreamStore) -> None:
+    _hdr("[2] NO-OP SUPPRESSION: append_if_changed skips an unchanged snapshot")
+    path = "sensors/door"
+    store.create(path)
+
+    # First reading for the subject: no prior state, so it always lands.
+    current = None
+    appended = append_if_changed(store, path, _json(state="closed"), current=current)
+    assert appended is True
+    current = {"state": "closed"}
+
+    # An identical save is suppressed — the audit log doesn't grow on no-ops,
+    # the way django-pghistory's `IS DISTINCT FROM` trigger wouldn't fire.
+    suppressed = append_if_changed(store, path, _json(state="closed"), current=current)
+    assert suppressed is False
+    assert snapshots_equal({"state": "closed"}, current)
+
+    # A real change lands again.
+    changed = append_if_changed(store, path, _json(state="open"), current=current)
+    assert changed is True
+
+    messages, _ = store.read(path)
+    assert [json.loads(m.data)["state"] for m in messages] == ["closed", "open"]
+    print("    3 saves (closed, closed, open) -> 2 events; the no-op vanished ✓")
+
+
+def section_producer_fencing(store: StreamStore) -> None:
+    _hdr("[3] PRODUCER FENCING: idempotent, gap-detecting, zombie-proof writes")
+    path = "sensors/fenced"
+    store.create(path)
+
+    def send(producer_id: str, epoch: int, seq: int) -> object:
+        result = store.append(
+            path,
+            _json(epoch=epoch, seq=seq),
+            AppendOptions(
+                producer_id=producer_id, producer_epoch=epoch, producer_seq=seq
+            ),
+        )
+        return result.producer_result
+
+    P = "writer-A"
+
+    # A fresh producer must open its epoch at seq=0.
+    assert isinstance(send(P, epoch=1, seq=0), ProducerAccepted)
+    assert isinstance(send(P, epoch=1, seq=1), ProducerAccepted)
+
+    # Re-sending an already-seen (epoch, seq) is a DUPLICATE, not a second write
+    # — this is what makes a network retry safe (idempotent append).
+    dup = send(P, epoch=1, seq=1)
+    assert isinstance(dup, ProducerDuplicate) and dup.last_seq == 1
+
+    # Skipping a sequence number is refused: the writer lost a message.
+    gap = send(P, epoch=1, seq=5)
+    assert isinstance(gap, ProducerSequenceGap)
+    assert gap.expected_seq == 2 and gap.received_seq == 5
+
+    # Fencing: a NEW epoch (a restarted/failed-over writer) must restart at seq=0.
+    assert isinstance(send(P, epoch=2, seq=0), ProducerAccepted)
+    # ...and a straggling write from the OLD epoch is a zombie — rejected so a
+    # partitioned old primary can't corrupt the log after failover.
+    zombie = send(P, epoch=1, seq=2)
+    assert isinstance(zombie, ProducerStaleEpoch) and zombie.current_epoch == 2
+    # A new epoch that forgets to restart its sequence is rejected too.
+    assert isinstance(send(P, epoch=3, seq=9), ProducerInvalidEpochSeq)
+
+    # Only the ACCEPTED writes materialised (2 in epoch 1 + 1 in epoch 2).
+    messages, _ = store.read(path)
+    assert len(messages) == 3
+    print("    accepted x3; duplicate, gap, stale-epoch, invalid-epoch all fenced")
+    print("    only the 3 accepted appends are in the log ✓")
+
+
+def section_close(store: StreamStore) -> None:
+    _hdr("[4] CLOSE: a closed stream is sealed against further appends")
+    path = "sensors/decommissioned"
+    store.create(path)
+    store.append(path, _json(temp=19.0))
+
+    result = store.close_stream(path)
+    assert result is not None
+    assert result.already_closed is False
+    # Closing again is idempotent, and reports it was already closed.
+    assert store.close_stream(path).already_closed is True
+
+    # Appends after close are refused (the AppendResult flags the closure).
+    after = store.append(path, _json(temp=99.0))
+    assert after.stream_closed is True
+    assert after.message is None
+    messages, _ = store.read(path)
+    assert len(messages) == 1  # the post-close append never landed
+    print(
+        f"    closed at final_offset={result.final_offset}; further appends refused ✓"
+    )
+
+
+def section_subscriber_cursors(store: StreamStore) -> None:
+    _hdr("[5] SUBSCRIBER CURSORS: poll() reads a stream incrementally")
+    path = "sensors/consumer"
+    store.create(path)
+    store.append(path, _json(n=1))
+    store.append(path, _json(n=2))
+
+    # First poll has no cursor: it's `fresh` and returns everything.
+    p1 = poll(store, path, cursor=None)
+    assert p1.status == "fresh"
+    assert [json.loads(m.data)["n"] for m in p1.messages] == [1, 2]
+
+    # Persist the watermark, poll again with nothing new -> `caught_up`.
+    p2 = poll(store, path, cursor=p1.cursor)
+    assert p2.status == "caught_up" and p2.messages == []
+
+    # New data arrives; the next poll `advanced`s and returns only the delta.
+    store.append(path, _json(n=3))
+    p3 = poll(store, path, cursor=p2.cursor)
+    assert p3.status == "advanced"
+    assert [json.loads(m.data)["n"] for m in p3.messages] == [3]
+
+    # Defensive `rewound`: a cursor that sorts *past* the head (a truncated or
+    # rebuilt log, or a cursor carried over from another stream) triggers a
+    # full re-read so the consumer can reset derived state.
+    bogus = "9999999999999999_9999999999999999"
+    p4 = poll(store, path, cursor=bogus)
+    assert p4.status == "rewound" and p4.rewound
+    assert [json.loads(m.data)["n"] for m in p4.messages] == [1, 2, 3]
+
+    # An absent stream is reported, not raised.
+    assert poll(store, "sensors/nope", cursor=None).status == "absent"
+    print("    fresh -> caught_up -> advanced(delta only) -> rewound(re-read) ✓")
+
+
+def section_cdn_cursor() -> None:
+    _hdr("[6] CDN CURSOR: interval cursors collapse cache stampedes (protocol 8.1)")
+    opts = CursorOptions(interval_seconds=20)
+    now = calculate_cursor(opts)
+    assert now.isdigit()
+
+    # A client already at/ahead of the current interval gets pushed forward
+    # (never backwards) so a CDN never loops A->B->A.
+    ahead = str(int(now) + 100)
+    forward = generate_response_cursor(ahead, opts)
+    assert int(forward) > int(ahead)
+    # A stale client cursor is snapped up to the current interval.
+    assert generate_response_cursor("0", opts) == now
+    print(f"    interval cursor now={now}; monotonic progression enforced ✓")
+
+
+def main() -> None:
+    print("=" * 60)
+    print("  Rakaia protocol layer — StreamStore + pure-protocol primitives")
+    print("=" * 60)
+    store = StreamStore()
+    section_append_and_read(store)
+    section_append_if_changed(store)
+    section_producer_fencing(store)
+    section_close(store)
+    section_subscriber_cursors(store)
+    section_cdn_cursor()
+    print("\nAll protocol checks passed ✓")
+
+
+if __name__ == "__main__":
+    main()

--- a/justfile
+++ b/justfile
@@ -236,6 +236,11 @@ formkit-demo:
     cd {{FORMKIT_DIR}} && uv run python manage.py migrate
     cd {{FORMKIT_DIR}} && uv run python manage.py demo_submissions --twice
 
+# Arrow-flip: SubmissionEvent (append log = source of truth) -> Submission projection
+formkit-stream-demo:
+    cd {{FORMKIT_DIR}} && uv run python manage.py migrate
+    cd {{FORMKIT_DIR}} && uv run python manage.py demo_submission_stream
+
 # Dev server showing the materialized submission projection
 formkit-dev:
     cd {{FORMKIT_DIR}} && uv run python manage.py migrate
@@ -291,6 +296,14 @@ partisipa-tree-demo:
 # Run the zero-dep ASGI rakaia app under uvicorn
 rakaia port="4437":
     uv run uvicorn rakaia:app --host 0.0.0.0 --port {{port}}
+
+# Protocol layer (no Django): append/read, producer fencing, close, poll cursors
+protocol-demo:
+    uv run python examples/protocol_streams/demo.py
+
+# Effect primitives (no Django): Ref, reconcile_aggregate(owns=), reconcile_by_key
+multi-owner-demo:
+    cd examples/multi_owner && uv run python demo.py
 
 # ---------------------------------------------------------------------------
 # Durable Streams conformance suite

--- a/okf/concepts/django-integration.md
+++ b/okf/concepts/django-integration.md
@@ -1,0 +1,41 @@
+---
+type: Concept
+title: Django integration
+description: Emit stream events from Django models and fan out changes over Server-Sent Events.
+tags: [concept, django, sse]
+status: stable
+generated: { by: claude-code/opus-4-8, at: 2026-07-28T00:00:00Z }
+---
+
+# Definition
+
+`django_rakaia` mounts rakaia in Django: model saves emit stream events (one save
+can fan out to several stream paths), events are stored durably in normalized
+`Stream` / `StreamEvent` / `StreamEntry` tables, and changes broadcast to browsers
+over Server-Sent Events via Django Channels. It provides the ORM-backed executor
+and reader that the [event-sourcing layer](../concepts/versioned-handlers-and-replay.md)
+runs against.
+
+# Public API
+
+From `django_rakaia`:
+
+* `@stream_model(stream_paths=…, to_dataclass=…)` — decorate a model so saves/
+  deletes emit events.
+* `create_stream_event(...)` — emit an event manually (e.g. for built-in models).
+* `DjangoStreamStore` — the durable, DB-backed store (`RAKAIA_STORE="durable"`).
+* `DjangoExecutor`, `DjangoProjectionReader`, `replay_stream` — apply/replay
+  against the ORM.
+* `diff_effects_against_rows` — migration/verification helper.
+* SSE views + Channels signals for live broadcast.
+
+# Demonstrated by
+
+* [chat](../examples/chat.md) — `@stream_model`, multi-stream events, live SSE.
+* [polyglot](../examples/polyglot.md) — `create_stream_event`, language-scoped streams, SSE.
+* [formkit_submissions (stream)](../examples/formkit-submission-stream.md) — durable `DjangoStreamStore`.
+
+# Deeper reference
+
+* Human docs: `docs/django-integration.md`, `docs/streams-backend-storage.md`, `docs/deployment.md`.
+* Source: `src/django_rakaia/`.

--- a/okf/concepts/effects-and-executors.md
+++ b/okf/concepts/effects-and-executors.md
@@ -1,0 +1,50 @@
+---
+type: Concept
+title: Effects & executors
+description: Pure data descriptions of side-effects, applied (or dry-run recorded) by an executor.
+tags: [concept, effects, executors]
+status: stable
+generated: { by: claude-code/opus-4-8, at: 2026-07-28T00:00:00Z }
+---
+
+# Definition
+
+Handlers return `Effect`s — pure data, not I/O — and a separate `Executor`
+applies them. This makes replay idempotent (re-applying an upsert converges) and
+handlers trivially testable. A `CollectingExecutor` records effects instead of
+applying them: the basis for dry-run and migration verification. Symbolic `Ref`s
+let one effect bind to a sibling effect's generated primary key within a batch,
+and `check_disjoint_defaults` enforces the invariant that lets several owners
+compose one row safely.
+
+# Public API
+
+Imported from `rakaia`:
+
+* `Effect(op, model_label, lookup, defaults, exclude, spare_keys, patch,
+  produces, kind, payload, …)`; `EffectOp` is one of `update_or_create` /
+  `update` / `delete` / `retire` / `external`.
+* `Ref(produces, field="pk")` and `RefResolver` — resolve batch-local FK refs;
+  `UnresolvedRefError`, `DuplicateProducesError` on misuse.
+* `check_disjoint_defaults` — raise `EffectCollisionError` if two write effects
+  write the same column of the same row (the multi-owner guard).
+* `dispatch_external(effects, handlers, on_unknown=…)` — route `op="external"`
+  effects (email, webhooks) that rakaia never applies itself.
+* `Executor` protocol; `CollectingExecutor` (dry-run).
+* Django: `DjangoExecutor` (applies to the ORM, resolves `Ref`s);
+  `diff_effects_against_rows` (verify replay reproduces existing rows).
+
+# Demonstrated by
+
+* [multi_owner](../examples/multi-owner.md) — `Ref`/`RefResolver`, `check_disjoint_defaults`, `dispatch_external`.
+* [orders](../examples/orders.md) — `op="update"`, `op="external"`, `CollectingExecutor` dry-run.
+* [projection_cookbook](../examples/projection-cookbook.md) — `diff_effects_against_rows` verification.
+
+# Known gaps
+
+* `DjangoExecutor(skip_unchanged=True)` is not exercised by an example.
+
+# Deeper reference
+
+* Human docs: `docs/dry-run-and-executors.md`.
+* Source: `src/rakaia/effects.py`, `src/rakaia/executors.py`, `src/django_rakaia/effect_executor.py`.

--- a/okf/concepts/event-envelope-and-provenance.md
+++ b/okf/concepts/event-envelope-and-provenance.md
@@ -1,0 +1,38 @@
+---
+type: Concept
+title: Event envelope & provenance
+description: The label/metadata/timestamp envelope on each event, and the history read-model derived from it.
+tags: [concept, event-sourcing, history]
+status: stable
+generated: { by: claude-code/opus-4-8, at: 2026-07-28T00:00:00Z }
+---
+
+# Definition
+
+Each appended event can carry an envelope: a change `label` (create/update/delete
+→ +/~/-), an open `metadata` dict (actor, url, causation), and a logical
+`event_ts`. `provenance()` attaches an ambient actor to appends within its scope.
+Because the log retains every enveloped event, a stream reproduces a
+django-pghistory-style audit trail and can recover a "peak" snapshot even after a
+blank save — the history read-model.
+
+# Public API
+
+Imported from `rakaia`:
+
+* Envelope fields on `AppendOptions(label, metadata, event_ts)` and
+  `StreamMessage(label, metadata, event_ts)`.
+* `provenance(...)` context manager; `get_provenance()`.
+* History helpers: `history_effects`, `recover_peak_snapshot`, `label_marker`,
+  `envelope_actor`.
+
+# Demonstrated by
+
+* [formkit_submissions (stream)](../examples/formkit-submission-stream.md) — envelope, `history_effects`, actor recovery.
+* [partisipa_history](../examples/partisipa-history.md) — pghistory-parity audit + `recover_peak_snapshot`.
+* [formkit_submissions](../examples/formkit-submissions.md) — `AppendOptions(label=…)` + `provenance()`.
+
+# Deeper reference
+
+* Human docs: `docs/event-envelope.md`, `docs/history-read-model.md`, `docs/pghistory-retirement.md`.
+* Source: `src/rakaia/history.py`, `src/rakaia/context.py`.

--- a/okf/concepts/index.md
+++ b/okf/concepts/index.md
@@ -1,0 +1,11 @@
+# Concepts
+
+Rakaia's public API surface, grouped into six areas. Each concept doc lists the
+APIs it covers, the examples that demonstrate it, and any still-uncovered APIs.
+
+* [Protocol layer & streams](protocol-and-streams.md) - `StreamStore`, producer fencing, close, subscriber/CDN cursors, no-op suppression.
+* [Versioned handlers & replay](versioned-handlers-and-replay.md) - `register_handler`, upcasters, staged `replay`, `merge_replay`, reducers.
+* [Effects & executors](effects-and-executors.md) - `Effect`, `Ref`/`RefResolver`, `CollectingExecutor`/`DjangoExecutor`, `dispatch_external`, verification.
+* [Projections & fan-out](projections-and-fan-out.md) - `reconcile_children`/`_by_key`/`_tree`/`_aggregate`, `project_latest`.
+* [Event envelope & provenance](event-envelope-and-provenance.md) - envelope fields, `provenance()`, history read-model.
+* [Django integration](django-integration.md) - `@stream_model`, `create_stream_event`, durable store, SSE.

--- a/okf/concepts/projections-and-fan-out.md
+++ b/okf/concepts/projections-and-fan-out.md
@@ -1,0 +1,52 @@
+---
+type: Concept
+title: Projections & fan-out
+description: Helpers that turn a record into idempotent, orphan-free child/aggregate rows.
+tags: [concept, projections]
+status: stable
+generated: { by: claude-code/opus-4-8, at: 2026-07-28T00:00:00Z }
+---
+
+# Definition
+
+The common projection shape is "one source record fans out into N rows" (a
+repeater, line items, answers). Replaying that with plain `update_or_create`
+leaks orphans when a later version has fewer children. These helpers emit
+idempotent upserts plus a single reconcile pass scoped to spare exactly the rows
+still present — so a rebuild converges with no stale rows and no double counting.
+
+# Public API
+
+Imported from `rakaia`:
+
+* `reconcile_children(model_label, parent_lookup, child_key, items, defaults_fn)`
+  — positional (index-keyed) fan-out.
+* `reconcile_by_key(model_label, scope, key_fields, items, key_fn, defaults_fn, *,
+  retire_filter=…, retire="delete"|patch, transition_kind=…)` — composite
+  natural key, with soft-delete (`retire=` patch) and per-flip notifications.
+* `reconcile_tree(model_label, scope_lookup, node_key, nodes, id_fn, defaults_fn)`
+  — unbounded nested tree, orphan-safe at any depth.
+* `reconcile_aggregate(model_label, scope_lookup, group_key, groups, *, owns=…,
+  retire_filter=…, allow_full_clear=…)` — one recomputed aggregate row per group;
+  `owns=` composes a **shared** row across several reducers (per-group `update`,
+  vanished group null-cleared on this owner's columns only).
+* `project_latest(messages, model_label, *, subject_of, defaults_of, …)` — each
+  subject's latest snapshot folded into one row (with tombstone deletes).
+
+# Demonstrated by
+
+* [multi_owner](../examples/multi-owner.md) — `reconcile_aggregate(owns=)`, `reconcile_by_key(retire=)`.
+* [formkit_submissions](../examples/formkit-submissions.md) — `reconcile_children`.
+* [formkit_submissions (stream)](../examples/formkit-submission-stream.md) — `project_latest`.
+* [partisipa_repeaters](../examples/partisipa-repeaters.md) — whole-subtree reconcile (hand-rolled tree case).
+* [partisipa_close](../examples/partisipa-close.md) — `reconcile_children` in a reducer.
+
+# Known gaps
+
+* `reconcile_tree` (the shipped primitive) is not used directly — the repeaters
+  spike hand-rolls the equivalent with `delete` + `exclude`.
+
+# Deeper reference
+
+* Human docs: `docs/projections-and-fan-out.md`, `docs/tree-reconcile.md`, `docs/alerts-projection.md`.
+* Source: `src/rakaia/projections.py`.

--- a/okf/concepts/protocol-and-streams.md
+++ b/okf/concepts/protocol-and-streams.md
@@ -1,0 +1,44 @@
+---
+type: Concept
+title: Protocol layer & streams
+description: The zero-dependency Durable Streams server underneath rakaia's event-sourcing layer.
+tags: [concept, protocol, standalone]
+status: stable
+generated: { by: claude-code/opus-4-8, at: 2026-07-28T00:00:00Z }
+---
+
+# Definition
+
+The lower of rakaia's two layers: an append-only, ordered, offset-addressed byte
+log (`StreamStore`) implementing the [Durable Streams protocol]. It has no Django
+and no third-party dependencies. Everything in the [event-sourcing layer]
+(../concepts/versioned-handlers-and-replay.md) is built on top of it.
+
+# Public API
+
+Imported from `rakaia`:
+
+* `StreamStore` — `create` / `append` / `read` / `close_stream` / `delete` /
+  `get_current_offset`. `read(path, offset)` returns messages after an offset, so
+  a reader can resume.
+* `AppendOptions(producer_id, producer_epoch, producer_seq, close, label,
+  metadata, event_ts)` and `AppendResult(message, producer_result,
+  stream_closed)`.
+* Producer fencing result types: `ProducerAccepted`, `ProducerDuplicate`,
+  `ProducerStaleEpoch`, `ProducerInvalidEpochSeq`, `ProducerSequenceGap`,
+  `ProducerStreamClosed` (idempotent retries, gap detection, zombie fencing).
+* `close_stream` -> `CloseResult(final_offset, already_closed)`; `ClosedBy`.
+* `append_if_changed` / `snapshots_equal` — write-side no-op suppression.
+* Subscriber cursors: `poll(store, path, cursor)` -> `Poll(messages, cursor,
+  status)`; `PollStatus` is one of `fresh` / `advanced` / `caught_up` / `rewound`
+  / `absent`.
+* CDN cursors: `calculate_cursor`, `generate_response_cursor`, `CursorOptions`.
+
+# Demonstrated by
+
+* [protocol_streams](../examples/protocol-streams.md) — every item above, asserted in one script.
+
+# Deeper reference
+
+* Human docs: `docs/protocol.md`, `docs/producer-fencing.md`, `docs/subscriber-cursors.md`.
+* Source: `src/rakaia/store.py`, `src/rakaia/subscription.py`, `src/rakaia/append.py`, `src/rakaia/cursor.py`, `src/rakaia/types.py`.

--- a/okf/concepts/versioned-handlers-and-replay.md
+++ b/okf/concepts/versioned-handlers-and-replay.md
@@ -1,0 +1,56 @@
+---
+type: Concept
+title: Versioned handlers & replay
+description: Pure event→Effect handlers registered against sequence ranges, replayed for time-correct projections.
+tags: [concept, event-sourcing, replay]
+status: stable
+generated: { by: claude-code/opus-4-8, at: 2026-07-28T00:00:00Z }
+---
+
+# Definition
+
+Projections are *derived* from the event log by pure functions (handlers) that
+map an event to an [Effect](../concepts/effects-and-executors.md). Handlers are
+registered against a **sequence range**, so an old event runs through the handler
+version that was correct *when it happened* — fixing a rule forward never
+rewrites the past. `replay` folds a stream through the registered handlers and
+applies the effects; multi-stage replay lets a later stage read what earlier
+stages materialised, resolving cross-entity references regardless of arrival order.
+
+# Public API
+
+Imported from `rakaia`:
+
+* `register_handler(name, event_match, effective_from, effective_to, stage=…,
+  match_field=…)` — versioned, optionally staged, optionally content-routed.
+* `register_simple(name, event_match)` — an always-on, single-version handler.
+* `register_reducer(name, stage)` — a per-stage reduce step run once after the
+  stage's per-event handlers (`fn(reader)` or `fn(reader, touched)`).
+* `register_upcaster` / `upcast` — normalise old event shapes before handlers run.
+* `replay(store, stream_path, executor, *, reader=…, on_drift=…, start_seq, end_seq)`.
+* `merge_replay(store, stream_paths, executor, *, order_key=…)` — replay N streams
+  in one deterministic total order (`order_key=ENVELOPE_TS` for envelope time).
+* Registries and drift errors: `HandlerRegistry`, `UpcasterRegistry`,
+  `HandlerVersion`, `ReducerVersion`, `HandlerOverlapError`, `HandlerGapError`,
+  `HandlerDriftError`, `UpcasterConflictError`, `UpcasterChainError`.
+* Results: `ReplayResult`, `TouchedSubject`, `ENVELOPE_TS`.
+
+# Demonstrated by
+
+* [orders](../examples/orders.md) — `effective_from`/`effective_to`, upcasters, drift.
+* [projection_cookbook](../examples/projection-cookbook.md) — staged replay, `register_simple`, `match_field`, reader.
+* [partisipa_staged](../examples/partisipa-staged.md) — staged replay for late-arriving links.
+* [partisipa_close](../examples/partisipa-close.md) — staged replay with per-stage reducers.
+* [partisipa_merge](../examples/partisipa-merge.md) — `merge_replay`.
+* [formkit_submissions](../examples/formkit-submissions.md) — versioned handlers + upcasters.
+
+# Known gaps
+
+* `register_reducer` as the public API is not directly used by an example (the
+  partisipa demos wire reducers via raw `{"reduce": […]}` stage config).
+* `replay_stream` (the Django convenience wrapper) has no example.
+
+# Deeper reference
+
+* Human docs: `docs/versioned-handlers.md`, `docs/staged-replay.md`, `docs/multi-stream-merge.md`.
+* Source: `src/rakaia/registry.py`, `src/rakaia/replay.py`.

--- a/okf/examples/chat.md
+++ b/okf/examples/chat.md
@@ -1,0 +1,28 @@
+---
+type: Example
+title: "chat — @stream_model, multi-stream events, live SSE"
+description: "A live chat app: each message save emits events to two streams (room + user activity) and fans out to browsers over Server-Sent Events."
+resource: https://github.com/joshbrooks/rakaia/tree/main/examples/chat
+tags: [example, django, live-sse]
+status: stable
+generated: { by: claude-code/opus-4-8, at: 2026-07-28T00:00:00Z }
+verified:
+  - { by: process:manage.py-check, at: 2026-07-28T00:00:00Z }
+---
+
+# What it proves
+
+A live chat app: each message save emits events to two streams (room + user
+activity) and fans out to browsers over Server-Sent Events. Demonstrates the
+`@stream_model` decorator, multi-stream events per save, and Channels-backed
+SSE.
+
+# Run
+
+```sh
+just dev
+```
+
+# Concepts demonstrated
+
+* [Django integration](../concepts/django-integration.md)

--- a/okf/examples/formkit-submission-stream.md
+++ b/okf/examples/formkit-submission-stream.md
@@ -1,0 +1,31 @@
+---
+type: Example
+title: "formkit_submissions (stream) — append log as source of truth"
+description: "The arrow-flip (Decision #13): a `SubmissionEvent` append log is the source of truth and `Submission` is a `project_latest` projection rebuilt from it, durable across processes."
+resource: https://github.com/joshbrooks/rakaia/tree/main/examples/formkit_submissions/submission_stream
+tags: [example, django, projections, event-sourcing]
+status: stable
+generated: { by: claude-code/opus-4-8, at: 2026-07-28T00:00:00Z }
+verified:
+  - { by: process:just-formkit-stream-demo, at: 2026-07-28T00:00:00Z }
+---
+
+# What it proves
+
+The arrow-flip (Decision #13): a `SubmissionEvent` append log is the source of
+truth and `Submission` is a `project_latest` projection rebuilt from it,
+durable across processes. Demonstrates `project_latest`, the durable
+`DjangoStreamStore`, the history read-model (`history_effects`), a self-
+healing reprojection, and tombstone deletes.
+
+# Run
+
+```sh
+just formkit-stream-demo
+```
+
+# Concepts demonstrated
+
+* [Projections & fan-out](../concepts/projections-and-fan-out.md)
+* [Event envelope & provenance](../concepts/event-envelope-and-provenance.md)
+* [Django integration](../concepts/django-integration.md)

--- a/okf/examples/formkit-submissions.md
+++ b/okf/examples/formkit-submissions.md
@@ -1,0 +1,30 @@
+---
+type: Example
+title: "formkit_submissions — projections, fan-out & migration parity"
+description: "An adoption spike for formkit-ninja: replaying a submission stream reproduces the same rows a direct `to_model()` writes (migration parity), while adding time-correctness."
+resource: https://github.com/joshbrooks/rakaia/tree/main/examples/formkit_submissions
+tags: [example, django, projections]
+status: stable
+generated: { by: claude-code/opus-4-8, at: 2026-07-28T00:00:00Z }
+verified:
+  - { by: process:just-formkit-demo, at: 2026-07-28T00:00:00Z }
+---
+
+# What it proves
+
+An adoption spike for formkit-ninja: replaying a submission stream reproduces
+the same rows a direct `to_model()` writes (migration parity), while adding
+time-correctness. Demonstrates `reconcile_children` fan-out, versioned
+handlers, upcasters, and the event envelope (`AppendOptions`, `provenance()`).
+
+# Run
+
+```sh
+just formkit-demo
+```
+
+# Concepts demonstrated
+
+* [Projections & fan-out](../concepts/projections-and-fan-out.md)
+* [Versioned handlers & replay](../concepts/versioned-handlers-and-replay.md)
+* [Event envelope & provenance](../concepts/event-envelope-and-provenance.md)

--- a/okf/examples/index.md
+++ b/okf/examples/index.md
@@ -1,0 +1,27 @@
+# Examples
+
+Runnable demos in `examples/`. Each is assertion-backed: it prints what it proves
+and fails loudly on a regression. Standalone demos need no database; Django demos
+migrate themselves.
+
+## Standalone (no Django)
+
+* [protocol_streams](protocol-streams.md) - `StreamStore`, producer fencing, close, `poll` cursors.
+* [multi_owner](multi-owner.md) - `Ref`/`RefResolver`, `reconcile_aggregate(owns=)`, `reconcile_by_key`.
+
+## Headless event-sourcing (Django)
+
+* [orders](orders.md) - versioned handlers, `effective_from/to`, upcasters, dry-run.
+* [formkit_submissions](formkit-submissions.md) - `reconcile_children`, migration parity.
+* [formkit_submissions (stream)](formkit-submission-stream.md) - `project_latest`, append log as source of truth.
+* [projection_cookbook](projection-cookbook.md) - staged replay, reader, verification.
+* [partisipa_history](partisipa-history.md) - pghistory-parity audit + recovery.
+* [partisipa_staged](partisipa-staged.md) - staged replay for late-arriving links.
+* [partisipa_close](partisipa-close.md) - close-precondition state machine.
+* [partisipa_merge](partisipa-merge.md) - `merge_replay` deterministic order.
+* [partisipa_repeaters](partisipa-repeaters.md) - nested-repeater tree reconcile.
+
+## Live SSE (Django, browser)
+
+* [chat](chat.md) - `@stream_model`, multi-stream events, live SSE.
+* [polyglot](polyglot.md) - language-scoped streams, live-editable translations.

--- a/okf/examples/multi-owner.md
+++ b/okf/examples/multi-owner.md
@@ -1,0 +1,34 @@
+---
+type: Example
+title: "multi_owner — one row, many writers (no Django)"
+description: "A zero-dependency script that drives rakaia's newest effect/projection primitives end-to-end through a ~90-line in-memory executor standing in for `DjangoExecutor`."
+resource: https://github.com/joshbrooks/rakaia/tree/main/examples/multi_owner
+tags: [example, standalone, effects, projections]
+status: stable
+generated: { by: claude-code/opus-4-8, at: 2026-07-28T00:00:00Z }
+verified:
+  - { by: process:just-multi-owner-demo, at: 2026-07-28T00:00:00Z }
+---
+
+# What it proves
+
+A zero-dependency script that drives rakaia's newest effect/projection
+primitives end-to-end through a ~90-line in-memory executor standing in for
+`DjangoExecutor`. It proves: `Ref`/`RefResolver` binding an FK to a sibling
+effect's generated primary key (with `UnresolvedRefError` on a dangling ref);
+`reconcile_aggregate(owns=)` composing a shared row across two owners so a
+vanished group null-clears only its own columns; `reconcile_by_key(retire=)`
+soft-deleting stale rows on a composite natural key; `check_disjoint_defaults`
+catching a same-column collision; and `dispatch_external` routing
+`op="external"` effects.
+
+# Run
+
+```sh
+just multi-owner-demo
+```
+
+# Concepts demonstrated
+
+* [Effects & executors](../concepts/effects-and-executors.md)
+* [Projections & fan-out](../concepts/projections-and-fan-out.md)

--- a/okf/examples/orders.md
+++ b/okf/examples/orders.md
@@ -1,0 +1,32 @@
+---
+type: Example
+title: "orders — versioned handlers, upcasters & replay"
+description: "An e-commerce projection showing time-correctness: the sales-tax rule changed on a date, and orders placed before it must keep the old tax."
+resource: https://github.com/joshbrooks/rakaia/tree/main/examples/orders
+tags: [example, django, versioned-handlers]
+status: stable
+generated: { by: claude-code/opus-4-8, at: 2026-07-28T00:00:00Z }
+verified:
+  - { by: process:just-orders-demo, at: 2026-07-28T00:00:00Z }
+---
+
+# What it proves
+
+An e-commerce projection showing time-correctness: the sales-tax rule changed
+on a date, and orders placed before it must keep the old tax. Demonstrates
+`register_handler` with `effective_from`/`effective_to` ranges, an upcaster
+(`register_upcaster`) normalising an old field name, a `CollectingExecutor`
+dry-run, `op="external"` receipt effects skipped on replay, `op="update"`
+(update-if-exists) for a loyalty bonus, and drift detection via
+`on_drift="raise"`.
+
+# Run
+
+```sh
+just orders-demo
+```
+
+# Concepts demonstrated
+
+* [Versioned handlers & replay](../concepts/versioned-handlers-and-replay.md)
+* [Effects & executors](../concepts/effects-and-executors.md)

--- a/okf/examples/partisipa-close.md
+++ b/okf/examples/partisipa-close.md
@@ -1,0 +1,29 @@
+---
+type: Example
+title: "partisipa_close — close-precondition state machine"
+description: "Decides a POM_1 cycle-close purely from cross-form projected state: a guarded transition rejects a premature close, then self-heals once the preconditions are met."
+resource: https://github.com/joshbrooks/rakaia/tree/main/examples/partisipa_close
+tags: [example, django, spike, state-machine]
+status: stable
+generated: { by: claude-code/opus-4-8, at: 2026-07-28T00:00:00Z }
+verified:
+  - { by: process:just-partisipa-close-demo, at: 2026-07-28T00:00:00Z }
+---
+
+# What it proves
+
+Decides a POM_1 cycle-close purely from cross-form projected state: a guarded
+transition rejects a premature close, then self-heals once the preconditions
+are met. Demonstrates staged replay with per-stage reducers and
+`reconcile_children`.
+
+# Run
+
+```sh
+just partisipa-close-demo
+```
+
+# Concepts demonstrated
+
+* [Versioned handlers & replay](../concepts/versioned-handlers-and-replay.md)
+* [Projections & fan-out](../concepts/projections-and-fan-out.md)

--- a/okf/examples/partisipa-history.md
+++ b/okf/examples/partisipa-history.md
@@ -1,0 +1,27 @@
+---
+type: Example
+title: "partisipa_history — pghistory-retirement spike"
+description: "Reproduces django-pghistory's audit log and blank-save recovery from an enveloped stream: a deleted submission's row is gone but every history row is retained."
+resource: https://github.com/joshbrooks/rakaia/tree/main/examples/partisipa_history
+tags: [example, django, spike, history]
+status: stable
+generated: { by: claude-code/opus-4-8, at: 2026-07-28T00:00:00Z }
+verified:
+  - { by: process:just-partisipa-history-demo, at: 2026-07-28T00:00:00Z }
+---
+
+# What it proves
+
+Reproduces django-pghistory's audit log and blank-save recovery from an
+enveloped stream: a deleted submission's row is gone but every history row is
+retained. Demonstrates the history read-model and `recover_peak_snapshot`.
+
+# Run
+
+```sh
+just partisipa-history-demo
+```
+
+# Concepts demonstrated
+
+* [Event envelope & provenance](../concepts/event-envelope-and-provenance.md)

--- a/okf/examples/partisipa-merge.md
+++ b/okf/examples/partisipa-merge.md
@@ -1,0 +1,27 @@
+---
+type: Example
+title: "partisipa_merge — multi-stream deterministic merge"
+description: "Merges three form streams into one deterministic replay order and asserts parity plus stable tie-breaks."
+resource: https://github.com/joshbrooks/rakaia/tree/main/examples/partisipa_merge
+tags: [example, django, spike, merge]
+status: stable
+generated: { by: claude-code/opus-4-8, at: 2026-07-28T00:00:00Z }
+verified:
+  - { by: process:just-partisipa-merge-demo, at: 2026-07-28T00:00:00Z }
+---
+
+# What it proves
+
+Merges three form streams into one deterministic replay order and asserts
+parity plus stable tie-breaks. Demonstrates `merge_replay`, a cross-stream
+readiness rollup, and self-healing on re-merge.
+
+# Run
+
+```sh
+just partisipa-merge-demo
+```
+
+# Concepts demonstrated
+
+* [Versioned handlers & replay](../concepts/versioned-handlers-and-replay.md)

--- a/okf/examples/partisipa-repeaters.md
+++ b/okf/examples/partisipa-repeaters.md
@@ -1,0 +1,27 @@
+---
+type: Example
+title: "partisipa_repeaters — nested-repeater tree reconcile"
+description: "Resubmits a pruned repeater tree and asserts no deep orphans and no double-count."
+resource: https://github.com/joshbrooks/rakaia/tree/main/examples/partisipa_repeaters
+tags: [example, django, spike, tree]
+status: stable
+generated: { by: claude-code/opus-4-8, at: 2026-07-28T00:00:00Z }
+verified:
+  - { by: process:just-partisipa-tree-demo, at: 2026-07-28T00:00:00Z }
+---
+
+# What it proves
+
+Resubmits a pruned repeater tree and asserts no deep orphans and no double-
+count. Demonstrates a whole-subtree reconcile using `delete` + `exclude`
+scoped by node id (the tree generalisation of `reconcile_children`).
+
+# Run
+
+```sh
+just partisipa-tree-demo
+```
+
+# Concepts demonstrated
+
+* [Projections & fan-out](../concepts/projections-and-fan-out.md)

--- a/okf/examples/partisipa-staged.md
+++ b/okf/examples/partisipa-staged.md
@@ -1,0 +1,28 @@
+---
+type: Example
+title: "partisipa_staged — staged replay for late-arriving links"
+description: "A spike on a real Partisipa form pipeline: reproduces an unlinked cross-form reference bug, then resolves it with staged replay — stage 0 builds reference entities, stage 1 resolves links via the reader regardless of arrival order — and self-heals on re-replay."
+resource: https://github.com/joshbrooks/rakaia/tree/main/examples/partisipa_staged
+tags: [example, django, spike, staged-replay]
+status: stable
+generated: { by: claude-code/opus-4-8, at: 2026-07-28T00:00:00Z }
+verified:
+  - { by: process:just-partisipa-demo, at: 2026-07-28T00:00:00Z }
+---
+
+# What it proves
+
+A spike on a real Partisipa form pipeline: reproduces an unlinked cross-form
+reference bug, then resolves it with staged replay — stage 0 builds reference
+entities, stage 1 resolves links via the reader regardless of arrival order —
+and self-heals on re-replay.
+
+# Run
+
+```sh
+just partisipa-demo
+```
+
+# Concepts demonstrated
+
+* [Versioned handlers & replay](../concepts/versioned-handlers-and-replay.md)

--- a/okf/examples/polyglot.md
+++ b/okf/examples/polyglot.md
@@ -1,0 +1,27 @@
+---
+type: Example
+title: "polyglot — language-scoped streams, live-editable translations"
+description: "Live-editable translations delivered over language-scoped streams and SSE, multi-instance via channels-redis."
+resource: https://github.com/joshbrooks/rakaia/tree/main/examples/polyglot
+tags: [example, django, live-sse, translations]
+status: stable
+generated: { by: claude-code/opus-4-8, at: 2026-07-28T00:00:00Z }
+verified:
+  - { by: process:manage.py-check, at: 2026-07-28T00:00:00Z }
+---
+
+# What it proves
+
+Live-editable translations delivered over language-scoped streams and SSE,
+multi-instance via channels-redis. Demonstrates `create_stream_event`,
+language-scoped stream paths, and SSE fan-out.
+
+# Run
+
+```sh
+just polyglot-dev
+```
+
+# Concepts demonstrated
+
+* [Django integration](../concepts/django-integration.md)

--- a/okf/examples/projection-cookbook.md
+++ b/okf/examples/projection-cookbook.md
@@ -1,0 +1,30 @@
+---
+type: Example
+title: "projection_cookbook — staged replay + reader + verification"
+description: "A two-form staged projection: stage 0 builds Projects, stage 1 links Tasks that may have arrived before their Project, resolved via a `ProjectionReader`."
+resource: https://github.com/joshbrooks/rakaia/tree/main/examples/projection_cookbook
+tags: [example, django, staged-replay]
+status: stable
+generated: { by: claude-code/opus-4-8, at: 2026-07-28T00:00:00Z }
+verified:
+  - { by: process:just-cookbook-demo, at: 2026-07-28T00:00:00Z }
+---
+
+# What it proves
+
+A two-form staged projection: stage 0 builds Projects, stage 1 links Tasks
+that may have arrived before their Project, resolved via a `ProjectionReader`.
+Demonstrates staged `replay`, `register_simple` with `match_field` routing,
+`DjangoProjectionReader`, and `diff_effects_against_rows` verification that
+replay reproduces the rows.
+
+# Run
+
+```sh
+just cookbook-demo
+```
+
+# Concepts demonstrated
+
+* [Versioned handlers & replay](../concepts/versioned-handlers-and-replay.md)
+* [Effects & executors](../concepts/effects-and-executors.md)

--- a/okf/examples/protocol-streams.md
+++ b/okf/examples/protocol-streams.md
@@ -1,0 +1,32 @@
+---
+type: Example
+title: "protocol_streams — the raw Durable Streams protocol (no Django)"
+description: "A zero-dependency script (imports only `rakaia` + the stdlib) that exercises the non-Django half of rakaia."
+resource: https://github.com/joshbrooks/rakaia/tree/main/examples/protocol_streams
+tags: [example, standalone, protocol]
+status: stable
+generated: { by: claude-code/opus-4-8, at: 2026-07-28T00:00:00Z }
+verified:
+  - { by: process:just-protocol-demo, at: 2026-07-28T00:00:00Z }
+---
+
+# What it proves
+
+A zero-dependency script (imports only `rakaia` + the stdlib) that exercises
+the non-Django half of rakaia. It asserts, in-process: an ordered offset-
+addressed log (`StreamStore` append/read with resumable offset reads); no-op
+suppression (`append_if_changed` / `snapshots_equal`); producer fencing
+(accepted / duplicate / sequence-gap / stale-epoch / invalid-epoch across an
+epoch change); stream `close_stream` sealing; subscriber cursors (`poll` ->
+fresh / caught_up / advanced / rewound); and CDN interval cursors
+(`calculate_cursor` / `generate_response_cursor`).
+
+# Run
+
+```sh
+just protocol-demo
+```
+
+# Concepts demonstrated
+
+* [Protocol layer & streams](../concepts/protocol-and-streams.md)

--- a/okf/index.md
+++ b/okf/index.md
@@ -1,0 +1,38 @@
+---
+okf_version: "0.2"
+---
+
+# Rakaia knowledge bundle
+
+An [Open Knowledge Format](https://github.com/GoogleCloudPlatform/knowledge-catalog)
+bundle describing **rakaia** — a Python implementation of the Durable Streams
+protocol plus a Django event-sourcing layer — for machine consumption by agents
+and tools.
+
+It catalogs two things:
+
+* **Concepts** — rakaia's public API surface, grouped into six areas, each with
+  the APIs it covers and the examples that demonstrate it.
+* **Examples** — every runnable demo in `examples/`, what it proves, the one
+  command that runs it, and which concepts it exercises. Demos verified green are
+  marked with a `verified` entry.
+
+The human-facing equivalent is the docs site page `docs/examples.md` ("Examples &
+concept coverage"); this bundle is its structured, cross-linked counterpart.
+
+## Concepts
+
+* [Protocol layer & streams](concepts/protocol-and-streams.md) - the zero-dependency Durable Streams server.
+* [Versioned handlers & replay](concepts/versioned-handlers-and-replay.md) - pure event→Effect handlers, replayed time-correctly.
+* [Effects & executors](concepts/effects-and-executors.md) - effect data, executors, dry-run, symbolic refs.
+* [Projections & fan-out](concepts/projections-and-fan-out.md) - orphan-free child/aggregate reconcile helpers.
+* [Event envelope & provenance](concepts/event-envelope-and-provenance.md) - the event envelope and history read-model.
+* [Django integration](concepts/django-integration.md) - stream events from models, live SSE.
+
+## Examples
+
+See the [examples index](examples/index.md) for the full list, or start with:
+
+* [protocol_streams](examples/protocol-streams.md) - the protocol layer, no Django.
+* [multi_owner](examples/multi-owner.md) - the newest effect/projection primitives, no Django.
+* [orders](examples/orders.md) - versioned handlers, upcasters, replay, dry-run.

--- a/okf/log.md
+++ b/okf/log.md
@@ -1,0 +1,7 @@
+# Directory Update Log
+
+## 2026-07-28
+
+* **Creation**: Rakaia knowledge bundle ([index](index.md)) — initial OKF catalog of rakaia's concepts and examples.
+* **Creation**: [Protocol layer & streams](concepts/protocol-and-streams.md), [Versioned handlers & replay](concepts/versioned-handlers-and-replay.md), [Effects & executors](concepts/effects-and-executors.md), [Projections & fan-out](concepts/projections-and-fan-out.md), [Event envelope & provenance](concepts/event-envelope-and-provenance.md), [Django integration](concepts/django-integration.md) — the six concept groups.
+* **Creation**: 13 example concepts under [examples/](examples/index.md), each cross-linked to the concepts it demonstrates; demos run green are marked `verified`.

--- a/zensical.toml
+++ b/zensical.toml
@@ -19,6 +19,7 @@ Copyright &copy; 2026 Josh Brooks
 nav = [
     { "Overview" = "index.md" },
     { "What's new" = "whats-new.md" },
+    { "Examples & concept coverage" = "examples.md" },
     { "Glossary" = "glossary.md" },
     { "Framework vs. protocol server" = "framework-vs-protocol-server.md" },
     { "Django integration" = "django-integration.md" },


### PR DESCRIPTION
## Summary

Evaluated the `examples/` demos after the recent codebase churn, repaired what broke off the happy path, added runnable coverage for the parts of rakaia no demo exercised, and documented the example surface for both humans and agents.

## 1. Demo repairs (papercuts)

- **Run-directly works now.** Each `demo_*` management command migrates itself (idempotent), so `manage.py demo_orders` works standalone, not only via the migrate-first `just` recipe.
- **`chat`/`polyglot` dev no longer hard-require the `prod` extra.** Their dev settings inserted `whitenoise` (a `prod`-only dep) unconditionally, breaking `just dev` on a dev-only sync. It's now inserted only when importable; `runserver` serves static in dev anyway.
- **Un-orphaned `submission_stream`** — wired into `just formkit-stream-demo` and the docs tour.

## 2. New coverage — two zero-dependency examples

- **`examples/protocol_streams/`** (`just protocol-demo`) — the non-Django half of rakaia, previously with no runnable proof: `StreamStore` append/read, `append_if_changed`, producer fencing, `close`, `poll` subscriber cursors, CDN cursors.
- **`examples/multi_owner/`** (`just multi-owner-demo`) — the newest effect/projection primitives, applied end-to-end through a small in-memory executor: `Ref`/`RefResolver`, `reconcile_aggregate(owns=)`, `reconcile_by_key(retire=)`, `check_disjoint_defaults`, `dispatch_external`.

## 3. Docs — human + machine

- **`docs/examples.md`** — "Examples & concept coverage": two-layer mental model, example tables, concept→example matrix, known gaps, contributor orientation. In the site nav.
- **`okf/`** — an Open Knowledge Format 0.2 bundle (6 concept docs + 13 example docs + indexes + log), the machine-readable counterpart for agents/tools. Conformance-validated; kept at repo root so it stays out of the Zensical build.

## Verification

- **11/11 headless demos pass** via `just` (9 existing + 2 new); `chat`/`polyglot` boot and serve HTTP 200.
- New example files pass `ruff check`/`ruff format`; `zensical build` passes (docs CI gate); OKF bundle passes a conformance + link check.
- `src/` and `tests/` are untouched, so the `ruff`/`pytest` CI gates are unaffected.

## Still uncovered (follow-up candidates, noted in docs)

`register_reducer` as a public API, `reconcile_tree` (shipped primitive), `replay_stream`, and `DjangoExecutor(skip_unchanged=True)`.