### PR TITLE
The two stores disagreed about whether an append was allowed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -241,6 +241,26 @@ is not yet tagged in a release.
   a signal that its own write strategy bypasses. Restoring the signal by saving
   rows one at a time would have undone the reason `append_many` exists.
 
+- **`append` now honours producer options on both stores.** `StreamStore.append`
+  validated producer epoch/seq inline and recognised the idempotent
+  close-duplicate; `DjangoStreamStore.append` ignored `options.producer_id`
+  entirely — while its docstring claimed "outcomes, all now matching the
+  in-memory store". Nothing caught it because every producer test routed through
+  `append_with_producer`, but `WritableStore.append` is public and its
+  `AppendOptions` carries those fields, so a consumer calling it directly got
+  adapter-dependent behaviour.
+
+  The whole admission sequence — closed → content-type → producer fencing →
+  Stream-Seq — now lives in one pure module, `rakaia.append_decision`, which both
+  stores ask. The ordering is the subtle part and was previously encoded only as
+  the order of if-statements in two separate methods: fencing runs **before**
+  Stream-Seq, because a retried append carries the same `Stream-Seq` it did the
+  first time, so checking Stream-Seq first would raise `SequenceConflict` on
+  exactly the retry that fencing exists to absorb. Seven new cases in
+  `tests/server_store_contract.py` hold both stores to the same verdicts, and the
+  rules themselves are now unit-testable as a table with no store, no database
+  and no async.
+
 - **A store now refuses an offset it did not issue.** Both stores accepted the
   other's offset format and resolved it to an unrelated position instead of
   failing: `int("0_5")` is `5` in Python, so the durable store read the wrong

--- a/src/django_rakaia/django_store.py
+++ b/src/django_rakaia/django_store.py
@@ -45,6 +45,7 @@ from asgiref.sync import sync_to_async
 from django.db import transaction
 from django.db.models import Max
 
+from rakaia.append_decision import StreamFacts, decide_append
 from rakaia.context import merge_provenance
 from rakaia.json_mode import (
     format_json_response,
@@ -414,7 +415,11 @@ class DjangoStreamStore:
         concurrent appends serialize on offset allocation instead of racing to
         the same value and failing `unique_together(stream, offset)`.
 
-        Outcomes, all now matching the in-memory store:
+        Admission (closed / content-type / producer fencing / Stream-Seq) is
+        decided by `rakaia.append_decision`, shared with the in-memory store, so
+        the two cannot reach different verdicts on the same options.
+
+        Outcomes, all matching the in-memory store:
 
         - Raises `StreamNotFound` if the stream is absent or expired.
         - Returns `AppendResult(stream_closed=True, message=None)` if closed.
@@ -428,13 +433,35 @@ class DjangoStreamStore:
         with transaction.atomic():
             stream = self._require(path, for_update=True)
 
-            if stream.closed:
-                return AppendResult(message=None, stream_closed=True)
-
-            self._check_content_type(stream, opts)
-            self._check_seq(stream, opts)
+            # Admission is decided in `rakaia.append_decision`, shared with the
+            # in-memory store. This path used to inline its own shorter sequence
+            # and ignore `opts.producer_id` entirely, so the same options
+            # reached different verdicts on the two stores while this method's
+            # docstring claimed they matched.
+            verdict = decide_append(
+                StreamFacts(
+                    closed=stream.closed,
+                    closed_by=stream.closed_by,
+                    content_type=stream.content_type,
+                    last_seq=stream.last_seq,
+                ),
+                opts,
+                producer_state=self._producer_state(
+                    stream, getattr(opts, "producer_id", None)
+                ),
+                now=time.time(),
+            )
+            if not verdict.write:
+                return AppendResult(
+                    message=None,
+                    stream_closed=verdict.stream_closed,
+                    producer_result=verdict.producer_result,
+                )
 
             messages = self._write(stream, data, opts)
+
+            if verdict.producer_result is not None:
+                self._commit_producer(stream, verdict.producer_result)
 
             if getattr(opts, "seq", None) is not None:
                 stream.last_seq = opts.seq
@@ -447,7 +474,9 @@ class DjangoStreamStore:
             # carries the last, whose offset is the stream's new head — which
             # is what a caller resumes from.
             return AppendResult(
-                message=messages[-1] if messages else None, stream_closed=close
+                message=messages[-1] if messages else None,
+                stream_closed=close,
+                producer_result=verdict.producer_result,
             )
 
     # =========================================================================
@@ -595,6 +624,26 @@ class DjangoStreamStore:
             )
         )
         return validate_producer(state, producer_id, epoch, seq, time.time())
