### PR TITLE
chore(ci): bump GitHub Actions to current majors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v3
+        # Pinned to an exact version on purpose: setup-uv stopped publishing
+        # floating major/minor tags at v8 (supply-chain hardening), so `@v9`
+        # does not exist. Bump this explicitly.
+        uses: astral-sh/setup-uv@v9.0.0
         with:
           enable-cache: true
 

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -23,10 +23,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v3
+        # Pinned to an exact version on purpose: setup-uv stopped publishing
+        # floating major/minor tags at v8 (supply-chain hardening), so `@v9`
+        # does not exist. Bump this explicitly.
+        uses: astral-sh/setup-uv@v9.0.0
         with:
           enable-cache: true
 
@@ -36,10 +39,10 @@ jobs:
       - name: Install Python dependencies
         run: uv sync --extra dev
 
-      - name: Set up Node 20
-        uses: actions/setup-node@v4
+      - name: Set up Node 22
+        uses: actions/setup-node@v7
         with:
-          node-version: "20"
+          node-version: "22"
           cache: npm
           cache-dependency-path: conformance/package-lock.json
 
@@ -60,7 +63,7 @@ jobs:
 
       - name: Upload logs and JSON report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: conformance-log
           path: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,10 +28,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v3
+        # Pinned to an exact version on purpose: setup-uv stopped publishing
+        # floating major/minor tags at v8 (supply-chain hardening), so `@v9`
+        # does not exist. Bump this explicitly.
+        uses: astral-sh/setup-uv@v9.0.0
         with:
           enable-cache: true
 
@@ -57,7 +60,7 @@ jobs:
       - name: Check distribution metadata
         run: uvx twine check dist/*
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: dist
           path: dist/
@@ -71,7 +74,7 @@ jobs:
       # Required for Trusted Publishing; mints the short-lived OIDC token.
       id-token: write
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: dist
           path: dist/


### PR DESCRIPTION
The `v0.1.0` publish run warned that `checkout@v4`, `upload-artifact@v4` and `setup-uv@v3` target Node 20 and were being force-run on Node 24. This brings every action up to its current major.

| Action | Before | After |
| --- | --- | --- |
| `actions/checkout` | v4 | **v7** |
| `actions/upload-artifact` | v4 | **v7** |
| `actions/download-artifact` | v4 | **v8** |
| `actions/setup-node` | v4 | **v7** |
| `astral-sh/setup-uv` | v3 | **v9.0.0** |

`pypa/gh-action-pypi-publish` stays on `release/v1` — that's the moving ref PyPA tells you to track.

### Why setup-uv is pinned exactly

setup-uv stopped publishing floating major/minor tags at v8 as [supply-chain hardening](https://github.com/astral-sh/setup-uv/releases/tag/v8.0.0) (citing the tj-actions compromise). `@v9` is not a valid ref — only `@v9.0.0`. There's an inline comment at each usage so nobody "fixes" it back to a floating tag.

### Behaviour changes

- **setup-uv v9** flips `prune-cache` to `false` by default, [deliberately](https://github.com/astral-sh/setup-uv/pull/967), to reduce load on PyPI infrastructure. The uv cache entry will get larger. Left at the new default; `prune-cache: true` restores the old behaviour if cache size ever matters.
- **download-artifact v8** now *errors* on a digest mismatch rather than warning. That's the right default for the publish path.
- **upload-artifact v7** adds unzipped direct uploads behind `archive: false`. We keep the default (zipped), and download-artifact v8 handles both.
- **setup-node v6** narrowed automatic caching to npm only; the conformance job already passes `cache: npm`.
- **checkout v7** blocks checking out fork PRs under `pull_request_target` / `workflow_run`. Neither trigger is used here.

### Also: conformance Node 20 → 22

Node 20 is past end-of-life, and the suite's vitest 4 wants 22.12+. This one changes the test surface rather than just the runner, so it's worth a look at the conformance result on this PR specifically.

### Note

`publish.yml` only triggers on `v*` tags, so this PR's CI does **not** exercise the download-artifact v8 or upload-artifact v7 change. Those are first exercised on the next release.