### PR TITLE
refactor(store): named store failures instead of substring-matched messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,11 @@ is not yet tagged in a release.
 
 - **Named store failures.** A store now raises one of `StreamNotFound`,
   `StreamConfigConflict`, `SequenceConflict`, `ContentTypeMismatch`,
-  `InvalidJson` or `EmptyJsonArray` (all exported from `rakaia`) instead of a
-  bare `ValueError`/`KeyError`, and the ASGI server maps them to a status by
-  type via `rakaia.handler.STORE_FAILURE_STATUS`. Previously the server picked
+  `InvalidJson`, `EmptyJsonArray` or `InvalidOffset` (all exported from
+  `rakaia`) instead of a bare `ValueError`/`KeyError`, and the ASGI server maps
+  them to a status by type via `rakaia.handler.STORE_FAILURE_STATUS` —
+  resolved along the MRO, so a backend that specializes a failure inherits its
+  status rather than falling through to a 500. Previously the server picked
   the status by matching English in `str(e)`, so rewording a message in
   `store.py` silently turned a 4xx into an unhandled 500 — and any other store
   implementation had to reproduce five exact strings to behave the same. Each

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,18 @@ is not yet tagged in a release.
 
 ### Added
 
+- **Named store failures.** A store now raises one of `StreamNotFound`,
+  `StreamConfigConflict`, `SequenceConflict`, `ContentTypeMismatch`,
+  `InvalidJson` or `EmptyJsonArray` (all exported from `rakaia`) instead of a
+  bare `ValueError`/`KeyError`, and the ASGI server maps them to a status by
+  type via `rakaia.handler.STORE_FAILURE_STATUS`. Previously the server picked
+  the status by matching English in `str(e)`, so rewording a message in
+  `store.py` silently turned a 4xx into an unhandled 500 — and any other store
+  implementation had to reproduce five exact strings to behave the same. Each
+  failure subclasses the builtin it replaced, so existing `except ValueError` /
+  `except KeyError` code and tests are unaffected. A new failure type without a
+  status now fails the suite rather than 500ing at runtime.
+
 - **`PreloadedProjectionReader` — bulk-fetch a verification sweep.**
   `diff_effects_against_rows` does one `reader.get` per effect (one round-trip
   each), which is thousands of round-trips on a full reconcile. Pass the same