+
+    @staticmethod
+    def _producer_state(
+        stream: Stream, producer_id: str | None
+    ) -> ProducerState | None:
+        """The last known state for `producer_id`, or None.
+
+        The one fact `decide_append` cannot work out for itself, since only the
+        store knows where producer state lives — here, a `StreamProducer` row.
+        """
+        if producer_id is None:
+            return None
+        row = StreamProducer.objects.filter(
+            stream=stream, producer_id=producer_id
+        ).first()
+        if row is None:
+            return None
+        return ProducerState(
+            epoch=row.epoch, last_seq=row.last_seq, last_updated=row.last_updated
+        )
 
     @staticmethod
     def _commit_producer(stream: Stream, result: ProducerValidationResult) -> None:

--- a/src/rakaia/append_decision.py
+++ b/src/rakaia/append_decision.py
@@ -1,0 +1,146 @@
+"""Whether an append is allowed, decided once for every store.
+
+`rakaia.producer` already does this for the *fencing* rules, and the two stores
+share it, so they cannot drift on epoch/seq. The rest of the admission sequence —
+closed? content-type? fence? Stream-Seq? — was restated in both adapters, and
+they had already drifted: `StreamStore.append` validated producer options inline
+and recognised the idempotent close-duplicate, while `DjangoStreamStore.append`
+ignored `options.producer_id` entirely, all while its docstring claimed
+"outcomes, all now matching the in-memory store".
+
+Nothing caught that because every producer test routed through
+`append_with_producer`. `WritableStore.append` is public and its `AppendOptions`
+carries those fields, so a consumer calling it directly got adapter-dependent
+behaviour.
+
+This module owns the sequence. A store's job becomes: gather the facts, ask, then
+persist — so a new backend implements *storage*, not protocol semantics.
+
+**The order is the subtle part** and is the reason this is worth centralising:
+
+1. **Closed** is checked first, and a matching `closed_by` tuple is reported as a
+   duplicate rather than a bare refusal — a producer retrying the append that
+   closed the stream must be able to tell "my close landed" from "someone else
+   closed this".
+2. **Content type** next: a mismatch is a caller error regardless of fencing.
+3. **Producer fencing before Stream-Seq.** A retried append carries the same
+   `Stream-Seq` it did the first time, so checking Stream-Seq first would raise
+   `SequenceConflict` on precisely the retry that fencing exists to absorb.
+4. **Stream-Seq** last, as a plain monotonicity conflict.
+
+Conflicts are *raised* (`ContentTypeMismatch`, `SequenceConflict`) because they
+are caller errors; fencing outcomes are *returned* because they are protocol
+results carrying their own statuses and headers.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from .json_mode import normalize_content_type
+from .producer import validate_producer
+from .types import (
+    ClosedBy,
+    ContentTypeMismatch,
+    ProducerDuplicate,
+    ProducerState,
+    ProducerValidationResult,
+    SequenceConflict,
+)
+
+
+@dataclass(frozen=True)
+class StreamFacts:
+    """What the decision needs to know about a stream, with no store attached.
+
+    A deliberately small surface: whatever a backend holds, these are the only
+    fields the admission rules read.
+    """
+
+    closed: bool = False
+    closed_by: ClosedBy | None = None
+    content_type: str | None = None
+    last_seq: int | None = None
+
+
+@dataclass(frozen=True)
+class AppendVerdict:
+    """The decision. ``write`` is the only field a caller must branch on.
+
+    ``producer_result`` is carried whether or not the write is allowed: on a
+    refusal it is the fencing outcome to report, and on an acceptance it is the
+    state to commit *after* the write lands (or None for an unfenced append).
+    """
+
+    write: bool
+    stream_closed: bool = False
+    producer_result: ProducerValidationResult | None = None
+
+
+def decide_append(
+    facts: StreamFacts,
+    opts: Any,
+    *,
+    producer_state: ProducerState | None = None,
+    now: float,
+) -> AppendVerdict:
+    """Decide whether this append may be written. See the module docstring for
+    the ordering and why it matters.
+
+    `producer_state` is the last known state for ``opts.producer_id`` — the one
+    fact the caller must look up, since only the store knows where it lives.
+    """
+    producer_id = getattr(opts, "producer_id", None)
+    producer_epoch = getattr(opts, "producer_epoch", None)
+    producer_seq = getattr(opts, "producer_seq", None)
+
+    # 1. Closed — including the idempotent re-send of the closing append.
+    if facts.closed:
+        closed_by = facts.closed_by
+        if (
+            producer_id is not None
+            and closed_by is not None
+            and closed_by.producer_id == producer_id
+            and closed_by.epoch == producer_epoch
+            and closed_by.seq == producer_seq
+        ):
+            return AppendVerdict(
+                write=False,
+                stream_closed=True,
+                producer_result=ProducerDuplicate(last_seq=producer_seq or 0),
+            )
+        return AppendVerdict(write=False, stream_closed=True)
+
+    # 2. Content type.
+    provided_ct = getattr(opts, "content_type", None)
+    if (
+        provided_ct
+        and facts.content_type
+        and normalize_content_type(provided_ct)
+        != normalize_content_type(facts.content_type)
+    ):
+        raise ContentTypeMismatch(
+            f"Content-type mismatch: expected {facts.content_type}, got {provided_ct}"
+        )
+
+    # 3. Producer fencing — before Stream-Seq, so a retry is absorbed as a
+    #    duplicate rather than raising on the seq it legitimately repeats.
+    producer_result: ProducerValidationResult | None = None
+    if (
+        producer_id is not None
+        and producer_epoch is not None
+        and producer_seq is not None
+    ):
+        producer_result = validate_producer(
+            producer_state, producer_id, producer_epoch, producer_seq, now
+        )
+        if producer_result.status != "accepted":
+            return AppendVerdict(write=False, producer_result=producer_result)
+
+    # 4. Stream-Seq monotonicity.
+    seq = getattr(opts, "seq", None)
+    if seq is not None and facts.last_seq is not None and seq <= facts.last_seq:
+        raise SequenceConflict(f"Sequence conflict: {seq} <= {facts.last_seq}")
+
+    return AppendVerdict(write=True, producer_result=producer_result)

--- a/src/rakaia/store.py
+++ b/src/rakaia/store.py
@@ -15,6 +15,7 @@ from collections.abc import Iterable
 from datetime import datetime, timezone
 from typing import Any
 
+from .append_decision import StreamFacts, decide_append
 from .context import merge_provenance
 from .json_mode import (
     format_json_response,
@@ -260,56 +261,28 @@ class StreamStore:
         if stream is None:
             raise StreamNotFound(f"Stream not found: {path}")
 
-        # Check if stream is closed
-        if stream.closed:
-            # Check for idempotent duplicate of closing request
-            if (
-                opts.producer_id is not None
-                and stream.closed_by is not None
-                and stream.closed_by.producer_id == opts.producer_id
-                and stream.closed_by.epoch == opts.producer_epoch
-                and stream.closed_by.seq == opts.producer_seq
-            ):
-                return AppendResult(
-                    message=None,
-                    stream_closed=True,
-                    producer_result=ProducerDuplicate(last_seq=opts.producer_seq or 0),
-                )
-            # Stream is closed - reject
-            return AppendResult(message=None, stream_closed=True)
-
-        # Check content type match
-        if opts.content_type and stream.content_type:
-            provided = normalize_content_type(opts.content_type)
-            stream_ct = normalize_content_type(stream.content_type)
-            if provided != stream_ct:
-                raise ContentTypeMismatch(
-                    f"Content-type mismatch: expected {stream.content_type}, "
-                    f"got {opts.content_type}"
-                )
-
-        # Producer validation (before Stream-Seq check for retry dedup)
-        producer_result: ProducerValidationResult | None = None
-        if (
-            opts.producer_id is not None
-            and opts.producer_epoch is not None
-            and opts.producer_seq is not None
-        ):
-            producer_result = self._validate_producer(
-                stream, opts.producer_id, opts.producer_epoch, opts.producer_seq
+        # Admission is decided in `rakaia.append_decision`, shared with the
+        # durable store, so the ordering (closed -> content-type -> fencing ->
+        # Stream-Seq) cannot drift between the two. This store's only job here
+        # is to supply the facts and then persist the verdict.
+        verdict = decide_append(
+            StreamFacts(
+                closed=stream.closed,
+                closed_by=stream.closed_by,
+                content_type=stream.content_type,
+                last_seq=stream.last_seq,
+            ),
+            opts,
+            producer_state=self._producer_state(stream, opts.producer_id),
+            now=time.time(),
+        )
+        if not verdict.write:
+            return AppendResult(
+                message=None,
+                stream_closed=verdict.stream_closed,
+                producer_result=verdict.producer_result,
             )
-            if producer_result.status != "accepted":
-                return AppendResult(message=None, producer_result=producer_result)
-
-        # Stream-Seq coordination
-        if (
-            opts.seq is not None
-            and stream.last_seq is not None
-            and opts.seq <= stream.last_seq
-        ):
-            raise SequenceConflict(
-                f"Sequence conflict: {opts.seq} <= {stream.last_seq}"
-            )
+        producer_result = verdict.producer_result
 
         # Append the data (may raise for invalid JSON). Provenance is merged
         # here at the public-append boundary — not in _append_to_stream — so a
@@ -619,6 +592,18 @@ class StreamStore:
     # =========================================================================
     # Producer validation
     # =========================================================================
+
+    def _producer_state(self, stream: Stream, producer_id: str | None):
+        """The last known state for `producer_id`, or None.
+
+        The one fact `decide_append` cannot work out for itself, since only the
+        store knows where producer state lives. Expired states are dropped
+        first, so an aged-out producer reads as a new one.
+        """
+        if producer_id is None:
+            return None
+        self._cleanup_expired_producers(stream)
+        return stream.producers.get(producer_id)
 
     def _validate_producer(
         self,

--- a/tests/server_store_contract.py
+++ b/tests/server_store_contract.py
@@ -407,6 +407,104 @@ class ServerStoreContract:
         assert isinstance(accepted.producer_result, ProducerAccepted)
 
     # =========================================================================
+    # Producer options on the plain `append` path
+    # =========================================================================
+    #
+    # A protocol server routes fenced writes to `append_with_producer`, so every
+    # case above goes through that door. Nothing said what the *other* door does
+    # with the same options — and the two stores answered differently:
+    # `StreamStore.append` validated the producer inline and recognised the
+    # idempotent close-duplicate, while `DjangoStreamStore.append` ignored
+    # `options.producer_id` entirely, all while its docstring claimed "outcomes,
+    # all now matching the in-memory store".
+    #
+    # `WritableStore.append` is public and takes an `AppendOptions` with those
+    # fields on it, so a consumer calling it directly got adapter-dependent
+    # behaviour. These cases make the two doors agree.
+
+    async def test_append_honours_producer_fencing(self, store):
+        """The same options through `append` reach the same verdict."""
+        await self._sync(store.create, "s")
+        await self._sync(store.append, "s", b'{"id": 1}', self._producer("p", 0, 0))
+
+        stale = await self._sync(
+            store.append, "s", b'{"id": 2}', self._producer("p", 0, 0)
+        )
+        assert isinstance(stale.producer_result, ProducerDuplicate)
+        assert stale.message is None
+
+        messages, _ = await self._sync(store.read, "s")
+        assert len(messages) == 1, "a duplicate must not write a second time"
+
+    async def test_append_refuses_a_stale_epoch(self, store):
+        await self._sync(store.create, "s")
+        await self._sync(store.append, "s", b'{"id": 1}', self._producer("p", 5, 0))
+        result = await self._sync(
+            store.append, "s", b'{"id": 2}', self._producer("p", 4, 0)
+        )
+        assert isinstance(result.producer_result, ProducerStaleEpoch)
+        assert result.message is None
+
+    async def test_append_refuses_a_sequence_gap(self, store):
+        await self._sync(store.create, "s")
+        await self._sync(store.append, "s", b'{"id": 1}', self._producer("p", 0, 0))
+        result = await self._sync(
+            store.append, "s", b'{"id": 2}', self._producer("p", 0, 5)
+        )
+        assert isinstance(result.producer_result, ProducerSequenceGap)
+        assert result.producer_result.expected_seq == 1
+
+    async def test_append_accepts_a_well_formed_producer_write(self, store):
+        await self._sync(store.create, "s")
+        result = await self._sync(
+            store.append, "s", b'{"id": 1}', self._producer("p", 0, 0)
+        )
+        assert isinstance(result.producer_result, ProducerAccepted)
+        assert result.message is not None
+
+    async def test_append_shares_producer_state_with_append_with_producer(self, store):
+        """One producer, one sequence — whichever door each write came through."""
+        await self._sync(store.create, "s")
+        await self._sync(store.append, "s", b'{"id": 1}', self._producer("p", 0, 0))
+        result = await store.append_with_producer(
+            "s", b'{"id": 2}', self._producer("p", 0, 1)
+        )
+        assert isinstance(result.producer_result, ProducerAccepted)
+
+    async def test_append_to_a_closed_stream_reports_the_duplicate_close(self, store):
+        """Re-sending the append that closed the stream is idempotent, not a
+        bare refusal — the producer needs to tell "my close landed" apart from
+        "someone else closed this"."""
+        await self._sync(store.create, "s")
+        opts = AppendOptions(
+            producer_id="p", producer_epoch=0, producer_seq=0, close=True
+        )
+        await self._sync(store.append, "s", b'{"id": 1}', opts)
+
+        again = await self._sync(store.append, "s", b'{"id": 1}', opts)
+        assert again.stream_closed is True
+        assert isinstance(again.producer_result, ProducerDuplicate)
+
+    async def test_append_to_a_closed_stream_by_another_producer_is_refused(
+        self, store
+    ):
+        await self._sync(store.create, "s")
+        await self._sync(
+            store.append,
+            "s",
+            b'{"id": 1}',
+            AppendOptions(
+                producer_id="p", producer_epoch=0, producer_seq=0, close=True
+            ),
+        )
+        other = await self._sync(
+            store.append, "s", b'{"id": 2}', self._producer("other", 0, 0)
+        )
+        assert other.stream_closed is True
+        assert other.producer_result is None
+        assert other.message is None
+
+    # =========================================================================
     # Long-poll
     # =========================================================================
 

--- a/tests/test_rakaia/test_append_decision.py
+++ b/tests/test_rakaia/test_append_decision.py
@@ -1,0 +1,199 @@
+"""The append admission rules, as a table — no store, no database, no async.
+
+This is the payoff of lifting the decision out of the two adapters. Asserting
+"a sequence gap is refused and reports the expected seq" used to need a live
+store; here it is a function call on a frozen dataclass.
+
+The ordering cases at the bottom are the ones worth having. Each was previously
+implicit in the *sequence of if-statements* inside two separate methods, where a
+reordering during an unrelated edit would change behaviour with nothing to catch
+it.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from rakaia.append_decision import StreamFacts, decide_append
+from rakaia.types import (
+    AppendOptions,
+    ClosedBy,
+    ContentTypeMismatch,
+    ProducerAccepted,
+    ProducerDuplicate,
+    ProducerSequenceGap,
+    ProducerStaleEpoch,
+    ProducerState,
+    SequenceConflict,
+)
+
+NOW = 1_000.0
+
+
+def _decide(facts=None, opts=None, *, producer_state=None):
+    return decide_append(
+        facts or StreamFacts(),
+        opts or AppendOptions(),
+        producer_state=producer_state,
+        now=NOW,
+    )
+
+
+class TestTheOpenHappyPath:
+    def test_a_plain_append_is_allowed(self):
+        verdict = _decide()
+        assert verdict.write is True
+        assert verdict.producer_result is None
+
+    def test_a_first_producer_write_is_accepted(self):
+        verdict = _decide(
+            opts=AppendOptions(producer_id="p", producer_epoch=0, producer_seq=0)
+        )
+        assert verdict.write is True
+        assert isinstance(verdict.producer_result, ProducerAccepted)
+
+
+class TestClosed:
+    def test_a_closed_stream_refuses(self):
+        verdict = _decide(StreamFacts(closed=True))
+        assert verdict.write is False
+        assert verdict.stream_closed is True
+        assert verdict.producer_result is None
+
+    def test_the_producer_that_closed_it_gets_a_duplicate(self):
+        """A retry of the closing append must be distinguishable from someone
+        else's stream being closed underneath you."""
+        facts = StreamFacts(closed=True, closed_by=ClosedBy("p", epoch=2, seq=7))
+        verdict = _decide(
+            facts,
+            AppendOptions(producer_id="p", producer_epoch=2, producer_seq=7),
+        )
+        assert verdict.stream_closed is True
+        assert isinstance(verdict.producer_result, ProducerDuplicate)
+
+    @pytest.mark.parametrize(
+        "producer_id,epoch,seq",
+        [
+            ("other", 2, 7),  # different producer
+            ("p", 3, 7),  # same producer, later epoch
+            ("p", 2, 8),  # same producer, different seq
+        ],
+    )
+    def test_any_other_tuple_is_a_bare_refusal(self, producer_id, epoch, seq):
+        facts = StreamFacts(closed=True, closed_by=ClosedBy("p", epoch=2, seq=7))
+        verdict = _decide(
+            facts,
+            AppendOptions(
+                producer_id=producer_id, producer_epoch=epoch, producer_seq=seq
+            ),
+        )
+        assert verdict.stream_closed is True
+        assert verdict.producer_result is None
+
+
+class TestContentType:
+    def test_a_mismatch_raises(self):
+        with pytest.raises(ContentTypeMismatch):
+            _decide(
+                StreamFacts(content_type="application/json"),
+                AppendOptions(content_type="text/plain"),
+            )
+
+    def test_a_match_is_allowed_despite_parameters(self):
+        verdict = _decide(
+            StreamFacts(content_type="application/json"),
+            AppendOptions(content_type="application/json; charset=utf-8"),
+        )
+        assert verdict.write is True
+
+    def test_no_declared_type_on_either_side_is_allowed(self):
+        assert _decide(opts=AppendOptions(content_type="text/csv")).write is True
+
+
+class TestStreamSeq:
+    def test_a_replayed_seq_conflicts(self):
+        with pytest.raises(SequenceConflict):
+            _decide(StreamFacts(last_seq=5), AppendOptions(seq=5))
+
+    def test_a_lower_seq_conflicts(self):
+        with pytest.raises(SequenceConflict):
+            _decide(StreamFacts(last_seq=5), AppendOptions(seq=4))
+
+    def test_a_higher_seq_is_allowed(self):
+        assert _decide(StreamFacts(last_seq=5), AppendOptions(seq=6)).write is True
+
+    def test_seq_is_compared_as_a_number(self):
+        """`"10" < "9"` lexicographically — the bug that broke every producer on
+        reaching double digits."""
+        assert _decide(StreamFacts(last_seq=9), AppendOptions(seq=10)).write is True
+
+
+class TestProducerFencing:
+    def test_a_stale_epoch_is_refused(self):
+        state = ProducerState(epoch=5, last_seq=0, last_updated=NOW)
+        verdict = _decide(
+            opts=AppendOptions(producer_id="p", producer_epoch=4, producer_seq=1),
+            producer_state=state,
+        )
+        assert verdict.write is False
+        assert isinstance(verdict.producer_result, ProducerStaleEpoch)
+
+    def test_a_gap_reports_the_expected_seq(self):
+        state = ProducerState(epoch=0, last_seq=0, last_updated=NOW)
+        verdict = _decide(
+            opts=AppendOptions(producer_id="p", producer_epoch=0, producer_seq=5),
+            producer_state=state,
+        )
+        assert isinstance(verdict.producer_result, ProducerSequenceGap)
+        assert verdict.producer_result.expected_seq == 1
+
+    def test_a_partial_producer_tuple_is_not_fenced(self):
+        """All three fields or none — a `Producer-Id` with no epoch/seq is not
+        enough to fence on, and must not be silently treated as one."""
+        verdict = _decide(opts=AppendOptions(producer_id="p"))
+        assert verdict.write is True
+        assert verdict.producer_result is None
+
+
+class TestOrdering:
+    """Each case pins one *relative* order. These are the rules that were
+    previously encoded only as the order of if-statements in two methods."""
+
+    def test_closed_is_checked_before_content_type(self):
+        """A closed stream refuses rather than raising, even with a bad type —
+        otherwise a client retrying against a closed stream gets a confusing
+        400 instead of the close it needs to see."""
+        verdict = _decide(
+            StreamFacts(closed=True, content_type="application/json"),
+            AppendOptions(content_type="text/plain"),
+        )
+        assert verdict.write is False
+        assert verdict.stream_closed is True
+
+    def test_fencing_is_checked_before_stream_seq(self):
+        """The load-bearing one. A retried append carries the same Stream-Seq it
+        did the first time, so checking Stream-Seq first would raise
+        SequenceConflict on exactly the retry that fencing exists to absorb."""
+        state = ProducerState(epoch=0, last_seq=3, last_updated=NOW)
+        verdict = _decide(
+            StreamFacts(last_seq=9),
+            AppendOptions(producer_id="p", producer_epoch=0, producer_seq=3, seq=9),
+            producer_state=state,
+        )
+        # Reported as a duplicate, not raised as a sequence conflict.
+        assert verdict.write is False
+        assert isinstance(verdict.producer_result, ProducerDuplicate)
+
+    def test_content_type_is_checked_before_fencing(self):
+        state = ProducerState(epoch=5, last_seq=0, last_updated=NOW)
+        with pytest.raises(ContentTypeMismatch):
+            _decide(
+                StreamFacts(content_type="application/json"),
+                AppendOptions(
+                    content_type="text/plain",
+                    producer_id="p",
+                    producer_epoch=4,
+                    producer_seq=1,
+                ),
+                producer_state=state,
+            )


### PR DESCRIPTION
Rakaia has two places to keep an event log — one in memory for tests and small
apps, one in your database for real deployments — and the whole point is that
they behave identically, so you can develop against one and ship on the other.
They didn't. The rules for deciding whether a write is allowed at all (is the
stream closed, does the content type match, is this a duplicate retry, is the
sequence number sane) were written out twice, once in each store, and the two
copies had already drifted apart. The database-backed one silently ignored the
duplicate-detection information callers passed it, while its documentation
claimed the opposite.

Those rules now live in one place that both stores consult, so a store's job is
to fetch some facts, ask, and then save — not to re-implement the protocol. The
shared test suite that both stores must pass has grown seven cases covering the
door this slipped through. As a bonus the rules are now testable on their own,
without spinning up a store or a database, which is what makes the ordering
between them — genuinely fiddly, and previously implicit in the order of some
if-statements — something we can actually pin down.