### PR TITLE
PreloadedProjectionReader — bulk-fetch a diff verification sweep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,17 @@ is not yet tagged in a release.
 
 ### Added
 
+- **`PreloadedProjectionReader` — bulk-fetch a verification sweep.**
+  `diff_effects_against_rows` does one `reader.get` per effect (one round-trip
+  each), which is thousands of round-trips on a full reconcile. Pass the same
+  effect batch to `django_rakaia.verification.PreloadedProjectionReader(effects,
+  using=...)` and it fetches every lookup up front — one query per `(model,
+  lookup-shape)` group — then serves each `get` from an in-memory snapshot;
+  lookups outside the batch (or relation-spanning ones) fall back to a live,
+  memoised read. A point-in-time snapshot: for read-only verification, not live
+  staged replay. Upstreamed from the Partisipa migration's `PreloadReader`
+  workaround. → [`docs/projection-cookbook.md`](docs/projection-cookbook.md).
+
 - **Handler hermeticity guard** (P1, [ADR 0003](docs/adr/0003-handler-hermeticity.md)).
   `django_rakaia.hermeticity.deny_database_access(*aliases)` raises
   `AmbientDatabaseAccess` on any query to the named aliases — the read-side

--- a/docs/projection-cookbook.md
+++ b/docs/projection-cookbook.md
@@ -128,6 +128,31 @@ assert report.ok, report                         # or: report.raise_if_diff()
 mismatches that produce false diffs — a `UUID` column read back vs a string in
 the effect, and a JSON float vs the column's rounded `Decimal`.
 
