### PR TITLE
Make the demos prove the new guarantees, not just describe them

### DIFF
--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -344,7 +344,68 @@ class ChatRoom(models.Model):
 
 → Deep dive: [Django integration](django-integration.md) · Demos: `just dev`, `just polyglot-dev`
 
-## 11. Protocol conformance
+## 11. Proof that a proof means something
+
+A migration is signed off on a verification sweep: replay the log, collect what
+it *would* write, diff that against the rows you already have. Two ways that
+answer can be worthless, both now guarded — see them in
+`just cookbook-demo`, checks **[3]** and **[4]**.
+
+**A sweep that compared nothing must not report success.** `report.ok` asks "did
+anything disagree?", which is vacuously true on an empty population — and the
+ways a sweep silently examines zero rows are all mundane: a store on the wrong
+backend, a replay over a renamed stream path, a filter that stopped matching, a
+registry that failed to autodiscover. Read `verdict` instead, which separates
+`GREEN` from `VACUOUS`, or `certified`, which is the assertion a proof wants:
+
+```python
+report = diff_effects_against_rows(ex.effects)
+assert report.certified, report      # not `report.ok` — see above
+report.raise_if_diff()               # raises VacuousVerification on an empty run
+```
+
+Failures are checked *before* vacuity, so a real failure is never hidden behind
+"empty".
+
+**A dry run must actually be dry.** `assert_no_live_writes` compares the live
+row counts across a block and raises if anything moved — so "this replay wrote
+nothing" becomes something you assert rather than something you trust:
+
+```python
+with assert_no_live_writes(Project, Task):
+    replay(store, STREAM, CollectingExecutor(), reader=DjangoProjectionReader())
+```
+
+It is the write-side half of the rebuild gate; `deny_database_access` is the
+read-side half, and the two compose in either nesting order.
+
+---
+
+## 12. One envelope, written once
+
+Recording an event with its label, actor and timestamp is four lines — encode
+the payload with Django's encoder, create the stream if it is missing, wrap the
+rest in an `AppendOptions`. Written at every call site, and every copy that
+drifted produced events that replay differently from their neighbours, with
+nothing looking at the difference. `append_event` is those four lines:
+
+```python
+from django_rakaia.envelope import append_event
+
+append_event(store, "submissions", payload, label="create", actor=user_id)
+```
+
+`examples/formkit_submissions` uses it for every append it makes, and its
+`/history` check still recovers the right actor for each — which is the point:
+adopting it is a deletion, not a rewrite.
+
+Its sibling `fold_events` runs a batch of events through your handlers *now*,
+via a throwaway in-memory stream, so write-time projection and rebuild-time
+projection run the same code rather than two implementations that can disagree.
+
+---
+
+## 13. Protocol conformance
 
 Rakaia is checked against the upstream, language-agnostic
 [`@durable-streams/server-conformance-tests`](https://github.com/durable-streams/durable-streams)

--- a/examples/formkit_submissions/submissions/management/commands/demo_submissions.py
+++ b/examples/formkit_submissions/submissions/management/commands/demo_submissions.py
@@ -29,14 +29,13 @@ from django.core.management import call_command
 from django.core.management.base import BaseCommand, CommandError, CommandParser
 
 from django_rakaia.effect_executor import DjangoExecutor
+from django_rakaia.envelope import append_event
 from django_rakaia.store import get_store
 from rakaia import (
-    AppendOptions,
     CollectingExecutor,
     envelope_actor,
     history_effects,
     label_marker,
-    provenance,
     upcast,
 )
 from rakaia.replay import replay
@@ -52,15 +51,17 @@ IR108_ID = "44444444-4444-4444-4444-444444444444"
 def _append_event(store: Any, event: dict, *, label: str, actor: str) -> None:
     """Append one *enveloped* event: the raw payload plus a change label and the
     acting user — exactly what `ProvenanceMiddleware` stamps on a real request.
-    The label drives the `/history` marker; the ambient `provenance(user=…)` is
-    merged into the message metadata so the audit read-model can recover *who*.
+    The label drives the `/history` marker; the actor lands in the message
+    metadata so the audit read-model can recover *who*.
+
+    This is `django_rakaia.envelope.append_event`, which exists precisely so this
+    function does not have to. The longhand it replaces — create-if-missing,
+    `json.dumps(...).encode()`, wrap the label in an `AppendOptions`, open a
+    `provenance()` block for the actor — is four lines that every consumer wrote
+    at every call site, and every copy that drifted produced events that replay
+    differently from their neighbours with nothing checking the difference.
     """
-    with provenance(user=actor):
-        store.append(
-            STREAM,
-            json.dumps(event).encode("utf-8"),
-            AppendOptions(label=label),
-        )
+    append_event(store, STREAM, event, label=label, actor=actor)
 
 
 def _snapshot() -> dict[str, list[tuple]]:

--- a/examples/projection_cookbook/cookbook/management/commands/demo_cookbook.py
+++ b/examples/projection_cookbook/cookbook/management/commands/demo_cookbook.py
@@ -20,9 +20,14 @@ from django.core.management.base import BaseCommand, CommandError
 from cookbook.models import Project, Task
 from cookbook.seed import SAMPLE_EVENTS
 from django_rakaia.effect_executor import DjangoExecutor
+from django_rakaia.hermeticity import assert_no_live_writes
 from django_rakaia.projection_reader import DjangoProjectionReader
 from django_rakaia.store import get_store
-from django_rakaia.verification import diff_effects_against_rows
+from django_rakaia.verification import (
+    VACUOUS,
+    VacuousVerification,
+    diff_effects_against_rows,
+)
 from rakaia import CollectingExecutor
 from rakaia.replay import replay
 
@@ -66,6 +71,8 @@ class Command(BaseCommand):
         # 3. Checks.
         self._check_out_of_order_link()
         self._check_replay_reproduces_rows(store)
+        self._check_a_sweep_that_compared_nothing_is_refused(store)
+        self._check_the_rebuild_does_not_touch_live(store)
         self._check_idempotent(store)
 
         self.stdout.write(self.style.SUCCESS("\nAll checks passed."))
@@ -95,12 +102,78 @@ class Command(BaseCommand):
         ex = CollectingExecutor()
         replay(store, STREAM, ex, reader=DjangoProjectionReader())
         report = diff_effects_against_rows(ex.effects)
-        if not report.ok:
+        # `certified`, not `ok`: `ok` asks "did anything disagree?", which is
+        # vacuously true when nothing was compared. `raise_if_diff()` refuses an
+        # empty population outright — see the next check.
+        if not report.certified:
             raise CommandError(f"Replay does not reproduce current rows:\n{report}")
         self.stdout.write(
             self.style.SUCCESS(
                 f"[2] verification: replay reproduces all "
-                f"{len(report.rows)} projected rows ✓"
+                f"{report.compared} projected rows — verdict {report.verdict} ✓"
+            )
+        )
+
+    def _check_a_sweep_that_compared_nothing_is_refused(self, store: Any) -> None:
+        """A verification that examined no rows must not report success.
+
+        The failure this guards against is not a wrong answer, it is a confident
+        one with nothing behind it. Every way a sweep silently compares zero rows
+        is mundane — a store on the wrong backend, a replay over a renamed
+        stream, a filter that stopped matching, a registry that failed to load —
+        and each one used to print a clean bill of health.
+
+        Here we cause it deliberately the way a rename does: replay a stream
+        that exists but holds no events. Nothing errors, nothing is compared,
+        and the sweep has no evidence either way.
+        """
+        renamed = f"{STREAM}-renamed"
+        store.create(renamed)
+
+        ex = CollectingExecutor()
+        replay(store, renamed, ex, reader=DjangoProjectionReader())
+        report = diff_effects_against_rows(ex.effects)
+
+        if report.ok:
+            # True, and worthless: `ok` is vacuous on an empty population. This
+            # is exactly the shape a false green takes.
+            pass
+        if report.certified or report.verdict != VACUOUS:
+            raise CommandError(
+                f"An empty sweep certified itself: verdict={report.verdict}"
+            )
+        try:
+            report.raise_if_diff()
+        except VacuousVerification:
+            pass
+        else:
+            raise CommandError("raise_if_diff() accepted a population of zero")
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                "[3] vacuous green: a sweep that compared 0 rows reports "
+                f"{report.verdict.upper()} and refuses to certify ✓"
+            )
+        )
+
+    def _check_the_rebuild_does_not_touch_live(self, store: Any) -> None:
+        """Prove the read-only verification really is read-only.
+
+        `assert_no_live_writes` is the write half of the rebuild gate: it
+        compares row counts across the block and raises if anything moved. Here
+        it certifies that the diff sweep above — which runs a full replay —
+        wrote nothing, which is the claim `CollectingExecutor` makes and which
+        nothing otherwise checks.
+        """
+        with assert_no_live_writes(Project, Task):
+            ex = CollectingExecutor()
+            replay(store, STREAM, ex, reader=DjangoProjectionReader())
+            diff_effects_against_rows(ex.effects)
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                "[4] rebuild isolation: a dry-run replay left every live row "
+                "untouched ✓"
             )
         )
 
