### PR TITLE
Stop making every project retype the same two rituals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,24 @@ is not yet tagged in a release.
   `except KeyError` code and tests are unaffected. A new failure type without a
   status now fails the suite rather than 500ing at runtime.
 
+- **`append_event` and `fold_events` — the two rituals every consumer retypes.**
+  Appending an enveloped event (JSON-encode with `DjangoJSONEncoder`,
+  create-the-stream-if-missing, wrap label/actor/`event_ts` in `AppendOptions`)
+  and folding a batch live (seed a scratch in-memory `StreamStore`, replay it
+  through a registry with a reader bound) were hand-written at nearly every
+  durable call site — ~37 and 11 copies respectively in the first production
+  consumer, whose own module carried the warning that motivates this: *"a second
+  write path which re-implements the envelope is a path no gate covers."* Both
+  now ship from `django_rakaia.envelope`, pinned byte-for-byte against the
+  longhand they replace. Upstreamed as its ADR-0020 anticipated.
+
+  The store contract also gained the property that makes the create-if-missing
+  shorthand safe: a redundant `create()` on a populated stream preserves its
+  messages and does not rewind its offsets. Both stores already satisfied it;
+  nothing had said so, and `test_create_is_idempotent` would have passed a
+  `create()` that truncated. With it pinned, the `has()`/`create()` dance is
+  provably redundant — `registry.py`'s three copies are now a single `create()`.
+
 - **`PreloadedProjectionReader` — bulk-fetch a verification sweep.**
   `diff_effects_against_rows` does one `reader.get` per effect (one round-trip
   each), which is thousands of round-trips on a full reconcile. Pass the same

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,7 +69,12 @@ is not yet tagged in a release.
   consumer, whose own module carried the warning that motivates this: *"a second
   write path which re-implements the envelope is a path no gate covers."* Both
   now ship from `django_rakaia.envelope`, pinned byte-for-byte against the
-  longhand they replace. Upstreamed as its ADR-0020 anticipated.
+  longhand they replace — with one deliberate departure: `append_event` omits
+  `metadata["user"]` when no actor is passed, rather than writing `None`.
+  `merge_provenance` layers ambient under explicit, so the copies in the wild
+  clobber the actor `ProvenanceMiddleware` stamped on the request whenever a
+  call site doesn't repeat it, and `envelope_actor` then falls back to the
+  payload's owner FK. Upstreamed as its ADR-0020 anticipated.
 
   The store contract also gained the property that makes the create-if-missing
   shorthand safe: a redundant `create()` on a populated stream preserves its

