### PR TITLE
Ship the other half of the rebuild guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,21 @@ is not yet tagged in a release.
   staged replay. Upstreamed from the Partisipa migration's `PreloadReader`
   workaround. → [`docs/projection-cookbook.md`](docs/projection-cookbook.md).
 
+- **`assert_no_live_writes` — the rebuild gate's write-side guard** (ADR 0003).
+  `django_rakaia.hermeticity` has documented this as the mirror of
+  `deny_database_access` since ADR 0003 landed, but only shipped the read half;
+  the write half lived in the first consumer's tree and every adopter would have
+  re-derived it. It now ships here: wrap a from-scratch rebuild in
+  `assert_no_live_writes(*models, using="default")` and any change to the live
+  database's row counts raises `LiveWriteLeaked` naming the drift. The leak it
+  exists to catch is a `post_save`/`pre_save` receiver saving without a `using=`
+  — which Postgres' `session_replication_role = replica` does *not* disable, so
+  a rebuild can silently mutate production while reporting itself green.
+  Unlike the read guard (an `execute_wrapper`, so it cannot be armed where any
+  legitimate query to the alias happens), counting rows tolerates reads — so this
+  is the guard that can wrap a whole rebuild whose event log lives on the
+  guarded alias.
+
 - **Handler hermeticity guard** (P1, [ADR 0003](docs/adr/0003-handler-hermeticity.md)).
   `django_rakaia.hermeticity.deny_database_access(*aliases)` raises
   `AmbientDatabaseAccess` on any query to the named aliases — the read-side

--- a/docs/adr/0003-handler-hermeticity.md
+++ b/docs/adr/0003-handler-hermeticity.md
@@ -5,9 +5,9 @@
 - **Deciders:** rakaia maintainers
 - **Related:** [`staged-replay.md`](../staged-replay.md),
   [`dry-run-and-executors.md`](../dry-run-and-executors.md),
