### PR TITLE
The producer error table was written out three times

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -203,6 +203,20 @@ is not yet tagged in a release.
   recipe** that runs the scripted demos end-to-end.
   → [`docs/whats-new.md`](docs/whats-new.md).
 
+### Changed
+
+- **One producer response table instead of three.** The five-arm `isinstance`
+  ladder over `ProducerValidationResult` — duplicate → 204, stale epoch → 403,
+  bad epoch opening → 400, sequence gap → 409, closed stream → 409, each with
+  its own headers — was written out three times inside `_handle_append`, the
+  largest function in the largest module. The exception half of the same mapping
+  had already been deepened into a single `_status_for` lookup; the union-typed
+  half never followed. `producer_response(result, *, producer_epoch, offset,
+  stream_closed)` now sits beside `_status_for`, and the three call sites pass
+  what differs rather than restating the table. `_handle_append` drops from 244
+  to 164 lines, and the status/header mapping is testable as a table — no ASGI
+  round trip, no live store.
+
 ### Fixed
 
 - **`RAKAIA_STORE` no longer fails open.** `get_store()` returned the

--- a/src/rakaia/handler.py
+++ b/src/rakaia/handler.py
@@ -55,6 +55,7 @@ from .types import (
     EmptyJsonArray,
     InvalidJson,
     InvalidOffset,
+    ProducerAccepted,
     ProducerDuplicate,
     ProducerInvalidEpochSeq,
     ProducerSequenceGap,
@@ -100,6 +101,97 @@ def _status_for(failure: BaseException) -> tuple[int, bytes] | None:
         if mapped is not None:
             return mapped
     return None
+
+
+def producer_response(
+    result: Any,
+    *,
+    producer_epoch: int | None,
+    offset: str | None = None,
+    stream_closed: bool = False,
+) -> tuple[int, bytes, dict[str, str]] | None:
+    """The HTTP response a refused fenced write becomes, or `None` if it was not
+    refused.
+
+    The union-typed twin of `_status_for`, which does the same job for store
+    *exceptions*. Both halves of "what status does this become" now live beside
+    each other instead of one being a lookup table and the other a ladder of
+    `isinstance` checks written out three times in `_handle_append`.
+
+    Returns `(status, body, extra_headers)`; the caller merges CORS and sends it.
+    An empty body means 204 — that arm is sent with `send_response`, the rest
+    with `_send_error`, which adds ``content-type: text/plain``.
+
+    The three call sites differ only in what they can supply, so those are
+    parameters rather than duplication:
+
+    * ``offset`` — the stream's next offset, when the caller has one to report.
+      Omitted rather than sent empty when it does not (the append-result path).
+    * ``stream_closed`` — whether to flag a duplicate as landing on a now-closed
+      stream.
+
+    A duplicate is **204, not an error**: the producer's write did land, it just
+    landed on an earlier attempt, and echoing `Producer-Epoch`/`Producer-Seq`
+    lets it resume from the right place rather than retrying forever.
+    """
+    if result is None or isinstance(result, ProducerAccepted):
+        return None
+
+    if isinstance(result, ProducerDuplicate):
+        headers = {
+            PRODUCER_EPOCH_HEADER: str(producer_epoch),
+            PRODUCER_SEQ_HEADER: str(result.last_seq),
+        }
+        if offset is not None:
+            headers[STREAM_OFFSET_HEADER_RESP] = offset
+        if stream_closed:
+            headers[STREAM_CLOSED_HEADER_RESP] = "true"
+        return 204, b"", headers
+
+    if isinstance(result, ProducerStaleEpoch):
+        # The epoch in force, not the one the client sent — that is what lets a
+        # fenced-out producer discover it has been superseded.
+        return (
+            403,
+            b"Stale producer epoch",
+            {PRODUCER_EPOCH_HEADER: str(result.current_epoch)},
+        )
+
+    if isinstance(result, ProducerInvalidEpochSeq):
+        return 400, b"New epoch must start with sequence 0", {}
+
+    if isinstance(result, ProducerSequenceGap):
+        return (
+            409,
+            b"Producer sequence gap",
+            {
+                PRODUCER_EXPECTED_SEQ_HEADER: str(result.expected_seq),
+                PRODUCER_RECEIVED_SEQ_HEADER: str(result.received_seq),
+            },
+        )
+
+    if isinstance(result, ProducerStreamClosed):
+        headers = {STREAM_CLOSED_HEADER_RESP: "true"}
+        if offset is not None:
+            headers[STREAM_OFFSET_HEADER_RESP] = offset
+        return 409, b"Stream is closed", headers
+
+    return None
+
+
+async def _send_producer_response(
+    send: Send, decided: tuple[int, bytes, dict[str, str]], cors: dict[str, str]
+) -> None:
+    """Send what `producer_response` decided.
+
+    A bodiless 204 goes through `send_response`; anything else through
+    `_send_error`, which stamps ``content-type: text/plain``.
+    """
+    status, body, extra = decided
+    if not body:
+        await send_response(send, status, {**cors, **extra})
+    else:
+        await _send_error(send, status, body, cors, extra)
 
 
 # Header names used in responses (title case for HTTP convention)
@@ -999,57 +1091,19 @@ async def _handle_append(
                 return
 
             pr = close_result.producer_result
-            if isinstance(pr, ProducerDuplicate):
-                await send_response(
-                    send,
-                    204,
-                    {
-                        **cors,
-                        STREAM_OFFSET_HEADER_RESP: close_result.final_offset,
-                        STREAM_CLOSED_HEADER_RESP: "true",
-                        PRODUCER_EPOCH_HEADER: str(producer_epoch),
-                        PRODUCER_SEQ_HEADER: str(pr.last_seq),
-                    },
-                )
-                return
-            if isinstance(pr, ProducerStaleEpoch):
-                await _send_error(
-                    send,
-                    403,
-                    b"Stale producer epoch",
-                    cors,
-                    {PRODUCER_EPOCH_HEADER: str(pr.current_epoch)},
-                )
-                return
-            if isinstance(pr, ProducerInvalidEpochSeq):
-                await _send_error(
-                    send, 400, b"New epoch must start with sequence 0", cors
-                )
-                return
-            if isinstance(pr, ProducerSequenceGap):
-                await _send_error(
-                    send,
-                    409,
-                    b"Producer sequence gap",
-                    cors,
-                    {
-                        PRODUCER_EXPECTED_SEQ_HEADER: str(pr.expected_seq),
-                        PRODUCER_RECEIVED_SEQ_HEADER: str(pr.received_seq),
-                    },
-                )
-                return
             if isinstance(pr, ProducerStreamClosed):
-                s = await store.run_sync(store.get, path)
-                await _send_error(
-                    send,
-                    409,
-                    b"Stream is closed",
-                    cors,
-                    {
-                        STREAM_CLOSED_HEADER_RESP: "true",
-                        STREAM_OFFSET_HEADER_RESP: s.current_offset if s else "",
-                    },
-                )
+                # Only this arm needs the stream's current offset, and fetching
+                # it costs a round trip — so it is resolved here rather than
+                # unconditionally before the decision.
+                st = await store.run_sync(store.get, path)
+                offset = st.current_offset if st else ""
+            else:
+                offset = close_result.final_offset
+            decided = producer_response(
+                pr, producer_epoch=producer_epoch, offset=offset, stream_closed=True
+            )
+            if decided is not None:
+                await _send_producer_response(send, decided, cors)
                 return
 
             # Success
@@ -1109,33 +1163,22 @@ async def _handle_append(
 
     # Handle closed stream
     if result.stream_closed and result.message is None:
-        pr = result.producer_result
-        if isinstance(pr, ProducerDuplicate):
-            s = await store.run_sync(store.get, path)
-            await send_response(
-                send,
-                204,
-                {
-                    **cors,
-                    STREAM_OFFSET_HEADER_RESP: s.current_offset if s else "",
-                    STREAM_CLOSED_HEADER_RESP: "true",
-                    PRODUCER_EPOCH_HEADER: str(producer_epoch),
-                    PRODUCER_SEQ_HEADER: str(pr.last_seq),
-                },
-            )
-            return
-
-        s = await store.run_sync(store.get, path)
-        await _send_error(
-            send,
-            409,
-            b"Stream is closed",
-            cors,
-            {
-                STREAM_CLOSED_HEADER_RESP: "true",
-                STREAM_OFFSET_HEADER_RESP: s.current_offset if s else "",
-            },
+        st = await store.run_sync(store.get, path)
+        offset = st.current_offset if st else ""
+        decided = producer_response(
+            result.producer_result,
+            producer_epoch=producer_epoch,
+            offset=offset,
+            stream_closed=True,
         )
+        if decided is None:
+            # Nothing to report about the producer — an unfenced append, or one
+            # whose fencing was fine. The closed stream is itself the answer.
+            decided = producer_response(
+                ProducerStreamClosed(), producer_epoch=producer_epoch, offset=offset
+            )
+        assert decided is not None
+        await _send_producer_response(send, decided, cors)
         return
 
     pr = result.producer_result
@@ -1156,42 +1199,11 @@ async def _handle_append(
         return
 
     # Producer validation failures
-    if isinstance(pr, ProducerDuplicate):
-        dup_headers: dict[str, str] = {
-            **cors,
-            PRODUCER_EPOCH_HEADER: str(producer_epoch),
-            PRODUCER_SEQ_HEADER: str(pr.last_seq),
-        }
-        if result.stream_closed:
-            dup_headers[STREAM_CLOSED_HEADER_RESP] = "true"
-        await send_response(send, 204, dup_headers)
-        return
-
-    if isinstance(pr, ProducerStaleEpoch):
-        await _send_error(
-            send,
-            403,
-            b"Stale producer epoch",
-            cors,
-            {PRODUCER_EPOCH_HEADER: str(pr.current_epoch)},
-        )
-        return
-
-    if isinstance(pr, ProducerInvalidEpochSeq):
-        await _send_error(send, 400, b"New epoch must start with sequence 0", cors)
-        return
-
-    if isinstance(pr, ProducerSequenceGap):
-        await _send_error(
-            send,
-            409,
-            b"Producer sequence gap",
-            cors,
-            {
-                PRODUCER_EXPECTED_SEQ_HEADER: str(pr.expected_seq),
-                PRODUCER_RECEIVED_SEQ_HEADER: str(pr.received_seq),
-            },
-        )
+    decided = producer_response(
+        pr, producer_epoch=producer_epoch, stream_closed=result.stream_closed
+    )
+    if decided is not None:
+        await _send_producer_response(send, decided, cors)
         return
 
 

--- a/tests/test_rakaia/test_producer_response.py
+++ b/tests/test_rakaia/test_producer_response.py
@@ -1,0 +1,194 @@
+"""The producer status/header table, as a table.
+
+A refused fenced write turns into a specific HTTP response: 204 for a duplicate,
+403 for a stale epoch, 400 for a bad epoch opening, 409 for a gap or a closed
+stream — each with its own headers. That mapping was written out three times in
+`_handle_append`, once for the close-only path, once for the closed-stream path
+and once for the append-result path, in the largest function of the largest file.
+Roughly a hundred lines saying the same thing, where two of the copies were
+byte-identical for three of the five arms and the third differed in ways that
+were hard to tell were deliberate.
+
+The exception half of this mapping was already deepened: commit `168c5e2`
+replaced substring-matched error strings with named failures and a single
+`_status_for` lookup. The union-typed half never followed, so the two halves of
+"what status does this become" lived in completely different shapes.
+
+Before this, asserting "a sequence gap returns 409 with `Producer-Expected-Seq`"
+meant a full ASGI round trip against a live store. Here it is a function call.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from rakaia.handler import producer_response
+from rakaia.types import (
+    PRODUCER_EPOCH_HEADER,
+    PRODUCER_EXPECTED_SEQ_HEADER,
+    PRODUCER_RECEIVED_SEQ_HEADER,
+    PRODUCER_SEQ_HEADER,
+    ProducerAccepted,
+    ProducerDuplicate,
+    ProducerInvalidEpochSeq,
+    ProducerSequenceGap,
+    ProducerStaleEpoch,
+    ProducerState,
+    ProducerStreamClosed,
+)
+
+
+class TestAcceptedIsNotARefusal:
+    """`None` means "no refusal response" — the caller sends its own success."""
+
+    def test_accepted_yields_no_response(self):
+        accepted = ProducerAccepted(
+            producer_id="p",
+            proposed_state=ProducerState(epoch=0, last_seq=0, last_updated=0.0),
+        )
+        assert producer_response(accepted, producer_epoch=0) is None
+
+    def test_no_producer_result_yields_no_response(self):
+        assert producer_response(None, producer_epoch=0) is None
+
+
+class TestTheRefusalTable:
+    def test_a_duplicate_is_204_echoing_the_producer_position(self):
+        status, body, headers = producer_response(
+            ProducerDuplicate(last_seq=4), producer_epoch=2
+        )
+        assert status == 204
+        assert body == b""
+        assert headers[PRODUCER_EPOCH_HEADER] == "2"
+        assert headers[PRODUCER_SEQ_HEADER] == "4"
+
+    def test_a_stale_epoch_is_403_naming_the_current_epoch(self):
+        status, body, headers = producer_response(
+            ProducerStaleEpoch(current_epoch=9), producer_epoch=3
+        )
+        assert status == 403
+        assert body == b"Stale producer epoch"
+        assert headers[PRODUCER_EPOCH_HEADER] == "9", (
+            "must report the epoch in force, not the one the client sent"
+        )
+
+    def test_an_invalid_epoch_opening_is_400(self):
+        status, body, headers = producer_response(
+            ProducerInvalidEpochSeq(), producer_epoch=1
+        )
+        assert status == 400
+        assert body == b"New epoch must start with sequence 0"
+
+    def test_a_sequence_gap_is_409_with_both_sequences(self):
+        status, body, headers = producer_response(
+            ProducerSequenceGap(expected_seq=1, received_seq=5), producer_epoch=0
+        )
+        assert status == 409
+        assert body == b"Producer sequence gap"
+        assert headers[PRODUCER_EXPECTED_SEQ_HEADER] == "1"
+        assert headers[PRODUCER_RECEIVED_SEQ_HEADER] == "5"
+
+    def test_a_closed_stream_is_409_flagged_closed(self):
+        status, body, headers = producer_response(
+            ProducerStreamClosed(), producer_epoch=0, offset="42"
+        )
+        assert status == 409
+        assert body == b"Stream is closed"
+        assert headers["Stream-Closed"] == "true"
+        assert headers["Stream-Next-Offset"] == "42"
+
+
+class TestTheVaryingParts:
+    """What differed between the three copies, now parameters rather than
+    divergence."""
+
+    def test_a_duplicate_carries_the_offset_when_one_is_known(self):
+        _, _, headers = producer_response(
+            ProducerDuplicate(last_seq=0), producer_epoch=0, offset="17"
+        )
+        assert headers["Stream-Next-Offset"] == "17"
+
+    def test_a_duplicate_omits_the_offset_when_none_is_known(self):
+        """The append-result path has no offset to report; it must not invent
+        an empty header."""
+        _, _, headers = producer_response(
+            ProducerDuplicate(last_seq=0), producer_epoch=0
+        )
+        assert "Stream-Next-Offset" not in headers
+
+    def test_a_duplicate_is_flagged_closed_when_the_stream_is(self):
+        _, _, headers = producer_response(
+            ProducerDuplicate(last_seq=0), producer_epoch=0, stream_closed=True
+        )
+        assert headers["Stream-Closed"] == "true"
+
+    def test_a_duplicate_is_not_flagged_closed_otherwise(self):
+        _, _, headers = producer_response(
+            ProducerDuplicate(last_seq=0), producer_epoch=0
+        )
+        assert "Stream-Closed" not in headers
+
+
+class TestOnlyARefusalCarriesAnErrorBody:
+    """The 204 arm must stay bodiless — a 204 with a body is malformed, and it
+    is the one arm the caller sends with `send_response` rather than
+    `_send_error`."""
+
+    def test_the_duplicate_arm_has_an_empty_body(self):
+        _, body, _ = producer_response(ProducerDuplicate(last_seq=0), producer_epoch=0)
+        assert body == b""
+
+    @pytest.mark.parametrize(
+        "result",
+        [
+            ProducerStaleEpoch(current_epoch=1),
+            ProducerInvalidEpochSeq(),
+            ProducerSequenceGap(expected_seq=0, received_seq=3),
+            ProducerStreamClosed(),
+        ],
+        ids=["stale", "invalid", "gap", "closed"],
+    )
+    def test_every_other_arm_has_a_body(self, result):
+        status, body, _ = producer_response(result, producer_epoch=0)
+        assert body, f"{type(result).__name__} must explain itself"
+        assert status >= 400
+
+
+class TestEveryResultTypeIsHandled:
+    """A new `ProducerValidationResult` without an arm must fail here rather
+    than fall through to a 500 at runtime — the same guarantee `_status_for`'s
+    closed-set test gives the exception half."""
+
+    def test_no_refusal_type_falls_through(self):
+        import rakaia.types as types
+
+        refusals = [
+            cls
+            for name, cls in vars(types).items()
+            if name.startswith("Producer")
+            and isinstance(cls, type)
+            and name not in ("ProducerAccepted", "ProducerState")
+            and name != "ProducerValidationResult"
+        ]
+        assert refusals, "sanity: the refusal types should be discoverable"
+        for cls in refusals:
+            instance = _build(cls)
+            assert producer_response(instance, producer_epoch=0) is not None, (
+                f"{cls.__name__} has no response arm"
+            )
+
+
+def _build(cls):
+    """Instantiate a refusal type with whatever fields it declares."""
+    import dataclasses
+
+    if not dataclasses.is_dataclass(cls):
+        return cls()
+    kwargs = {}
+    for f in dataclasses.fields(cls):
+        if f.default is not dataclasses.MISSING or (
+            f.default_factory is not dataclasses.MISSING  # type: ignore[misc]
+        ):
+            continue
+        kwargs[f.name] = 0 if f.type in ("int", int) else "x"
+    return cls(**kwargs)


### PR DESCRIPTION
When a writer sends an event and rakaia refuses it — because it already arrived,
because another writer has taken over, because a number is out of sequence, or
because the stream is closed — each case turns into a particular HTTP status with
particular headers. That table was spelled out three separate times inside the
same function, which is already the longest one in the codebase. Two of the
copies agreed; the third differed, and it took a careful read to work out whether
those differences were intentional or just drift.

We'd already fixed exactly this problem for the other half of the same
question — errors thrown by the storage layer used to be identified by matching
English text and now go through one small lookup. This brings the writer-refusal
half into the same shape. The function it lived in loses about a third of its
length, and the table can now be checked directly rather than by starting a
server, opening a stream, and driving it into each failure in turn.

No behaviour change intended; the existing protocol conformance suite and the
full test suite both pass.