--- a/src/django_rakaia/envelope.py
+++ b/src/django_rakaia/envelope.py
@@ -1,0 +1,129 @@
+"""The append envelope and the live fold — the two rituals every consumer retypes.
+
+Two shapes show up at nearly every durable call site in a real Django consumer,
+and neither is hard enough to be interesting or short enough to be safe:
+
+* **Append an enveloped event** — JSON-encode the payload with Django's encoder,
+  create the stream if it isn't there, wrap the label/actor/timestamp in an
+  `AppendOptions`.
+* **Fold a batch live** — seed a scratch in-memory `StreamStore`, then `replay()`
+  it through a handler registry with a reader bound, so a projection can be
+  materialised at write time using the same handlers a rebuild will use.
+
+The first production consumer wrote the append ~37 times across 18 files and the
+fold 11 times, and left a warning in its own module that names the risk exactly:
+*"a second write path which re-implements the envelope is a path no gate
+covers."* A copy that drifts — a missing `event_ts`, a `metadata` that is `None`
+instead of `{}`, a `json.dumps` without the Django encoder — produces events that
+replay differently from every other event in the same stream, and no test
+anywhere is looking at the difference.
+
+These live in `django_rakaia` rather than `rakaia` because both are Django-shaped:
+the encoder is `DjangoJSONEncoder`, and the fold's default executor writes Django
+models. The core package stays dependency-free.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Sequence
+from typing import Any
+
+from django.core.serializers.json import DjangoJSONEncoder
+
+from rakaia import AppendOptions, StreamStore
+from rakaia.protocols import ProjectionReader, WritableStore
+from rakaia.registry import HandlerRegistry
+from rakaia.replay import replay
+
+#: The in-memory stream path a live fold replays through. A fold is not a
+#: durable append — it exists to run the *same handlers* a rebuild will run, so
+#: the write-time projection and the replayed one cannot diverge. The path is a
+#: constant so a registry's ``event_match`` can name it.
+SCRATCH_PATH = "produce/submission"
+
+
+def append_event(
+    store: WritableStore,
+    stream_path: str,
+    payload: dict[str, Any],
+    *,
+    label: str,
+    actor: Any = None,
+    event_ts: float | None = None,
+) -> None:
+    """Append one enveloped event to ``stream_path``, creating the stream if absent.
+
+    The envelope, fixed so every call site produces the same shape:
+
+    * the payload is JSON-encoded with `DjangoJSONEncoder`, so a `UUID`,
+      `datetime` or `Decimal` survives the trip rather than raising `TypeError`
+      at insert time;
+    * ``metadata`` is always a dict carrying ``user`` — the key
+      `rakaia.history.envelope_actor` reads. Ambient `provenance()` still merges
+      underneath, so a request-scoped `url`/`causation` is not shut out;
+    * ``event_ts`` is passed through. ``None`` means "order by append time",
+      which is the pre-existing default, not a silent loss of ordering.
+
+    ``create()`` is called unconditionally rather than guarded by ``has()``:
+    creation is idempotent by contract and — as
+    ``tests/store_contract.py::test_create_on_an_existing_stream_preserves_its_messages``
+    pins — a redundant create cannot truncate a populated stream or rewind its
+    offsets. One round trip instead of two.
+    """
+    store.create(stream_path)
+    store.append(
+        stream_path,
+        json.dumps(payload, cls=DjangoJSONEncoder).encode(),
+        AppendOptions(label=label, metadata={"user": actor}, event_ts=event_ts),
+    )
+
+
+def fold_events(
+    events: Sequence[dict[str, Any]],
+    registry: HandlerRegistry,
+    *,
+    reader: ProjectionReader | None = None,
+    executor: Any = None,
+    label: str = "import",
+    scratch_path: str = SCRATCH_PATH,
+) -> None:
+    """Project ``events`` now, through the handlers a replay would use.
+
+    Seeds a throwaway in-memory `StreamStore` with ``events`` in list order and
+    replays it through ``registry`` — staged, and reader-bound when ``reader`` is
+    given so stage-1 handlers resolve against the rows stage 0 just wrote.
+
+    The point is that write-time projection and rebuild-time projection run the
+    *same* handler code. A consumer that instead materialises rows directly at
+    write time has two implementations of one projection, and a rebuild that
+    disagrees with live is then indistinguishable from a rebuild that is correct.
+
+    The scratch store is in-memory and fresh per call: a fold leaves nothing in
+    the durable log (append separately, with `append_event`, if the event should
+    also be recorded), and successive folds cannot replay each other's events.
+
+    ``executor`` defaults to a `DjangoExecutor`. Pass a `CollectingExecutor` to
+    see what a fold *would* write without writing it.
+    """
+    if not events:
+        return
+
+    from .effect_executor import DjangoExecutor
+
+    scratch = StreamStore()
+    scratch.create(scratch_path)
+    for event in events:
+        scratch.append(
+            scratch_path,
+            json.dumps(event, cls=DjangoJSONEncoder).encode(),
+            AppendOptions(label=label),
+        )
+
+    replay(
+        scratch,
+        scratch_path,
+        executor or DjangoExecutor(),
+        handler_registry=registry,
+        reader=reader,
+    )

--- a/src/django_rakaia/envelope.py
+++ b/src/django_rakaia/envelope.py
@@ -59,9 +59,13 @@ def append_event(
     * the payload is JSON-encoded with `DjangoJSONEncoder`, so a `UUID`,
       `datetime` or `Decimal` survives the trip rather than raising `TypeError`
       at insert time;
-    * ``metadata`` is always a dict carrying ``user`` — the key
+    * an ``actor`` is recorded under ``user`` — the key
       `rakaia.history.envelope_actor` reads. Ambient `provenance()` still merges
-      underneath, so a request-scoped `url`/`causation` is not shut out;
+      underneath, so a request-scoped `url`/`causation` is not shut out. A
+      ``None`` actor is *omitted* rather than written: `merge_provenance` layers
+      ambient under explicit, so an explicit ``{"user": None}`` would beat the
+      actor `ProvenanceMiddleware` had already stamped on the block — turning
+      the caller's silence into a positive assertion that nobody did this;
     * ``event_ts`` is passed through. ``None`` means "order by append time",
       which is the pre-existing default, not a silent loss of ordering.
 
@@ -75,7 +79,11 @@ def append_event(
     store.append(
         stream_path,
         json.dumps(payload, cls=DjangoJSONEncoder).encode(),
-        AppendOptions(label=label, metadata={"user": actor}, event_ts=event_ts),
+        AppendOptions(
+            label=label,
+            metadata={"user": actor} if actor is not None else None,
+            event_ts=event_ts,
+        ),
     )
 
 

--- a/src/rakaia/registry.py
+++ b/src/rakaia/registry.py
@@ -453,9 +453,13 @@ class HandlerRegistry:
         # standalone bytes blob (one JSON object per message). We avoid
         # application/json mode because it appends a trailing comma and
         # treats the whole stream as a flattened JSON array.
+        #
+        # `create()` unguarded: creation is idempotent by contract, and a
+        # redundant create cannot truncate a populated stream or rewind its
+        # offsets (`tests/store_contract.py`). The `has()` it replaces was a
+        # second round trip buying nothing.
         assert self._store is not None
-        if not self._store.has(self._stream_path):
-            self._store.create(self._stream_path)
+        self._store.create(self._stream_path)
 
     def _load_persisted_ids(self) -> None:
         assert self._store is not None
@@ -500,8 +504,7 @@ class HandlerRegistry:
 
     def _ensure_reducer_stream(self) -> None:
         assert self._store is not None
-        if not self._store.has(self._reducer_stream_path):
-            self._store.create(self._reducer_stream_path)
+        self._store.create(self._reducer_stream_path)
 
     def _load_reducer_ids(self) -> None:
         assert self._store is not None
@@ -801,8 +804,7 @@ class UpcasterRegistry:
 
     def _ensure_stream(self) -> None:
         assert self._store is not None
-        if not self._store.has(self._stream_path):
-            self._store.create(self._stream_path)
+        self._store.create(self._stream_path)
 
     def _load_persisted_ids(self) -> None:
         assert self._store is not None

--- a/tests/store_contract.py
+++ b/tests/store_contract.py
@@ -62,6 +62,34 @@ class StoreContract:
         store.create("s")
         assert store.has("s") is True
 
+    def test_create_on_an_existing_stream_preserves_its_messages(self, store):
+        """Idempotent means *no-op*, not *reset*.
+
+        `test_create_is_idempotent` only checks the stream still exists, which a
+        create-that-truncates would also satisfy. This is the property callers
+        rely on when they drop the `has()` guard and call `create()`
+        unconditionally: the create-if-missing shorthand is safe only because a
+        redundant `create()` cannot destroy a populated stream.
+        """
+        store.create("s")
+        store.append("s", b'{"n": 1}', AppendOptions(label="create"))
+        store.append("s", b'{"n": 2}', AppendOptions(label="update"))
+
+        store.create("s")
+
+        messages, _ = store.read("s")
+        assert [json.loads(m.data)["n"] for m in messages] == [1, 2]
+
+    def test_create_on_an_existing_stream_does_not_rewind_offsets(self, store):
+        """Any offset a caller is already holding stays valid."""
+        store.create("s")
+        store.append("s", b'{"n": 1}', AppendOptions(label="create"))
+        offset_before = store.get_current_offset("s")
+
+        store.create("s")
+
+        assert store.get_current_offset("s") == offset_before
+
     def test_has_reflects_existence(self, store):
         assert store.has("s") is False
         store.create("s")

--- a/tests/test_django_rakaia/test_envelope.py
+++ b/tests/test_django_rakaia/test_envelope.py
@@ -1,0 +1,189 @@
+"""One append envelope, one fold ritual — instead of both re-typed per call site.
+
+Two shapes are written by hand at nearly every durable call site in a real
+consumer: appending an enveloped event (JSON-encode with Django's encoder,
+create-the-stream-if-missing, wrap the label/actor/timestamp in `AppendOptions`),
+and folding a batch of events live (seed a scratch in-memory `StreamStore`, then
+`replay()` it through a registry with a reader bound). The first production
+consumer counted ~37 copies of the append across 18 files and 11 copies of the
+fold, and its own module carried the warning that motivates this: *"a second
+write path which re-implements the envelope is a path no gate covers."*
+
+The rule these tests exist to enforce is **byte-identical to the hand-rolled
+ritual**. The helpers are only worth having if adopting them is a pure deletion,
+so every test here pins the helper's output against the longhand it replaces
+rather than against a hand-written expectation.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from django.core.serializers.json import DjangoJSONEncoder
+
+from django_rakaia.effect_executor import DjangoExecutor
+from django_rakaia.envelope import SCRATCH_PATH, append_event, fold_events
+from django_rakaia.projection_reader import DjangoProjectionReader
+from rakaia import AppendOptions, Effect, StreamStore, provenance
+from rakaia.registry import HandlerRegistry
+
+from .models import FinanceLine
+
+pytestmark = pytest.mark.django_db
+
+
+def _hand_rolled(store, path, payload, *, label, actor=None, event_ts=None):
+    """The longhand `append_event` replaces, kept here as the oracle."""
+    if not store.has(path):
+        store.create(path)
+    store.append(
+        path,
+        json.dumps(payload, cls=DjangoJSONEncoder).encode(),
+        AppendOptions(label=label, metadata={"user": actor}, event_ts=event_ts),
+    )
+
+
+class TestAppendEventMatchesTheLonghand:
+    def test_the_message_is_byte_identical(self):
+        payload = {"submission": "s1", "amount": 10}
+
+        longhand = StreamStore()
+        _hand_rolled(longhand, "p", payload, label="create", actor=7)
+        helper = StreamStore()
+        append_event(helper, "p", payload, label="create", actor=7)
+
+        (a,), _ = longhand.read("p")
+        (b,), _ = helper.read("p")
+        assert a.data == b.data
+        assert a.label == b.label
+        assert a.metadata == b.metadata
+
+    def test_it_creates_the_stream_when_missing(self):
+        store = StreamStore()
+        append_event(store, "brand-new", {"n": 1}, label="create")
+        assert store.has("brand-new")
+
+    def test_it_appends_to_an_existing_stream_without_resetting_it(self):
+        store = StreamStore()
+        append_event(store, "p", {"n": 1}, label="create")
+        append_event(store, "p", {"n": 2}, label="update")
+        messages, _ = store.read("p")
+        assert [json.loads(m.data)["n"] for m in messages] == [1, 2]
+
+    def test_the_actor_lands_where_envelope_actor_reads_it(self):
+        """`history.envelope_actor` reads `metadata['user']` — the helper must
+        write the key the rest of rakaia already agrees on."""
+        from rakaia.history import envelope_actor
+
+        store = StreamStore()
+        append_event(store, "p", {"user_id": 1}, label="update", actor=42)
+        (msg,), _ = store.read("p")
+        assert envelope_actor(msg, json.loads(msg.data)) == 42
+
+    def test_django_types_are_encoded(self):
+        """A UUID/Decimal/datetime payload is why the encoder is part of the
+        ritual rather than a plain `json.dumps`."""
+        import uuid
+        from decimal import Decimal
+
+        store = StreamStore()
+        ref = uuid.uuid4()
+        append_event(
+            store, "p", {"ref": ref, "amount": Decimal("1.50")}, label="create"
+        )
+        (msg,), _ = store.read("p")
+        assert json.loads(msg.data)["ref"] == str(ref)
+
+    def test_event_ts_is_carried_when_given(self):
+        store = StreamStore()
+        append_event(store, "p", {"n": 1}, label="create", event_ts=1234.5)
+        (msg,), _ = store.read("p")
+        assert msg.event_ts == 1234.5
+
+    def test_ambient_provenance_still_merges(self):
+        """The helper sets `metadata['user']` explicitly, but must not shut the
+        ambient block out of the other fields."""
+        store = StreamStore()
+        with provenance(url="/imports/"):
+            append_event(store, "p", {"n": 1}, label="create", actor=5)
+        (msg,), _ = store.read("p")
+        assert msg.metadata["user"] == 5
+        assert msg.metadata["url"] == "/imports/"
+
+
+def _handler(event):
+    return Effect(
+        op="update_or_create",
+        model_label="test_django_rakaia.FinanceLine",
+        lookup={"submission_id": event["id"]},
+        defaults={"suku": event["suku"]},
+    )
+
+
+def _registry() -> HandlerRegistry:
+    registry = HandlerRegistry()
+    registry.register(
+        name="finance",
+        event_match=SCRATCH_PATH,
+        fn=_handler,
+        effective_from=0,
+    )
+    return registry
+
+
+class TestFoldEvents:
+    def test_it_projects_a_batch_through_the_registry(self):
+        fold_events(
+            [{"id": "a", "suku": "one"}, {"id": "b", "suku": "two"}],
+            _registry(),
+        )
+        assert FinanceLine.objects.count() == 2
+        assert FinanceLine.objects.get(submission_id="a").suku == "one"
+
+    def test_list_order_is_the_replay_order(self):
+        """The scratch stream is seeded in list order, so a later event wins."""
+        fold_events(
+            [{"id": "a", "suku": "first"}, {"id": "a", "suku": "second"}],
+            _registry(),
+        )
+        assert FinanceLine.objects.get(submission_id="a").suku == "second"
+
+    def test_it_leaves_no_durable_trace(self):
+        """The scratch store is in-memory — a live fold must not append to the
+        durable log."""
+        from django_rakaia.models import StreamEvent
+
+        before = StreamEvent.objects.count()
+        fold_events([{"id": "a", "suku": "one"}], _registry())
+        assert StreamEvent.objects.count() == before
+
+    def test_an_explicit_executor_is_used(self):
+        from rakaia.executors import CollectingExecutor
+
+        executor = CollectingExecutor()
+        fold_events([{"id": "a", "suku": "one"}], _registry(), executor=executor)
+
+        assert len(executor.effects) == 1
+        assert FinanceLine.objects.count() == 0  # dry run wrote nothing
+
+    def test_an_empty_batch_is_a_no_op(self):
+        fold_events([], _registry())
+        assert FinanceLine.objects.count() == 0
+
+    def test_successive_folds_do_not_leak_into_each_other(self):
+        """Each call gets a fresh scratch store, so event 1 is not replayed
+        again by the second call."""
+        registry = _registry()
+        fold_events([{"id": "a", "suku": "one"}], registry)
+        fold_events([{"id": "b", "suku": "two"}], registry)
+        assert FinanceLine.objects.count() == 2
+
+    def test_a_reader_is_forwarded_for_staged_folds(self):
+        fold_events(
+            [{"id": "a", "suku": "one"}],
+            _registry(),
+            reader=DjangoProjectionReader(),
+            executor=DjangoExecutor(),
+        )
+        assert FinanceLine.objects.count() == 1

