### PR TITLE
The registry kept the same bookkeeping in three places, keyed by tuple position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,24 @@ is not yet tagged in a release.
   `create()` that truncated. With it pinned, the `has()`/`create()` dance is
   provably redundant — `registry.py`'s three copies are now a single `create()`.
 
+- **One registration log instead of three.** The meta-stream mechanism —
+  create the stream, read back what is recorded, append if new — was written
+  three times in `registry.py` (handlers, reducers, upcasters), alongside six
+  module-level identity functions in hand-mirrored pairs: one building a tuple
+  from the object, one rebuilding the same tuple from stored JSON, with nothing
+  checking that they agreed. The tuples were then read back **positionally**
+  (`ident[4]` for a handler's dotted path, `ident[2]` for a reducer's), and two
+  of the builders carried comments warning editors to append new fields at the
+  end so those indices stayed valid.
+
+  `rakaia.registration_log.RegistrationLog` owns the mechanism once, and each
+  record type owns its own `identity` / `to_payload` / `identity_from_payload` —
+  so the round trip is a property of the type rather than an agreement between
+  two functions, and `modules()` reads `dotted_path` by name. No behaviour
+  change; `registry.py` loses 89 lines and every positional index lookup, and
+  the log is now testable against a bare in-memory store with no decorators,
+  no source hashing and no import machinery.
+
 - **`PreloadedProjectionReader` — bulk-fetch a verification sweep.**
   `diff_effects_against_rows` does one `reader.get` per effect (one round-trip
   each), which is thousands of round-trips on a full reconcile. Pass the same