+### Verifying a large sweep in bulk
+
+The diff does one `reader.get` per effect — one round-trip each. Fine for a
+cookbook; on a full reconcile (tens of thousands of effects) it is tens of
+thousands of round-trips. Give the *same* batch to a
+[`PreloadedProjectionReader`](../src/django_rakaia/verification.py) and it
+bulk-fetches every lookup up front, one query per `(model, lookup-shape)` group,
+then serves each `get` from an in-memory snapshot:
+
+```python
+from django_rakaia.verification import (
+    PreloadedProjectionReader,
+    diff_effects_against_rows,
+)
+
+effects = list(ex.effects)
+reader = PreloadedProjectionReader(effects, using="rebuild")   # one bulk fetch per shape
+diff_effects_against_rows(effects, reader=reader).raise_if_diff()
+```
+
+It is a **point-in-time snapshot** — build it for read-only verification, not for
+live staged replay (where rows change as the replay writes them; use a plain
+`DjangoProjectionReader` there). A `get` for a lookup outside the batch, or one
+that spans a relation (`field__gte`), falls back to a live query and memoises it.
+
 ## Run it
 
 ```sh

--- a/src/django_rakaia/verification.py
+++ b/src/django_rakaia/verification.py
@@ -33,7 +33,7 @@ from uuid import UUID
 
 from django.apps import apps
 from django.core.exceptions import FieldDoesNotExist
-from django.db.models import DecimalField
+from django.db.models import DecimalField, Q
 
 from rakaia.effects import Effect
 
@@ -251,6 +251,125 @@ def diff_effects_against_rows(
             RowDiff(eff.model_label, eff.lookup, missing=False, field_diffs=field_diffs)
         )
     return DiffReport(rows=rows)
+
+
+# =============================================================================
+# Batch-fetching reader (for large sweeps)
+# =============================================================================
+
+
+class PreloadedProjectionReader(DjangoProjectionReader):
+    """A :class:`DjangoProjectionReader` that bulk-fetches, up front, the rows a
+    batch of effects will look up — so each :meth:`get` serves from an in-memory
+    snapshot instead of issuing one ``SELECT`` per effect.
+
+    :func:`diff_effects_against_rows` does one ``reader.get`` per effect, which is
+    one round-trip per effect: fine for a handful, thousands on a full reconcile
+    sweep. Give the *same* batch to this reader and to the diff and that collapses
+    to **one query per (model, lookup-shape) group**::
+
+        effects = list(collecting_executor.effects)
+        reader = PreloadedProjectionReader(effects, using="rebuild")
+        diff_effects_against_rows(effects, reader=reader).raise_if_diff()
+
+    Semantics and limits:
+
+    * The cache is a **point-in-time snapshot** taken at construction. Use it for
+      read-only verification, *not* during live staged replay — there the rows
+      change as the replay writes them, so use a plain
+      :class:`DjangoProjectionReader`.
+    * A :meth:`get` for a lookup not in the batch (or one that spans a relation,
+      e.g. ``field__gte``) falls back to a live query and memoises the result, so
+      a repeat is free.
+    * :meth:`filter` and :meth:`query` are inherited unchanged — always live. Only
+      the exact-match :meth:`get` path (all :func:`diff_effects_against_rows`
+      uses) is preloaded.
+    """
+
+    _MISSING = object()
+
+    def __init__(self, effects: Iterable[Effect], *, using: str | None = None) -> None:
+        super().__init__(using=using)
+        # (model_label, canonical-key) -> row, or None for a recorded miss ("no
+        # such row" — a real cached answer). A key *absent* from the map has never
+        # been fetched, so get() does a live lookup and memoises it.
+        self._cache: dict[tuple[str, tuple], Any] = {}
+        self._preload(effects)
+
+    def _preload(self, effects: Iterable[Effect]) -> None:
+        # Group every usable lookup by its "shape" — (model_label, sorted field
+        # names) — so one query per shape fetches all of its rows at once.
+        by_shape: dict[tuple[str, tuple[str, ...]], list[dict[str, Any]]] = {}
+        for eff in effects:
+            if eff.model_label is None or not eff.lookup:
+                continue
+            if any("__" in k for k in eff.lookup):
+                continue  # spanning lookup — can't index by exact match; left to live get()
+            shape = (eff.model_label, tuple(sorted(eff.lookup)))
+            by_shape.setdefault(shape, []).append(eff.lookup)
+
+        for (model_label, fields), lookups in by_shape.items():
+            model = apps.get_model(model_label)
+            # De-dup requested keys and seed each as a miss; a fetched row overwrites.
+            requested: dict[tuple[str, tuple], Any] = {}
+            unique_lookups: list[dict[str, Any]] = []
+            for lookup in lookups:
+                key = (model_label, self._key(model, lookup.items()))
+                if key not in requested:
+                    requested[key] = None
+                    unique_lookups.append(lookup)
+            if not unique_lookups:
+                continue
+            for row in self._fetch(model_label, fields, unique_lookups):
+                key = (
+                    model_label,
+                    self._key(model, [(f, getattr(row, f)) for f in fields]),
+                )
+                if (
+                    requested.get(key) is None
+                ):  # first row wins, mirroring get()->first()
+                    requested[key] = row
+            self._cache.update(requested)
+
+    def _fetch(
+        self, model_label: str, fields: tuple[str, ...], lookups: list[dict[str, Any]]
+    ) -> Iterable[Any]:
+        manager = self._manager(model_label)
+        if len(fields) == 1:
+            # Single natural key — a ``field__in=[...]`` beats an N-clause OR.
+            (field,) = fields
+            return manager.filter(**{f"{field}__in": [lk[field] for lk in lookups]})
+        # Composite key — OR one Q per lookup. (Seed from None, not an empty
+        # ``Q()``: ``Q() | Q(...)`` matches *everything*.)
+        combined: Q | None = None
+        for lookup in lookups:
+            clause = Q(**lookup)
+            combined = clause if combined is None else combined | clause
+        return manager.filter(combined)
+
+    @staticmethod
+    def _key(model: type, items: Iterable[tuple[str, Any]]) -> tuple:
+        """A field-order-independent key, canonicalised through the same
+        normalizers as the diff so a str-UUID lookup keys to the same slot as the
+        stored ``uuid.UUID`` row it matched."""
+        return tuple(
+            (f, canonical_value(model, f, v))
+            for f, v in sorted(items, key=lambda kv: kv[0])
+        )
+
+    def get(self, model_label: str, /, **lookup: Any) -> Any | None:
+        if any("__" in k for k in lookup):
+            return super().get(model_label, **lookup)  # spanning — not preloadable
+        model = apps.get_model(model_label)
+        key = (model_label, self._key(model, lookup.items()))
+        cached = self._cache.get(key, self._MISSING)
+        if cached is not self._MISSING:
+            return cached  # a preloaded hit, or a recorded miss (None)
+        row = super().get(
+            model_label, **lookup
+        )  # outside the batch — live, then memoise
+        self._cache[key] = row
+        return row
 
 
 # =============================================================================

--- a/tests/test_django_rakaia/test_preloaded_reader.py
+++ b/tests/test_django_rakaia/test_preloaded_reader.py
@@ -1,0 +1,170 @@
+"""Tests for ``PreloadedProjectionReader`` — the batch-fetching reader that backs
+a large ``diff_effects_against_rows`` sweep.
+
+The friction it removes: the diff helper does one ``reader.get`` per effect, so a
+20k-effect reconcile is ~20k round-trips. Given the same batch up front, this
+reader bulk-fetches every lookup in one query per (model, lookup-shape) group and
+serves each ``get`` from an in-memory snapshot. These tests pin the query count
+(the whole point) and the snapshot/fallback semantics.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from uuid import uuid4
+
+import pytest
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
+
+from django_rakaia.projection_reader import DjangoProjectionReader
+from django_rakaia.verification import (
+    PreloadedProjectionReader,
+    diff_effects_against_rows,
+)
+from rakaia.effects import Effect
+
+from .models import Alert, FinanceLine, Measure
+
+
+def _finance_effect(submission_id: str, suku: str, delta: int) -> Effect:
+    return Effect(
+        op="update_or_create",
+        model_label="test_django_rakaia.FinanceLine",
+        lookup={"submission_id": submission_id},
+        defaults={"suku": suku, "delta": delta},
+    )
+
+
+@pytest.mark.django_db
+class TestPreloadedProjectionReader:
+    def test_single_field_batch_uses_one_query_for_the_whole_sweep(self):
+        for i in range(10):
+            FinanceLine.objects.create(submission_id=f"s{i}", suku="A", delta=i)
+        effects = [_finance_effect(f"s{i}", "A", i) for i in range(10)]
+
+        with CaptureQueriesContext(connection) as ctx:
+            reader = PreloadedProjectionReader(effects)
+            report = diff_effects_against_rows(effects, reader=reader)
+
+        assert report.ok
+        # One `submission_id__in=[...]` fetch for the whole batch — not one per row.
+        assert len(ctx) == 1
+
+    def test_plain_reader_issues_one_query_per_effect(self):
+        # Contrast fixture: the un-preloaded path this reader replaces.
+        for i in range(10):
+            FinanceLine.objects.create(submission_id=f"s{i}", suku="A", delta=i)
+        effects = [_finance_effect(f"s{i}", "A", i) for i in range(10)]
+
+        with CaptureQueriesContext(connection) as ctx:
+            diff_effects_against_rows(effects, reader=DjangoProjectionReader())
+
+        assert len(ctx) == 10
+
+    def test_composite_key_batch_uses_one_query(self):
+        for i in range(5):
+            Alert.objects.create(
+                stream_key=f"sub{i}", alert_type="ff4", field_key="", message="m"
+            )
+        effects = [
+            Effect(
+                op="update_or_create",
+                model_label="test_django_rakaia.Alert",
+                lookup={"stream_key": f"sub{i}", "alert_type": "ff4", "field_key": ""},
+                defaults={"message": "m"},
+            )
+            for i in range(5)
+        ]
+
+        with CaptureQueriesContext(connection) as ctx:
+            reader = PreloadedProjectionReader(effects)
+            report = diff_effects_against_rows(effects, reader=reader)
+
+        assert report.ok
+        # A single OR-of-tuples query covers the composite-key shape.
+        assert len(ctx) == 1
+
+    def test_uuid_string_lookup_keys_to_stored_uuid_row(self):
+        # The lookup carries a UUID *string* (post-JSON), the column stores a
+        # ``uuid.UUID``; the canonicalised key must land them in the same slot.
+        ref = uuid4()
+        Measure.objects.create(ref=ref, amount=Decimal("2.10"))
+        effect = Effect(
+            op="update_or_create",
+            model_label="test_django_rakaia.Measure",
+            lookup={"ref": str(ref)},
+            defaults={"amount": Decimal("2.10")},
+        )
+        reader = PreloadedProjectionReader([effect])
+        with CaptureQueriesContext(connection) as ctx:
+            row = reader.get("test_django_rakaia.Measure", ref=str(ref))
+        assert row is not None and row.ref == ref
+        assert len(ctx) == 0  # served from the snapshot, no live query
+
+    def test_absent_row_is_a_cached_miss_not_a_repeat_query(self):
+        effect = _finance_effect("ghost", "A", 1)  # no such row
+        with CaptureQueriesContext(connection) as ctx:
+            reader = PreloadedProjectionReader([effect])
+        assert len(ctx) == 1  # the preload fetch (returns nothing)
+
+        with CaptureQueriesContext(connection) as ctx:
+            assert (
+                reader.get("test_django_rakaia.FinanceLine", submission_id="ghost")
+                is None
+            )
+            assert (
+                reader.get("test_django_rakaia.FinanceLine", submission_id="ghost")
+                is None
+            )
+        assert len(ctx) == 0  # the miss is cached; neither get re-queries
+
+    def test_lookup_outside_the_batch_falls_back_live_then_memoises(self):
+        FinanceLine.objects.create(submission_id="in", suku="A", delta=1)
+        FinanceLine.objects.create(submission_id="out", suku="B", delta=2)
+        reader = PreloadedProjectionReader([_finance_effect("in", "A", 1)])
+
+        with CaptureQueriesContext(connection) as ctx:
+            first = reader.get("test_django_rakaia.FinanceLine", submission_id="out")
+            second = reader.get("test_django_rakaia.FinanceLine", submission_id="out")
+        assert first is not None and first.suku == "B"
+        assert second is not None
+        assert len(ctx) == 1  # one live fetch, then memoised
+
+    def test_snapshot_is_point_in_time(self):
+        # A row created *after* construction is not visible to a lookup that was
+        # in the batch — the reader is a snapshot, for read-only verification.
+        effect = _finance_effect("late", "A", 1)
+        reader = PreloadedProjectionReader([effect])
+        FinanceLine.objects.create(submission_id="late", suku="A", delta=1)
+        assert (
+            reader.get("test_django_rakaia.FinanceLine", submission_id="late") is None
+        )
+
+    def test_spanning_lookup_is_not_preloaded_and_reads_live(self):
+        FinanceLine.objects.create(submission_id="s1", suku="A", delta=5)
+        # A relation/transform lookup (`__`) can't be indexed by exact match, so
+        # it's excluded from the preload and served live.
+        reader = PreloadedProjectionReader([_finance_effect("s1", "A", 5)])
+        with CaptureQueriesContext(connection) as ctx:
+            row = reader.get("test_django_rakaia.FinanceLine", delta__gte=1)
+        assert row is not None
+        assert len(ctx) == 1
+
+    def test_filter_and_query_remain_live(self):
+        FinanceLine.objects.create(submission_id="s1", suku="A", delta=1)
+        FinanceLine.objects.create(submission_id="s2", suku="A", delta=2)
+        reader = PreloadedProjectionReader([_finance_effect("s1", "A", 1)])
+        assert reader.filter("test_django_rakaia.FinanceLine", suku="A").count() == 2
+        assert reader.query("test_django_rakaia.FinanceLine").count() == 2
+
+    def test_duplicate_lookups_across_effects_fetch_once(self):
+        FinanceLine.objects.create(submission_id="s1", suku="A", delta=1)
+        # Same lookup repeated (e.g. two effects touching one row) de-dups.
+        effects = [_finance_effect("s1", "A", 1), _finance_effect("s1", "A", 1)]
+        with CaptureQueriesContext(connection) as ctx:
+            reader = PreloadedProjectionReader(effects)
+        assert len(ctx) == 1
+        assert (
+            reader.get("test_django_rakaia.FinanceLine", submission_id="s1") is not None
+        )


### PR DESCRIPTION
Stacked on #76 — depends on `verification.canonical_value`, added there (not yet on `main`). Rebase onto `main` once #76 lands.

## What

`diff_effects_against_rows` does one `reader.get` per effect — one round-trip each. Fine for a cookbook; on a full reconcile (tens of thousands of effects) it is tens of thousands of round-trips. `PreloadedProjectionReader` takes the **same** effect batch, bulk-fetches every lookup up front, and serves each `get` from an in-memory snapshot:

```python
from django_rakaia.verification import PreloadedProjectionReader, diff_effects_against_rows

