### PR TITLE
Pin down the store return type that broke our first consumer, and write an upgrade guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -289,6 +289,18 @@ is not yet tagged in a release.
   there was executed or linted by CI at all — which is how it drifted far enough
   to need a repair pass. `ruff` now covers `examples/` too.
 
+- **`StreamServerStore.get` is typed, and the contract asserts it.** It was
+  declared `-> Any`, and the conformance suite only checked `hasattr` for the six
+  fields a server reads — which a backend's own row object satisfies too. So when
+  `DjangoStreamStore.get` changed from returning its ORM `Stream` row to a
+  `rakaia.types.Stream` metadata snapshot, nothing noticed, and the first
+  downstream consumer broke on it. The snapshot is the right shape (a protocol
+  server is async and reads these fields outside the `run_sync` bridge, so
+  anything lazy would fail there); the mistake was that nothing said so. `get` is
+  now `-> Stream | None` and two contract cases assert the type and its inertness
+  on both backends. A new [`UPGRADING.md`](UPGRADING.md) documents this and the
+  other breaks since `5e4a6e3`, with the exact edits.
+
 - **A store now refuses an offset it did not issue.** Both stores accepted the
   other's offset format and resolved it to an unrelated position instead of
   failing: `int("0_5")` is `5` in Python, so the durable store read the wrong

--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ pip install "rakaia-streams[django,prod]"  # + channels-redis + hypercorn for pr
 The distribution is named `rakaia-streams` on PyPI (plain `rakaia` was already
 taken); the import names are unchanged — `import rakaia`, `import django_rakaia`.
 
