### PR TITLE
feat(store): append_many bulk-append on both stores (#78)

### DIFF
--- a/src/django_rakaia/django_store.py
+++ b/src/django_rakaia/django_store.py
@@ -21,6 +21,7 @@ validation, stream closing) are intentionally not implemented here.
 from __future__ import annotations
 
 import json
+from collections.abc import Iterable
 from typing import Any
 
 from django.db import transaction
@@ -105,6 +106,72 @@ class DjangoStreamStore:
                 event=event,
                 offset=stream.get_next_offset(),
             )
+
+    def append_many(
+        self, path: str, events: Iterable[tuple[bytes, Any]]
+    ) -> list[StreamEntry]:
+        """Append an ordered batch in ONE transaction, returning the entries in
+        input order.
+
+        Semantically identical to calling :meth:`append` once per item — same
+        event rows, same envelope mapping (``label``->``event_type``,
+        per-event ``merge_provenance`` for ``metadata``, ``event_ts``) — but it
+        locks the stream's high-water once, allocates a single contiguous offset
+        block for the whole batch (so ``unique_together(stream, offset)`` still
+        holds and concurrent writers serialize exactly as ``append`` does), and
+        ``bulk_create``s the events then the entries. This collapses an N-append
+        seed/replay from N transactions into **one** transaction with a bounded
+        number of queries: the events and entries are each ``bulk_create``d,
+        chunked under the driver's bind-parameter cap, so it is a handful of
+        INSERTs regardless of N (not the 2N a loop of ``append`` issues).
+
+        The entries link to the just-created events by instance, which relies on
+        ``bulk_create`` populating primary keys — backends with
+        ``INSERT ... RETURNING`` (Postgres, and the modern SQLite used in CI).
+        The durable store targets Postgres, where this holds.
+
+        One ``append_many`` holds the watermark lock for the whole batch, which
+        is ideal for exclusive backfills; on a live, high-throughput stream a
+        very large batch would stall concurrent appends, so chunk it caller-side
+        if that matters.
+
+        Each item is a ``(data, options)`` tuple where ``options`` is an
+        ``AppendOptions`` or ``None`` (a raw append). An empty batch is a no-op
+        that returns ``[]`` without touching the database (so it never raises
+        for a missing stream). A non-empty batch raises ``KeyError`` if the
+        stream does not exist, like :meth:`append`.
+        """
+        items = list(events)
+        if not items:
+            return []
+
+        with transaction.atomic():
+            try:
+                stream = Stream.objects.get(stream_id=path)
+            except Stream.DoesNotExist as exc:
+                raise KeyError(f"Stream not found: {path}") from exc
+
+            # Mirror `append`'s per-event envelope mapping. `merge_provenance`
+            # is evaluated per item so ambient provenance is captured for each.
+            stream_events = [
+                StreamEvent(
+                    data=json.loads(data),
+                    event_type=(getattr(options, "label", "") or "")
+                    or _APPEND_EVENT_TYPE,
+                    metadata=merge_provenance(getattr(options, "metadata", None)) or {},
+                    event_ts=getattr(options, "event_ts", None),
+                )
+                for data, options in items
+            ]
+            StreamEvent.objects.bulk_create(stream_events)
+
+            start = stream.get_next_offset_block(len(stream_events))
+            entries = [
+                StreamEntry(stream=stream, event=event, offset=start + i)
+                for i, event in enumerate(stream_events)
+            ]
+            StreamEntry.objects.bulk_create(entries)
+            return entries
 
     def read(
         self, path: str, offset: str | None = None

--- a/src/django_rakaia/models.py
+++ b/src/django_rakaia/models.py
@@ -47,12 +47,25 @@ class Stream(models.Model):
     def get_next_offset(self) -> int:
         """Calculate the next globally-monotonic offset for this stream.
 
+        Thin wrapper over :meth:`get_next_offset_block` for the single-event
+        write path; see that method for the locking and monotonicity contract.
+        """
+        return self.get_next_offset_block(1)
+
+    def get_next_offset_block(self, count: int) -> int:
+        """Atomically reserve ``count`` contiguous offsets, returning the first.
+
+        The reserved block is ``start .. start + count - 1``. ``count`` must be
+        ``>= 1``. This is the single offset-allocation path shared by every
+        write surface (durable store single + bulk append, ``@stream_model``
+        signals, protocol views).
+
         Must be called inside a transaction: locks the per-path high-water row
         (``StreamOffsetWatermark``) with select_for_update() so concurrent
         writers serialize on offset allocation instead of colliding on
-        unique_together(stream, offset). This is the single offset-allocation
-        path shared by every write surface (durable store, ``@stream_model``
-        signals, protocol views).
+        unique_together(stream, offset). A bulk writer holds the lock once and
+        advances the high-water by the whole block, so interleaved single and
+        bulk appends never overlap offsets.
 
         Offsets are **globally monotonic across delete+recreate** (#34, Defect
         #2): the high-water row is keyed by ``stream_id`` and is never
@@ -62,6 +75,8 @@ class Stream(models.Model):
         subscriber cursor collides with the recreated stream's head. This is the
         durable analogue of the in-memory store's in-process ``_retired_seq``.
         """
+        if count < 1:
+            raise ValueError(f"count must be >= 1, got {count}")
         # Lock the per-path high-water for the duration of the enclosing
         # transaction. get_or_create tolerates the first-writer race (it retries
         # on the unique-key IntegrityError); the subsequent locked read then
@@ -75,10 +90,10 @@ class Stream(models.Model):
         # correctly from any pre-existing entries (e.g. rows written before this
         # high-water table existed) on the first allocation after migration.
         entries_max = self.entries.aggregate(max_offset=Max("offset"))["max_offset"]
-        nxt = max(entries_max or 0, watermark.high) + 1
-        watermark.high = nxt
+        start = max(entries_max or 0, watermark.high) + 1
+        watermark.high = start + count - 1
         watermark.save(update_fields=["high"])
-        return nxt
+        return start
 
 
 class StreamOffsetWatermark(models.Model):

--- a/src/rakaia/protocols.py
+++ b/src/rakaia/protocols.py
@@ -17,6 +17,7 @@ All store-facing protocols live here so they read as one coherent seam:
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from typing import Any, Protocol, runtime_checkable
 
 from .types import StreamMessage
@@ -109,6 +110,19 @@ class WritableStore(ReadableStore, Protocol):
         The envelope — `label` and `metadata` on `options` (an `AppendOptions`) —
         is recorded and read back by `read`; ambient `provenance()` merges under
         explicit metadata.
+        """
+        ...
+
+    def append_many(self, path: str, events: Iterable[tuple[bytes, Any]]) -> list[Any]:
+        """Append an ordered batch of `(data, options)` events, returning one
+        result per item in input order.
+
+        Semantically identical to calling `append` once per item — same
+        `KeyError`-if-missing guarantee and same per-event envelope handling —
+        but a backend may collapse the batch into a single transaction (the
+        durable `DjangoStreamStore` does, which is the point). An empty batch is
+        a no-op returning `[]`. Result element types stay backend-specific and
+        loose, exactly as `append`'s do.
         """
         ...
 

--- a/src/rakaia/store.py
+++ b/src/rakaia/store.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
+from collections.abc import Iterable
 from datetime import datetime, timezone
 
 from .context import merge_provenance
@@ -329,6 +330,22 @@ class StreamStore:
             producer_result=producer_result,
             stream_closed=opts.close,
         )
+
+    def append_many(
+        self,
+        path: str,
+        events: Iterable[tuple[bytes, AppendOptions | None]],
+    ) -> list[AppendResult]:
+        """Append an ordered batch, returning one ``AppendResult`` per item.
+
+        API parity with :meth:`DjangoStreamStore.append_many` so a consumer can
+        call one method against either backend. The in-memory store has no
+        per-append transaction cost to amortise, so this simply delegates to
+        :meth:`append` per item, preserving every append semantic
+        (producer/seq/close validation, TTL touch, long-poll notification). An
+        empty batch returns ``[]``.
+        """
+        return [self.append(path, data, options) for data, options in events]
 
     async def append_with_producer(
         self,

--- a/tests/store_contract.py
+++ b/tests/store_contract.py
@@ -175,3 +175,43 @@ class StoreContract:
         store.append("s", b'{"id": 1}')
         after = store.get_current_offset("s")
         assert after is not None and after != before
+
+    def test_append_many_matches_append_loop(self, store):
+        # append_many([...]) produces the same read-back stream state as calling
+        # append once per item — same data, order, envelope (label/metadata/
+        # event_ts), and strictly-increasing offsets — on every backend. Result
+        # object types differ per backend (AppendResult vs StreamEntry), so the
+        # contract asserts read-back state, not the return values.
+        batch = [
+            (b'{"id": 1}', None),
+            (b'{"id": 2}', AppendOptions(label="update", metadata={"user": 7})),
+            (b'{"id": 3}', AppendOptions(event_ts=1_600_000_000.5)),
+        ]
+
+        store.create("loop")
+        for data, options in batch:
+            store.append("loop", data, options)
+
+        store.create("bulk")
+        store.append_many("bulk", batch)
+
+        loop_msgs, _ = store.read("loop")
+        bulk_msgs, _ = store.read("bulk")
+        assert len(bulk_msgs) == len(loop_msgs) == 3
+        for loop_m, bulk_m in zip(loop_msgs, bulk_msgs, strict=True):
+            assert json.loads(bulk_m.data) == json.loads(loop_m.data)
+            assert bulk_m.label == loop_m.label
+            assert bulk_m.metadata == loop_m.metadata
+        # A producer-set event_ts round-trips verbatim; an unset one defaults to
+        # each store's own append time (so it differs between the two runs by
+        # design) — assert it's populated as a float rather than equal.
+        assert bulk_msgs[2].event_ts == 1_600_000_000.5
+        assert isinstance(bulk_msgs[0].event_ts, float)
+        offsets = [m.offset for m in bulk_msgs]
+        assert all(a < b for a, b in zip(offsets, offsets[1:], strict=False))
+
+    def test_append_many_empty_is_noop(self, store):
+        store.create("s")
+        assert store.append_many("s", []) == []
+        messages, _ = store.read("s")
+        assert messages == []

--- a/tests/test_django_rakaia/test_django_store.py
+++ b/tests/test_django_rakaia/test_django_store.py
@@ -9,7 +9,12 @@ import pytest
 from django.db.models.query import QuerySet
 
 from django_rakaia.django_store import DjangoStreamStore
-from django_rakaia.models import Stream, StreamEntry
+from django_rakaia.models import (
+    Stream,
+    StreamEntry,
+    StreamEvent,
+    StreamOffsetWatermark,
+)
 from rakaia import CollectingExecutor
 from rakaia.effects import Effect
 from rakaia.registry import HandlerRegistry
@@ -176,6 +181,174 @@ class TestDjangoStreamStore:
         DjangoStreamStore().append("s", b'{"id": 42}')
         messages, _ = DjangoStreamStore().read("s")
         assert [json.loads(m.data) for m in messages] == [{"id": 42}]
+
+    def test_append_many_byte_identical_to_append_loop(self):
+        # Acceptance criterion: append_many([...]) produces byte-identical
+        # persisted state (event data/type/metadata/event_ts + contiguous
+        # offsets) to a loop of append(...). Build one stream each way and
+        # compare the ORM rows directly.
+        batch = [
+            (b'{"id": 1}', None),
+            (b'{"id": 2}', AppendOptions(label="update", metadata={"user": 7})),
+            (b'{"id": 3}', AppendOptions(event_ts=1_600_000_000.5)),
+        ]
+
+        store = DjangoStreamStore()
+        store.create("loop")
+        for data, options in batch:
+            store.append("loop", data, options)
+        store.create("bulk")
+        returned = store.append_many("bulk", batch)
+
+        def rows(path):
+            return [
+                (e.event.data, e.event.event_type, e.event.metadata, e.event.event_ts)
+                for e in StreamEntry.objects.filter(stream__stream_id=path)
+                .select_related("event")
+                .order_by("offset")
+            ]
+
+        assert rows("bulk") == rows("loop")
+        # Entries returned in input order, offsets contiguous from 1.
+        assert [e.offset for e in returned] == [1, 2, 3]
+        assert [
+            json.loads(store.read("bulk")[0][i].data.decode()) for i in range(3)
+        ] == [
+            {"id": 1},
+            {"id": 2},
+            {"id": 3},
+        ]
+
+    def test_append_many_bounded_queries(self):
+        # Acceptance criterion: a large batch runs in an N-independent, bounded
+        # number of queries — O(1)-ish transactions, not the ~O(N) a loop of
+        # append() does. bulk_create may split into a few batches under SQLite's
+        # bind-param cap, so assert a small constant ceiling (well under the
+        # ~5*N a loop of append() would issue) rather than an exact count.
+        from django.db import connection
+        from django.test.utils import CaptureQueriesContext
+
+        store = DjangoStreamStore()
+        store.create("s")
+        batch = [(json.dumps({"id": i}).encode(), None) for i in range(1000)]
+        with CaptureQueriesContext(connection) as ctx:
+            store.append_many("s", batch)
+        assert len(ctx.captured_queries) < 30
+        assert StreamEntry.objects.filter(stream__stream_id="s").count() == 1000
+
+    def test_append_many_locks_watermark_once(self):
+        # The single-contiguous-allocation guarantee: the whole batch takes the
+        # watermark select_for_update() lock exactly once (vs once per item for
+        # a loop of append). Mirrors test_append_locks_for_offset_allocation.
+        store = DjangoStreamStore()
+        store.create("s")
+
+        original = QuerySet.select_for_update
+        locked = []
+
+        def spy(qs, *args, **kwargs):
+            locked.append(True)
+            return original(qs, *args, **kwargs)
+
+        with patch.object(QuerySet, "select_for_update", spy):
+            store.append_many("s", [(b'{"id": 1}', None), (b'{"id": 2}', None)])
+
+        assert len(locked) == 1, "append_many must lock the watermark exactly once"
+
+    def test_append_many_interleaves_with_append_without_collision(self):
+        # Interleaved append + append_many share the one offset-allocation path,
+        # so offsets stay unique, contiguous and strictly increasing (same lock
+        # semantics as today). SQLite can't reproduce a true cross-connection
+        # race, so assert the allocation is contiguous rather than triggering it.
+        store = DjangoStreamStore()
+        store.create("s")
+        store.append("s", b'{"id": 1}')
+        store.append_many("s", [(b'{"id": 2}', None), (b'{"id": 3}', None)])
+        store.append("s", b'{"id": 4}')
+
+        offsets = list(
+            StreamEntry.objects.filter(stream__stream_id="s")
+            .order_by("offset")
+            .values_list("offset", flat=True)
+        )
+        assert offsets == [1, 2, 3, 4]
+
+    def test_append_many_empty_is_noop_without_stream(self):
+        # Empty batch returns [] without a DB hit, so it never raises for a
+        # missing stream (unlike a non-empty batch).
+        store = DjangoStreamStore()
+        assert store.append_many("missing", []) == []
+
+    def test_append_many_missing_stream_raises(self):
+        store = DjangoStreamStore()
+        with pytest.raises(KeyError):
+            store.append_many("missing", [(b'{"id": 1}', None)])
+
+    def test_append_many_preserves_distinct_per_item_envelopes(self):
+        # Sharpens the "identical to N appends" claim on the envelope: every
+        # item carries its OWN label/metadata/event_ts (not a uniform batch),
+        # and a raw-append item keeps the default label / empty metadata / null
+        # ts — asserted row-by-row.
+        store = DjangoStreamStore()
+        store.create("s")
+        batch = [
+            (
+                b'{"id": 1}',
+                AppendOptions(label="create", metadata={"a": 1}, event_ts=1000.0),
+            ),
+            (
+                b'{"id": 2}',
+                AppendOptions(label="update", metadata={"b": 2}, event_ts=2000.0),
+            ),
+            (b'{"id": 3}', None),
+        ]
+        store.append_many("s", batch)
+        rows = [
+            (e.event.data, e.event.event_type, e.event.metadata, e.event.event_ts)
+            for e in StreamEntry.objects.filter(stream__stream_id="s")
+            .select_related("event")
+            .order_by("offset")
+        ]
+        assert rows == [
+            ({"id": 1}, "create", {"a": 1}, 1000.0),
+            ({"id": 2}, "update", {"b": 2}, 2000.0),
+            ({"id": 3}, "append", {}, None),
+        ]
+
+    def test_append_many_rolls_back_atomically_on_failure(self):
+        # The whole batch is one transaction: if entry creation fails, the
+        # already-bulk_created events AND the watermark advance roll back with
+        # it — no partial write, no leaked offset block.
+        store = DjangoStreamStore()
+        store.create("s")
+        store.append("s", b'{"id": 0}')  # seed one entry -> watermark high = 1
+        high_before = StreamOffsetWatermark.objects.get(stream_path="s").high
+        events_before = StreamEvent.objects.count()
+
+        with (
+            patch.object(
+                StreamEntry.objects, "bulk_create", side_effect=RuntimeError("boom")
+            ),
+            pytest.raises(RuntimeError, match="boom"),
+        ):
+            store.append_many("s", [(b'{"id": 1}', None), (b'{"id": 2}', None)])
+
+        assert StreamEvent.objects.count() == events_before
+        assert StreamOffsetWatermark.objects.get(stream_path="s").high == high_before
+        # The seeded entry survives; nothing from the failed batch persisted.
+        assert list(
+            StreamEntry.objects.filter(stream__stream_id="s")
+            .order_by("offset")
+            .values_list("offset", flat=True)
+        ) == [1]
+
+    def test_get_next_offset_block_rejects_non_positive_count(self):
+        # The shared allocation path guards its precondition: a caller must
+        # reserve at least one offset. append_many short-circuits an empty batch
+        # before allocating, so this guard only trips on direct misuse.
+        stream = Stream.objects.create(stream_id="s")
+        with pytest.raises(ValueError, match="count must be >= 1"):
+            stream.get_next_offset_block(0)
 
 
 @pytest.mark.django_db

--- a/tests/test_rakaia/test_store.py
+++ b/tests/test_rakaia/test_store.py
@@ -289,6 +289,27 @@ class TestAppend:
         assert stream.last_seq == "2"
 
 
+class TestAppendMany:
+    def test_append_many_delegates_to_append(self, store: StreamStore):
+        # append_many returns one AppendResult per item in order, and delegates
+        # to append so per-item semantics (here: producer seq progression) are
+        # preserved exactly as a loop of append would be.
+        store.create("foo", content_type="application/octet-stream")
+        batch = [
+            (b"a", AppendOptions(producer_id="p", producer_epoch=0, producer_seq=0)),
+            (b"b", AppendOptions(producer_id="p", producer_epoch=0, producer_seq=1)),
+            (b"c", AppendOptions(producer_id="p", producer_epoch=0, producer_seq=2)),
+        ]
+        results = store.append_many("foo", batch)
+        assert len(results) == 3
+        assert [r.message.data for r in results] == [b"a", b"b", b"c"]
+        assert all(r.producer_result.status == "accepted" for r in results)
+
+    def test_append_many_empty_returns_empty(self, store: StreamStore):
+        store.create("foo", content_type="application/octet-stream")
+        assert store.append_many("foo", []) == []
+
+
 # =============================================================================
 # Producer validation
 # =============================================================================


### PR DESCRIPTION
Closes #78.

## Summary

`DjangoStreamStore.append` persists one event per call inside its own transaction, so seeding/replaying a stream is N transactions + 2N inserts. The Partisipa `durable-streams` backfill spends ~74s appending ~23.4k events one-by-one — the #1 dev/gate iteration cost, all per-append round-trip overhead (row lock + 2 inserts + a transaction per event).

This adds an **additive** `append_many` that appends an ordered batch in **one transaction**: lock the stream high-water once, allocate a single contiguous offset block, then `bulk_create` the events and entries. Semantically identical to calling `append` N times.

## Changes

- **`models.py`** — extract `Stream.get_next_offset_block(count)` as the single offset-allocation path (one `select_for_update` lock, advances the high-water by the whole block). `get_next_offset()` delegates to it (`count=1`), so existing single-append lock/monotonicity behavior is preserved bit-for-bit.
- **`django_store.py`** — `append_many(path, events)` in one `transaction.atomic()`. Same per-event envelope mapping as `append` (`label`→`event_type`, per-item `merge_provenance` for `metadata`, `event_ts`). Returns entries in input order; empty batch is a no-op returning `[]` (no DB hit, so no `KeyError` for a missing stream); non-empty batch on a missing stream raises `KeyError`.
- **`store.py`** — in-memory `StreamStore.append_many` for API parity, delegating to `append` per item (returns `list[AppendResult]`), preserving all producer/seq/close semantics.
- **`protocols.py`** — add `append_many` to the `WritableStore` protocol (loose return type, as `append`).

## Acceptance criteria → tests

- **Byte-identical to an append loop** — shared-contract test (both backends) + Django ORM-row comparison.
- **O(1)-ish transactions** — a 1000-event batch runs in **12 queries** (asserted `< 30`) vs ~5·N for a loop; a spy test proves the watermark is `select_for_update`-locked **exactly once** per batch.
- **No `(stream, offset)` collision when interleaving** — `append` / `append_many` / `append` yields contiguous `[1,2,3,4]`.
- **Empty batch → `[]`** — asserted on both backends.
- Plus: missing-stream `KeyError`, in-memory producer-seq progression across items, and the `get_next_offset_block` `count >= 1` guard.

## Deliberate non-goals

- Keeps the store's documented divergences (no `closed` concept, `options.seq` ignored on the Django side).
- No migration — only a new model **method**, no schema change.

## Verification

- Full suite: **794 passed, 1 skipped**.
- `ruff check src/ tests/` and `ruff format --check src/ tests/` clean.
- `pytest-cov` (line + branch) over the four touched modules: all new-feature code fully covered.