effects = list(collecting_executor.effects)
reader = PreloadedProjectionReader(effects, using="rebuild")   # one bulk fetch per shape
diff_effects_against_rows(effects, reader=reader).raise_if_diff()
```

## How

- Groups lookups by **shape** = `(model_label, sorted field names)`; issues **one query per shape** — `field__in=[...]` for a single natural key, OR-of-`Q` for a composite key.
- Indexes results by a **canonicalised** key (reuses `canonical_value`), so a post-JSON `str` UUID lookup lands on the stored `uuid.UUID` row it matched.
- **Misses are cached** — a batch lookup with no row returns `None` without re-querying.
- Lookups **outside the batch**, or that **span a relation** (`field__gte`), fall back to a live, memoised read. `filter()` / `query()` stay live.
- **Point-in-time snapshot** — for read-only verification, not live staged replay (there the rows change as the replay writes them; use a plain `DjangoProjectionReader`).

Placed in `verification.py` (not `projection_reader.py`) to avoid the `verification` ↔ `projection_reader` import cycle, and to sit next to its only consumer.

Upstreamed from the Partisipa migration's local `PreloadReader` workaround (~20k-effect sweep was thousands of round-trips).

## Tests

`tests/test_django_rakaia/test_preloaded_reader.py` (10) pins the query counts (single-field, composite, contrast-vs-plain-reader) and the snapshot/fallback semantics (cached miss, out-of-batch fallback, point-in-time, spanning lookup, `filter`/`query` live, dedup).

All four CI gates green locally: `ruff check`, `ruff format --check`, `pytest` (792 passed / 1 skipped), `zensical build`.