--- a/src/rakaia/registration_log.py
+++ b/src/rakaia/registration_log.py
@@ -1,0 +1,155 @@
+"""The meta-stream that remembers what has been registered.
+
+A registry persists each registration to an append-only meta-stream, so a fresh
+process can re-import the modules holding those registrations rather than relying
+on import side effects having happened in the right order.
+
+That mechanism was written three times — once for handlers, once for reducers,
+once for upcasters — as a trio of `_ensure_stream` / `_load_persisted_ids` /
+`_persist_if_new` methods plus a hand-mirrored *pair* of module-level identity
+functions per kind: one building a tuple from the object, one rebuilding the same
+tuple from stored JSON. Six functions that had to agree, with nothing checking
+that they did.
+
+They were also read back **positionally**. `rehydrate()` did `ident[4]` for a
+handler's dotted path and `ident[2]` for a reducer's, and two of the builders
+carried comments telling future editors to append new fields at the end so those
+indices stayed valid. Adding one field to a registration meant editing four
+functions and re-checking two index comments in a third.
+
+Here the mechanism exists once and each record kind owns its own identity and
+payload (`RegistrationRecord` below), so the round trip is a property of the type
+rather than an agreement between two functions — and the dotted path is read by
+name, so field order stops being load-bearing.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Protocol, runtime_checkable
+
+from .protocols import WritableStore
+
+
+@runtime_checkable
+class RegistrationRecord(Protocol):
+    """A registration that knows how to identify and serialize itself.
+
+    Three types satisfy it — `HandlerVersion`, `ReducerVersion`,
+    `UpcasterVersion`. Keeping all three parts on the type is the point: an
+    identity built in one place and rebuilt in another is exactly the pair that
+    used to drift.
+
+    `to_payload` must round-trip through **JSON**, not just through a dict: a
+    `frozenset` event match has to serialize as a sorted list (sorted, so the
+    meta-stream doesn't change with set iteration order and re-append on every
+    restart), and `identity_from_payload` has to rebuild the frozenset from it.
+    """
+
+    @property
+    def identity(self) -> tuple:
+        """The dedup key. Two registrations with the same identity are the same
+        registration."""
+        ...
+
+    def to_payload(self) -> dict[str, Any]:
+        """The JSON-serializable form written to the meta-stream. Must include
+        ``dotted_path``, which is what `RegistrationLog.modules` re-imports."""
+        ...
+
+    @staticmethod
+    def identity_from_payload(payload: dict[str, Any]) -> tuple:
+        """Rebuild `identity` from a payload this type wrote.
+
+        Must tolerate payloads written by older versions that predate a field —
+        meta-streams already in the wild still have to load.
+        """
+        ...
+
+
+class RegistrationLog:
+    """Append-only record of registrations of one kind, on one stream.
+
+    Construct one per (store, stream, record type), call `load()` once, then
+    `record()` per registration. A `store` of `None` makes every operation a
+    no-op, so a registry without persistence needs no special-casing at its call
+    sites.
+    """
+
+    def __init__(
+        self,
+        store: WritableStore | None,
+        stream_path: str,
+        record_type: type[RegistrationRecord] | Any,
+    ) -> None:
+        self._store = store
+        self._stream_path = stream_path
+        self._record_type = record_type
+        self._known: set[tuple] = set()
+        self._payloads: list[dict[str, Any]] = []
+
+    def load(self) -> None:
+        """Create the stream if absent and read back what is already recorded.
+
+        The meta-stream declares no content type, so each append is a standalone
+        blob (one JSON object per message) rather than being treated as one
+        flattened JSON array — which is what JSON mode would do.
+
+        `create()` is called unconditionally: creation is idempotent by contract
+        and cannot truncate a populated stream.
+        """
+        if self._store is None:
+            return
+        self._store.create(self._stream_path)
+        messages, _ = self._store.read(self._stream_path)
+        for msg in messages:
+            try:
+                payload = json.loads(msg.data)
+            except (ValueError, UnicodeDecodeError):
+                # A message this log did not write, or wrote in a format it no
+                # longer understands. Skipping beats refusing to start.
+                continue
+            self._known.add(self._record_type.identity_from_payload(payload))
+            self._payloads.append(payload)
+
+    def record(self, item: RegistrationRecord) -> bool:
+        """Append `item` unless an identical registration is already recorded.
+
+        Returns whether it was appended.
+        """
+        if self._store is None:
+            return False
+        identity = item.identity
+        if identity in self._known:
+            return False
+        payload = item.to_payload()
+        self._store.append(self._stream_path, json.dumps(payload).encode("utf-8"))
+        self._known.add(identity)
+        self._payloads.append(payload)
+        return True
+
+    def known(self) -> set[tuple]:
+        """Every recorded identity."""
+        return set(self._known)
+
+    def modules(self) -> set[str]:
+        """The importable module of every recorded registration.
+
+        Read from ``payload["dotted_path"]`` **by name**. The predecessor pulled
+        this out of the identity tuple by index, which is why two identity
+        builders carried "append new fields at the end" comments.
+        """
+        return {
+            payload["dotted_path"].rsplit(".", 1)[0]
+            for payload in self._payloads
+            if payload.get("dotted_path")
+        }
+
+    def reset(self) -> None:
+        """Forget what has been recorded, without touching the stream.
+
+        For test isolation: a registry reset drops its in-memory dedup state, and
+        a subsequent `load()` rebuilds it from the stream.
+        """
+        self._known.clear()
+        self._payloads.clear()

--- a/src/rakaia/registry.py
+++ b/src/rakaia/registry.py
@@ -15,11 +15,11 @@ from __future__ import annotations
 
 import fnmatch
 import importlib
-import json
 from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
+from .registration_log import RegistrationLog
 from .source_hash import hash_function_source
 
 if TYPE_CHECKING:
@@ -100,6 +100,63 @@ class HandlerVersion:
     resolve facts materialised by earlier stages. Default 0 = single-stage,
     called with just the event (backward compatible)."""
 
