### PR TITLE
A verification that compared nothing should not report itself clean

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -163,6 +163,22 @@ is not yet tagged in a release.
   string with no interface check"); the first production consumer had written
   its own check downstream to catch it.
 
+- **A verification sweep no longer certifies a population of zero.**
+  `diff_effects_against_rows(...).ok` answers "did anything disagree?", which is
+  vacuously `True` when nothing was compared — so an empty effect list reported
+  a clean bill of health with nothing behind it. The ways that happens are all
+  ordinary: a store on the wrong backend, a replay over a renamed stream path,
+  an `event_match` filter that stopped matching, a registry that failed to
+  autodiscover. `DiffReport` now carries a three-state `verdict`
+  (`GREEN`/`RED`/`VACUOUS`) plus `compared` and `certified`, and
+  `raise_if_diff()` raises the new `VacuousVerification` rather than passing.
+  Failures are checked **before** vacuity, so a real failure is never hidden
+  behind "empty"; pass `allow_empty=True` where a zero population is genuinely
+  expected. `ok` keeps its original meaning, so existing callers are unaffected.
+  Upstreamed from the first production consumer, which named this **the vacuous
+  green** and had built the same guard downstream.
+  → [`docs/projection-cookbook.md`](docs/projection-cookbook.md)
+
 - **A store now refuses an offset it did not issue.** Both stores accepted the
   other's offset format and resolved it to an unrelated position instead of
   failing: `int("0_5")` is `5` in Python, so the durable store read the wrong

--- a/docs/projection-cookbook.md
+++ b/docs/projection-cookbook.md
@@ -120,13 +120,41 @@ ex = CollectingExecutor()
 replay(store, "cookbook", ex, reader=DjangoProjectionReader())
 
 report = diff_effects_against_rows(ex.effects)   # UUID/Decimal normalised by default