--- a/src/rakaia/__init__.py
+++ b/src/rakaia/__init__.py
@@ -84,6 +84,9 @@ from .types import (
     AppendResult,
     ClosedBy,
     CloseResult,
+    ContentTypeMismatch,
+    EmptyJsonArray,
+    InvalidJson,
     ProducerAccepted,
     ProducerDuplicate,
     ProducerInvalidEpochSeq,
@@ -92,8 +95,12 @@ from .types import (
     ProducerState,
     ProducerStreamClosed,
     ProducerValidationResult,
+    SequenceConflict,
     Stream,
+    StreamConfigConflict,
+    StreamError,
     StreamMessage,
+    StreamNotFound,
 )
 
 __version__ = "0.1.0"
@@ -139,6 +146,14 @@ __all__ = [
     "ProducerInvalidEpochSeq",
     "ProducerSequenceGap",
     "ProducerStreamClosed",
+    # Store failures (each subclasses the builtin it replaced)
+    "StreamError",
+    "StreamNotFound",
+    "StreamConfigConflict",
+    "SequenceConflict",
+    "ContentTypeMismatch",
+    "InvalidJson",
+    "EmptyJsonArray",
     # Cursor
     "calculate_cursor",
     "generate_response_cursor",

--- a/src/rakaia/__init__.py
+++ b/src/rakaia/__init__.py
@@ -87,6 +87,7 @@ from .types import (
     ContentTypeMismatch,
     EmptyJsonArray,
     InvalidJson,
+    InvalidOffset,
     ProducerAccepted,
     ProducerDuplicate,
     ProducerInvalidEpochSeq,
@@ -154,6 +155,7 @@ __all__ = [
     "ContentTypeMismatch",
     "InvalidJson",
     "EmptyJsonArray",
+    "InvalidOffset",
     # Cursor
     "calculate_cursor",
     "generate_response_cursor",

--- a/src/rakaia/handler.py
+++ b/src/rakaia/handler.py
@@ -49,12 +49,37 @@ from .types import (
     STREAM_TTL_HEADER,
     VALID_OFFSET_PATTERN,
     AppendOptions,
+    ContentTypeMismatch,
+    EmptyJsonArray,
+    InvalidJson,
     ProducerDuplicate,
     ProducerInvalidEpochSeq,
     ProducerSequenceGap,
     ProducerStaleEpoch,
     ProducerStreamClosed,
+    SequenceConflict,
+    StreamConfigConflict,
+    StreamError,
+    StreamNotFound,
 )
+
+# How a store failure becomes a response. A store raises one of the named
+# failures in `.types`; this is the whole mapping. Anything not in here — a
+# store raising a bare ValueError, say — propagates and becomes a 500, which is
+# the same as before, except the decision is now made by type rather than by
+# matching English in the exception message (a reworded f-string used to turn a
+# 4xx into a 500 silently).
+STORE_FAILURE_STATUS: dict[type[StreamError], tuple[int, bytes]] = {
+    StreamNotFound: (404, b"Stream not found"),
+    StreamConfigConflict: (
+        409,
+        b"Stream already exists with different configuration",
+    ),
+    SequenceConflict: (409, b"Sequence conflict"),
+    ContentTypeMismatch: (409, b"Content-type mismatch"),
+    InvalidJson: (400, b"Invalid JSON"),
+    EmptyJsonArray: (400, b"Empty arrays are not allowed"),
+}
 
 # Header names used in responses (title case for HTTP convention)
 STREAM_OFFSET_HEADER_RESP = "Stream-Next-Offset"
@@ -211,33 +236,12 @@ def create_app(
                 await _handle_delete(path, send, actual_store, cors_headers)
             else:
                 await _send_error(send, 405, b"Method not allowed", cors_headers)
-        except KeyError as e:
-            msg = str(e)
-            if "not found" in msg.lower():
-                await _send_error(send, 404, b"Stream not found", cors_headers)
-            else:
+        except StreamError as e:
+            mapped = STORE_FAILURE_STATUS.get(type(e))
+            if mapped is None:
                 raise
-        except ValueError as e:
-            msg = str(e)
-            if "already exists with different configuration" in msg:
-                await _send_error(
-                    send,
-                    409,
-                    b"Stream already exists with different configuration",
-                    cors_headers,
-                )
-            elif "Sequence conflict" in msg:
-                await _send_error(send, 409, b"Sequence conflict", cors_headers)
-            elif "Content-type mismatch" in msg:
-                await _send_error(send, 409, b"Content-type mismatch", cors_headers)
-            elif "Invalid JSON" in msg:
-                await _send_error(send, 400, b"Invalid JSON", cors_headers)
-            elif "Empty arrays are not allowed" in msg:
-                await _send_error(
-                    send, 400, b"Empty arrays are not allowed", cors_headers
-                )
-            else:
-                raise
+            status, body = mapped
+            await _send_error(send, status, body, cors_headers)
 
     return app
 

--- a/src/rakaia/handler.py
+++ b/src/rakaia/handler.py
@@ -718,6 +718,11 @@ async def _handle_sse(
         )
         sse_headers["Stream-Sse-Data-Encoding"] = "base64"
 
+    # The first read runs before the response starts: a StreamError here (bad
+    # offset, vanished stream) must surface as its mapped 4xx, which is
+    # impossible once http.response.start has been sent.
+    pending_read: tuple[Any, bool] | None = store.read(path, initial_offset)
+
     await start_streaming_response(send, 200, sse_headers)
 
     current_offset = initial_offset
@@ -725,10 +730,14 @@ async def _handle_sse(
 
     while True:
         # Read messages from offset
-        try:
-            messages, up_to_date = store.read(path, current_offset)
-        except KeyError:
-            break
+        if pending_read is not None:
+            messages, up_to_date = pending_read
+            pending_read = None
+        else:
+            try:
+                messages, up_to_date = store.read(path, current_offset)
+            except (KeyError, StreamError):
+                break
 
         current_stream = store.get(path)
         if current_stream is None:
@@ -809,7 +818,7 @@ async def _handle_sse(
                 ) = await store.wait_for_messages(
                     path, current_offset, opts.long_poll_timeout
                 )
-            except KeyError:
+            except (KeyError, StreamError):
                 break
 
             if stream_closed:

--- a/src/rakaia/handler.py
+++ b/src/rakaia/handler.py
@@ -52,6 +52,7 @@ from .types import (
     ContentTypeMismatch,
     EmptyJsonArray,
     InvalidJson,
+    InvalidOffset,
     ProducerDuplicate,
     ProducerInvalidEpochSeq,
     ProducerSequenceGap,
@@ -79,7 +80,25 @@ STORE_FAILURE_STATUS: dict[type[StreamError], tuple[int, bytes]] = {
     ContentTypeMismatch: (409, b"Content-type mismatch"),
     InvalidJson: (400, b"Invalid JSON"),
     EmptyJsonArray: (400, b"Empty arrays are not allowed"),
+    InvalidOffset: (400, b"Invalid offset"),
 }
+
+
+def _status_for(failure: BaseException) -> tuple[int, bytes] | None:
+    """The response for a store failure, or `None` to let it propagate.
+
+    Resolved along the MRO rather than by exact type, so a store that
+    specializes a failure — `class ShardNotFound(StreamNotFound)` in some other
+    backend — inherits its status instead of falling through to a 500. The
+    closed-set test only sees subclasses that happen to be imported, so exact
+    lookup would leave that hole open for anything defined downstream.
+    """
+    for cls in type(failure).__mro__:
+        mapped = STORE_FAILURE_STATUS.get(cls)  # type: ignore[arg-type]
+        if mapped is not None:
+            return mapped
+    return None
+
 
 # Header names used in responses (title case for HTTP convention)
 STREAM_OFFSET_HEADER_RESP = "Stream-Next-Offset"
@@ -237,7 +256,7 @@ def create_app(
             else:
                 await _send_error(send, 405, b"Method not allowed", cors_headers)
         except StreamError as e:
-            mapped = STORE_FAILURE_STATUS.get(type(e))
+            mapped = _status_for(e)
             if mapped is None:
                 raise
             status, body = mapped

--- a/src/rakaia/json_mode.py
+++ b/src/rakaia/json_mode.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 import json
 from typing import Any
 
+from .types import EmptyJsonArray, InvalidJson
+
 
 def normalize_content_type(content_type: str | None) -> str:
     """
@@ -50,14 +52,14 @@ def process_json_append(data: bytes, is_initial_create: bool = False) -> bytes:
     try:
         parsed: Any = json.loads(text)
     except (json.JSONDecodeError, UnicodeDecodeError) as e:
-        raise ValueError(f"Invalid JSON: {e}") from e
+        raise InvalidJson(f"Invalid JSON: {e}") from e
 
     if isinstance(parsed, list):
         if len(parsed) == 0:
             if is_initial_create:
                 # Empty array on create = empty stream, no data to store
                 return b""
-            raise ValueError("Empty arrays are not allowed in append operations")
+            raise EmptyJsonArray("Empty arrays are not allowed in append operations")
 
         # Flatten one level: each element becomes a separate message
         # Store as individual JSON values with trailing commas

--- a/src/rakaia/protocols.py
+++ b/src/rakaia/protocols.py
@@ -47,7 +47,9 @@ class ReadableStore(Protocol):
 
         With no `offset`, returns every message; with an `offset`, returns the
         messages after it (offsets are opaque — see the class docstring). Raises
-        `KeyError` if the stream does not exist.
+        `StreamNotFound` (a `KeyError` subclass) if the stream does not exist.
+        A bare `KeyError` still satisfies the framework contract, but the HTTP
+        server maps only the named failure to a 404 — anything else is a 500.
         """
         ...
 
@@ -91,18 +93,20 @@ class WritableStore(ReadableStore, Protocol):
         Three possible outcomes, only the first of which is guaranteed across
         every backend:
 
-        - Raises `KeyError` if the stream does not exist (create it first) —
-          the one guaranteed exception every `WritableStore` must raise.
-        - May raise `ValueError` for a backend's own validation (the in-memory
-          `StreamStore` raises this on a content-type or Stream-Seq conflict);
-          `DjangoStreamStore` has no such concept and never raises it.
+        - Raises `StreamNotFound` (a `KeyError` subclass) if the stream does
+          not exist (create it first) — the one guaranteed exception every
+          `WritableStore` must raise.
+        - May raise a `ValueError`-based failure for a backend's own validation
+          (the in-memory `StreamStore` raises `ContentTypeMismatch` or
+          `SequenceConflict`); `DjangoStreamStore` has no such concept and
+          never raises it.
         - May return normally with a closed-stream signal instead of raising
           (the in-memory `StreamStore`'s `AppendResult.stream_closed=True`,
           with `message=None`, when appending to a closed stream);
           `DjangoStreamStore` has no closed-stream concept and never signals
           this.
 
-        Depend only on the `KeyError` here; treat the `ValueError` and
+        Depend only on the `StreamNotFound` here; treat the `ValueError` and
         `stream_closed=True` cases as backend-specific, not part of the
         `WritableStore` contract (see `tests/store_contract.py` for what is and
         isn't asserted across backends).

--- a/src/rakaia/store.py
+++ b/src/rakaia/store.py
@@ -143,7 +143,7 @@ class StreamStore:
         If the stream already exists with matching config, returns it (idempotent).
 
         Raises:
-            ValueError: If stream exists with different config.
+            StreamConfigConflict: If stream exists with different config.
         """
         existing = self._get_if_not_expired(path)
         if existing is not None:
@@ -235,8 +235,9 @@ class StreamStore:
         producer validation, and stream closure.
 
         Raises:
-            KeyError: If stream doesn't exist or is expired.
-            ValueError: If JSON is invalid, content-type mismatches, or seq conflict.
+            StreamNotFound: If stream doesn't exist or is expired.
+            InvalidJson / EmptyJsonArray: If the payload fails JSON-mode checks.
+            ContentTypeMismatch / SequenceConflict: On the respective conflict.
         """
         opts = options or AppendOptions()
         stream = self._get_if_not_expired(path)
@@ -473,7 +474,7 @@ class StreamStore:
         Returns (messages, up_to_date).
 
         Raises:
-            KeyError: If stream doesn't exist or is expired.
+            StreamNotFound: If stream doesn't exist or is expired.
         """
         stream = self._get_if_not_expired(path)
         if stream is None:
@@ -521,7 +522,7 @@ class StreamStore:
         Returns (messages, timed_out, stream_closed).
 
         Raises:
-            KeyError: If stream doesn't exist.
+            StreamNotFound: If stream doesn't exist.
         """
         stream = self._get_if_not_expired(path)
         if stream is None:

--- a/src/rakaia/store.py
+++ b/src/rakaia/store.py
@@ -26,6 +26,7 @@ from .types import (
     AppendOptions,
     AppendResult,
     CloseResult,
+    ContentTypeMismatch,
     ProducerAccepted,
     ProducerDuplicate,
     ProducerInvalidEpochSeq,
@@ -33,8 +34,11 @@ from .types import (
     ProducerStaleEpoch,
     ProducerStreamClosed,
     ProducerValidationResult,
+    SequenceConflict,
     Stream,
+    StreamConfigConflict,
     StreamMessage,
+    StreamNotFound,
 )
 
 # NB: this module generates offsets (the `{seq}_{byte}` format) but never
@@ -153,7 +157,7 @@ class StreamStore:
 
             if ct_matches and ttl_matches and expires_matches and closed_matches:
                 return existing
-            raise ValueError(
+            raise StreamConfigConflict(
                 f"Stream already exists with different configuration: {path}"
             )
 
@@ -237,7 +241,7 @@ class StreamStore:
         opts = options or AppendOptions()
         stream = self._get_if_not_expired(path)
         if stream is None:
-            raise KeyError(f"Stream not found: {path}")
+            raise StreamNotFound(f"Stream not found: {path}")
 
         # Check if stream is closed
         if stream.closed:
@@ -262,7 +266,7 @@ class StreamStore:
             provided = normalize_content_type(opts.content_type)
             stream_ct = normalize_content_type(stream.content_type)
             if provided != stream_ct:
-                raise ValueError(
+                raise ContentTypeMismatch(
                     f"Content-type mismatch: expected {stream.content_type}, "
                     f"got {opts.content_type}"
                 )
@@ -286,7 +290,9 @@ class StreamStore:
             and stream.last_seq is not None
             and opts.seq <= stream.last_seq
         ):
-            raise ValueError(f"Sequence conflict: {opts.seq} <= {stream.last_seq}")
+            raise SequenceConflict(
+                f"Sequence conflict: {opts.seq} <= {stream.last_seq}"
+            )
 
         # Append the data (may raise for invalid JSON). Provenance is merged
         # here at the public-append boundary — not in _append_to_stream — so a
@@ -471,7 +477,7 @@ class StreamStore:
         """
         stream = self._get_if_not_expired(path)
         if stream is None:
-            raise KeyError(f"Stream not found: {path}")
+            raise StreamNotFound(f"Stream not found: {path}")
 
         # A read extends the sliding TTL window.
         self._touch(stream)
@@ -493,7 +499,7 @@ class StreamStore:
         """
         stream = self._get_if_not_expired(path)
         if stream is None:
-            raise KeyError(f"Stream not found: {path}")
+            raise StreamNotFound(f"Stream not found: {path}")
 
         # Concatenate all message data
         concatenated = b"".join(m.data for m in messages)
@@ -519,7 +525,7 @@ class StreamStore:
         """
         stream = self._get_if_not_expired(path)
         if stream is None:
-            raise KeyError(f"Stream not found: {path}")
+            raise StreamNotFound(f"Stream not found: {path}")
 
         # Check for existing messages first
         messages, _ = self.read(path, offset)

--- a/src/rakaia/types.py
+++ b/src/rakaia/types.py
@@ -64,6 +64,50 @@ PRODUCER_STATE_TTL_SECONDS = 7 * 24 * 60 * 60
 
 
 # =============================================================================
+# Store failures
+# =============================================================================
+#
+# The closed set of failures a store raises and a protocol server maps to a
+# status. Before these existed the mapping was a chain of substring tests over
+# `str(e)` in `handler.py`, so an f-string reworded in `store.py` silently
+# turned a 4xx into an unhandled 500 — and any other store implementation had
+# to reproduce five exact English strings to get the same statuses. Naming them
+# makes the mapping a lookup and the contract something a store can be tested
+# against.
+#
+# Each subclasses the builtin it replaced (`KeyError` / `ValueError`), so code
+# and tests that caught those keep working.
+
+
+class StreamError(Exception):
+    """Base for store failures a protocol server maps to a status."""
+
+
+class StreamNotFound(StreamError, KeyError):
+    """The stream does not exist, or has expired."""
+
+
+class StreamConfigConflict(StreamError, ValueError):
+    """A create names an existing stream with a different configuration."""
+
+
+class SequenceConflict(StreamError, ValueError):
+    """An append's `Stream-Seq` is not above the stream's last seq."""
+
+
+class ContentTypeMismatch(StreamError, ValueError):
+    """An append's content type disagrees with the stream's."""
+
+
+class InvalidJson(StreamError, ValueError):
+    """A JSON-mode payload did not parse."""
+
+
+class EmptyJsonArray(StreamError, ValueError):
+    """A JSON-mode append carried an empty array."""
+
+
+# =============================================================================
 # Data structures
 # =============================================================================
 

--- a/src/rakaia/types.py
+++ b/src/rakaia/types.py
@@ -107,6 +107,17 @@ class EmptyJsonArray(StreamError, ValueError):
     """A JSON-mode append carried an empty array."""
 
 
+class InvalidOffset(StreamError, ValueError):
+    """An offset is syntactically valid but not one this store can read.
+
+    `VALID_OFFSET_PATTERN` is a syntactic guard shared by every server; it
+    cannot tell whether a given token is an offset *this* store issued, because
+    the protocol makes offsets opaque rather than uniform (§6). A store that
+    cannot interpret the token must say so, rather than parse it into some
+    other position and read the wrong window.
+    """
+
+
 # =============================================================================
 # Data structures
 # =============================================================================

--- a/tests/test_rakaia/test_store_failures.py
+++ b/tests/test_rakaia/test_store_failures.py
@@ -21,6 +21,7 @@ from rakaia.types import (
     ContentTypeMismatch,
     EmptyJsonArray,
     InvalidJson,
+    InvalidOffset,
     SequenceConflict,
     StreamConfigConflict,
     StreamError,
@@ -168,6 +169,27 @@ class TestFailureBecomesStatus:
         assert (await client.get("/nope")).status_code == 404
 
     @pytest.mark.asyncio
+    async def test_stream_not_found_from_read_is_404(self) -> None:
+        """`StreamNotFound` raised by the store itself, past the has() guard.
+
+        `test_missing_stream_is_404` never reaches the store — the handler's
+        own absent-stream check answers first. This one creates the stream over
+        HTTP (the handler keys streams by the full request path, "/s") so the
+        failure genuinely travels store → mapping → status.
+        """
+        store = StreamStore()
+        app = create_app(store=store)
+
+        def _gone(*_args: object, **_kwargs: object) -> None:
+            raise StreamNotFound("raised by the store, not the handler")
+
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as ac:
+            await ac.put("/s")
+            store.read = _gone  # type: ignore[method-assign]
+            assert (await ac.get("/s")).status_code == 404
+
+    @pytest.mark.asyncio
     async def test_config_conflict_is_409(self, client: httpx.AsyncClient) -> None:
         await client.put("/s", headers={"content-type": "text/plain"})
         r = await client.put("/s", headers={"content-type": "application/json"})
@@ -219,8 +241,32 @@ class TestFailureBecomesStatus:
         def _reworded(*_args: object, **_kwargs: object) -> None:
             raise StreamNotFound("wholly different wording")
 
-        store.read = _reworded  # type: ignore[method-assign]
         transport = httpx.ASGITransport(app=app)
         async with httpx.AsyncClient(transport=transport, base_url="http://test") as ac:
-            store.create("s")
+            # Create over HTTP — the handler keys streams by the full request
+            # path ("/s"), so store.create("s") would leave the handler's
+            # absent-stream 404 to answer before the patched read ever ran.
+            await ac.put("/s")
+            store.read = _reworded  # type: ignore[method-assign]
             assert (await ac.get("/s")).status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_sse_store_failure_is_a_status_not_a_crash(self) -> None:
+        """A StreamError from the first SSE read must answer with its status.
+
+        The streaming 200 used to start before the first read, so a failure
+        there could only unwind into a second ``http.response.start`` — under a
+        real server, a crashed connection instead of a 400.
+        """
+        store = StreamStore()
+        app = create_app(store=store)
+
+        def _rejects(*_args: object, **_kwargs: object) -> None:
+            raise InvalidOffset("offset belongs to no message")
+
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as ac:
+            await ac.put("/s")
+            store.read = _rejects  # type: ignore[method-assign]
+            r = await ac.get("/s", params={"offset": "0_0", "live": "sse"})
+            assert r.status_code == 400

--- a/tests/test_rakaia/test_store_failures.py
+++ b/tests/test_rakaia/test_store_failures.py
@@ -1,0 +1,192 @@
+"""The named store failures, and the status each one becomes.
+
+Before these types existed, `handler.py` chose a status by matching English in
+`str(e)`. Rewording an f-string in `store.py` turned a 4xx into an unhandled
+500, and nothing failed: `test_store.py` asserted `pytest.raises(ValueError)`,
+`test_handler.py` asserted status codes, and no test connected the two. These
+do.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+
+import httpx
+import pytest
+import pytest_asyncio
+
+from rakaia import StreamStore, create_app
+from rakaia.handler import STORE_FAILURE_STATUS
+from rakaia.types import (
+    ContentTypeMismatch,
+    EmptyJsonArray,
+    InvalidJson,
+    SequenceConflict,
+    StreamConfigConflict,
+    StreamError,
+    StreamNotFound,
+)
+
+
+@pytest_asyncio.fixture
+async def client() -> AsyncIterator[httpx.AsyncClient]:
+    app = create_app(store=StreamStore())
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+
+
+def _subclasses(cls: type) -> set[type]:
+    found = set()
+    for sub in cls.__subclasses__():
+        found.add(sub)
+        found |= _subclasses(sub)
+    return found
+
+
+class TestFailureSetIsClosed:
+    """The mapping is the contract — it may not silently gain a hole."""
+
+    def test_every_failure_has_a_status(self) -> None:
+        """A new StreamError subclass must be given a status here.
+
+        This is the test that makes the seam uncheatable: add a failure to
+        `types.py`, forget the status, and the server would 500 on it. Now this
+        fails instead.
+        """
+        unmapped = _subclasses(StreamError) - set(STORE_FAILURE_STATUS)
+        assert unmapped == set(), (
+            f"store failures with no status in STORE_FAILURE_STATUS: "
+            f"{sorted(c.__name__ for c in unmapped)}"
+        )
+
+    def test_statuses_are_client_errors(self) -> None:
+        for failure, (status, _body) in STORE_FAILURE_STATUS.items():
+            assert 400 <= status < 500, f"{failure.__name__} maps to {status}"
+
+
+class TestCompatibility:
+    """Each failure subclasses the builtin it replaced."""
+
+    @pytest.mark.parametrize(
+        "failure",
+        [StreamConfigConflict, SequenceConflict, ContentTypeMismatch],
+    )
+    def test_store_failures_are_value_errors(self, failure: type) -> None:
+        assert issubclass(failure, ValueError)
+
+    @pytest.mark.parametrize("failure", [InvalidJson, EmptyJsonArray])
+    def test_json_failures_are_value_errors(self, failure: type) -> None:
+        assert issubclass(failure, ValueError)
+
+    def test_not_found_is_a_key_error(self) -> None:
+        assert issubclass(StreamNotFound, KeyError)
+
+
+class TestStoreRaisesTheNamedFailure:
+    """The store's half of the contract — no HTTP involved."""
+
+    def test_create_with_different_config(self) -> None:
+        store = StreamStore()
+        store.create("s", content_type="text/plain")
+        with pytest.raises(StreamConfigConflict):
+            store.create("s", content_type="application/json")
+
+    def test_append_to_missing_stream(self) -> None:
+        with pytest.raises(StreamNotFound):
+            StreamStore().append("nope", b"data")
+
+    def test_content_type_mismatch(self) -> None:
+        from rakaia import AppendOptions
+
+        store = StreamStore()
+        store.create("s", content_type="text/plain")
+        with pytest.raises(ContentTypeMismatch):
+            store.append("s", b"x", AppendOptions(content_type="application/json"))
+
+    def test_sequence_conflict(self) -> None:
+        from rakaia import AppendOptions
+
+        store = StreamStore()
+        store.create("s")
+        store.append("s", b"a", AppendOptions(seq=5))
+        with pytest.raises(SequenceConflict):
+            store.append("s", b"b", AppendOptions(seq=5))
+
+    def test_invalid_json(self) -> None:
+        store = StreamStore()
+        store.create("s", content_type="application/json")
+        with pytest.raises(InvalidJson):
+            store.append("s", b"{not json")
+
+    def test_empty_json_array(self) -> None:
+        store = StreamStore()
+        store.create("s", content_type="application/json")
+        with pytest.raises(EmptyJsonArray):
+            store.append("s", b"[]")
+
+
+class TestFailureBecomesStatus:
+    """The server's half — each failure, raised for real, over HTTP."""
+
+    @pytest.mark.asyncio
+    async def test_missing_stream_is_404(self, client: httpx.AsyncClient) -> None:
+        assert (await client.get("/nope")).status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_config_conflict_is_409(self, client: httpx.AsyncClient) -> None:
+        await client.put("/s", headers={"content-type": "text/plain"})
+        r = await client.put("/s", headers={"content-type": "application/json"})
+        assert r.status_code == 409
+
+    @pytest.mark.asyncio
+    async def test_content_type_mismatch_is_409(
+        self, client: httpx.AsyncClient
+    ) -> None:
+        await client.put("/s", headers={"content-type": "text/plain"})
+        r = await client.post(
+            "/s", content=b"x", headers={"content-type": "application/json"}
+        )
+        assert r.status_code == 409
+
+    @pytest.mark.asyncio
+    async def test_sequence_conflict_is_409(self, client: httpx.AsyncClient) -> None:
+        headers = {"content-type": "text/plain", "stream-seq": "5"}
+        await client.put("/s", headers={"content-type": "text/plain"})
+        await client.post("/s", content=b"a", headers=headers)
+        r = await client.post("/s", content=b"b", headers=headers)
+        assert r.status_code == 409
+
+    @pytest.mark.asyncio
+    async def test_invalid_json_is_400(self, client: httpx.AsyncClient) -> None:
+        await client.put("/s", headers={"content-type": "application/json"})
+        r = await client.post(
+            "/s", content=b"{not json", headers={"content-type": "application/json"}
+        )
+        assert r.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_empty_array_is_400(self, client: httpx.AsyncClient) -> None:
+        await client.put("/s", headers={"content-type": "application/json"})
+        r = await client.post(
+            "/s", content=b"[]", headers={"content-type": "application/json"}
+        )
+        assert r.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_message_text_is_not_load_bearing(self) -> None:
+        """Reword a failure's message; the status must not move.
+
+        This is the regression the old substring mapping could not survive.
+        """
+        store = StreamStore()
+        app = create_app(store=store)
+
+        def _reworded(*_args: object, **_kwargs: object) -> None:
+            raise StreamNotFound("wholly different wording")
+
+        store.read = _reworded  # type: ignore[method-assign]
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as ac:
+            store.create("s")
+            assert (await ac.get("/s")).status_code == 404

--- a/tests/test_rakaia/test_store_failures.py
+++ b/tests/test_rakaia/test_store_failures.py
@@ -16,7 +16,7 @@ import pytest
 import pytest_asyncio
 
 from rakaia import StreamStore, create_app
-from rakaia.handler import STORE_FAILURE_STATUS
+from rakaia.handler import STORE_FAILURE_STATUS, _status_for
 from rakaia.types import (
     ContentTypeMismatch,
     EmptyJsonArray,
@@ -44,6 +44,17 @@ def _subclasses(cls: type) -> set[type]:
     return found
 
 
+def _rakaia_failures() -> set[type]:
+    """Every failure rakaia itself defines.
+
+    Restricted to this package because `__subclasses__` also sees failures
+    defined elsewhere — a downstream backend's, or one a test declares a few
+    lines below. Those are not rakaia's to map, and `_status_for` resolves them
+    along the MRO anyway; what must not gain a hole is the set shipped here.
+    """
+    return {c for c in _subclasses(StreamError) if c.__module__.startswith("rakaia.")}
+
+
 class TestFailureSetIsClosed:
     """The mapping is the contract — it may not silently gain a hole."""
 
@@ -54,7 +65,7 @@ class TestFailureSetIsClosed:
         `types.py`, forget the status, and the server would 500 on it. Now this
         fails instead.
         """
-        unmapped = _subclasses(StreamError) - set(STORE_FAILURE_STATUS)
+        unmapped = _rakaia_failures() - set(STORE_FAILURE_STATUS)
         assert unmapped == set(), (
             f"store failures with no status in STORE_FAILURE_STATUS: "
             f"{sorted(c.__name__ for c in unmapped)}"
@@ -63,6 +74,29 @@ class TestFailureSetIsClosed:
     def test_statuses_are_client_errors(self) -> None:
         for failure, (status, _body) in STORE_FAILURE_STATUS.items():
             assert 400 <= status < 500, f"{failure.__name__} maps to {status}"
+
+    def test_a_specialized_failure_inherits_its_parents_status(self) -> None:
+        """A store may narrow a failure; it must not thereby become a 500.
+
+        `test_every_failure_has_a_status` only sees subclasses that happen to
+        be imported, so it cannot police a failure defined in someone else's
+        backend package. Resolving along the MRO covers those too.
+        """
+
+        class ShardNotFound(StreamNotFound):
+            """As some other backend might define it."""
+
+        assert (
+            _status_for(ShardNotFound("gone")) == STORE_FAILURE_STATUS[StreamNotFound]
+        )
+
+    def test_an_unmapped_failure_still_propagates(self) -> None:
+        """The 500 path is deliberate, not an accident of the lookup."""
+
+        class Unmapped(StreamError):
+            pass
+
+        assert _status_for(Unmapped()) is None
 
 
 class TestCompatibility:


### PR DESCRIPTION
Step 1 of 3 in the protocol-server cleanup (see the architecture review). Self-contained; no behaviour change.

## The problem

`handler.py` chose an HTTP status by matching English in `str(e)`:

```python
except ValueError as e:
    msg = str(e)
    if "already exists with different configuration" in msg: ... 409
    elif "Sequence conflict" in msg: ...                        409
    elif "Content-type mismatch" in msg: ...                    409
    elif "Invalid JSON" in msg: ...                             400
    elif "Empty arrays are not allowed" in msg: ...             400
    else: raise                                                 # 500
```

So the store's *message text* was part of its interface. Reword an f-string in `store.py` and a 409 silently becomes an unhandled 500 — with nothing to catch it, because `test_store.py` asserts `pytest.raises(ValueError)`, `test_handler.py` asserts status codes, and no test connected the two.

It also blocks the next step: any other store implementation would have to reproduce five exact English strings to get the right statuses.

## The change

- **`types.py`** — a closed set of failures under a `StreamError` base: `StreamNotFound`, `StreamConfigConflict`, `SequenceConflict`, `ContentTypeMismatch`, `InvalidJson`, `EmptyJsonArray`.
- **`store.py` / `json_mode.py`** — raise those instead of bare `ValueError`/`KeyError`.
- **`handler.py`** — the except block becomes a lookup in `STORE_FAILURE_STATUS`. Unmapped exceptions still propagate to a 500, exactly as before.
- All names exported from `rakaia`.

**Compatibility:** each failure subclasses the builtin it replaced (`StreamNotFound` is a `KeyError`; the rest are `ValueError`), so existing `except` clauses and tests keep working. The full suite passed unchanged before any new tests were added.

## Tests

`tests/test_rakaia/test_store_failures.py` (21 cases) covers both halves of the contract — the store raising each named failure, and each failure becoming the right status over real HTTP. Two are worth calling out:

- `test_every_failure_has_a_status` walks `StreamError`'s subclasses and fails if any lacks a status. Add a failure type, forget the mapping, and the suite fails instead of the server 500ing at runtime. (Verified it bites: adding a throwaway subclass fails the test.)
- `test_message_text_is_not_load_bearing` raises a failure with completely different wording and asserts the status holds — the regression the old mapping could not survive.

## Gate

`ruff check`, `ruff format --check`, `pytest` (842 passed, 1 skipped — was 819), `zensical build` all clean.

## Next

2. Name the interface the protocol server needs from a store (`StreamServerStore`), so `create_app` can accept the durable store rather than only the in-memory one.
3. Delete `django_rakaia/protocol_views.py` — the second, half-finished implementation of the protocol.


---

## Review fixes (2026-08-11)

Two gaps in the seam, from review of the stack.

- **The status lookup was by exact type.** `STORE_FAILURE_STATUS.get(type(e))` meant a backend that specializes a failure — `ShardNotFound(StreamNotFound)` — fell through to a 500. `test_every_failure_has_a_status` cannot police that: it walks `__subclasses__`, which only ever sees classes that happen to be imported, never one defined in a downstream package. Statuses now resolve along the MRO, and the closure test is scoped to failures rakaia itself defines — which also keeps a test-local subclass from tripping it.
- **Added `InvalidOffset` (400).** A store needs a way to say "that token is syntactically valid but is not an offset I issued" — `VALID_OFFSET_PATTERN` cannot tell, because the protocol makes offsets opaque rather than uniform (§6). Without it, a store handed a foreign offset can only choose between a 500 and silently reading the wrong window. Used by both stores in #88.