+    # -- meta-stream record (see `rakaia.registration_log`) -----------------
+    #
+    # Identity and serialization live together on the type, so the round trip is
+    # a property of `HandlerVersion` rather than an agreement between two
+    # module-level functions that had to be kept mirrored by hand.
+
+    @property
+    def identity(self) -> tuple:
+        """Dedup key for the meta-stream. Excludes `fn` (not serializable, and
+        two registrations of the same source are the same registration)."""
+        return (
+            self.name,
+            self.event_match,
+            self.effective_from,
+            self.effective_to,
+            self.dotted_path,
+            self.source_hash,
+            self.match_field,
+            self.stage,
+        )
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            # A frozenset serializes as a *sorted* list, so the meta-stream is
+            # stable regardless of set iteration order — otherwise every restart
+            # would see a "new" identity and re-append the same handler.
+            "event_match": (
+                self.event_match
+                if isinstance(self.event_match, str)
+                else sorted(self.event_match)
+            ),
+            "effective_from": self.effective_from,
+            "effective_to": self.effective_to,
+            "dotted_path": self.dotted_path,
+            "source_hash": self.source_hash,
+            "match_field": self.match_field,
+            "stage": self.stage,
+        }
+
+    @staticmethod
+    def identity_from_payload(p: dict[str, Any]) -> tuple:
+        return (
+            p["name"],
+            # Rebuild the frozenset a list-serialized set was persisted from, so
+            # a reload dedups against the live version.
+            p["event_match"]
+            if isinstance(p["event_match"], str)
+            else frozenset(p["event_match"]),
+            int(p["effective_from"]),
+            p["effective_to"] if p["effective_to"] is None else int(p["effective_to"]),
+            p["dotted_path"],
+            p["source_hash"],
+            p.get("match_field"),  # tolerate pre-match_field persisted payloads
+            int(p.get("stage", 0)),  # tolerate pre-stage persisted payloads
+        )
+
 
 @dataclass(frozen=True)
 class ReducerVersion:
@@ -145,6 +202,24 @@ class ReducerVersion:
     dotted_path: str
     source_hash: str
 
+    # -- meta-stream record (see `rakaia.registration_log`) -----------------
+
+    @property
+    def identity(self) -> tuple:
+        return (self.name, self.stage, self.dotted_path, self.source_hash)
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "stage": self.stage,
+            "dotted_path": self.dotted_path,
+            "source_hash": self.source_hash,
+        }
+
+    @staticmethod
+    def identity_from_payload(p: dict[str, Any]) -> tuple:
+        return (p["name"], int(p["stage"]), p["dotted_path"], p["source_hash"])
+
 
 # =============================================================================
 # Registry
@@ -180,16 +255,15 @@ class HandlerRegistry:
         self._store = store
         self._stream_path = stream_path
         self._reducer_stream_path = REDUCERS_META_STREAM
-        # Identity tuples already persisted to the stream — used for dedup.
-        self._persisted_ids: set[
-            tuple[str, str | frozenset[str], int, int | None, str, str, str | None, int]
-        ] = set()
-        self._reducer_persisted_ids: set[tuple[str, int, str, str]] = set()
-        if store is not None:
-            self._ensure_stream()
-            self._load_persisted_ids()
-            self._ensure_reducer_stream()
-            self._load_reducer_ids()
+        # One log per record kind. Each owns create/read/dedup/append for its
+        # stream; `RegistrationLog` is a no-op when `store` is None, so nothing
+        # below needs to special-case an unbacked registry.
+        self._handler_log = RegistrationLog(store, stream_path, HandlerVersion)
+        self._reducer_log = RegistrationLog(
+            store, self._reducer_stream_path, ReducerVersion
+        )
+        self._handler_log.load()
+        self._reducer_log.load()
 
     def register(
         self,
@@ -250,13 +324,12 @@ class HandlerRegistry:
 
         # In-memory dedup: exact identical registration → no-op
         for existing in series:
-            if _identity(existing) == _identity(version):
+            if existing.identity == version.identity:
                 return existing
 
         self._check_overlap(version, series)
 
-        if self._store is not None:
-            self._persist_if_new(version)
+        self._handler_log.record(version)
 
         series.append(version)
         series.sort(key=lambda v: v.effective_from)
@@ -287,13 +360,10 @@ class HandlerRegistry:
         )
 
         existing = self._reducers.get(name)
-        if existing is not None and _reducer_identity(existing) == _reducer_identity(
-            reducer
-        ):
+        if existing is not None and existing.identity == reducer.identity:
             return existing
 
-        if self._store is not None:
-            self._persist_reducer_if_new(reducer)
+        self._reducer_log.record(reducer)
 
         self._reducers[name] = reducer
         return reducer
@@ -312,8 +382,8 @@ class HandlerRegistry:
         """
         self._versions.clear()
         self._reducers.clear()
-        self._persisted_ids.clear()
-        self._reducer_persisted_ids.clear()
+        self._handler_log.reset()
+        self._reducer_log.reset()
 
     def reducers_for_stage(self, stage: int) -> list[ReducerVersion]:
         """Reducers registered for `stage`, in deterministic (name) order."""
@@ -434,104 +504,12 @@ class HandlerRegistry:
         (Python caches imports), so calling this after some modules have
         already been imported is safe.
         """
