### PR TITLE
chore(release): publish to PyPI as rakaia-streams

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,80 @@
+name: Publish
+
+# Publishes `rakaia-streams` to PyPI when a `v*` tag is pushed, e.g.
+#
+#   git tag v0.1.0 && git push origin v0.1.0
+#
+# Uses PyPI Trusted Publishing (OIDC) — no API token is stored anywhere.
+# One-time setup on https://pypi.org, under the project's "Publishing" tab
+# (or "Add a pending publisher" if the project doesn't exist yet):
+#
+#   PyPI project name:  rakaia-streams
+#   Owner:              joshbrooks
+#   Repository name:    rakaia
+#   Workflow name:      publish.yml
+#   Environment name:   pypi
+#
+# The `pypi` environment below must also exist in the repo's
+# Settings -> Environments (create it; no secrets required).
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          enable-cache: true
+
+      - name: Set up Python 3.12
+        run: uv python install 3.12
+
+      # Guard against tagging v1.2.3 while pyproject.toml still says 0.1.0.
+      - name: Check tag matches project version
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          tag="${GITHUB_REF_NAME#v}"
+          version="$(uv run --no-project python -c \
+            'import tomllib,pathlib; print(tomllib.loads(pathlib.Path("pyproject.toml").read_text())["project"]["version"])')"
+          if [ "$tag" != "$version" ]; then
+            echo "Tag $GITHUB_REF_NAME does not match pyproject version $version" >&2
+            exit 1
+          fi
+          echo "Publishing version $version"
+
+      - name: Build sdist and wheel
+        run: uv build
+
+      - name: Check distribution metadata
+        run: uvx twine check dist/*
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment: pypi
+    permissions:
+      # Required for Trusted Publishing; mints the short-lived OIDC token.
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/README.md
+++ b/README.md
@@ -14,15 +14,18 @@ It ships two installable packages:
 ## Install
 
 ```bash
-pip install rakaia                 # core protocol server
-pip install "rakaia[django]"       # + Django integration
-pip install "rakaia[django,prod]"  # + channels-redis + hypercorn for prod
+pip install rakaia-streams                 # core protocol server
+pip install "rakaia-streams[django]"       # + Django integration
+pip install "rakaia-streams[django,prod]"  # + channels-redis + hypercorn for prod
 ```
+
+The distribution is named `rakaia-streams` on PyPI (plain `rakaia` was already
+taken); the import names are unchanged — `import rakaia`, `import django_rakaia`.
 
 ## Quick start (standalone)
 
 ```bash
-pip install rakaia uvicorn
+pip install rakaia-streams uvicorn
 uvicorn rakaia:app --port 4437
 ```
 

--- a/docs/framework-vs-protocol-server.md
+++ b/docs/framework-vs-protocol-server.md
@@ -48,19 +48,19 @@ declares `dependencies = []`), and within `django_rakaia` **only SSE needs
 
 ```bash
 # 1. Framework + standalone protocol server, zero dependencies
-pip install rakaia
+pip install rakaia-streams
 
 # 2. Django durable store + projections + DB-backed protocol server (no SSE)
-pip install rakaia django            # NB: not the [django] extra — see below
+pip install rakaia-streams django            # NB: not the [django] extra — see below
 
 # 3. Everything, including real-time SSE
-pip install "rakaia[django]"         # pulls django + channels + daphne
+pip install "rakaia-streams[django]"         # pulls django + channels + daphne
 ```
 
 !!! note "The `[django]` extra currently bundles `channels`+`daphne`"
-    `rakaia[django]` installs `django`, `channels`, **and** `daphne` together, so
-    profile 2 (framework-tier Django use with no SSE) is expressed by installing
-    `rakaia` + `django` directly rather than via the extra. The **runtime** import
+    `rakaia-streams[django]` installs `django`, `channels`, **and** `daphne`
+    together, so profile 2 (framework-tier Django use with no SSE) is expressed
+    by installing `rakaia-streams` + `django` directly rather than via the extra. The **runtime** import
     of `channels` is already optional (below); splitting the extra into
     `[django]` (ORM only) and `[sse]` (`channels`+`daphne`) so the *install* is
     also minimal is a natural follow-up (tracked under #41).

--- a/docs/index.md
+++ b/docs/index.md
@@ -40,19 +40,19 @@ flowchart LR
 
 ```bash
 # Core protocol server only (zero runtime dependencies)
-pip install rakaia
+pip install rakaia-streams
 
 # With the Django integration
-pip install "rakaia[django]"
+pip install "rakaia-streams[django]"
 
 # With Redis-backed channel layer (for multi-process SSE)
-pip install "rakaia[django,redis]"
+pip install "rakaia-streams[django,redis]"
 ```
 
 ## Quick Start (standalone server)
 
 ```bash
-pip install rakaia uvicorn
+pip install rakaia-streams uvicorn
 uvicorn rakaia:app --port 4437
 ```
 

--- a/justfile
+++ b/justfile
@@ -366,6 +366,34 @@ docs-serve:
 check: lint fmt-check test docs
 
 # ---------------------------------------------------------------------------
+# Release / publishing (dist name: rakaia-streams)
+# ---------------------------------------------------------------------------
+
+# Build the sdist + wheel into dist/ (clears stale artifacts first)
+build:
+    rm -rf dist/
+    uv build
+    uvx twine check dist/*
+
+# Tag the current pyproject version and push it — this triggers .github/workflows/publish.yml
+release: check build
+    #!/usr/bin/env bash
+    set -euo pipefail
+    version="$(uv run --no-project python -c \
+        'import tomllib,pathlib; print(tomllib.loads(pathlib.Path("pyproject.toml").read_text())["project"]["version"])')"
+    if [ -n "$(git status --porcelain)" ]; then
+        echo "Working tree is dirty — commit before releasing." >&2
+        exit 1
+    fi
+    echo "Tagging v${version} and pushing (CI publishes to PyPI)."
+    git tag "v${version}"
+    git push origin "v${version}"
+
+# Upload dist/ to TestPyPI by hand (needs a TestPyPI token; CI is the normal path)
+publish-test: build
+    uvx twine upload --repository testpypi dist/*
+
+# ---------------------------------------------------------------------------
 # Cleanup
 # ---------------------------------------------------------------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,8 @@
 [project]
-name = "rakaia"
+# Distribution name is `rakaia-streams` because `rakaia` is already taken on
+# PyPI by an unrelated placeholder. The import name is unaffected:
+#   pip install rakaia-streams   ->   import rakaia
+name = "rakaia-streams"
 version = "0.1.0"
 description = "Python server implementation of the Durable Streams protocol"
 readme = "README.md"
@@ -21,6 +24,12 @@ classifiers = [
 ]
 # Zero runtime dependencies - pure ASGI, stdlib only
 dependencies = []
+
+[project.urls]
+Homepage = "https://github.com/joshbrooks/rakaia"
+Repository = "https://github.com/joshbrooks/rakaia"
+Issues = "https://github.com/joshbrooks/rakaia/issues"
+Changelog = "https://github.com/joshbrooks/rakaia/blob/main/CHANGELOG.md"
 
 [project.optional-dependencies]
 django = [

--- a/uv.lock
+++ b/uv.lock
@@ -1134,7 +1134,7 @@ wheels = [
 ]
 
 [[package]]
-name = "rakaia"
+name = "rakaia-streams"
 version = "0.1.0"
 source = { editable = "." }
 


### PR DESCRIPTION
## Why

`rakaia` is already taken on PyPI — an unrelated placeholder at v0.0.1 with no summary and no repository link. So the distribution goes out as **`rakaia-streams`**.

Import names are untouched. The wheel's top-level packages are independent of the dist name, so `import rakaia` / `import django_rakaia` keep working:

```
pip install rakaia-streams   ->   import rakaia
```

Verified against the built wheel: `Name: rakaia-streams`, top-level `['django_rakaia', 'rakaia']`.

## What

- **`pyproject.toml`** — rename the distribution; add `[project.urls]` (Homepage / Repository / Issues / Changelog) so the PyPI page isn't bare.
- **`.github/workflows/publish.yml`** (new) — on a `v*` tag: build sdist + wheel, `twine check` them, then publish via **PyPI Trusted Publishing** (OIDC). No API token is stored anywhere. A guard step fails the build if the tag disagrees with `project.version`, so `v1.2.3` can't ship a 0.1.0 artifact.
- **`justfile`** — `just build`, `just release` (runs the full `check` gate, refuses a dirty tree, tags and pushes), `just publish-test` for a TestPyPI dry run.
- **README / docs** — install lines and extras specs use the new dist name.
- **`uv.lock`** — regenerated.

## Before the first tag will publish

Two one-time steps that can't live in the repo:

1. **PyPI** → Publishing → *Add a pending publisher*: project `rakaia-streams`, owner `joshbrooks`, repo `rakaia`, workflow `publish.yml`, environment `pypi`.
2. **GitHub** → Settings → Environments → create `pypi` (no secrets needed; optionally add a required reviewer so releases need a click).

Then `just release` from `main`.

## Checks

Local: `ruff check`, `ruff format --check`, `pytest` (819 passed, 1 skipped), `zensical build`, `uv build` + `twine check` (both dists PASSED).