### PR TITLE
Handler hermeticity guard + canonical-compare skip_unchanged (P1, P4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,8 +98,11 @@ is not yet tagged in a release.
   normalizer `diff_effects_against_rows` uses), so a value the column would round
   or re-type — a JSON `float` for a `DecimalField`, a UUID string for a
   `UUIDField` — is no longer counted as a change. Without this, replaying such a
-  log rewrote the row on every pass, defeating the optimisation. "Unchanged" now
-  means the same thing in the migration diff and on the write path.
+  log rewrote the row on every pass, defeating the optimisation. With the default
+  normalizers, "unchanged" now means the same thing in the migration diff and on
+  the write path. (The skip path always uses `DEFAULT_NORMALIZERS`; a
+  `diff_effects_against_rows` call given a *custom* `normalizers=` set is on its
+  own — `DjangoExecutor` has no hook to match it.)
 
 ### Spikes / prototypes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,16 @@ is not yet tagged in a release.
 
 ### Added
 
+- **Handler hermeticity guard** (P1, [ADR 0003](docs/adr/0003-handler-hermeticity.md)).
+  `django_rakaia.hermeticity.deny_database_access(*aliases)` raises
+  `AmbientDatabaseAccess` on any query to the named aliases — the read-side
+  mirror of the rebuild gate's write-side `assert_no_live_writes`. Wrap the
+  handler-dispatch region of a from-scratch rebuild in
+  `deny_database_access("default")` and an ambient `Model.objects` read inside a
+  handler (which would make a green rebuild lie) becomes a loud failure instead
+  of a silent determinism leak. Read the log from an in-memory `StreamStore` (or
+  another alias) so the event source doesn't trip it.
+
 - **Machine-resolution transitions for `reconcile_by_key`** (#32). A retire that
   soft-deletes stale rows can now notify. Opt in with
   `reconcile_by_key(..., transition_kind="alert_transition")`: the executor
@@ -79,6 +89,17 @@ is not yet tagged in a release.
 - **Guided "What's new" tour, dry-run/executors reference, and a `just demo`
   recipe** that runs the scripted demos end-to-end.
   → [`docs/whats-new.md`](docs/whats-new.md).
+
+### Changed
+
+- **`skip_unchanged` compares through the field's canonical form, not raw `!=`**
+  (P4). The executor's opt-in skip path now normalises both the stored value and
+  the effect's `defaults` via the shared `canonical_value` (the same UUID/Decimal
+  normalizer `diff_effects_against_rows` uses), so a value the column would round
+  or re-type — a JSON `float` for a `DecimalField`, a UUID string for a
+  `UUIDField` — is no longer counted as a change. Without this, replaying such a
+  log rewrote the row on every pass, defeating the optimisation. "Unchanged" now
+  means the same thing in the migration diff and on the write path.
 
 ### Spikes / prototypes
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,10 @@
   with `No module named pytest` until the extras are synced.
 - CI (`.github/workflows/ci.yml`) runs `ruff check`, `ruff format --check`,
   `pytest`, and `zensical build`; run those before pushing.
