### PR TITLE
A safety guard was blaming the rebuild for its own query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -205,6 +205,28 @@ is not yet tagged in a release.
 
 ### Fixed
 
+- **The two rebuild guards compose in either nesting order** (#101).
+  `assert_no_live_writes` counts rows on the alias `deny_database_access`
+  forbids reading, so nesting them the "wrong" way round made the closing
+  `COUNT(*)` trip the read guard — and the `AmbientDatabaseAccess` it raised
+  said *"replay touched the 'default' database directly"*, blaming the rebuild
+  for a query the guard itself issued. In a tool whose only job is to say where
+  a leak is, that sends the reader after one that does not exist. The guard now
+  suspends rakaia's own deny wrappers while taking its counts — checking for a
+  leak is bookkeeping, not the rebuild reading live data. A consumer's own
+  `execute_wrapper` is left armed, and a genuine leak is still caught in either
+  order.
+
+- **`fold_events` no longer defaults to another project's vocabulary** (#100).
+  `SCRATCH_PATH` was `"produce/submission"` — domain language from the first
+  consumer, sitting in the generic Django integration. The value is arbitrary
+  (the store is in-memory and discarded per call) but *load-bearing*, because a
+  registry's `event_match` has to name it, so every other consumer was
+  registering handlers against a stranger's stream naming. It is now
+  `"_scratch/fold"`, namespaced so it cannot collide with a consumer's paths,
+  and the docstrings say plainly that the value is arbitrary but must match
+  `event_match`.
+
 - **`RAKAIA_STORE` no longer fails open.** `get_store()` returned the
   *in-memory* store for any backend string that wasn't exactly `"durable"`, so a
   one-character typo (`"durrable"`, a stray space from a `.env` file, `"Durable"`)

--- a/src/django_rakaia/envelope.py
+++ b/src/django_rakaia/envelope.py
@@ -36,11 +36,20 @@ from rakaia.protocols import ProjectionReader, WritableStore
 from rakaia.registry import HandlerRegistry
 from rakaia.replay import replay
 
-#: The in-memory stream path a live fold replays through. A fold is not a
-#: durable append — it exists to run the *same handlers* a rebuild will run, so
-#: the write-time projection and the replayed one cannot diverge. The path is a
-#: constant so a registry's ``event_match`` can name it.
-SCRATCH_PATH = "produce/submission"
+#: The in-memory stream path a live fold replays through.
+#:
+#: **Arbitrary, but load-bearing.** The store is in-memory and thrown away per
+#: call, so the value means nothing on its own — but a registry's ``event_match``
+#: has to name it for the handlers to fire, which makes it part of the calling
+#: contract rather than an implementation detail. It is a constant so both sides
+#: can refer to one name instead of repeating a string.
+#:
+#: The leading underscore marks it as rakaia's own namespace, so it cannot
+#: collide with a consumer's stream paths. It previously read
+#: ``"produce/submission"`` — domain language borrowed from the first consumer,
+#: which implied a convention that does not exist and made every other consumer
+#: register handlers against another project's vocabulary (#100).
+SCRATCH_PATH = "_scratch/fold"
 
 
 def append_event(
@@ -101,6 +110,10 @@ def fold_events(
     Seeds a throwaway in-memory `StreamStore` with ``events`` in list order and
     replays it through ``registry`` — staged, and reader-bound when ``reader`` is
     given so stage-1 handlers resolve against the rows stage 0 just wrote.
+
+    ``scratch_path`` must match the ``event_match`` the registry's handlers were
+    registered against, or nothing fires. It defaults to `SCRATCH_PATH`; register
+    against that same constant rather than repeating the string.
 
     The point is that write-time projection and rebuild-time projection run the
     *same* handler code. A consumer that instead materialises rows directly at

--- a/src/django_rakaia/hermeticity.py
+++ b/src/django_rakaia/hermeticity.py
@@ -103,12 +103,43 @@ def deny_database_access(*aliases: str) -> Iterator[None]:
                 f"the reader, or move it to a stage that has one."
             )
 
+        # Tagged so `assert_no_live_writes` can suspend *this* wrapper for its
+        # own row counts without disturbing a wrapper the consumer installed.
+        _wrap._rakaia_deny_guard = True  # type: ignore[attr-defined]
         return _wrap
 
     with ExitStack() as stack:
         for alias in aliases:
             stack.enter_context(connections[alias].execute_wrapper(_blocker(alias)))
         yield
+
+
+@contextmanager
+def _without_deny_guards(alias: str) -> Iterator[None]:
+    """Suspend rakaia's own `deny_database_access` wrappers on `alias`.
+
+    Counting rows to *check* for a leak is the guard's bookkeeping, not the
+    rebuild reading live data — so it must not be reported as a leak, and the
+    two guards must compose in either nesting order (#101). Without this,
+    `deny_database_access` on the outside made `assert_no_live_writes`'s closing
+    `COUNT(*)` raise `AmbientDatabaseAccess` blaming *the rebuild* for a query
+    the guard itself issued, sending the reader after a leak that did not exist.
+
+    Only wrappers this module installed are removed — a consumer's own
+    `execute_wrapper` (query logging, timing) still sees these counts, since
+    suppressing it would be a surprise we have no business causing.
+    """
+    from django.db import connections
+
+    conn = connections[alias]
+    saved = list(conn.execute_wrappers)
+    conn.execute_wrappers[:] = [
+        w for w in saved if not getattr(w, "_rakaia_deny_guard", False)
+    ]
+    try:
+        yield
+    finally:
+        conn.execute_wrappers[:] = saved
 
 
 @contextmanager
@@ -127,6 +158,10 @@ def assert_no_live_writes(
         with assert_no_live_writes(Submission, ProjectLink):
             replay(store, path, DjangoExecutor(using="rebuild"),
                    reader=DjangoProjectionReader(using="rebuild"), ...)
+
+    Composes with :func:`deny_database_access` in **either** nesting order: this
+    guard's own row counts are taken with rakaia's deny wrappers suspended, so
+    its bookkeeping is never mistaken for the rebuild reading live data (#101).
 
     **Why this exists alongside the read-side guard.** `deny_database_access`
     installs a statement wrapper, so it can only be armed around a region where
@@ -156,7 +191,8 @@ def assert_no_live_writes(
         return
 
     def _counts() -> dict[type[Model], int]:
-        return {m: m.objects.using(using).count() for m in models}
+        with _without_deny_guards(using):
+            return {m: m.objects.using(using).count() for m in models}
 
     before = _counts()
     try:

--- a/tests/test_django_rakaia/test_envelope.py
+++ b/tests/test_django_rakaia/test_envelope.py
@@ -219,3 +219,37 @@ class TestFoldEvents:
             executor=DjangoExecutor(),
         )
         assert FinanceLine.objects.count() == 1
+
+
+class TestTheScratchPathIsRakaiasOwnNamespace:
+    """#100 — the default was `produce/submission`, domain language from the
+    first consumer sitting in the generic integration. It reads like a
+    convention; it is not one. But it *is* load-bearing, because a registry's
+    `event_match` has to name it, so every other consumer was registering
+    handlers against another project's vocabulary."""
+
+    def test_it_is_namespaced_and_not_consumer_domain_language(self):
+        assert SCRATCH_PATH.startswith("_")
+        assert "submission" not in SCRATCH_PATH
+
+    def test_an_explicit_scratch_path_overrides_it(self):
+        """A consumer whose handlers match their own vocabulary can say so."""
+        registry = HandlerRegistry()
+        registry.register(
+            name="finance", event_match="my/own/path", fn=_handler, effective_from=0
+        )
+        fold_events([{"id": "a", "suku": "one"}], registry, scratch_path="my/own/path")
+        assert FinanceLine.objects.count() == 1
+
+    def test_a_registry_matching_a_different_path_projects_nothing(self):
+        """The coupling made explicit: mismatch is silent, which is why the
+        constant exists for both sides to name."""
+        registry = HandlerRegistry()
+        registry.register(
+            name="finance",
+            event_match="somewhere/else",
+            fn=_handler,
+            effective_from=0,
+        )
+        fold_events([{"id": "a", "suku": "one"}], registry)
+        assert FinanceLine.objects.count() == 0

--- a/tests/test_django_rakaia/test_rebuild_isolation.py
+++ b/tests/test_django_rakaia/test_rebuild_isolation.py
@@ -26,7 +26,11 @@ from __future__ import annotations
 
 import pytest
 
-from django_rakaia.hermeticity import LiveWriteLeaked, assert_no_live_writes
+from django_rakaia.hermeticity import (
+    LiveWriteLeaked,
+    assert_no_live_writes,
+    deny_database_access,
+)
 
 from .models import FinanceLine
 
@@ -118,8 +122,6 @@ class TestPairingWithTheReadSideGuard:
     def test_both_guards_compose(self):
         """The documented shape of a full gate: deny reads of the live alias,
         and assert nothing was written to it."""
-        from django_rakaia.hermeticity import deny_database_access
-
         with assert_no_live_writes(FinanceLine), deny_database_access("default"):
             _line("rebuilt", using="overlay")
 
@@ -129,3 +131,77 @@ class TestPairingWithTheReadSideGuard:
         """Matches `AmbientDatabaseAccess` — a rebuild that mutates live is a
         defect, not a warning."""
         assert issubclass(LiveWriteLeaked, RuntimeError)
+
+
+class TestTheTwoGuardsComposeInEitherOrder:
+    """Nesting order must not change the outcome (#101).
+
+    `assert_no_live_writes` counts rows on the alias `deny_database_access`
+    forbids reading. Nested the wrong way round, the closing `COUNT(*)` tripped
+    the read guard — and the resulting `AmbientDatabaseAccess` said *"replay
+    touched the 'default' database directly"*, blaming the rebuild for a query
+    the guard itself issued. Someone reading that goes hunting for a leak that
+    is not there, in a tool whose whole job is to tell them where the leak is.
+
+    Every docstring and test shipped with the guard used the working order, so
+    this was latent rather than live — which is exactly the kind of thing that
+    surfaces months later in someone else's rebuild.
+
+    The fix makes the order irrelevant rather than merely documented: the
+    guard's own bookkeeping is suspended from the deny wrapper, because counting
+    rows to *check* for a leak is not the rebuild reading live data.
+    """
+
+    def test_write_guard_outside_read_guard(self):
+        with assert_no_live_writes(FinanceLine), deny_database_access("default"):
+            _line("rebuilt", using="overlay")
+        assert FinanceLine.objects.using("default").count() == 0
+
+    def test_read_guard_outside_write_guard(self):
+        """The order that used to raise from the guard's own COUNT(*)."""
+        with deny_database_access("default"), assert_no_live_writes(FinanceLine):
+            _line("rebuilt", using="overlay")
+        assert FinanceLine.objects.using("default").count() == 0
+
+    def test_a_real_leak_is_still_caught_in_the_hard_order(self):
+        """Suspending the deny wrapper for the count must not blind the write
+        guard — otherwise the fix would trade a confusing error for no error."""
+        with (
+            pytest.raises(LiveWriteLeaked),
+            deny_database_access("overlay"),
+            assert_no_live_writes(FinanceLine),
+        ):
+            _line("leaked")
+
+    def test_the_read_guard_still_catches_a_real_ambient_read(self):
+        """And the deny wrapper must be restored afterwards, still armed."""
+        from django_rakaia.hermeticity import AmbientDatabaseAccess
+
+        with (
+            pytest.raises(AmbientDatabaseAccess),
+            deny_database_access("default"),
+            assert_no_live_writes(FinanceLine),
+        ):
+            FinanceLine.objects.using("default").count()
+
+    def test_an_unrelated_execute_wrapper_is_not_disturbed(self):
+        """Only rakaia's own deny wrapper is suspended for the count. A
+        consumer's query logger keeps seeing everything it would otherwise."""
+        from django.db import connections
+
+        seen: list[str] = []
+
+        def _spy(execute, sql, params, many, context):
+            seen.append(sql)
+            return execute(sql, params, many, context)
+
+        with (
+            connections["default"].execute_wrapper(_spy),
+            deny_database_access("default"),
+            assert_no_live_writes(FinanceLine),
+        ):
+            pass
+
+        assert any("COUNT" in sql.upper() for sql in seen), (
+            "the guard's own counts should still reach an unrelated wrapper"
+        )


### PR DESCRIPTION
Rakaia ships two guards for proving that rebuilding your tables from the event
log doesn't touch the live database — one watches for reads, one watches for
writes. Used together in one order they work; used in the other order the
write-guard's own row count sets off the read-guard, and the resulting error says
the rebuild touched the live database. It didn't. The guard did, while checking.
For a tool whose entire purpose is to tell you where a leak is, pointing at one
that doesn't exist is about the worst failure it can have — and every example we
shipped happened to use the order that works, so nobody would find out until
they wrote it the other way round.

The order no longer matters. The write guard now takes its counts with rakaia's
own read-guard stood down, on the grounds that counting rows to check for a leak
isn't the rebuild reading live data. A genuine leak is still caught either way,
and if you have your own query logging installed it still sees everything.

Also in here, from the same review: the helper that replays a batch of events was
defaulting to a stream name borrowed from the first project that used rakaia.
It's an arbitrary name, but not an unimportant one — your handlers have to be
registered against it — so every other project was quietly adopting a stranger's
naming. It's now a neutral one, and the docs say what it's for. Closes #101 and
#100.