### PR TITLE
@stream_model was throwing away who made the change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -194,6 +194,18 @@ is not yet tagged in a release.
   green** and had built the same guard downstream.
   → [`docs/projection-cookbook.md`](docs/projection-cookbook.md)
 
+- **`@stream_model` now records the ambient envelope.** The decorator wrote
+  `StreamEvent` rows directly rather than through a store, so `metadata` was
+  always `{}` and `event_ts` always `NULL` — on the most-used append path in the
+  Django integration. Two consequences: `ProvenanceMiddleware`, which exists to
+  stamp actor and URL onto envelopes, could not reach the appends it was built
+  for, and `history.envelope_actor` silently fell back to the payload's owner FK,
+  answering "who owns this" in place of "who saved this". `event_ts` being NULL
+  also forced `merge_replay` onto transport time, the ordering trap ADR 0002
+  item 5 closed. The decorator now calls `merge_provenance` and sets `event_ts`
+  exactly as both stores do; a fan-out to several streams shares one envelope,
+  since it is one event. Appends outside a `provenance()` block are unchanged.
+
 - **A store now refuses an offset it did not issue.** Both stores accepted the
   other's offset format and resolved it to an unrelated position instead of
   failing: `int("0_5")` is `5` in Python, so the durable store read the wrong

--- a/docs/event-envelope.md
+++ b/docs/event-envelope.md
@@ -122,6 +122,14 @@ Explicit metadata on an individual `AppendOptions` still wins over the ambient
 values (`merge_provenance` layers ambient *under* explicit), so a call can always
 override a field.
 
+Every append path merges the ambient block — both stores, and `@stream_model`.
+That last one was the exception until recently: the decorator wrote its event
+rows directly, so its `metadata` was always empty and its `event_ts` always
+unset, which meant the middleware built to stamp actor and URL could not reach
+the appends most Django consumers actually make. `envelope_actor` then fell back
+to the payload's owner foreign key — quietly answering "who owns this" in place
+of "who saved this".
+
 In a Django app you rarely call `provenance()` by hand — the shipped
 `HistoryMiddleware` opens the block for you around each request, mirroring
 `pghistory.middleware.HistoryMiddleware`:

--- a/src/django_rakaia/decorators.py
+++ b/src/django_rakaia/decorators.py
@@ -7,6 +7,7 @@ streams with independent, monotonic offsets per stream.
 
 import dataclasses
 import json
+import time
 from collections.abc import Callable
 from typing import Any, Literal
 
@@ -16,6 +17,7 @@ from django.db.models.signals import post_delete, post_save
 from django.dispatch import receiver
 
 from django_rakaia.models import Stream, StreamEntry, StreamEvent