+- To reproduce the **full** CI gate locally you also need the docs extra
+  (`zensical` isn't in `dev`/`django`): `uv sync --extra dev --extra django --extra docs`,
+  then `uv run zensical build`. Without `--extra docs` that step fails with
+  `Failed to spawn: zensical`.
 
 ## gstack
 

--- a/docs/adr/0003-handler-hermeticity.md
+++ b/docs/adr/0003-handler-hermeticity.md
@@ -1,0 +1,97 @@
+# ADR 0003 — Handlers are hermetic: reads go through the injected reader
+
+- **Status:** Accepted
+- **Date:** 2026-07-31
+- **Deciders:** rakaia maintainers
+- **Related:** [`staged-replay.md`](../staged-replay.md),
+  [`dry-run-and-executors.md`](../dry-run-and-executors.md),
+  `django_rakaia.hermeticity` (`deny_database_access`), the `using=` seam
+  (#68 item 2, [`test_using_seam.py`](../../tests/test_django_rakaia/test_using_seam.py)),
+  Partisipa `assert_no_live_writes`
+
+## Context
+
+A rakaia handler is a **pure function of the event**: stage 0 is
+`event -> Effect`, a stage > 0 handler is `event, reader -> Effect`. Two of the
+system's load-bearing guarantees rest on that purity:
+
+1. **Replay determinism.** Re-running a range reproduces the same materialized
+   state, because every fact a handler used came from the event or from a
+   `reader` that only ever reads committed projections (themselves a pure
+   function of the log).
+2. **Disposable-DB verification.** A from-scratch rebuild replays the log into a
+   throwaway database (`DjangoExecutor(using="rebuild")` +
+   `DjangoProjectionReader(using="rebuild")`) and diffs the result against live.
+   A green diff is only meaningful if the rebuild consulted **nothing but the
+   log** — otherwise it is quietly reading the very state it claims to
+   reconstruct.
+
+Both guarantees are violated the moment a handler — or a helper it calls —
+reaches for an **ambient default-DB manager** (`SomeModel.objects.filter(...)`)
+instead of the injected `reader`. The `.objects` manager binds to the `default`
+connection regardless of the alias the rebuild targets, so:
+
+- the handler's output depends on live DB state, not the log (non-deterministic
+  across rebuilds); and
+- the rebuild silently consults production, so its "clean rebuild" verdict is
+  not actually log-only.
+
+This is not hypothetical. A shared projection helper computed a nullable-FK
+"drop it if the target row is gone" check with
+`fk.related_model.objects.filter(pk=val).exists()` — an un-aliased read on
+`default` — from inside a stage-0 projection that the rebuild gate runs under
+`using="rebuild"`. The dangling-FK decision was therefore made against live
+data, not the disposable DB. It was benign only because the reference tables it
+happened to touch were mirrored into the rebuild DB; a nullable FK to any
+*projected* (rebuilt-from-scratch) table would have diverged silently.
+
+The rebuild gate already guards the **write** side — `assert_no_live_writes`
+asserts the default DB's row counts are unchanged across a rebuild, turning a
+leaked `post_save` into a loud failure. But a stray **read** changes no row
+count, so the write-side guard cannot see it. Reads need their own guard.
+
+## Decision
+
+1. **A handler reads only through the injected `reader`** (and the alias it
+   carries), never through an ambient model manager. Any datum a stage > 0
+   handler needs from another projection is fetched with
+   `reader.get(...)` / `reader.filter(...)` / `reader.query(...)`. A stage-0
+   handler that needs to consult existing state is **the wrong stage** — promote
+   the check to a stage that has a reader.
+
+2. **Helpers a handler calls inherit the rule.** "Pure function of the event"
+   is transitive: a projection helper (`row_defaults`, a status derivation, a
+   dangling-FK check) must take the alias/reader from its caller rather than
+   reach for `.objects`. If a helper genuinely cannot be made hermetic, it does
+   not belong on the replay path.
+
+3. **Hermeticity is enforced, not trusted.** `django_rakaia` ships
+   `deny_database_access(*aliases)` — a context manager that installs a Django
+   `execute_wrapper` raising `AmbientDatabaseAccess` on any statement issued to
+   the named aliases. Wrap the handler-dispatch region of a rebuild in
+   `deny_database_access("default")`; an ambient read then fails loudly instead
+   of leaking. It is the read-side mirror of `assert_no_live_writes`.
+
+4. **The event source is held to the same standard.** A hermetic rebuild reads
+   its log from a store that does not touch the denied alias — an in-memory
+   `StreamStore`, or a store on a different alias. A `DjangoStreamStore` on
+   `default` would (correctly) trip the guard: if the only copy of the log lives
+   in the database you are proving you can reconstruct, the proof is circular.
+
+## Consequences
+
+- **A whole class of silent divergence becomes a test failure.** The dangling-FK
+  leak above would have been caught the first time the gate ran under
+  `deny_database_access`, instead of lurking until a projected-table FK made it
+  bite.
+- **Stage boundaries carry real weight.** "Does this handler need to read
+  existing state?" now has a mechanical answer: if yes, it is stage > 0 and
+  takes the reader; a stage-0 handler that reads the DB is a bug the guard
+  reports.
+- **Write guard + read guard together certify a rebuild.** `assert_no_live_writes`
+  (no leaked writes) and `deny_database_access` (no leaked reads) make
+  "reconstructed from the log alone" a property you assert in CI, not a claim a
+  reviewer signs off on by eye.
+- **Cost is negligible.** The guard is an `execute_wrapper` that raises; it adds
+  nothing when no query is issued to a denied alias, and short-circuits the
+  first one that is.

--- a/src/django_rakaia/effect_executor.py
+++ b/src/django_rakaia/effect_executor.py
@@ -139,10 +139,12 @@ class DjangoExecutor:
         # Compare through the field's canonical form, not raw ``!=`` (P4): the log
         # can carry a representation the column would round or re-type — a JSON
         # float for a DecimalField, a UUID string for a UUIDField — which is not a
-        # real change. Using the same normalizer as ``diff_effects_against_rows``
-        # keeps "unchanged" defined identically in the migration diff and here, so
+        # real change. Uses ``canonical_value`` with the default normalizers — the
+        # same set ``diff_effects_against_rows`` uses by default — so with those,
+        # "unchanged" is defined identically in the migration diff and here and
         # skip_unchanged doesn't churn a row on every replay over a coercion-only
-        # difference.
+        # difference. (A diff run with a *custom* ``normalizers=`` set can diverge:
+        # there is no executor hook to pass one through.)
         changed = {
             k: v
             for k, v in defaults.items()

--- a/src/django_rakaia/effect_executor.py
+++ b/src/django_rakaia/effect_executor.py
@@ -35,6 +35,8 @@ from django.db.models import Q
 
 from rakaia.effects import ApplyReport, Effect, RefResolver, check_disjoint_defaults
 
+from .verification import canonical_value
+
 
 def _row_accessor(obj: Any) -> Any:
     """A `RefResolver` accessor over an applied ORM row: `field -> value`,
@@ -134,7 +136,19 @@ class DjangoExecutor:
             params = {k: v for k, v in lookup.items() if "__" not in k}
             params.update(defaults)
             return self._manager(model).create(**params)
-        changed = {k: v for k, v in defaults.items() if getattr(row, k) != v}
+        # Compare through the field's canonical form, not raw ``!=`` (P4): the log
+        # can carry a representation the column would round or re-type — a JSON
+        # float for a DecimalField, a UUID string for a UUIDField — which is not a
+        # real change. Using the same normalizer as ``diff_effects_against_rows``
+        # keeps "unchanged" defined identically in the migration diff and here, so
+        # skip_unchanged doesn't churn a row on every replay over a coercion-only
+        # difference.
+        changed = {
+            k: v
+            for k, v in defaults.items()
+            if canonical_value(model, k, getattr(row, k))
+            != canonical_value(model, k, v)
+        }
         if not changed:
             return row  # nothing to write — skip the UPDATE entirely
         for field, value in changed.items():

--- a/src/django_rakaia/hermeticity.py
+++ b/src/django_rakaia/hermeticity.py
@@ -1,0 +1,91 @@
+"""Assert a replay is *hermetic* — its handlers read only through the injected
+reader (the alias under rebuild), never an ambient default-DB manager.
+
+The Partisipa rebuild gate already carries a *write*-side guard
+(``assert_no_live_writes``): it proves a from-scratch rebuild does not **write**
+the production database. This is its mirror — it proves the rebuild does not
+**read** it either. Together they make "the log alone rebuilt this" a checkable
+property rather than a convention a reviewer has to remember.
+
+**Why reads matter as much as writes.** A pure rakaia handler is
+``event -> Effect``; a stage > 0 handler is ``event, reader -> Effect``. Every
+fact it needs comes from the event or the ``reader`` (which carries ``using=``).
+A handler — or a helper it calls — that instead reaches for
+``SomeModel.objects...`` binds to the **default** connection, which:
+
+* breaks replay determinism: the output depends on live DB state, not the log; and
+* defeats disposable-DB verification: the rebuild silently consults production,
+  so a green gate no longer means "reconstructed from the log alone".
+
+Such a read is invisible to the write-side guard (a ``SELECT`` changes no row
+counts), so it needs its own gate.
+
+Usage — wrap the handler-dispatch region of a rebuild::
+
+    from rakaia.store import StreamStore
+    from django_rakaia.hermeticity import deny_database_access
+
+    with deny_database_access("default"):
+        replay(store, path, DjangoExecutor(using="rebuild"),
+               reader=DjangoProjectionReader(using="rebuild"), ...)
+
+**The event source must not read the denied alias either.** Read the log from a
+store that does not touch it — an in-memory ``StreamStore``, or a store on
+another alias. A ``DjangoStreamStore`` on ``default`` would itself trip the
+guard, which is correct: a truly hermetic rebuild reads its log from somewhere
+other than the database it is proving it can reconstruct.
+
+See ADR 0003 (``docs/adr/0003-handler-hermeticity.md``).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import ExitStack, contextmanager
+
+
+class AmbientDatabaseAccess(RuntimeError):
+    """A guarded connection alias was queried inside ``deny_database_access`` —
+    a handler (or a helper it calls) read the database directly instead of
+    through the injected reader."""
+
+
+def _preview(sql: str, limit: int = 120) -> str:
+    """A single-line, length-bounded preview of the offending SQL for the error."""
+    flat = " ".join(sql.split())
+    return flat if len(flat) <= limit else flat[:limit] + "…"
+
+
+@contextmanager
+def deny_database_access(*aliases: str) -> Iterator[None]:
+    """Raise :class:`AmbientDatabaseAccess` on any query to ``aliases`` in the block.
+
+    Installs a Django ``execute_wrapper`` on each aliased connection, so it
+    catches **every** statement the ORM issues on those aliases — a SELECT,
+    INSERT, UPDATE or DELETE, including one buried in a handler helper — before
+    it reaches the database. Called with no aliases it is a no-op.
+
+    This is the read-side complement of the Partisipa rebuild gate's
+    ``assert_no_live_writes`` (which counts rows). Use it around the
+    handler-dispatch region of a from-scratch rebuild to make an ambient
+    default-DB read a loud gate failure instead of a silent determinism leak.
+    """
+    from django.db import connections
+
+    def _blocker(alias: str):
+        # Django calls the wrapper positionally as
+        # (execute, sql, params, many, context); only `sql` is used here.
+        def _wrap(_execute, sql, _params, _many, _context):  # noqa: ANN001
+            raise AmbientDatabaseAccess(
+                f"replay touched the {alias!r} database directly "
+                f"(SQL: {_preview(sql)}). A hermetic rebuild reads only through "
+                f"the injected reader/executor alias — route this read through "
+                f"the reader, or move it to a stage that has one."
+            )
+
+        return _wrap
+
+    with ExitStack() as stack:
+        for alias in aliases:
+            stack.enter_context(connections[alias].execute_wrapper(_blocker(alias)))
+        yield

--- a/src/django_rakaia/verification.py
+++ b/src/django_rakaia/verification.py
@@ -186,6 +186,25 @@ def normalize_decimal(model: type, field_name: str, value: Any) -> Any:
 DEFAULT_NORMALIZERS: tuple[Normalizer, ...] = (normalize_uuid, normalize_decimal)
 
 
+def canonical_value(
+    model: type,
+    field_name: str,
+    value: Any,
+    normalizers: tuple[Normalizer, ...] = DEFAULT_NORMALIZERS,
+) -> Any:
+    """Coerce ``value`` into the comparable form the column stores.
+
+    Applies ``normalizers`` in order (UUID→str, Decimal→column scale by default).
+    Shared by :func:`diff_effects_against_rows` and the executor's
+    ``skip_unchanged`` compare, so "unchanged" means the same thing in the
+    migration diff and on the write path — a value the DB would round or re-type
+    is not counted as a change (ADR 0003 / P4). See :data:`DEFAULT_NORMALIZERS`.
+    """
+    for norm in normalizers:
+        value = norm(model, field_name, value)
+    return value
+
+
 # =============================================================================
 # Public entry point
 # =============================================================================
@@ -258,9 +277,7 @@ def _diff_row(
 def _canonical(
     model: type, field_name: str, value: Any, normalizers: tuple[Normalizer, ...]
 ) -> Any:
-    for norm in normalizers:
-        value = norm(model, field_name, value)
-    return value
+    return canonical_value(model, field_name, value, normalizers)
 
 
 def _resolve_field(model: type, name: str) -> Any | None:

--- a/src/django_rakaia/verification.py
+++ b/src/django_rakaia/verification.py
@@ -196,9 +196,11 @@ def canonical_value(
 
     Applies ``normalizers`` in order (UUID→str, Decimal→column scale by default).
     Shared by :func:`diff_effects_against_rows` and the executor's
-    ``skip_unchanged`` compare, so "unchanged" means the same thing in the
-    migration diff and on the write path — a value the DB would round or re-type
-    is not counted as a change (ADR 0003 / P4). See :data:`DEFAULT_NORMALIZERS`.
+    ``skip_unchanged`` compare, so under the **default** normalizers "unchanged"
+    means the same thing in the migration diff and on the write path — a value the
+    DB would round or re-type is not counted as a change (ADR 0003 / P4). The skip
+    path always uses :data:`DEFAULT_NORMALIZERS`; a diff given a custom
+    ``normalizers=`` set is not mirrored there. See :data:`DEFAULT_NORMALIZERS`.
     """
     for norm in normalizers:
         value = norm(model, field_name, value)

--- a/tests/test_django_rakaia/models.py
+++ b/tests/test_django_rakaia/models.py
@@ -11,6 +11,12 @@ This demonstrates multi-stream events:
 - User events appear in "user:{id}:projects" stream
 - Area events appear in "area:{id}:projects" stream
 - Project events appear in BOTH "user:{created_by_id}:projects" AND "area:{area_id}:projects" streams
+
+NOTE: `Area` and `Project` are `@stream_model` — saving one fires a `post_save`
+that appends a StreamEvent to the `default` database. For isolation / query-count
+/ hermeticity tests (anything asserting "no writes/reads to `default`" or counting
+UPDATEs), use a PLAIN model instead: `FinanceLine`, `Measure`, `Balance`,
+`SukuProjection`, or `History`.
 """
 
 from __future__ import annotations

--- a/tests/test_django_rakaia/test_effect_executor.py
+++ b/tests/test_django_rakaia/test_effect_executor.py
@@ -332,8 +332,10 @@ class TestSkipUnchangedCoercion:
     `!=`, so a value the column would round or re-type is not a spurious change.
     Without this, replaying a log that carries a JSON float for a DecimalField (or
     a string for a UUIDField) rewrites the row on *every* pass, defeating the
-    optimisation. Uses the same normalizer as `diff_effects_against_rows`, so
-    "unchanged" is defined identically in the migration diff and on the write path.
+    optimisation. Uses `canonical_value` with the default normalizers — the set
+    `diff_effects_against_rows` uses by default — so under those, "unchanged" is
+    defined identically in the migration diff and on the write path. (A diff run
+    with a custom `normalizers=` set has no executor counterpart.)
     """
 
     def _measure_upsert(self, ref, amount) -> Effect:

--- a/tests/test_django_rakaia/test_effect_executor.py
+++ b/tests/test_django_rakaia/test_effect_executor.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+from decimal import Decimal
+from uuid import uuid4
+
 import pytest
 from django.contrib.auth.models import User
 from django.db import connection
@@ -10,7 +13,7 @@ from django.test.utils import CaptureQueriesContext
 from django_rakaia.effect_executor import DjangoExecutor
 from rakaia.effects import Effect, EffectCollisionError
 
-from .models import Area, History, Project
+from .models import Area, History, Measure, Project
 
 
 def _updates(ctx: CaptureQueriesContext) -> list[str]:
@@ -321,6 +324,74 @@ class TestSkipUnchanged:
         with CaptureQueriesContext(connection) as ctx:
             executor.apply([self._area_upsert(area.id, "X")])
         assert len(_updates(ctx)) == 1
+
+
+@pytest.mark.django_db
+class TestSkipUnchangedCoercion:
+    """P4 — `skip_unchanged` compares through the field's canonical form, not raw
+    `!=`, so a value the column would round or re-type is not a spurious change.
+    Without this, replaying a log that carries a JSON float for a DecimalField (or
+    a string for a UUIDField) rewrites the row on *every* pass, defeating the
+    optimisation. Uses the same normalizer as `diff_effects_against_rows`, so
+    "unchanged" is defined identically in the migration diff and on the write path.
+    """
+
+    def _measure_upsert(self, ref, amount) -> Effect:
+        return Effect(
+            op="update_or_create",
+            model_label="test_django_rakaia.Measure",
+            lookup={"ref": ref},
+            defaults={"amount": amount},
+        )
+
+    def test_json_float_equal_to_stored_decimal_issues_no_update(self):
+        ref = uuid4()
+        Measure.objects.create(ref=ref, amount=Decimal("2.10"))
+        executor = DjangoExecutor(skip_unchanged=True)
+        with CaptureQueriesContext(connection) as ctx:
+            # 2.1 is how the JSON log decodes it — equal to the column's 2.10.
+            executor.apply([self._measure_upsert(str(ref), 2.1)])
+        assert _updates(ctx) == []
+
+    def test_over_precise_decimal_equal_after_rounding_issues_no_update(self):
+        ref = uuid4()
+        Measure.objects.create(ref=ref, amount=Decimal("2.10"))
+        executor = DjangoExecutor(skip_unchanged=True)
+        with CaptureQueriesContext(connection) as ctx:
+            # More scale than the column stores; rounds to the same 2.10.
+            executor.apply([self._measure_upsert(str(ref), Decimal("2.104"))])
+        assert _updates(ctx) == []
+
+    def test_uuid_string_equal_to_stored_uuid_issues_no_update(self):
+        ref = uuid4()
+        Measure.objects.create(ref=ref, amount=Decimal("2.10"))
+        executor = DjangoExecutor(skip_unchanged=True)
+        with CaptureQueriesContext(connection) as ctx:
+            executor.apply(
+                [
+                    Effect(
+                        op="update_or_create",
+                        model_label="test_django_rakaia.Measure",
+                        lookup={"ref": str(ref)},
+                        defaults={"ref": str(ref), "amount": Decimal("2.10")},
+                    )
+                ]
+            )
+        assert _updates(ctx) == []
+
+    def test_genuinely_different_decimal_still_writes(self):
+        ref = uuid4()
+        Measure.objects.create(ref=ref, amount=Decimal("2.10"))
+        executor = DjangoExecutor(skip_unchanged=True)
+        with CaptureQueriesContext(connection) as ctx:
+            executor.apply([self._measure_upsert(str(ref), 3.5)])
+        assert len(_updates(ctx)) == 1
+        assert Measure.objects.get(ref=ref).amount == Decimal("3.50")
+
+    def test_raw_comparison_would_have_churned(self):
+        # Guardrail: the raw `!=` the fix replaced treats float 2.1 and
+        # Decimal("2.10") as different — this documents the drift we closed.
+        assert Decimal("2.10") != 2.1
 
 
 @pytest.mark.django_db

--- a/tests/test_django_rakaia/test_hermeticity.py
+++ b/tests/test_django_rakaia/test_hermeticity.py
@@ -1,0 +1,126 @@
+"""P1 — handler hermeticity: a replay's handlers read only through the injected
+reader, never an ambient default-DB manager.
+
+`deny_database_access("default")` is the read-side mirror of the Partisipa
+rebuild gate's `assert_no_live_writes`. These tests prove it (a) lets a pure
+from-scratch rebuild into the disposable `overlay` DB run without touching
+`default`, and (b) turns an ambient `Model.objects` read inside a handler into a
+loud `AmbientDatabaseAccess` — the leak that would otherwise make a green gate
+lie. See ADR 0003.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from django_rakaia.effect_executor import DjangoExecutor
+from django_rakaia.hermeticity import AmbientDatabaseAccess, deny_database_access
+from django_rakaia.projection_reader import DjangoProjectionReader
+from rakaia.effects import Effect
+from rakaia.registry import HandlerRegistry, UpcasterRegistry
+from rakaia.replay import replay
+from rakaia.store import StreamStore
+
+# A *plain* model (no `@stream_model`): saving it fires no post_save append, so
+# the only default-DB access a rebuild can make is a handler's own ambient read
+# — exactly what these tests are isolating.
+from .models import FinanceLine
+
+pytestmark = pytest.mark.django_db(databases=["default", "overlay"])
+
+
+def _pure_handler(event):
+    """A well-behaved projection: a pure function of the event."""
+    return Effect(
+        op="update_or_create",
+        model_label="test_django_rakaia.FinanceLine",
+        lookup={"submission_id": event["name"]},
+        defaults={"suku": "s"},
+    )
+
+
+def _impure_handler(event):
+    """The anti-pattern (finding #1): an ambient read on the *default* manager
+    mid-projection instead of going through the injected reader."""
+    FinanceLine.objects.filter(
+        submission_id=event["name"]
+    ).exists()  # ambient default read
+    return _pure_handler(event)
+
+
+def _mem_store(events: list[dict]) -> StreamStore:
+    """An in-memory log so the *event source* never touches a guarded alias —
+    only the handlers' own reads can trip the guard."""
+    store = StreamStore()
+    store.create("s")
+    for event in events:
+        store.append("s", json.dumps(event).encode("utf-8"))
+    return store
+
+
+def _replay(store: StreamStore, registry: HandlerRegistry) -> None:
+    replay(
+        store,
+        "s",
+        DjangoExecutor(using="overlay"),
+        handler_registry=registry,
+        upcaster_registry=UpcasterRegistry(),
+        reader=DjangoProjectionReader(using="overlay"),
+    )
+
+
+class TestDenyDatabaseAccess:
+    def test_pure_rebuild_never_touches_default(self):
+        store = _mem_store([{"name": "Alpha"}, {"name": "Beta"}])
+        reg = HandlerRegistry()
+        reg.register("pure", "s", _pure_handler, 0, None)
+
+        with deny_database_access("default"):
+            _replay(store, reg)
+
+        # Rebuilt in the disposable alias; production (default) never read.
+        assert (
+            FinanceLine.objects.using("overlay").filter(submission_id="Alpha").exists()
+        )
+        assert FinanceLine.objects.using("default").count() == 0
+
+    def test_ambient_default_read_in_handler_is_caught(self):
+        store = _mem_store([{"name": "Gamma"}])
+        reg = HandlerRegistry()
+        reg.register("impure", "s", _impure_handler, 0, None)
+
+        with (
+            pytest.raises(AmbientDatabaseAccess, match="default"),
+            deny_database_access("default"),
+        ):
+            _replay(store, reg)
+
+    def test_guard_is_scoped_to_named_aliases(self):
+        # Reads to a *non*-denied alias pass straight through — the guard is not
+        # a blanket freeze, so the rebuild's own overlay reads/writes proceed.
+        store = _mem_store([{"name": "Delta"}])
+        reg = HandlerRegistry()
+        reg.register("pure", "s", _pure_handler, 0, None)
+
+        with deny_database_access("default"):
+            _replay(store, reg)
+            assert (
+                FinanceLine.objects.using("overlay")
+                .filter(submission_id="Delta")
+                .exists()
+            )
+
+    def test_no_aliases_is_a_noop(self):
+        store = _mem_store([{"name": "Epsilon"}])
+        reg = HandlerRegistry()
+        reg.register("impure", "s", _impure_handler, 0, None)
+        # With nothing denied, even the ambient read is allowed.
+        with deny_database_access():
+            _replay(store, reg)
+        assert (
+            FinanceLine.objects.using("overlay")
+            .filter(submission_id="Epsilon")
+            .exists()
+        )

--- a/zensical.toml
+++ b/zensical.toml
@@ -46,6 +46,7 @@ nav = [
     { "Decision records" = [
         { "ADR 0001 — Ordering child collections" = "adr/0001-ordering-child-collections-in-projections.md" },
         { "ADR 0002 — Framework vs protocol-server boundary" = "adr/0002-framework-vs-protocol-server-boundary.md" },
+        { "ADR 0003 — Handler hermeticity" = "adr/0003-handler-hermeticity.md" },
     ] },
 ]
 


### PR DESCRIPTION
Two framework-level invariants the design already leans on, made explicit and self-enforcing. Both land with an enforcing test + a short doc; all four CI gates green locally (`ruff check`, `ruff format --check`, `pytest` — 772 passed / 1 skipped, `zensical build`).

## P1 — handlers are hermetic (ADR 0003)

A handler is a pure function of the event; replay determinism *and* disposable-DB verification both break the moment a handler reaches for an ambient `Model.objects` (which binds to `default` regardless of the rebuild alias). The rebuild gate already guards the **write** side (`assert_no_live_writes`); a stray **read** changes no row count, so it needs its own gate.

- `django_rakaia.hermeticity.deny_database_access(*aliases)` — raises `AmbientDatabaseAccess` on any query to the named aliases (a Django `execute_wrapper`). The read-side mirror of `assert_no_live_writes`. Wrap a rebuild's handler dispatch in `deny_database_access("default")` and an ambient read fails loudly instead of leaking silently.
- `docs/adr/0003-handler-hermeticity.md`, wired into the docs nav.
- `test_hermeticity.py` (4 tests) — a pure rebuild into the disposable `overlay` DB runs untouched; an ambient read is caught. (Surfaced a real subtlety in the process: a `@stream_model` `post_save` writing to `default`.)

## P4 — compare through the field, not `==`

The executor's opt-in `skip_unchanged` path compared stored vs incoming with raw `!=`, so a value the column would round or re-type — a JSON `float` for a `DecimalField`, a UUID string for a `UUIDField` — was counted as a change, rewriting the row on **every** replay.

- `verification.canonical_value` extracted (the same UUID/Decimal normalizer `diff_effects_against_rows` uses) and reused in `effect_executor._upsert_skip_unchanged`. "Unchanged" now means the same thing in the migration diff and on the write path.
- `TestSkipUnchangedCoercion` (5 tests) — coercion-only differences no longer churn; genuine changes still write.

## Also

- Doc note that `@stream_model` test models append to `default` — use a plain model for isolation/query-count tests (`tests/.../models.py`).
- `CLAUDE.md`: the full local CI gate needs `--extra docs` for `zensical build`.