-assert report.ok, report                         # or: report.raise_if_diff()
+assert report.certified, report                  # or: report.raise_if_diff()
 ```
 
-`diff_effects_against_rows` returns a `DiffReport` (`.ok` / `.problems` /
-`.raise_if_diff()`); its default normalizers handle the two representation
-mismatches that produce false diffs — a `UUID` column read back vs a string in
-the effect, and a JSON float vs the column's rounded `Decimal`.
+`diff_effects_against_rows` returns a `DiffReport` (`.verdict` / `.certified` /
+`.compared` / `.problems` / `.raise_if_diff()`); its default normalizers handle
+the two representation mismatches that produce false diffs — a `UUID` column read
+back vs a string in the effect, and a JSON float vs the column's rounded
+`Decimal`.
+
+### Don't accept a vacuous green
+
+Note `assert report.certified` above, not `assert report.ok`. `.ok` answers "did
+anything disagree?", which is vacuously true when **nothing was compared** — and
+the ways a sweep silently compares zero rows are all ordinary: a store on the
+wrong backend, a replay over a stream path that was renamed, an `event_match`
+filter that stopped matching, a handler registry that failed to autodiscover.
+Each yields an empty effect list, and `.ok` reports a clean bill of health with
+nothing behind it.
+
+`.verdict` separates the three outcomes that matter:
+
+| Verdict | Meaning |
+|---|---|
+| `GREEN` | Rows were compared and all of them matched — real evidence. |
+| `RED` | Something was compared and disagreed. |
+| `VACUOUS` | Nothing was compared. This run certifies nothing. |
+
+Failures are checked **before** vacuity: if anything disagreed then something was
+evidently compared, so a real failure is never hidden behind "empty".
+
+`.raise_if_diff()` raises `VerificationError` on `RED` and `VacuousVerification`
+on `VACUOUS`. If an empty population is genuinely expected, say so explicitly at
+the call site with `raise_if_diff(allow_empty=True)` — which still raises on a
+real failure. `.ok` keeps its original meaning, so existing callers are
+unaffected; `.certified` is the stricter property a migration proof wants.
 
 ### Verifying a large sweep in bulk
 

--- a/src/django_rakaia/verification.py
+++ b/src/django_rakaia/verification.py
@@ -97,13 +97,28 @@ class RowDiff:
         return f"{head}: " + "; ".join(str(d) for d in self.field_diffs)
 
 
+#: The three verdicts a verification sweep can reach. ``VACUOUS`` is deliberately
+#: distinct from both others: "nothing was wrong" and "nothing was looked at" are
+#: different facts, and a proof that conflates them is worthless as evidence.
+GREEN, RED, VACUOUS = "green", "red", "vacuous"
+
+
 @dataclass(frozen=True)
 class DiffReport:
     """Aggregate result of :func:`diff_effects_against_rows`.
 
     ``rows`` holds one :class:`RowDiff` per write effect checked (in effect
-    order); ``problems`` is the subset that disagree. ``ok`` is the assertion a
-    migration proof cares about.
+    order); ``problems`` is the subset that disagree.
+
+    **The population guard.** ``ok`` answers "did anything disagree?", which is
+    vacuously ``True`` when nothing was compared. That made a sweep over an empty
+    effect list — a store on the wrong backend, a replay over a renamed stream
+    path, an ``event_match`` filter that stopped matching, a registry that failed
+    to autodiscover — print a clean bill of health with nothing behind it. Read
+    :attr:`verdict` (or :attr:`certified`) instead: it separates `GREEN` from
+    `VACUOUS`, and :meth:`raise_if_diff` refuses to certify a zero population.
+
+    ``ok`` keeps its original meaning so existing callers are unaffected.
     """
 
     rows: list[RowDiff]
@@ -113,28 +128,91 @@ class DiffReport:
         return [r for r in self.rows if not r.ok]
 
     @property
+    def compared(self) -> int:
+        """How many rows this report actually checked.
+
+        The population the verdict rests on. Note this counts *checked* rows, not
+        input effects: non-write effects (delete/retire/external) carry no values
+        to diff and are skipped, so a batch of only those compares nothing.
+        """
+        return len(self.rows)
+
+    @property
     def ok(self) -> bool:
+        """Whether any checked row disagreed.
+
+        Vacuously ``True`` for an empty population — prefer :attr:`certified`.
+        """
         return not self.problems
 
-    def raise_if_diff(self) -> None:
-        """Raise :class:`VerificationError` if any checked row disagrees."""
-        if self.ok:
-            return
-        raise VerificationError(self)
+    @property
+    def verdict(self) -> str:
+        """`GREEN`, `RED` or `VACUOUS`.
+
+        **Failures are checked before vacuity.** If anything disagreed then
+        something was evidently compared, and reporting `RED` is strictly safer
+        than hiding a real failure behind "empty".
+        """
+        if self.problems:
+            return RED
+        if self.compared == 0:
+            return VACUOUS
+        return GREEN
+
+    @property
+    def certified(self) -> bool:
+        """Whether this report is positive evidence: a non-empty population, all
+        of it matching. The assertion a migration proof wants."""
+        return self.verdict == GREEN
+
+    def raise_if_diff(self, *, allow_empty: bool = False) -> None:
+        """Raise unless this report certifies the projection.
+
+        Raises :class:`VerificationError` if any checked row disagrees, or
+        :class:`VacuousVerification` if nothing was compared at all. Pass
+        ``allow_empty=True`` when an empty population is genuinely expected —
+        explicitly, at the call site. It never suppresses a real failure.
+        """
+        verdict = self.verdict
+        if verdict == RED:
+            raise VerificationError(self)
+        if verdict == VACUOUS and not allow_empty:
+            raise VacuousVerification(self)
 
     def __str__(self) -> str:
         problems = self.problems
-        if not problems:
-            return f"DiffReport: {len(self.rows)} row(s) verified, no differences"
-        lines = [
-            f"DiffReport: {len(problems)} of {len(self.rows)} row(s) differ:",
-            *(f"  - {p}" for p in problems),
-        ]
-        return "\n".join(lines)
+        if problems:
+            lines = [
+                f"DiffReport: {len(problems)} of {self.compared} row(s) differ:",
+                *(f"  - {p}" for p in problems),
+            ]
+            return "\n".join(lines)
+        if self.compared == 0:
+            return (
+                "DiffReport: NOTHING COMPARED (rows=0) — this run certifies "
+                "nothing. No write effects reached the diff: check the store "
+                "backend, the stream path, and that handlers were registered."
+            )
+        return f"DiffReport: {self.compared} row(s) verified, no differences"
 
 
 class VerificationError(AssertionError):
     """Raised by :meth:`DiffReport.raise_if_diff` when a projection disagrees."""
+
+    def __init__(self, report: DiffReport) -> None:
+        self.report = report
+        super().__init__(str(report))
+
+
+class VacuousVerification(AssertionError):
+    """Raised by :meth:`DiffReport.raise_if_diff` when nothing was compared.
+
+    A sibling of :class:`VerificationError`, not a subclass: they mean opposite
+    things. `VerificationError` says the projection is wrong; this says the run
+    produced no evidence either way, so treating it as a pass would be a false
+    green. Both subclass `AssertionError`, so a proof written as
+    ``except AssertionError`` still catches either.
+    """
 
     def __init__(self, report: DiffReport) -> None:
         self.report = report

--- a/tests/test_django_rakaia/test_verification_vacuous.py
+++ b/tests/test_django_rakaia/test_verification_vacuous.py
@@ -1,0 +1,171 @@
+"""A verification that compared nothing must not report itself clean.
+
+`diff_effects_against_rows` answers "does replaying the log reproduce the
+projection we already have?" — the go/no-go for a migration cutover. It answers
+by diffing each write effect against its row, so with **no effects** it finds no
+problems and reports success. "Nothing was wrong" and "nothing was looked at"
+come back as the same verdict.
+
+That is not hypothetical. The ways a sweep silently compares zero rows are all
+ordinary: a store pointed at the wrong backend, a `replay()` over a stream path
+that no longer exists, an `event_match` filter that stops matching after a
+rename, a handler registry that failed to autodiscover. Each yields an empty
+effect list, and the proof prints a clean bill of health with nothing behind it.
+
+The first production consumer hit exactly this and named it **the vacuous
+green**, adding a population guard to its own gates. These tests are that guard,
+upstream. The rule it settled on, preserved here: *failures are checked before
+vacuity* — if anything was compared and disagreed, report the disagreement. RED
+is strictly safer than hiding a real failure behind "empty".
+"""
+
+from __future__ import annotations
+
+import uuid
+from decimal import Decimal
+
+import pytest
+
+from django_rakaia.verification import (
+    GREEN,
+    RED,
+    VACUOUS,
+    DiffReport,
+    VacuousVerification,
+    VerificationError,
+    diff_effects_against_rows,
+)
+from rakaia.effects import Effect
+
+from .models import Measure
+
+REF = uuid.UUID("11111111-1111-1111-1111-111111111111")
+OTHER_REF = uuid.UUID("22222222-2222-2222-2222-222222222222")
+
+
+def _effect(ref: uuid.UUID, amount: str) -> Effect:
+    return Effect(
+        op="update_or_create",
+        model_label="test_django_rakaia.Measure",
+        lookup={"ref": ref},
+        defaults={"amount": Decimal(amount)},
+    )
+
+
+class TestAnEmptyReportIsNotClean:
+    """The RED core: today every assertion below fails."""
+
+    def test_an_empty_report_is_vacuous_not_green(self):
+        assert DiffReport(rows=[]).verdict == VACUOUS
+
+    def test_raise_if_diff_refuses_to_certify_an_empty_population(self):
+        with pytest.raises(VacuousVerification):
+            DiffReport(rows=[]).raise_if_diff()
+
+    def test_an_empty_report_says_it_certifies_nothing(self):
+        text = str(DiffReport(rows=[]))
+        assert "NOTHING COMPARED" in text
+        assert "certifies nothing" in text
+
+    def test_certified_is_false_for_an_empty_report(self):
+        assert DiffReport(rows=[]).certified is False
+
+
+class TestVerdictOrdering:
+    """Failures are checked *before* vacuity — a real failure must never be
+    reported as "empty"."""
+
+    @pytest.mark.django_db
+    def test_a_compared_and_matching_population_is_green(self):
+        Measure.objects.create(ref=REF, amount=Decimal("10.00"))
+        report = diff_effects_against_rows([_effect(REF, "10.00")])
+        assert report.verdict == GREEN
+        assert report.certified is True
+        report.raise_if_diff()  # must not raise
+
+    @pytest.mark.django_db
+    def test_a_mismatch_is_red(self):
+        Measure.objects.create(ref=REF, amount=Decimal("10.00"))
+        report = diff_effects_against_rows([_effect(REF, "99.00")])
+        assert report.verdict == RED
+        assert report.certified is False
+        with pytest.raises(VerificationError):
+            report.raise_if_diff()
+
+    @pytest.mark.django_db
+    def test_a_missing_row_is_red_not_vacuous(self):
+        """A lookup that finds nothing *was* compared — it is a failure, not an
+        empty population."""
+        report = diff_effects_against_rows([_effect(OTHER_REF, "1.00")])
+        assert report.verdict == RED
+        with pytest.raises(VerificationError):
+            report.raise_if_diff()
+
+
+class TestTheWaysASweepSilentlyComparesNothing:
+    """Each of these produces an empty effect list in the wild."""
+
+    @pytest.mark.django_db
+    def test_no_effects_at_all(self):
+        with pytest.raises(VacuousVerification):
+            diff_effects_against_rows([]).raise_if_diff()
+
+    @pytest.mark.django_db
+    def test_only_non_write_effects_were_produced(self):
+        """delete/retire/external effects are skipped, so a batch of only those
+        compares nothing — the report must say so rather than report clean."""
+        effects = [
+            Effect(
+                op="delete",
+                model_label="test_django_rakaia.Measure",
+                lookup={"ref": OTHER_REF},
+            ),
+            Effect(op="external", payload={"kind": "notify"}),
+        ]
+        report = diff_effects_against_rows(effects)
+        assert report.verdict == VACUOUS
+        with pytest.raises(VacuousVerification):
+            report.raise_if_diff()
+
+
+class TestOptingOut:
+    """A caller who genuinely expects an empty population must be able to say
+    so — explicitly, at the call site, never by default."""
+
+    def test_allow_empty_downgrades_vacuous_to_a_pass(self):
+        DiffReport(rows=[]).raise_if_diff(allow_empty=True)
+
+    @pytest.mark.django_db
+    def test_allow_empty_does_not_suppress_a_real_failure(self):
+        report = diff_effects_against_rows([_effect(OTHER_REF, "1.00")])
+        with pytest.raises(VerificationError):
+            report.raise_if_diff(allow_empty=True)
+
+
+class TestBackwardCompatibility:
+    """`ok` keeps its old meaning — "no problems" — so existing callers and the
+    `VerificationError` message are unaffected. `certified` is the new, stricter
+    property a migration proof should assert."""
+
+    def test_ok_is_still_true_for_an_empty_report(self):
+        assert DiffReport(rows=[]).ok is True
+
+    def test_vacuous_verification_is_an_assertion_error(self):
+        """So `except AssertionError` / a bare pytest.raises in existing proofs
+        still catches it."""
+        assert issubclass(VacuousVerification, AssertionError)
+
+    @pytest.mark.django_db
+    def test_compared_counts_only_what_was_checked(self):
+        Measure.objects.create(ref=REF, amount=Decimal("10.00"))
+        report = diff_effects_against_rows(
+            [
+                _effect(REF, "10.00"),
+                Effect(
+                    op="delete",
+                    model_label="test_django_rakaia.Measure",
+                    lookup={"ref": OTHER_REF},
+                ),
+            ]
+        )
+        assert report.compared == 1


### PR DESCRIPTION
The way you prove a migration is safe with rakaia is to replay the log, collect
what it would write, and diff that against the rows you already have. If nothing
disagrees, you cut over. The problem is what happens when the diff has nothing to
compare: it finds no disagreements, so it reports success. A run that examined
ten thousand rows and a run that examined none give you the same green light.

That is easy to hit by accident — a store pointed at the wrong backend, a replay
over a stream path that got renamed, a filter that quietly stopped matching, a
registry that failed to load. Any of those hands you an empty batch, and the
proof tells you everything is fine. This adds a third answer alongside pass and
fail: *nothing was compared, so this run certifies nothing*. A real failure still
takes priority over it, so an empty-looking result can never mask a genuine one.
If you honestly expect nothing to compare, you now have to say so at the call
site rather than getting it by default.