-        if self._store is None:
-            return
-        for ident in self._persisted_ids:
-            dotted_path = ident[4]
-            module_name = dotted_path.rsplit(".", 1)[0]
-            importlib.import_module(module_name)
-        for r_ident in self._reducer_persisted_ids:
-            module_name = r_ident[2].rsplit(".", 1)[0]  # index 2 = dotted_path
+        for module_name in self._handler_log.modules() | self._reducer_log.modules():
             importlib.import_module(module_name)
 
     # ------------------------------------------------------------------
     # Internal — persistence
     # ------------------------------------------------------------------
-
-    def _ensure_stream(self) -> None:
-        # Meta-stream uses no content_type so each append is stored as a
-        # standalone bytes blob (one JSON object per message). We avoid
-        # application/json mode because it appends a trailing comma and
-        # treats the whole stream as a flattened JSON array.
-        #
-        # `create()` unguarded: creation is idempotent by contract, and a
-        # redundant create cannot truncate a populated stream or rewind its
-        # offsets (`tests/store_contract.py`). The `has()` it replaces was a
-        # second round trip buying nothing.
-        assert self._store is not None
-        self._store.create(self._stream_path)
-
-    def _load_persisted_ids(self) -> None:
-        assert self._store is not None
-        messages, _ = self._store.read(self._stream_path)
-        for msg in messages:
-            try:
-                payload = json.loads(msg.data)
-            except (ValueError, UnicodeDecodeError):
-                continue
-            self._persisted_ids.add(_identity_from_payload(payload))
-
-    def _persist_if_new(self, version: HandlerVersion) -> None:
-        assert self._store is not None
-        ident = _identity(version)
-        if ident in self._persisted_ids:
-            return
-        payload = {
-            "name": version.name,
-            # A frozenset event_match serializes as a sorted list so the
-            # meta-stream is stable regardless of set iteration order.
-            "event_match": (
-                version.event_match
-                if isinstance(version.event_match, str)
-                else sorted(version.event_match)
-            ),
-            "effective_from": version.effective_from,
-            "effective_to": version.effective_to,
-            "dotted_path": version.dotted_path,
-            "source_hash": version.source_hash,
-            "match_field": version.match_field,
-            "stage": version.stage,
-        }
-        self._store.append(
-            self._stream_path,
-            json.dumps(payload).encode("utf-8"),
-        )
-        self._persisted_ids.add(ident)
-
-    # ------------------------------------------------------------------
-    # Internal — reducer persistence (parallels the handler helpers)
-    # ------------------------------------------------------------------
-
-    def _ensure_reducer_stream(self) -> None:
-        assert self._store is not None
-        self._store.create(self._reducer_stream_path)
-
-    def _load_reducer_ids(self) -> None:
-        assert self._store is not None
-        messages, _ = self._store.read(self._reducer_stream_path)
-        for msg in messages:
-            try:
-                payload = json.loads(msg.data)
-            except (ValueError, UnicodeDecodeError):
-                continue
-            self._reducer_persisted_ids.add(_reducer_identity_from_payload(payload))
-
-    def _persist_reducer_if_new(self, reducer: ReducerVersion) -> None:
-        assert self._store is not None
-        ident = _reducer_identity(reducer)
-        if ident in self._reducer_persisted_ids:
-            return
-        payload = {
-            "name": reducer.name,
-            "stage": reducer.stage,
-            "dotted_path": reducer.dotted_path,
-            "source_hash": reducer.source_hash,
-        }
-        self._store.append(
-            self._reducer_stream_path,
-            json.dumps(payload).encode("utf-8"),
-        )
-        self._reducer_persisted_ids.add(ident)
 
     # ------------------------------------------------------------------
     # Internal — overlap check
