### PR TITLE
Bulk appends were never reaching live subscribers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -229,6 +229,18 @@ is not yet tagged in a release.
   exactly as both stores do; a fan-out to several streams shares one envelope,
   since it is one event. Appends outside a `provenance()` block are unchanged.
 
+- **A bulk append now reaches live subscribers** (#82). `append_many` persists
+  with `bulk_create`, which does not fire `post_save` — and on the durable store
+  publication *was* a `post_save` receiver on `StreamEntry`, so every bulk append
+  was silently invisible to SSE subscribers. The docstring's promise that it is
+  "semantically identical to calling `append` once per item" was true of the rows
+  written and false of the subscribers reached; nothing caught it because that
+  semantic was never in the interface. The wire frame now has a single definition
+  (`channels_signals.broadcast_entries`) which both the receiver and the store
+  call, and `DjangoStreamStore` publishes its own appends rather than relying on
+  a signal that its own write strategy bypasses. Restoring the signal by saving
+  rows one at a time would have undone the reason `append_many` exists.
+
 - **A store now refuses an offset it did not issue.** Both stores accepted the
   other's offset format and resolved it to an unrelated position instead of
   failing: `int("0_5")` is `5` in Python, so the durable store read the wrong

--- a/src/django_rakaia/channels_signals.py
+++ b/src/django_rakaia/channels_signals.py
@@ -141,10 +141,13 @@ def broadcast_entries(stream_id: str, entries: Sequence[StreamEntry]) -> None:
 def handle_stream_entry_created(sender, instance, created, **kwargs):  # noqa: ARG001
     """Broadcast an ORM-written stream entry to the stream's channel group.
 
-    Covers the write paths that do not go through `DjangoStreamStore` — chiefly
-    `@stream_model`. The store publishes its own appends via `broadcast_entries`
-    and writes with `bulk_create`, so this receiver does not double-fire for
-    them.
+    Covers every entry written through the ORM: `@stream_model`, and
+    `DjangoStreamStore.append`, which persists one entry with `create()`.
+
+    It does *not* cover `DjangoStreamStore.append_many`, which persists with
+    `bulk_create` — that path calls `broadcast_entries` itself. So the two
+    mechanisms partition the write paths rather than overlapping, and no entry is
+    published twice.
     """
     # Skip fixture rows. Beyond the phantom frame, the `instance.stream` /
     # `instance.event` dereferences are separate queries that raise DoesNotExist

--- a/src/django_rakaia/channels_signals.py
+++ b/src/django_rakaia/channels_signals.py
@@ -5,6 +5,8 @@ Replaces the custom SSEManager/Unix socket/Redis broadcasting with
 Django Channels' channel layer for cross-process event distribution.
 """
 
+from collections.abc import Sequence
+
 from asgiref.sync import async_to_sync
 from channels.layers import get_channel_layer
 from django.db.models.signals import post_save
@@ -77,39 +79,79 @@ def handle_stream_event_created(sender, instance, created, **kwargs):  # noqa: A
     async_to_sync(channel_layer.group_send)("translations", message)
 
 
-@receiver(post_save, sender=StreamEntry)
-def handle_stream_entry_created(sender, instance, created, **kwargs):  # noqa: ARG001
-    """Broadcast stream events to the stream's channel group."""
-    # As above: skip fixture rows. Beyond the phantom frame, the `instance.stream`
-    # / `instance.event` dereferences below are separate queries that raise
-    # DoesNotExist mid-`loaddata` if the parent rows are not restored yet.
-    if kwargs.get("raw"):
-        return
-    if not created:
+def _frame(stream_id: str, entry: StreamEntry) -> dict:
+    """The SSE frame for one appended entry.
+
+    Sole definition of the wire shape. It used to live inline in the `post_save`
+    receiver, which made it unreachable from any write path that does not fire
+    `post_save` — see `broadcast_entries`.
+    """
+    return {
+        "type": "stream.event",
+        # The group name is a lossy sanitization — distinct stream ids can share
+        # a group (every disallowed character becomes ".", and long names
+        # truncate). The payload carries the exact id so a consumer can filter
+        # out a group-mate's events instead of cross-delivering them.
+        "stream_id": stream_id,
+        "event": {
+            "id": entry.event.id,
+            "offset": entry.offset,
+            "event_type": entry.event.event_type,
+            "created_at": entry.event.created_at.isoformat()
+            if entry.event.created_at
+            else None,
+            "data": entry.event.data,
+        },
+    }
+
+
+def broadcast_entries(stream_id: str, entries: Sequence[StreamEntry]) -> None:
+    """Publish `entries` to the stream's channel group, oldest first.
+
+    The one implementation of "an append reaches subscribers". Two callers reach
+    it, because there are two ways an entry gets written:
+
+    * the `post_save` receiver below, for entries written through the ORM —
+      `@stream_model` and anything else that does not go through the store;
+    * `DjangoStreamStore` directly, for its own appends.
+
+    The store has to call it rather than lean on the signal: `append_many`
+    persists with `bulk_create`, which does not fire `post_save`, so every bulk
+    append was silently invisible to subscribers (issue #82). Restoring the
+    signal by saving rows one at a time would undo the reason `append_many`
+    exists; publishing explicitly keeps the batch write a batch write.
+
+    A no-op when the channel layer is absent, so a framework-tier consumer that
+    never installed `channels` is unaffected.
+    """
+    if not entries:
         return
 
     channel_layer = get_channel_layer()
     if channel_layer is None:
         return
 
-    stream_id = instance.stream.stream_id
-    message = {
-        "type": "stream.event",
-        # The group name below is a lossy sanitization — distinct stream ids
-        # can share a group (every disallowed character becomes ".", and long
-        # names truncate). The payload carries the exact id so a consumer can
-        # filter out a group-mate's events instead of cross-delivering them.
-        "stream_id": stream_id,
-        "event": {
-            "id": instance.event.id,
-            "offset": instance.offset,
-            "event_type": instance.event.event_type,
-            "created_at": instance.event.created_at.isoformat()
-            if instance.event.created_at
-            else None,
-            "data": instance.event.data,
-        },
-    }
-
     group_name = _sanitize_group_name(f"stream.{stream_id}")
-    async_to_sync(channel_layer.group_send)(group_name, message)
+    send = async_to_sync(channel_layer.group_send)
+    for entry in entries:
+        send(group_name, _frame(stream_id, entry))
+
+
+@receiver(post_save, sender=StreamEntry)
+def handle_stream_entry_created(sender, instance, created, **kwargs):  # noqa: ARG001
+    """Broadcast an ORM-written stream entry to the stream's channel group.
+
+    Covers the write paths that do not go through `DjangoStreamStore` — chiefly
+    `@stream_model`. The store publishes its own appends via `broadcast_entries`
+    and writes with `bulk_create`, so this receiver does not double-fire for
+    them.
+    """
+    # Skip fixture rows. Beyond the phantom frame, the `instance.stream` /
+    # `instance.event` dereferences are separate queries that raise DoesNotExist
+    # mid-`loaddata` if the parent rows are not restored yet.
+    if kwargs.get("raw"):
+        return
+    if not created:
+        return
+
+    broadcast_entries(instance.stream.stream_id, [instance])

--- a/src/django_rakaia/django_store.py
+++ b/src/django_rakaia/django_store.py
@@ -688,7 +688,8 @@ class DjangoStreamStore:
 
         Semantically identical to calling :meth:`append` once per item — same
         event rows, same envelope mapping (``label``->``event_type``,
-        per-event ``merge_provenance`` for ``metadata``, ``event_ts``) — but it
+        per-event ``merge_provenance`` for ``metadata``, ``event_ts``), and the
+        same frames delivered to live subscribers — but it
         locks the stream's high-water once, allocates a single contiguous offset
         block for the whole batch (so ``unique_together(stream, offset)`` still
         holds and concurrent writers serialize exactly as ``append`` does), and