+Already using rakaia from a pinned git revision? See
+[`UPGRADING.md`](UPGRADING.md) before bumping the pin — the distribution rename
+above is itself a breaking change for a `[tool.uv.sources]` entry spelled
+`rakaia`.
+
 ## Quick start (standalone)
 
 ```bash

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,0 +1,143 @@
+---
+icon: lucide/arrow-up-circle
+---
+
+# Upgrading
+
+Breaking changes, and what to do about each. Rakaia is pre-1.0 and the version
+number has not moved yet, so this file is organised by the change rather than by
+release — find the ones you are crossing and apply them in order.
+
+If you pin rakaia to a git revision (which every current consumer does, since
+`0.1.0` predates most of what follows), the relevant question is *which
+revision*, not which version.
+
+---
+
+## Upgrading past `5e4a6e3` (`append_many`, 2026-08-08)
+
+Three changes need action. Nothing else in this range requires a code change.
+
+### 1. The distribution is now `rakaia-streams`
+
+`rakaia` was already taken on PyPI by an unrelated placeholder, so the published
+distribution is **`rakaia-streams`**. **The import name is unchanged** — it is
+still `import rakaia` and `import django_rakaia`. Only the packaging name moved.
+
+This matters even if you install from git: `uv` resolves the requirement name
+against the name the source builds, so a source pinned past `f676302` no longer
+satisfies a requirement spelled `rakaia`, and `uv sync` fails.
+
+```diff
+ dependencies = [
+-    "rakaia",
++    "rakaia-streams",
+ ]
+
+ [tool.uv.sources]
+-rakaia = { git = "https://github.com/joshbrooks/rakaia.git", rev = "<old>" }
++rakaia-streams = { git = "https://github.com/joshbrooks/rakaia.git", rev = "<new>" }
+```
+
+From PyPI instead: `pip install rakaia-streams` / `uv add rakaia-streams`.
+No import statement changes.
+
+### 2. `DjangoStreamStore.get()` returns metadata, not the ORM row
+
+`get()` used to return the `django_rakaia.models.Stream` **row**. It now returns
+a `rakaia.types.Stream` — a plain metadata snapshot, the same type the in-memory
+store returns.
+
+The change is deliberate. A protocol server is async, and an ORM row is lazy:
+reading `stream.current_offset` off one issues a query at attribute access,
+outside the store's `run_sync` bridge, which Django refuses from an async
+context. Everything a server reads is now resolved inside the sync call and
+handed over inert. That is what lets one protocol server run on either store.
+
+The snapshot carries `path`, `content_type`, `current_offset`, `last_seq`,
+`ttl_seconds`, `expires_at`, `created_at`, `last_activity_at`, `closed` and
+`closed_by`. Its `messages` list is always empty — read the stream with `read()`.
+
+**If you were using the result as an ORM row**, query the row directly. You do
+not need `get()` at all for this:
+
+```diff
+-stream = store.get(path)
+-entries = StreamEntry.objects.filter(stream=stream)
++entries = StreamEntry.objects.filter(stream__stream_id=path)
+```
+
+That is one query instead of two, and it does not go through the store — which
+is the point: the ORM row was never part of the store interface, it just happened
+to be what came back.
+
+Where you genuinely want the row (admin, a migration, a data fix), reach for it
+by name: `Stream.objects.get(stream_id=path)`.
+
+`StreamServerStore.get` is now declared `-> Stream | None` rather than `-> Any`,
+and `tests/server_store_contract.py` asserts the type on both backends — so this
+particular change cannot happen again unannounced.
+
+### 3. Two migrations to apply
+
+```bash
+python manage.py migrate django_rakaia
+```
+
+- `0006` — re-declares `StreamEvent.data` and `.metadata` with
+  `encoder=DjangoJSONEncoder`, so a payload containing a `UUID`, `datetime` or
+  `Decimal` no longer raises `TypeError` at insert time. No data is rewritten.
+- `0007` — adds the protocol-lifecycle columns to `Stream` (content type, TTL,
+  expiry, closed/closed-by, last-seq, last-activity) and the `StreamProducer`
+  table. It carries a **data migration** seeding `last_activity_at` from
+  `created_at` for existing rows, so plan for it to touch every `Stream` row.
+
+Both are additive; neither drops a column.
+
+### Not a break, despite looking like one
+
+`read()` now raises `StreamNotFound` where it used to raise a bare `KeyError`,
+and `InvalidOffset` for an offset the store did not issue. Every named store
+failure subclasses the builtin it replaced (`StreamNotFound` is a `KeyError`,
+`StreamConfigConflict` and the rest are `ValueError`s), so existing
+`except KeyError` / `except ValueError` code keeps working. Catching the named
+types is better, but it is not required to upgrade.
+
+`append()` now returns an `AppendResult` on the durable store rather than the
+`StreamEntry` row. If you were discarding the return value — as every known
+consumer was — nothing changes. The entry is still reachable via `read()`.
+
+`create()` gained keyword-only options (`content_type`, `ttl_seconds`,
+`expires_at`, `initial_data`, `closed`). `create(path)` is unchanged.
+
+`StreamMessage.seq` and `Stream.last_seq` are now `int | None` where they were
+`str | None`. The header is parsed strictly, which is what fixed `Stream-Seq: 10`
+being rejected after `9` because `"10" < "9"` as text.
+
+---
+
+## Behaviour worth re-checking after upgrading
+
+These are not API breaks — nothing to edit — but each changes what your code
+*does*, and each is easy to have been relying on:
+
+- **`RAKAIA_STORE` no longer falls back to memory.** An unrecognised backend
+  raises `ImproperlyConfigured` instead of silently selecting the in-memory
+  store. If a typo has been hiding in your settings, this is where you find out.
+  `manage.py check` reports it as `rakaia.E001`.
+- **`diff_effects_against_rows(...).raise_if_diff()` now refuses an empty
+  population**, raising `VacuousVerification`. A verification sweep that compared
+  nothing used to report itself clean. If a proof of yours is expected to run
+  against zero effects, say so with `raise_if_diff(allow_empty=True)`.
+- **`@stream_model` now records ambient provenance and `event_ts`.** Events it
+  writes carry `metadata` and a logical timestamp where they previously carried
+  `{}` and `NULL`. If you were compensating for the empty actor field — for
+  instance by reading the owner FK yourself — that workaround is now redundant
+  and may disagree with the recorded actor.
+- **`append()` honours producer options on the durable store.** It previously
+  ignored `producer_id`/`producer_epoch`/`producer_seq` entirely. Fenced writes
+  through `append` are now refused with a producer result where they used to be
+  accepted unconditionally.
+- **Bulk appends now reach SSE subscribers.** `append_many` was invisible to the
+  channel layer. If you worked around that by also sending your own frame, you
+  will now get two.

--- a/src/rakaia/protocols.py
+++ b/src/rakaia/protocols.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 from collections.abc import Iterable
 from typing import Any, Protocol, runtime_checkable
 
+from .types import Stream as StreamMetadata
 from .types import StreamMessage
 
 
@@ -176,8 +177,21 @@ class StreamServerStore(WritableStore, Protocol):
         """
         ...
 
-    def get(self, path: str) -> Any:
-        """The stream at `path`, or `None` if absent or expired."""
+    def get(self, path: str) -> StreamMetadata | None:
+        """The stream at `path`, or `None` if absent or expired.
+
+        Returns `rakaia.types.Stream` — **metadata only**, and the same type from
+        every backend. Not the backend's own row: a protocol server is async and
+        reads these fields outside the `run_sync` bridge, so anything lazy (an
+        ORM row issuing a query at attribute access) would fail there. Resolve
+        everything inside the sync call and hand it over inert.
+
+        Declared here rather than left as `Any` because it has already gone
+        wrong: `DjangoStreamStore.get` once returned its ORM row, and nothing —
+        not this protocol, not the conformance suite, which only checked
+        `hasattr` — noticed when it changed. A consumer holding the row broke.
+        `messages` is always empty; read the stream with `read()`.
+        """
         ...
 
     def touch(self, path: str) -> None:

--- a/tests/server_store_contract.py
+++ b/tests/server_store_contract.py
@@ -39,6 +39,7 @@ from rakaia.types import (
     StreamConfigConflict,
     StreamNotFound,
 )
+from rakaia.types import Stream as ProtocolStream
 
 
 def _protocol_methods() -> list[str]:
@@ -136,6 +137,51 @@ class ServerStoreContract:
 
     def test_get_is_none_for_a_missing_stream(self, store):
         assert store.get("nope") is None
+
+    def test_get_returns_the_shared_stream_type(self, store):
+        """`get()` returns `rakaia.types.Stream` — the same type from every store.
+
+        `test_get_exposes_what_a_server_reads` only checks `hasattr`, which a
+        backend's own row object satisfies too: the durable store used to return
+        its ORM `Stream` model, which carries all six of those attributes. So the
+        contract passed while the two stores returned structurally similar but
+        entirely different types, and `StreamServerStore.get` was declared
+        `-> Any`, so the type checker had nothing to say either.
+
+        That is not hypothetical — it is exactly what happened, and it broke the
+        first downstream consumer, which was doing
+        `StreamEntry.objects.filter(stream=store.get(path))` and relying on
+        getting an ORM row back. Returning a snapshot is the *right* call (a
+        protocol server is async, and an ORM row is lazy — reading
+        `stream.current_offset` off it would issue a query at attribute access,
+        which Django refuses from an async context). The mistake was that
+        nothing stated it, so the change was invisible until it reached a
+        consumer.
+        """
+        store.create("s", content_type="text/plain", ttl_seconds=60)
+        assert isinstance(store.get("s"), ProtocolStream)
+
+    def test_get_does_not_leak_a_backend_row(self, store):
+        """The returned metadata is inert: reading it issues no further query.
+
+        The reason the durable store hands back a snapshot rather than its ORM
+        row. A server resolves everything inside the store's `run_sync` bridge
+        and reads it afterwards, outside — so anything lazy would blow up there
+        rather than here.
+        """
+        store.create("s", ttl_seconds=60)
+        stream = store.get("s")
+        # Consuming every field a server touches must not need a live connection.
+        snapshot = (
+            stream.path,
+            stream.current_offset,
+            stream.content_type,
+            stream.ttl_seconds,
+            stream.expires_at,
+            stream.last_seq,
+            stream.closed,
+        )
+        assert snapshot[0] == "s"
 
     # =========================================================================
     # Create


### PR DESCRIPTION
Asking a store for a stream used to hand back the raw database record. It now
hands back a plain snapshot of the stream's metadata instead, which is the
correct thing to do — the server reads those fields from async code, and a live
database record would try to fetch itself at exactly the wrong moment. The
problem is that nothing anywhere said the return type had changed, and the shared
test suite both stores must pass only checked that certain field names existed,
which was true of the old shape too. So the change sailed through, and the first
project using rakaia in production broke on it.

That gap is closed: the return type is now declared, and the shared suite checks
it on both stores. There is also a new UPGRADING.md, because this was not the
only thing waiting to bite anyone bumping their pinned version — the package
itself was renamed on PyPI, which breaks the dependency entry even though the
import name never changed, and there are two database migrations to run. Each one
is written up with the exact change to make.