### PR TITLE
Refuse an unknown RAKAIA_STORE instead of silently using memory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -149,6 +149,20 @@ is not yet tagged in a release.
 
 ### Fixed
 
+- **`RAKAIA_STORE` no longer fails open.** `get_store()` returned the
+  *in-memory* store for any backend string that wasn't exactly `"durable"`, so a
+  one-character typo (`"durrable"`, a stray space from a `.env` file, `"Durable"`)
+  selected a process-local dict while the deployment believed it was durable:
+  appends succeeded, nothing warned, and the entire event log vanished on the
+  next restart. An unknown backend now raises `ImproperlyConfigured` naming the
+  valid choices, and a refused backend is not cached, so correcting the setting
+  works without a restart. A new system check reports the same problem at
+  startup (`rakaia.E001`) rather than on the first append — which in a worker
+  process could be hours in — and `"memory"` with `DEBUG = False` warns
+  (`rakaia.W001`). ADR 0002 named this gap ("`RAKAIA_STORE` swaps stores by
+  string with no interface check"); the first production consumer had written
+  its own check downstream to catch it.
+
 - **A store now refuses an offset it did not issue.** Both stores accepted the
   other's offset format and resolved it to an unrelated position instead of
   failing: `int("0_5")` is `5` in Python, so the durable store read the wrong

--- a/docs/django-integration.md
+++ b/docs/django-integration.md
@@ -94,6 +94,16 @@ Both `manage.py replay` and the mounted protocol app resolve their store through
 `get_store()`, so flipping this one setting switches the whole integration over.
 The chosen store is cached one-per-backend for the process.
 
+Only those two values are accepted. Anything else — a typo like `"durrable"`, a
+stray space, a plausible guess like `"postgres"` — raises `ImproperlyConfigured`
+rather than falling back. It used to fall back to the in-memory store, which made
+a one-character mistake indistinguishable from a working durable deployment:
+appends succeeded, nothing complained, and the whole log vanished on the next
+restart. `manage.py check` reports the same problem at startup as `rakaia.E001`,
+so a misconfigured deployment fails before it serves a request. Running
+`"memory"` with `DEBUG = False` is allowed but warns (`rakaia.W001`) — silence it
+via `SILENCED_SYSTEM_CHECKS` if that is deliberate.
+
 | | `"memory"` (default) | `"durable"` |
 |---|---|---|
 | Backend | `rakaia.StreamStore` | `DjangoStreamStore` |

--- a/src/django_rakaia/apps.py
+++ b/src/django_rakaia/apps.py
@@ -8,6 +8,12 @@ class DjangoRakaiaConfig(AppConfig):
     verbose_name = "Rakaia Streams"
 
     def ready(self) -> None:
+        # Registering the checks is what runs them: importing the module binds
+        # them to Django's registry via @register(). Kept first and dependency
+        # -free so `manage.py check` reports a bad RAKAIA_STORE even when the
+        # rest of `ready()` would fail for the same reason.
+        from django_rakaia import checks  # noqa: F401
+
         # Framework tier: always wire handler/upcaster autodiscovery. This path
         # has no `channels` dependency, so it must load for a projections-only
         # consumer that never touches the protocol server (ADR-0002 / #41).

--- a/src/django_rakaia/checks.py
+++ b/src/django_rakaia/checks.py
@@ -1,0 +1,59 @@
+"""Startup checks for the Rakaia settings a deployment can get quietly wrong.
+
+`django_rakaia.store.get_store` refuses an unknown ``RAKAIA_STORE`` — but it
+only runs on the first append, which in a web process is during a request, and
+in a worker may be hours in. These checks move the same verdict to
+``manage.py check``, so a misconfigured deployment fails before it serves
+anything.
+
+The one that matters is `rakaia.E001`: the setting is free-form text, so a
+misspelt backend used to select the in-memory store and lose every append on
+restart. `rakaia.W001` is softer — a correctly-spelt ``"memory"`` is legitimate
+for development but is worth flagging if `DEBUG` is off, because a production
+deployment almost never means it.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from django.conf import settings
+from django.core.checks import Error, Warning, register
+
+from .store import BACKENDS, DEFAULT_BACKEND
+
+
+@register()
+def check_store_backend(app_configs: Any, **kwargs: Any) -> list[Any]:  # noqa: ARG001
+    """Verify ``RAKAIA_STORE`` names a real backend, and flag in-memory in prod."""
+    backend = getattr(settings, "RAKAIA_STORE", DEFAULT_BACKEND)
+
+    if backend not in BACKENDS:
+        return [
+            Error(
+                f"RAKAIA_STORE={backend!r} is not a known store backend.",
+                hint=(
+                    f"Set it to one of {', '.join(repr(b) for b in BACKENDS)}. "
+                    "Until this is fixed every append raises "
+                    "ImproperlyConfigured."
+                ),
+                id="rakaia.E001",
+            )
+        ]
+
+    if backend == "memory" and not settings.DEBUG:
+        return [
+            Warning(
+                "RAKAIA_STORE is 'memory' with DEBUG off — the event log is "
+                "held in process memory and is lost on every restart.",
+                hint=(
+                    "Set RAKAIA_STORE = 'durable' and run "
+                    "`manage.py migrate django_rakaia` to persist the log. "
+                    "Silence this with SILENCED_SYSTEM_CHECKS if in-memory is "
+                    "deliberate here."
+                ),
+                id="rakaia.W001",
+            )
+        ]
+
+    return []

--- a/src/django_rakaia/store.py
+++ b/src/django_rakaia/store.py
@@ -2,8 +2,15 @@ import threading
 from typing import Any
 
 from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
 
 from rakaia import StreamStore
+
+#: The backends ``RAKAIA_STORE`` accepts, mapped to what they build. Anything
+#: else is a configuration error, not a fallback — see `_build_store`.
+BACKENDS = ("memory", "durable")
+
+DEFAULT_BACKEND = "memory"
 
 # One cached store instance per backend name. Keeping the in-memory store a
 # process-wide singleton is essential — it holds all stream state in memory —
@@ -14,11 +21,32 @@ _store_lock = threading.Lock()
 
 
 def _build_store(backend: str) -> Any:
+    """Build the store `backend` names, or refuse.
+
+    An unrecognised name is **refused rather than defaulted**. This used to
+    return the in-memory store for any string that wasn't exactly ``"durable"``,
+    which made the one mistake that matters — a misspelt backend — invisible:
+    ``RAKAIA_STORE = "durrable"`` selected a process-local dict, so every append
+    a deployment believed it was persisting was lost on the next restart, with
+    nothing in the logs. Since the setting is free-form text, the selector is
+    the only place that can tell a typo from a choice.
+
+    ADR 0002 flagged this ("swaps stores by string with no interface check").
+    `django_rakaia.checks` reports the same problem at startup, so a misspelling
+    fails `manage.py check` rather than waiting for the first append.
+    """
     if backend == "durable":
         from .django_store import DjangoStreamStore
 
         return DjangoStreamStore()
-    return StreamStore()
+    if backend == "memory":
+        return StreamStore()
+    raise ImproperlyConfigured(
+        f"RAKAIA_STORE={backend!r} is not a known store backend. "
+        f"Valid backends are: {', '.join(repr(b) for b in BACKENDS)}. "
+        f"(The default is {DEFAULT_BACKEND!r}, which is in-memory and "
+        f"process-local — it does not survive a restart.)"
+    )
 
 
 def get_store() -> Any:
@@ -27,11 +55,13 @@ def get_store() -> Any:
 
     Selected by the ``RAKAIA_STORE`` Django setting: ``"memory"`` (default) for
     the in-memory `StreamStore`, or ``"durable"`` for the DB-backed
-    `DjangoStreamStore`. Thread-safe lazy initialization, one instance per
-    backend.
+    `DjangoStreamStore`. Any other value raises `ImproperlyConfigured`.
+    Thread-safe lazy initialization, one instance per backend.
     """
-    backend = getattr(settings, "RAKAIA_STORE", "memory")
+    backend = getattr(settings, "RAKAIA_STORE", DEFAULT_BACKEND)
     with _store_lock:
         if backend not in _stores:
+            # Built before the assignment, so a refused backend leaves no entry
+            # behind: correcting the setting works without restarting.
             _stores[backend] = _build_store(backend)
     return _stores[backend]

--- a/tests/test_django_rakaia/test_store_selection.py
+++ b/tests/test_django_rakaia/test_store_selection.py
@@ -1,0 +1,124 @@
+"""`RAKAIA_STORE` must not fail open.
+
+`get_store()` reads one setting and returns one of two stores. The failure mode
+that matters is a *misspelt* backend: the setting is a free-form string, so
+``"durrable"`` is indistinguishable from ``"memory"`` to the selector. Falling
+back to the in-memory store in that case is the worst possible default — every
+append lands in a process-local dict and is lost on restart, silently, with the
+deployment believing it is durable.
+
+ADR 0002 named this ("`RAKAIA_STORE` swaps stores by string with no interface
+check"), and the first real consumer wrote its own Django system check to catch
+it downstream. These tests move the guard upstream, where it belongs.
+"""
+
+from __future__ import annotations
+
+import pytest
+from django.core.exceptions import ImproperlyConfigured
+
+from django_rakaia.django_store import DjangoStreamStore
+from django_rakaia.store import get_store
+from rakaia import StreamStore
+
+
+@pytest.fixture(autouse=True)
+def _clear_store_cache():
+    """`get_store()` memoises per backend name; drop the cache around each test
+    so one test's selection can't satisfy the next one's lookup."""
+    from django_rakaia import store as store_module
+
+    store_module._stores.clear()
+    yield
+    store_module._stores.clear()
+
+
+class TestBackendSelection:
+    def test_default_is_the_in_memory_store(self, settings):
+        del settings.RAKAIA_STORE
+        assert isinstance(get_store(), StreamStore)
+
+    def test_memory_selects_the_in_memory_store(self, settings):
+        settings.RAKAIA_STORE = "memory"
+        assert isinstance(get_store(), StreamStore)
+
+    def test_durable_selects_the_django_store(self, settings):
+        settings.RAKAIA_STORE = "durable"
+        assert isinstance(get_store(), DjangoStreamStore)
+
+
+class TestUnknownBackendIsRefused:
+    """The RED case: today every string below returns a `StreamStore`."""
+
+    @pytest.mark.parametrize(
+        "backend",
+        [
+            "durrable",  # the typo that motivates this
+            "durable ",  # a stray space from a .env file
+            "Durable",  # wrong case
+            "postgres",  # a plausible-but-wrong guess
+            "db",
+            "",
+        ],
+    )
+    def test_unknown_backend_raises_instead_of_falling_back(self, settings, backend):
+        settings.RAKAIA_STORE = backend
+        with pytest.raises(ImproperlyConfigured):
+            get_store()
+
+    def test_the_error_names_the_backend_and_the_valid_choices(self, settings):
+        settings.RAKAIA_STORE = "durrable"
+        with pytest.raises(ImproperlyConfigured) as exc:
+            get_store()
+        message = str(exc.value)
+        assert "durrable" in message
+        assert "durable" in message
+        assert "memory" in message
+
+    def test_the_check_reports_it_before_the_first_append(self, settings):
+        """`get_store()` only refuses on first use, which in a worker may be
+        hours in. The check has to catch it at startup."""
+        from django_rakaia.checks import check_store_backend
+
+        settings.RAKAIA_STORE = "durrable"
+        ids = [e.id for e in check_store_backend(None)]
+        assert ids == ["rakaia.E001"]
+
+    def test_a_refused_backend_is_not_cached(self, settings):
+        """A failed selection must not poison the cache — fixing the setting
+        without restarting the process has to work."""
+        from django_rakaia import store as store_module
+
+        settings.RAKAIA_STORE = "durrable"
+        with pytest.raises(ImproperlyConfigured):
+            get_store()
+        assert "durrable" not in store_module._stores
+
+        settings.RAKAIA_STORE = "memory"
+        assert isinstance(get_store(), StreamStore)
+
+
+class TestInMemoryInProductionIsFlagged:
+    """A correctly-spelt `"memory"` is legitimate in development and almost
+    never meant in production — worth a warning, never an error."""
+
+    def test_memory_with_debug_off_warns(self, settings):
+        from django_rakaia.checks import check_store_backend
+
+        settings.RAKAIA_STORE = "memory"
+        settings.DEBUG = False
+        assert [w.id for w in check_store_backend(None)] == ["rakaia.W001"]
+
+    def test_memory_with_debug_on_is_silent(self, settings):
+        from django_rakaia.checks import check_store_backend
+
+        settings.RAKAIA_STORE = "memory"
+        settings.DEBUG = True
+        assert check_store_backend(None) == []
+
+    def test_durable_is_silent(self, settings):
+        from django_rakaia.checks import check_store_backend
+
+        settings.RAKAIA_STORE = "durable"
+        settings.DEBUG = False
+        assert check_store_backend(None) == []


### PR DESCRIPTION
Rakaia picks its event store from one Django setting, `RAKAIA_STORE`, which is
free-form text. Until now anything that wasn't exactly `"durable"` got the
in-memory store — so a single mistyped character, or a stray space picked up
from a `.env` file, quietly selected a store that keeps everything in process
memory. Nothing failed and nothing warned: appends succeeded, the app looked
healthy, and the entire event log disappeared at the next restart. A setting
that is one keystroke away from losing all your data should not fail silently.

An unrecognised backend is now refused outright, with an error that names what
you typed and what the valid choices are. A new startup check reports the same
problem when you run `manage.py check`, so a misconfigured deployment fails
before it serves a single request rather than hours later when a background
worker happens to write its first event. Running in memory deliberately is still
fine; doing it with `DEBUG` switched off now gets a warning you can silence.