-  `django_rakaia.hermeticity` (`deny_database_access`), the `using=` seam
-  (#68 item 2, [`test_using_seam.py`](../../tests/test_django_rakaia/test_using_seam.py)),
-  Partisipa `assert_no_live_writes`
+  `django_rakaia.hermeticity` (`deny_database_access`, `assert_no_live_writes`),
+  the `using=` seam
+  (#68 item 2, [`test_using_seam.py`](../../tests/test_django_rakaia/test_using_seam.py))
 
 ## Context
 
@@ -49,6 +49,13 @@ The rebuild gate already guards the **write** side — `assert_no_live_writes`
 asserts the default DB's row counts are unchanged across a rebuild, turning a
 leaked `post_save` into a loud failure. But a stray **read** changes no row
 count, so the write-side guard cannot see it. Reads need their own guard.
+
+> **Update — 2026-08-14.** When this ADR was written the write-side guard lived
+> only in the first consumer's tree, and this ADR referred to it as
+> "Partisipa `assert_no_live_writes`". Both halves now ship in
+> `django_rakaia.hermeticity`, so the pairing this ADR describes is available
+> to every consumer rather than being re-derived per adopter. The decision is
+> unchanged; only the location is.
 
 ## Decision
 

--- a/src/django_rakaia/hermeticity.py
+++ b/src/django_rakaia/hermeticity.py
@@ -1,11 +1,17 @@
-"""Assert a replay is *hermetic* — its handlers read only through the injected
-reader (the alias under rebuild), never an ambient default-DB manager.
+"""The two halves of a rebuild gate: a from-scratch replay must neither **read**
+nor **write** the live database it is proving it can reconstruct.
 
-The Partisipa rebuild gate already carries a *write*-side guard
-(``assert_no_live_writes``): it proves a from-scratch rebuild does not **write**
-the production database. This is its mirror — it proves the rebuild does not
-**read** it either. Together they make "the log alone rebuilt this" a checkable
-property rather than a convention a reviewer has to remember.
+* :func:`deny_database_access` — the *read* guard. Handlers must read only
+  through the injected reader (the alias under rebuild), never an ambient
+  default-DB manager.
+* :func:`assert_no_live_writes` — the *write* guard. The live database's row
+  counts must be unchanged across the rebuild.
+
+Together they make "the log alone rebuilt this" a checkable property rather than
+a convention a reviewer has to remember. Neither subsumes the other: a ``SELECT``
+changes no row counts, and a row count says nothing about what was read. They
+also differ in where they can be armed — see `assert_no_live_writes` for why the
+write guard is the one you can wrap a whole rebuild in.
 
 **Why reads matter as much as writes.** A pure rakaia handler is
 ``event -> Effect``; a stage > 0 handler is ``event, reader -> Effect``. Every
@@ -20,14 +26,19 @@ A handler — or a helper it calls — that instead reaches for
 Such a read is invisible to the write-side guard (a ``SELECT`` changes no row
 counts), so it needs its own gate.
 
-Usage — wrap the handler-dispatch region of a rebuild::
+Usage — the write guard around the whole rebuild, the read guard around the
+handler-dispatch region inside it::
 
     from rakaia.store import StreamStore
-    from django_rakaia.hermeticity import deny_database_access
+    from django_rakaia.hermeticity import (
+        assert_no_live_writes,
+        deny_database_access,
+    )
 
-    with deny_database_access("default"):
-        replay(store, path, DjangoExecutor(using="rebuild"),
-               reader=DjangoProjectionReader(using="rebuild"), ...)
+    with assert_no_live_writes(Submission, ProjectLink):
+        with deny_database_access("default"):
+            replay(store, path, DjangoExecutor(using="rebuild"),
+                   reader=DjangoProjectionReader(using="rebuild"), ...)
 
 **The event source must not read the denied alias either.** Read the log from a
 store that does not touch it — an in-memory ``StreamStore``, or a store on
@@ -42,12 +53,21 @@ from __future__ import annotations
 
 from collections.abc import Iterator
 from contextlib import ExitStack, contextmanager
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from django.db.models import Model
 
 
 class AmbientDatabaseAccess(RuntimeError):
     """A guarded connection alias was queried inside ``deny_database_access`` —
     a handler (or a helper it calls) read the database directly instead of
     through the injected reader."""
+
+
+class LiveWriteLeaked(RuntimeError):
+    """A guarded model's row count changed inside ``assert_no_live_writes`` — a
+    rebuild mutated the live database it was only supposed to reconstruct."""
 
 
 def _preview(sql: str, limit: int = 120) -> str:
@@ -89,3 +109,72 @@ def deny_database_access(*aliases: str) -> Iterator[None]:
         for alias in aliases:
             stack.enter_context(connections[alias].execute_wrapper(_blocker(alias)))
         yield
+
+
+@contextmanager
+def assert_no_live_writes(
+    *models: type[Model], using: str = "default"
+) -> Iterator[None]:
+    """Assert the ``using`` row counts of ``models`` are unchanged across the block.
+
+    The write-side mirror of :func:`deny_database_access`. Raises
+    :class:`LiveWriteLeaked` naming the drift if a write leaked — a rebuild that
+    mutates the database it is proving it can reconstruct is a defect, not a
+    warning. Called with no models it is a no-op.
+
+    Wrap the **whole** rebuild::
+
+        with assert_no_live_writes(Submission, ProjectLink):
+            replay(store, path, DjangoExecutor(using="rebuild"),
+                   reader=DjangoProjectionReader(using="rebuild"), ...)
+
+    **Why this exists alongside the read-side guard.** `deny_database_access`
+    installs a statement wrapper, so it can only be armed around a region where
+    *no* legitimate query to the alias happens — and a rebuild often cannot meet
+    that bar, because the event log itself may live on the alias being guarded
+    (the constraint noted in this module's docstring). Counting rows tolerates
+    arbitrary reads and still catches a mutation, so this is the guard you can
+    put around everything. Use both where you can: they catch different leaks,
+    and a ``SELECT`` is invisible here just as a row count is invisible there.
+
+    **The leak it is built for.** Postgres' ``session_replication_role =
+    replica`` disables *triggers* but **not** Django ``post_save``/``pre_save``
+    receivers, so a receiver that saves without a ``using=`` writes to the live
+    alias from inside a rebuild — silently, while the gate reports green.
+    Suppressing the receiver prevents it; this *verifies* the prevention held,
+    which is the part a reviewer cannot be expected to remember.
+
+    **What it does not catch.** It compares counts, so an in-place ``UPDATE`` of
+    an existing row leaves it silent. Counts are what a rebuild leak actually
+    looks like (a receiver minting rows), they are cheap enough to wrap a whole
+    replay, and they need no per-model knowledge of which columns matter. For
+    field-level assurance, diff the projection afterwards with
+    :func:`django_rakaia.verification.diff_effects_against_rows`.
+    """
+    if not models:
+        yield
+        return
+
+    def _counts() -> dict[type[Model], int]:
+        return {m: m.objects.using(using).count() for m in models}
+
+    before = _counts()
+    try:
+        yield
+    finally:
+        # `finally`, not `else`: a rebuild that raised half-way must still be
+        # held to the invariant — a leak that happened before the failure is
+        # exactly the kind that would otherwise go unnoticed.
+        drift = {
+            m.__name__: (before[m], after)
+            for m, after in _counts().items()
+            if after != before[m]
+        }
+        if drift:
+            raise LiveWriteLeaked(
+                f"rebuild isolation VIOLATED — the {using!r} database changed "
+                f"during the block: {drift} (model: before -> after). A rebuild "
+                f"must write only to its disposable alias. Something wrote "
+                f"without a `using=` — most often a post_save/pre_save receiver, "
+                f"which `session_replication_role = replica` does not disable."
+            )

--- a/tests/test_django_rakaia/test_rebuild_isolation.py
+++ b/tests/test_django_rakaia/test_rebuild_isolation.py
@@ -1,0 +1,131 @@
+"""The write-side half of the rebuild gate: a rebuild must not mutate live.
+
+`deny_database_access` (ADR 0003) proves a from-scratch rebuild does not **read**
+the production database. This is its mirror: proof it does not **write** it
+either. `hermeticity.py`'s own docstring has named `assert_no_live_writes` as the
+write-side guard since ADR 0003 landed, while the implementation lived only in
+the first consumer's tree. These tests bring it upstream, where the pairing is
+documented.
+
+**Why both halves are needed, and why row counts.** The read-side guard is a
+statement wrapper, so it can only be armed around a region where *no* legitimate
+query to the alias happens. A rebuild frequently cannot meet that bar: the event
+log itself may live on `default`, and the read guard would trip on the store's
+own reads (the constraint `deny_database_access`'s docstring already records).
+The write guard has no such limit — it compares row counts across the block, so
+it tolerates arbitrary reads and still catches a mutation. It is the guard you
+can arm around the *whole* rebuild rather than a hand-picked region.
+
+The specific leak it exists to catch: `session_replication_role = replica`
+disables Postgres triggers but **not** Django `post_save`/`pre_save` signals, so
+a signal receiver that writes without a `using=` lands on `default` — silently
+mutating production during a rebuild that reports itself green.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from django_rakaia.hermeticity import LiveWriteLeaked, assert_no_live_writes
+
+from .models import FinanceLine
+
+pytestmark = pytest.mark.django_db(databases=["default", "overlay"])
+
+
+def _line(submission_id: str, *, using: str = "default") -> FinanceLine:
+    return FinanceLine.objects.using(using).create(
+        submission_id=submission_id, suku="s"
+    )
+
+
+class TestAWriteToTheLiveDatabaseIsCaught:
+    """The RED core."""
+
+    def test_a_create_on_the_default_alias_raises(self):
+        with pytest.raises(LiveWriteLeaked), assert_no_live_writes(FinanceLine):
+            _line("leaked")
+
+    def test_a_delete_on_the_default_alias_raises(self):
+        """Row counts move in both directions — a rebuild that *removes* live
+        rows is just as much a live mutation as one that adds them."""
+        _line("pre-existing")
+        with pytest.raises(LiveWriteLeaked), assert_no_live_writes(FinanceLine):
+            FinanceLine.objects.using("default").all().delete()
+
+    def test_the_error_names_the_model_and_the_counts(self):
+        with pytest.raises(LiveWriteLeaked) as exc, assert_no_live_writes(FinanceLine):
+            _line("leaked")
+        message = str(exc.value)
+        assert "FinanceLine" in message
+        assert "0" in message and "1" in message
+
+
+class TestALegitimateRebuildPasses:
+    def test_writing_only_to_the_disposable_alias_is_fine(self):
+        """The whole point: a rebuild replays into `overlay` and `default` is
+        untouched."""
+        with assert_no_live_writes(FinanceLine):
+            _line("rebuilt", using="overlay")
+        assert FinanceLine.objects.using("overlay").count() == 1
+        assert FinanceLine.objects.using("default").count() == 0
+
+    def test_reads_of_the_live_alias_are_tolerated(self):
+        """Unlike the read-side guard, this one permits reads — which is what
+        lets it wrap a whole rebuild whose event log lives on `default`."""
+        _line("pre-existing")
+        with assert_no_live_writes(FinanceLine):
+            assert FinanceLine.objects.using("default").count() == 1
+
+    def test_no_models_is_a_no_op(self):
+        with assert_no_live_writes():
+            _line("unguarded")
+
+
+class TestGuardingAnExplicitAlias:
+    def test_using_names_the_alias_to_protect(self):
+        """Symmetric with `deny_database_access(*aliases)` — you say which
+        database is the live one."""
+        with (
+            pytest.raises(LiveWriteLeaked),
+            assert_no_live_writes(FinanceLine, using="overlay"),
+        ):
+            _line("leaked", using="overlay")
+
+    def test_a_write_to_a_different_alias_is_ignored(self):
+        with assert_no_live_writes(FinanceLine, using="overlay"):
+            _line("fine", using="default")
+
+
+class TestTheGuardChecksEvenWhenTheBlockFails:
+    """A rebuild that raised half-way still must not have mutated live — and the
+    original failure must survive, since it is the more informative one."""
+
+    def test_the_original_exception_propagates_when_nothing_leaked(self):
+        with (
+            pytest.raises(ValueError, match="boom"),
+            assert_no_live_writes(FinanceLine),
+        ):
+            raise ValueError("boom")
+
+    def test_a_leak_is_reported_even_if_the_block_raised(self):
+        with pytest.raises(LiveWriteLeaked), assert_no_live_writes(FinanceLine):
+            _line("leaked")
+            raise ValueError("boom")
+
+
+class TestPairingWithTheReadSideGuard:
+    def test_both_guards_compose(self):
+        """The documented shape of a full gate: deny reads of the live alias,
+        and assert nothing was written to it."""
+        from django_rakaia.hermeticity import deny_database_access
+
+        with assert_no_live_writes(FinanceLine), deny_database_access("default"):
+            _line("rebuilt", using="overlay")
+
+        assert FinanceLine.objects.using("default").count() == 0
+
+    def test_live_write_leaked_is_a_runtime_error(self):
+        """Matches `AmbientDatabaseAccess` — a rebuild that mutates live is a
+        defect, not a warning."""
+        assert issubclass(LiveWriteLeaked, RuntimeError)


### PR DESCRIPTION
Rakaia can rebuild your database tables from scratch by replaying the event log
into a throwaway database, then comparing the result against what you already
have. For that comparison to mean anything, the rebuild has to leave the real
database completely alone — it must not read from it, and it must not write to
it. We shipped the half that catches reads. The half that catches writes was
described in our own documentation and in ADR 0003, but never actually included,
so anyone adopting rakaia had to write it themselves.

It ships now. You wrap a rebuild, name the tables that matter, and if the real
database gains or loses a single row during the run you get a loud failure that
says which table and by how much. The specific accident it is built for is easy
to have and hard to notice: Django save-hooks keep firing during a rebuild, and
one that forgets to say which database it is writing to lands on the live one —
quietly corrupting production during the very run that was supposed to prove
nothing was touched.