@@ -781,6 +782,13 @@ class DjangoStreamStore:
                 for i, event in enumerate(stream_events)
             ]
             StreamEntry.objects.bulk_create(entries)
+            # `bulk_create` does not fire `post_save`, so the receiver that
+            # publishes single appends never sees these rows — every bulk append
+            # used to be invisible to subscribers (issue #82). Publish them
+            # explicitly rather than saving one at a time, which would undo the
+            # reason this method exists. Inside the transaction, matching the
+            # receiver's existing timing on the `append` path.
+            self._publish(stream.stream_id, entries)
 
             if last_seq != stream.last_seq:
                 stream.last_seq = last_seq
@@ -815,6 +823,27 @@ class DjangoStreamStore:
                     written, stream_events, entries, strict=True
                 )
             ] + [AppendResult(message=None, stream_closed=True) for _ in refused]
+
+    @staticmethod
+    def _publish(stream_id: str, entries: list[StreamEntry]) -> None:
+        """Publish appended entries to live subscribers.
+
+        The store's own publish step. Delegates to
+        `channels_signals.broadcast_entries`, the single definition of the wire
+        frame, which the `post_save` receiver also uses — so the two write paths
+        cannot describe the same event differently.
+
+        Imported lazily and tolerantly: `channels` is an optional extra
+        (ADR 0002 / #41), and a framework-tier consumer that never installed it
+        must still be able to append.
+        """
+        if not entries:
+            return
+        try:
+            from .channels_signals import broadcast_entries
+        except ImportError:
+            return
+        broadcast_entries(stream_id, entries)
 
     def read(
         self, path: str, offset: str | None = None

--- a/tests/test_django_rakaia/test_publish_on_append.py
+++ b/tests/test_django_rakaia/test_publish_on_append.py
@@ -1,0 +1,189 @@
+"""An append reaches subscribers because the *store* published it (issue #82).
+
+`append_many`'s docstring promises it is "semantically identical to calling
+`append` once per item". That is true of the rows it writes and false of the
+subscribers it reaches, because the two stores implement "an append reaches
+subscribers" by different mechanisms and only one of them is named anywhere:
+
+* the in-memory store publishes **inside** `append`;
+* the durable store did not publish at all — publication was a `post_save`
+  receiver on `StreamEntry`, and `append_many` writes with `bulk_create`, which
+  does not fire `post_save`.
+
+So every bulk append was invisible to SSE subscribers. The semantics that broke
+were never in the interface, which is why nothing caught it: no docstring claimed
+them, no contract asserted them, and the row-level behaviour the docstring *did*
+describe was correct throughout.
+
+The fix is to make publication part of what a store does when it appends, rather
+than a side effect of how it happened to write rows. These tests pin that: they
+drive the **store**, not the ORM, and assert what a subscriber receives.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+
+import pytest
+from channels.layers import get_channel_layer
+
+from django_rakaia.django_store import DjangoStreamStore
+from rakaia import AppendOptions
+
+pytestmark = pytest.mark.django_db(transaction=True)
+
+GROUP = "stream.bulk"
+PATH = "bulk"
+
+
+async def _subscribe() -> tuple[object, str]:
+    layer = get_channel_layer()
+    assert layer is not None
+    channel = await layer.new_channel()
+    await layer.group_add(GROUP, channel)
+    return layer, channel
+
+
+async def _drain(layer, channel, *, expected: int, timeout: float = 3.0) -> list[dict]:
+    """Collect up to `expected` frames, giving up quickly rather than hanging."""
+    received: list[dict] = []
+
+    async def _consume():
+        while len(received) < expected:
+            received.append(await layer.receive(channel))
+
+    with contextlib.suppress(TimeoutError):
+        await asyncio.wait_for(_consume(), timeout=timeout)
+    return received
+
+
+def _offsets(frames: list[dict]) -> list[str]:
+    out = []
+    for frame in frames:
+        event = frame.get("event") or {}
+        out.append(str(event.get("offset")))
+    return out
+
+
+class TestAppendPublishes:
+    """The case that already worked — kept so the fix is a widening, not a swap."""
+
+    async def test_a_single_append_reaches_a_subscriber(self):
+        layer, channel = await _subscribe()
+        store = DjangoStreamStore()
+
+        await store.run_sync(store.create, PATH)
+        await store.run_sync(
+            store.append, PATH, b'{"n": 1}', AppendOptions(label="create")
+        )
+
+        frames = await _drain(layer, channel, expected=1)
+        assert len(frames) == 1
+
+
+class TestAppendManyPublishes:
+    """The RED core: zero frames today."""
+
+    async def test_a_bulk_append_reaches_a_subscriber(self):
+        layer, channel = await _subscribe()
+        store = DjangoStreamStore()
+
+        await store.run_sync(store.create, PATH)
+        await store.run_sync(
+            store.append_many,
+            PATH,
+            [
+                (b'{"n": 1}', AppendOptions(label="create")),
+                (b'{"n": 2}', AppendOptions(label="update")),
+                (b'{"n": 3}', AppendOptions(label="update")),
+            ],
+        )
+
+        frames = await _drain(layer, channel, expected=3)
+        assert len(frames) == 3, (
+            f"bulk append reached {len(frames)} subscriber(s), expected 3 — "
+            "bulk_create does not fire post_save"
+        )
+
+    async def test_every_appended_event_is_delivered_in_order(self):
+        layer, channel = await _subscribe()
+        store = DjangoStreamStore()
+
+        await store.run_sync(store.create, PATH)
+        await store.run_sync(
+            store.append_many,
+            PATH,
+            [
+                (json.dumps({"n": n}).encode(), AppendOptions(label="u"))
+                for n in range(3)
+            ],
+        )
+
+        frames = await _drain(layer, channel, expected=3)
+        payloads = [f["event"]["data"]["n"] for f in frames]
+        assert payloads == [0, 1, 2]
+
+    async def test_offsets_are_the_ones_the_store_assigned(self):
+        """The frame carries the raw entry offset, matching the shape the
+        `post_save` receiver has always sent — not the zero-padded protocol
+        form `read()` returns. Pinned so the bulk path cannot drift from the
+        single-append path that live SSE consumers already parse."""
+        from django_rakaia.models import StreamEntry
+
+        layer, channel = await _subscribe()
+        store = DjangoStreamStore()
+
+        await store.run_sync(store.create, PATH)
+        await store.run_sync(
+            store.append_many,
+            PATH,
+            [(b'{"n": 1}', AppendOptions(label="u")) for _ in range(2)],
+        )
+
+        frames = await _drain(layer, channel, expected=2)
+        assigned = await store.run_sync(
+            lambda: list(
+                StreamEntry.objects.filter(stream__stream_id=PATH)
+                .order_by("offset")
+                .values_list("offset", flat=True)
+            )
+        )
+        assert _offsets(frames) == [str(o) for o in assigned]
+
+    async def test_an_empty_batch_publishes_nothing(self):
+        layer, channel = await _subscribe()
+        store = DjangoStreamStore()
+
+        await store.run_sync(store.create, PATH)
+        await store.run_sync(store.append_many, PATH, [])
+
+        assert await _drain(layer, channel, expected=1, timeout=0.3) == []
+
+
+class TestParityBetweenTheTwoPaths:
+    """The invariant `append_many`'s docstring claims, now asserted."""
+
+    async def test_one_bulk_append_delivers_what_n_single_appends_deliver(self):
+        layer, channel = await _subscribe()
+        store = DjangoStreamStore()
+
+        await store.run_sync(store.create, "singles")
+        await store.run_sync(store.create, "bulk")
+
+        # Only the `bulk` path is subscribed; count frames for each in turn.
+        await store.run_sync(
+            store.append_many,
+            PATH,
+            [(b'{"n": 1}', AppendOptions(label="u")) for _ in range(2)],
+        )
+        bulk_frames = await _drain(layer, channel, expected=2)
+
+        for _ in range(2):
+            await store.run_sync(
+                store.append, PATH, b'{"n": 1}', AppendOptions(label="u")
+            )
+        single_frames = await _drain(layer, channel, expected=2)
+
+        assert len(bulk_frames) == len(single_frames) == 2


### PR DESCRIPTION
Rakaia can push new events to connected browsers as they happen. It also has a
fast path for writing many events at once, added so that seeding and replaying
don't cost one database round trip per event. Those two features did not work
together: anything written through the fast path was saved correctly but never
announced, so live pages simply never heard about it. You would only notice on
reload, when the missing events suddenly appeared.

The cause is that live notification had been riding on a database hook that the
fast bulk write deliberately skips — that skipping is the whole reason the fast
path is fast. So the store now announces its own writes rather than hoping
something downstream notices, and there is one shared definition of what a
notification looks like so the two paths cannot describe the same event
differently. Fixes #82.