@@ -582,6 +560,37 @@ class UpcasterVersion:
     string — mirrors ``register_handler``, so a per-form upcaster can route on a
     per-entity stream (e.g. ``submissions:<uuid>``) whose path carries no type."""
 
+    # -- meta-stream record (see `rakaia.registration_log`) -----------------
+
+    @property
+    def identity(self) -> tuple:
+        return (
+            self.event_match,
+            self.from_version,
+            self.dotted_path,
+            self.source_hash,
+            self.match_field,
+        )
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "event_match": self.event_match,
+            "from_version": self.from_version,
+            "dotted_path": self.dotted_path,
+            "source_hash": self.source_hash,
+            "match_field": self.match_field,
+        }
+
+    @staticmethod
+    def identity_from_payload(p: dict[str, Any]) -> tuple:
+        return (
+            p["event_match"],
+            int(p["from_version"]),
+            p["dotted_path"],
+            p["source_hash"],
+            p.get("match_field"),  # tolerate pre-match_field persisted payloads
+        )
+
 
 class UpcasterRegistry:
     """
@@ -601,10 +610,8 @@ class UpcasterRegistry:
         self._upcasters: dict[tuple[str, int, str | None], UpcasterVersion] = {}
         self._store = store
         self._stream_path = stream_path
-        self._persisted_ids: set[tuple[str, int, str, str, str | None]] = set()
-        if store is not None:
-            self._ensure_stream()
-            self._load_persisted_ids()
+        self._log = RegistrationLog(store, stream_path, UpcasterVersion)
+        self._log.load()
 
     def register(
         self,
@@ -641,7 +648,7 @@ class UpcasterRegistry:
         key = (event_match, from_version, match_field)
         existing = self._upcasters.get(key)
         if existing is not None:
-            if _u_identity(existing) == _u_identity(new):
+            if existing.identity == new.identity:
                 return existing
             raise UpcasterConflictError(
                 f"Upcaster already registered for event_match={event_match!r}, "
@@ -650,8 +657,7 @@ class UpcasterRegistry:
                 f"new dotted_path={new.dotted_path!r})."
             )
 
-        if self._store is not None:
-            self._persist_if_new(new)
+        self._log.record(new)
         self._upcasters[key] = new
         return new
 
@@ -788,51 +794,15 @@ class UpcasterRegistry:
         meta-stream (delete that via the store if you need to).
         """
         self._upcasters.clear()
-        self._persisted_ids.clear()
+        self._log.reset()
 
     def rehydrate(self) -> None:
-        if self._store is None:
-            return
-        for ident in self._persisted_ids:
-            dotted_path = ident[2]
-            module_name = dotted_path.rsplit(".", 1)[0]
+        for module_name in self._log.modules():
             importlib.import_module(module_name)
 
     # ------------------------------------------------------------------
     # Internal — persistence (parallels HandlerRegistry)
     # ------------------------------------------------------------------
-
-    def _ensure_stream(self) -> None:
-        assert self._store is not None
-        self._store.create(self._stream_path)
-
-    def _load_persisted_ids(self) -> None:
-        assert self._store is not None
-        messages, _ = self._store.read(self._stream_path)
-        for msg in messages:
-            try:
-                payload = json.loads(msg.data)
-            except (ValueError, UnicodeDecodeError):
-                continue
-            self._persisted_ids.add(_u_identity_from_payload(payload))
-
-    def _persist_if_new(self, version: UpcasterVersion) -> None:
-        assert self._store is not None
-        ident = _u_identity(version)
-        if ident in self._persisted_ids:
-            return
-        payload = {
-            "event_match": version.event_match,
-            "from_version": version.from_version,
-            "dotted_path": version.dotted_path,
-            "source_hash": version.source_hash,
-            "match_field": version.match_field,
-        }
-        self._store.append(
-            self._stream_path,
-            json.dumps(payload).encode("utf-8"),
-        )
-        self._persisted_ids.add(ident)
 
 
 # =============================================================================
@@ -871,67 +841,6 @@ def _pattern_matches(pattern: str | frozenset[str], subject: str) -> bool:
 # =============================================================================
 # Identity helpers
 # =============================================================================
-
-
-def _identity(
-    v: HandlerVersion,
-) -> tuple[str, str | frozenset[str], int, int | None, str, str, str | None, int]:
-    # match_field / stage are appended after dotted_path (index 4) and
-    # source_hash (index 5) so rehydrate()'s ident[4] lookup stays valid.
-    return (
-        v.name,
-        v.event_match,
-        v.effective_from,
-        v.effective_to,
-        v.dotted_path,
-        v.source_hash,
-        v.match_field,
-        v.stage,
-    )
-
-
-def _identity_from_payload(
-    p: dict[str, Any],
-) -> tuple[str, str | frozenset[str], int, int | None, str, str, str | None, int]:
-    return (
-        p["name"],
-        # Reconstruct the same canonical (frozenset) identity a list-serialized
-        # set was persisted from, so a reload dedups against the live version.
-        p["event_match"]
-        if isinstance(p["event_match"], str)
-        else frozenset(p["event_match"]),
-        int(p["effective_from"]),
-        p["effective_to"] if p["effective_to"] is None else int(p["effective_to"]),
-        p["dotted_path"],
-        p["source_hash"],
-        p.get("match_field"),  # tolerate pre-match_field persisted payloads
-        int(p.get("stage", 0)),  # tolerate pre-stage persisted payloads
-    )
-
-
-def _reducer_identity(r: ReducerVersion) -> tuple[str, int, str, str]:
-    return (r.name, r.stage, r.dotted_path, r.source_hash)
-
-
-def _reducer_identity_from_payload(p: dict[str, Any]) -> tuple[str, int, str, str]:
-    return (p["name"], int(p["stage"]), p["dotted_path"], p["source_hash"])
-
-
-def _u_identity(v: UpcasterVersion) -> tuple[str, int, str, str, str | None]:
-    # match_field appended last so rehydrate()'s ident[2] (dotted_path) stays valid.
-    return (v.event_match, v.from_version, v.dotted_path, v.source_hash, v.match_field)
-
-
-def _u_identity_from_payload(
-    p: dict[str, Any],
-) -> tuple[str, int, str, str, str | None]:
-    return (
-        p["event_match"],
-        int(p["from_version"]),
-        p["dotted_path"],
-        p["source_hash"],
-        p.get("match_field"),  # tolerate pre-match_field persisted payloads
-    )
 
 
 # =============================================================================

--- a/tests/test_rakaia/test_registration_log.py
+++ b/tests/test_rakaia/test_registration_log.py
@@ -1,0 +1,243 @@
+"""The meta-stream, testable without decorators, imports or real handlers.
+
+Registries persist what has been registered to a meta-stream, so a fresh process
+can re-import the modules that hold the registrations. Three kinds of record
+(handlers, reducers, upcasters) each had their own `_ensure_stream` /
+`_load_persisted_ids` / `_persist_if_new` trio and their own hand-mirrored pair
+of identity functions — one building a tuple from the object, one rebuilding the
+same tuple from the stored JSON. Six functions that must agree, with nothing
+checking that they do.
+
+Worse, the tuples were read back **positionally**. `rehydrate()` did `ident[4]`
+for a handler's dotted path and `ident[2]` for a reducer's and an upcaster's, and
+two of the identity builders carried comments warning future editors to append
+new fields at the end so those indices stayed valid. Adding one field to a
+registration meant editing four functions and re-checking two index comments in
+a third.
+
+`RegistrationLog` owns the mechanism once, and each record kind owns its own
+identity and serialization — so the round trip is a property of the type rather
+than an agreement between two functions. These tests drive it against a bare
+in-memory store: no `@register_handler`, no `hash_function_source`, no import
+machinery. None of that was reachable before.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from rakaia.registration_log import RegistrationLog
+from rakaia.registry import HandlerVersion, ReducerVersion, UpcasterVersion
+from rakaia.store import StreamStore
+
+PATH = "_meta/test"
+
+
+def _handler(name="h", event_match="orders", stage=0, match_field=None):
+    return HandlerVersion(
+        name=name,
+        event_match=event_match,
+        effective_from=0,
+        effective_to=None,
+        fn=lambda _event: [],
+        dotted_path=f"pkg.mod.{name}",
+        source_hash="abc123",
+        stage=stage,
+        match_field=match_field,
+    )
+
+
+def _log(store=None, kind=HandlerVersion):
+    log = RegistrationLog(store or StreamStore(), PATH, kind)
+    log.load()
+    return log
+
+
+class TestRecordingAndDedup:
+    def test_a_new_record_is_appended(self):
+        log = _log()
+        assert log.record(_handler()) is True
+
+    def test_the_same_record_twice_appends_once(self):
+        log = _log()
+        version = _handler()
+        assert log.record(version) is True
+        assert log.record(version) is False
+
+    def test_an_equal_but_distinct_object_is_still_a_duplicate(self):
+        """Dedup is by identity, not by object — two separate registrations of
+        the same handler must not both persist."""
+        log = _log()
+        log.record(_handler())
+        assert log.record(_handler()) is False
+
+    def test_a_differing_field_is_a_different_record(self):
+        log = _log()
+        log.record(_handler(stage=0))
+        assert log.record(_handler(stage=1)) is True
+
+    def test_known_reports_what_has_been_recorded(self):
+        log = _log()
+        log.record(_handler(name="a"))
+        log.record(_handler(name="b"))
+        assert len(log.known()) == 2
+
+
+class TestSurvivingAProcessRestart:
+    def test_a_second_log_over_the_same_store_dedups_against_the_first(self):
+        """The whole point of persisting: a fresh registry must not re-append
+        what a previous process already recorded."""
+        store = StreamStore()
+        first = _log(store)
+        first.record(_handler())
+
+        second = _log(store)
+        assert second.record(_handler()) is False
+        assert len(second.known()) == 1
+
+    def test_the_stream_holds_one_message_per_record(self):
+        store = StreamStore()
+        log = _log(store)
+        log.record(_handler(name="a"))
+        log.record(_handler(name="b"))
+        log.record(_handler(name="a"))  # duplicate
+
+        messages, _ = store.read(PATH)
+        assert len(messages) == 2
+
+    def test_the_stream_is_created_if_absent(self):
+        store = StreamStore()
+        assert store.has(PATH) is False
+        _log(store)
+        assert store.has(PATH) is True
+
+
+class TestModulesAreResolvedByName:
+    """`rehydrate()` used to pull the dotted path out of the identity tuple by
+    index — `ident[4]` for handlers, `ident[2]` for reducers and upcasters — with
+    comments warning editors to keep those positions stable. The log reads the
+    field by name, so field order stops being load-bearing."""
+
+    def test_modules_returns_the_importable_module_of_each_record(self):
+        log = _log()
+        log.record(_handler(name="a"))
+        log.record(_handler(name="b"))
+        assert log.modules() == {"pkg.mod"}
+
+    def test_modules_survives_a_reload(self):
+        store = StreamStore()
+        _log(store).record(_handler())
+        assert _log(store).modules() == {"pkg.mod"}
+
+
+class TestIdentityRoundTrip:
+    """The bug class the hand-mirrored function pairs invited: an object's
+    identity and the identity rebuilt from its own stored payload must match."""
+
+    @pytest.mark.parametrize(
+        "version",
+        [
+            _handler(),
+            _handler(stage=2),
+            _handler(match_field="form_type"),
+            _handler(event_match=frozenset({"a", "b"})),
+        ],
+        ids=["plain", "staged", "content-routed", "set-matched"],
+    )
+    def test_a_record_round_trips_through_its_payload(self, version):
+        payload = version.to_payload()
+        # Must survive JSON, not just a dict round trip — a frozenset does not.
+        decoded = json.loads(json.dumps(payload))
+        assert HandlerVersion.identity_from_payload(decoded) == version.identity
+
+    def test_a_set_event_match_serializes_stably(self):
+        """Sorted on the way out, so the meta-stream does not change with set
+        iteration order — otherwise a restart re-appends the same handler."""
+        one = _handler(event_match=frozenset({"b", "a"})).to_payload()
+        two = _handler(event_match=frozenset({"a", "b"})).to_payload()
+        assert one["event_match"] == two["event_match"] == ["a", "b"]
+
+
+class TestBackwardCompatibilityWithOlderPayloads:
+    """Meta-streams written by earlier versions are still out there and must
+    keep loading — these fields were added after the format shipped."""
+
+    def test_a_payload_without_match_field_loads(self):
+        payload = _handler().to_payload()
+        del payload["match_field"]
+        assert HandlerVersion.identity_from_payload(payload)[6] is None
+
+    def test_a_payload_without_stage_loads_as_stage_zero(self):
+        payload = _handler().to_payload()
+        del payload["stage"]
+        assert HandlerVersion.identity_from_payload(payload)[7] == 0
+
+
+class TestUnreadableMessagesAreSkipped:
+    def test_a_non_json_message_does_not_break_loading(self):
+        store = StreamStore()
+        store.create(PATH)
+        store.append(PATH, b"not json at all")
+        log = _log(store)
+        assert log.known() == set()
+        assert log.record(_handler()) is True
+
+
+class TestEveryRecordKind:
+    """One mechanism, three kinds — the duplication this replaces."""
+
+    def test_a_reducer_round_trips(self):
+        reducer = ReducerVersion(
+            name="r",
+            stage=1,
+            fn=lambda *_args: [],
+            dotted_path="pkg.red.r",
+            source_hash="deadbeef",
+        )
+        log = _log(kind=ReducerVersion)
+        assert log.record(reducer) is True
+        assert log.record(reducer) is False
+        assert ReducerVersion.identity_from_payload(reducer.to_payload()) == (
+            reducer.identity
+        )
+
+    def test_an_upcaster_round_trips(self):
+        upcaster = UpcasterVersion(
+            event_match="orders",
+            from_version=1,
+            fn=lambda e: e,
+            dotted_path="pkg.up.u",
+            source_hash="cafe",
+            match_field=None,
+        )
+        log = _log(kind=UpcasterVersion)
+        assert log.record(upcaster) is True
+        assert log.record(upcaster) is False
+        assert UpcasterVersion.identity_from_payload(upcaster.to_payload()) == (
+            upcaster.identity
+        )
+
+    def test_each_kind_keeps_its_own_stream(self):
+        store = StreamStore()
+        handlers = RegistrationLog(store, "_meta/h", HandlerVersion)
+        handlers.load()
+        reducers = RegistrationLog(store, "_meta/r", ReducerVersion)
+        reducers.load()
+
+        handlers.record(_handler())
+        assert reducers.known() == set()
+
+
+class TestNoStore:
+    """A registry with no backing store must still work — persistence is
+    optional, and this was previously an `if self._store is None` at every one
+    of the trio's call sites."""
+
+    def test_recording_without_a_store_is_a_no_op(self):
+        log = RegistrationLog(None, PATH, HandlerVersion)
+        log.load()
+        assert log.record(_handler()) is False
+        assert log.known() == set()
+        assert log.modules() == set()

--- a/tests/test_rakaia/test_registry_persistence.py
+++ b/tests/test_rakaia/test_registry_persistence.py
@@ -152,7 +152,7 @@ class TestPersistence:
         }
         store.append(HANDLERS_META_STREAM, json.dumps(payload).encode("utf-8"))
         reg = HandlerRegistry(store=store)