@@ -116,7 +189,7 @@ class Command(BaseCommand):
         if before != after or Project.objects.count() != 2 or Task.objects.count() != 3:
             raise CommandError("Second replay changed the projection — not idempotent.")
         self.stdout.write(
-            self.style.SUCCESS("[3] idempotent: a second replay is a no-op ✓")
+            self.style.SUCCESS("[5] idempotent: a second replay is a no-op ✓")
         )
 
     # ----------------------------------------------------------------- display

--- a/examples/projection_cookbook/cookbook/management/commands/demo_cookbook.py
+++ b/examples/projection_cookbook/cookbook/management/commands/demo_cookbook.py
@@ -134,10 +134,15 @@ class Command(BaseCommand):
         replay(store, renamed, ex, reader=DjangoProjectionReader())
         report = diff_effects_against_rows(ex.effects)
 
-        if report.ok:
-            # True, and worthless: `ok` is vacuous on an empty population. This
-            # is exactly the shape a false green takes.
-            pass
+        # The false green itself: `ok` is True here and means nothing, because
+        # it asks "did anything disagree?" of a population of zero. Asserting it
+        # is the demonstration — a demo that only checked the new properties
+        # would show the fix while hiding what it fixes.
+        if not report.ok:
+            raise CommandError(
+                "expected the vacuous case to still report ok=True — that is "
+                "precisely the false green this check exists to show"
+            )
         if report.certified or report.verdict != VACUOUS:
             raise CommandError(
                 f"An empty sweep certified itself: verdict={report.verdict}"


### PR DESCRIPTION
The recent batch of work added a few guarantees — a verification sweep that
refuses to certify itself when it examined nothing, a guard that checks a rebuild
really didn't touch your live data, and a one-line way to record an event with
its author and timestamp. All of it was documented. None of it was demonstrated,
and the examples are the part CI actually runs, so a claim isn't really pinned
down until a demo asserts it.

The projection cookbook now deliberately triggers the "certified something with
no evidence" case — by replaying a stream that exists but is empty, which is what
a renamed stream path actually leaves you with — and checks that it's reported
as such rather than as success. It also wraps its dry-run verification in the
rebuild guard, so "this replay wrote nothing" is checked rather than assumed.

The formkit example switches its own hand-written event-recording helper to the
shipped one. Its audit-history check still identifies the right person for every
event, which is the thing worth proving: switching over is deleting code, not
rewriting it.

One thing not demonstrated, deliberately: bulk writes reaching live browsers.
That only means anything with a browser attached, and a batch command has no
subscriber to observe — faking one would demo the fake. It stays covered by
tests.