+from rakaia.context import merge_provenance
 
 StreamPathResolver = (
     str
@@ -116,12 +118,34 @@ def create_stream_event(
         json.dumps(dataclasses.asdict(dc_instance), cls=DjangoJSONEncoder)
     )
 
+    # The envelope, resolved exactly as the stores resolve it. `@stream_model`
+    # used to write `StreamEvent` rows with neither field, so `metadata` was
+    # always `{}` and `event_ts` always NULL on the busiest append path in the
+    # integration:
+    #
+    #   * `ProvenanceMiddleware` exists to stamp actor + URL onto envelopes, and
+    #     could not reach the appends it was built for. `history.envelope_actor`
+    #     then fell back to the payload's owner FK — turning "who saved this"
+    #     into "who owns this", a different question with often a different
+    #     answer.
+    #   * `event_ts` is the deterministic merge key (ADR 0002 item 5). Leaving it
+    #     NULL forces `merge_replay` onto transport time, which is the ordering
+    #     trap that item closed.
+    #
+    # `merge_provenance(None)` returns None when no block is active, so an append
+    # outside `provenance()` still records `{}` — this is additive.
+    metadata = merge_provenance(None) or {}
+    event_ts = time.time()
+
     # Create event and entries atomically
     with transaction.atomic():
-        # Create the event (data stored once)
+        # Create the event (data stored once) — one envelope shared by every
+        # entry, since a fan-out is one event appearing in several streams.
         event = StreamEvent.objects.create(
             data=payload,
             event_type=action,
+            metadata=metadata,
+            event_ts=event_ts,
         )
 
         # Create an entry for each stream

--- a/tests/test_django_rakaia/test_decorators_provenance.py
+++ b/tests/test_django_rakaia/test_decorators_provenance.py
@@ -1,0 +1,124 @@
+"""`@stream_model` must record the ambient envelope, like every other append path.
+
+`provenance(actor=..., url=...)` sets envelope metadata for the duration of a
+block, and `ProvenanceMiddleware` opens such a block around every request. Both
+stores merge it on append (`store.py`, `django_store.py` both call
+`merge_provenance`). `@stream_model` — the most-used append path in the Django
+integration, and the only one a typical consumer touches — did not: it wrote
+`StreamEvent` rows directly, so `metadata` was always `{}` and `event_ts` always
+`NULL`.
+
+The effect is that the middleware built to stamp actor and URL onto envelopes
+could not reach the appends it exists for. `rakaia.history.envelope_actor` then
+silently fell back to the payload's owner FK for every `@stream_model` event —
+"who saved this" quietly became "who owns this", which is a different question
+and often a different answer.
+
+ADR 0002 item 7 makes the envelope first-class. These tests hold the decorator
+to that.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from django_rakaia.models import StreamEvent
+from rakaia import provenance
+
+from .models import Area
+
+pytestmark = pytest.mark.django_db
+
+
+def _latest() -> StreamEvent:
+    return StreamEvent.objects.latest("id")
+
+
+class TestAmbientProvenanceIsRecorded:
+    """The RED core: `metadata` is `{}` today, whatever the ambient block says."""
+
+    def test_a_save_inside_provenance_records_the_actor(self):
+        with provenance(user=1):
+            Area.objects.create(name="a")
+        assert _latest().metadata["user"] == 1
+
+    def test_every_ambient_field_is_recorded(self):
+        with provenance(user=7, url="/areas/", causation="req-abc"):
+            Area.objects.create(name="a")
+        metadata = _latest().metadata
+        assert metadata["user"] == 7
+        assert metadata["url"] == "/areas/"
+        assert metadata["causation"] == "req-abc"
+
+    def test_an_update_records_provenance_too(self):
+        area = Area.objects.create(name="a")
+        with provenance(user=2):
+            area.name = "b"
+            area.save()
+        event = _latest()
+        assert event.event_type == "update"
+        assert event.metadata["user"] == 2
+
+    def test_a_delete_records_provenance_too(self):
+        area = Area.objects.create(name="a")
+        with provenance(user=3):
+            area.delete()
+        event = _latest()
+        assert event.event_type == "delete"
+        assert event.metadata["user"] == 3
+
+
+class TestNoAmbientProvenance:
+    """Outside a `provenance()` block nothing changes — this is additive."""
+
+    def test_metadata_is_empty_without_an_ambient_block(self):
+        Area.objects.create(name="a")
+        assert _latest().metadata == {}
+
+    def test_the_event_is_otherwise_unchanged(self):
+        area = Area.objects.create(name="solo")
+        event = _latest()
+        assert event.event_type == "create"
+        assert event.data["name"] == "solo"
+        assert event.data["id"] == area.pk
+
+
+class TestEnvelopeTimestamp:
+    """`event_ts` is the deterministic merge key. A path that leaves it NULL
+    forces `merge_replay` onto transport time, which is the ordering trap ADR
+    0002 item 5 closed."""
+
+    def test_event_ts_is_set(self):
+        Area.objects.create(name="a")
+        assert _latest().event_ts is not None
+
+    def test_event_ts_is_monotonic_across_successive_saves(self):
+        Area.objects.create(name="a")
+        first = _latest().event_ts
+        Area.objects.create(name="b")
+        second = _latest().event_ts
+        assert second >= first
+
+
+class TestFanOutSharesOneEnvelope:
+    """A `@stream_model` event can appear in several streams. It is one event, so
+    it carries one envelope — the metadata lives on `StreamEvent`, which the
+    entries share."""
+
+    def test_a_multi_stream_event_records_provenance_once(self):
+        from django.contrib.auth import get_user_model
+
+        from .models import Project
+
+        user = get_user_model().objects.create(username="u")
+        area = Area.objects.create(name="a")
+        before = StreamEvent.objects.count()
+
+        with provenance(user=99):
+            Project.objects.create(name="p", area=area, created_by=user)
+
+        # One new StreamEvent, fanned out to several StreamEntry rows.
+        event = _latest()
+        assert StreamEvent.objects.count() == before + 1
+        assert event.metadata["user"] == 99
+        assert event.entries.count() > 1


### PR DESCRIPTION
Rakaia can record who made each change and what request it came from, and it
ships middleware that fills that in automatically for every web request. It turns
out the one append path most Django users actually use — the `@stream_model`
decorator on their models — was quietly dropping all of it. The middleware was
doing its job; the decorator just wasn't listening. Every event it wrote had an
empty author field.

The visible symptom is that the audit history answered the wrong question. Asked
who saved a record, it fell back to whoever owns the record — usually a different
person, and no way to tell from the log which one you were looking at. The
decorator now fills in the same envelope every other append path does, including
the logical timestamp that replay uses to order events. Nothing changes for code
that wasn't setting this in the first place.