-        ident = next(iter(reg._persisted_ids))  # type: ignore[attr-defined]
+        ident = next(iter(reg._handler_log.known()))  # type: ignore[attr-defined]
         assert ident[-1] == 0  # stage defaulted to 0
 
 
@@ -275,7 +275,7 @@ class TestRehydrate:
         # We assert that by checking the internal set was loaded.
         assert any(
             ident[0] == "ghost"
-            for ident in reg._persisted_ids  # type: ignore[attr-defined]
+            for ident in reg._handler_log.known()  # type: ignore[attr-defined]
         )
 
 


### PR DESCRIPTION
When you register a handler, rakaia writes a note about it to a log so that a
fresh process can find and reload it later. There are three kinds of thing you
can register, and each one had its own copy of that bookkeeping — creating the
log, reading it back, deciding whether an entry is new. Alongside them sat six
small functions in matched pairs: one to describe a registration, one to
reconstruct that description from what was written down. The two halves of each
pair had to stay in step by hand, and nothing checked that they did.

They were also read back by position rather than by name, so the code that
reloads modules asked for "field five" of one kind of record and "field two" of
another. Two of those functions carried comments telling whoever edited them next
to only ever add fields at the end, or the reloading would break. Adding a single
field to a registration meant touching four functions and re-verifying two
position comments in a fifth.

That bookkeeping now exists once, each kind of record describes itself, and
fields are looked up by name. Nothing behaves differently — but the log can
finally be tested directly, without registering real handlers or importing
anything, which is where the twenty-two new tests come from.