--- a/tests/test_django_rakaia/test_envelope.py
+++ b/tests/test_django_rakaia/test_envelope.py
@@ -34,7 +34,14 @@ pytestmark = pytest.mark.django_db
 
 
 def _hand_rolled(store, path, payload, *, label, actor=None, event_ts=None):
-    """The longhand `append_event` replaces, kept here as the oracle."""
+    """The longhand `append_event` replaces, kept here as the oracle.
+
+    Faithful to the copies in the wild, including the one bug they share: with
+    no actor this writes `{"user": None}`, which out-ranks an ambient
+    `provenance(user=...)`. The helper omits the key instead — the single
+    deliberate divergence, pinned by
+    `test_no_actor_does_not_clobber_the_ambient_one`.
+    """
     if not store.has(path):
         store.create(path)
     store.append(
@@ -110,6 +117,31 @@ class TestAppendEventMatchesTheLonghand:
         (msg,), _ = store.read("p")
         assert msg.metadata["user"] == 5
         assert msg.metadata["url"] == "/imports/"
+
+    def test_no_actor_does_not_clobber_the_ambient_one(self):
+        """The one place the helper deliberately departs from the longhand.
+
+        `merge_provenance` layers ambient *under* explicit, so writing
+        `{"user": None}` for a caller who simply didn't pass an actor would beat
+        the user `ProvenanceMiddleware` already stamped on the request — the
+        caller's silence would become a positive assertion that nobody did this,
+        and `envelope_actor` would fall back to the payload's owner FK. Omit the
+        key instead, and the ambient actor survives.
+        """
+        store = StreamStore()
+        with provenance(user=7, url="/imports/"):
+            append_event(store, "p", {"n": 1}, label="create")
+        (msg,), _ = store.read("p")
+        assert msg.metadata["user"] == 7
+        assert msg.metadata["url"] == "/imports/"
+
+    def test_no_actor_and_no_ambient_block_keeps_the_bare_default(self):
+        """With nothing to record, the message keeps rakaia's no-envelope
+        default rather than carrying a `user: None` that means nothing."""
+        store = StreamStore()
+        append_event(store, "p", {"n": 1}, label="create")
+        (msg,), _ = store.read("p")
+        assert msg.metadata is None
 
 
 def _handler(event):


### PR DESCRIPTION
There are two small pieces of boilerplate that anyone using rakaia with Django
ends up writing over and over: the handful of lines that record an event with its
author and timestamp, and the handful that run a batch of events through your
projection logic right now rather than waiting for a rebuild. Neither is hard.
Both are easy to get subtly wrong, and a copy that drifts — a missing timestamp,
an author field left empty — produces events that behave differently from every
other event in the same stream, with no test anywhere looking at the difference.
The first project to use rakaia in production ended up with around thirty-seven
copies of one and eleven of the other.

Both now ship with rakaia. The tests check them against the longhand they
replace rather than against something hand-written, so switching over is pure
deletion with nothing to re-verify. Along the way this also pins down a rule the
codebase had been relying on without stating: asking to create a stream that
already exists leaves its contents alone. That was true of both stores but
untested, and it's what makes the shorter form safe — so rakaia's own code now
uses the shorter form too.