### PR TITLE
docs(agents): tell the skills where issues, labels, and domain language live

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,22 @@
   then `uv run zensical build`. Without `--extra docs` that step fails with
   `Failed to spawn: zensical`.
 
+## Agent skills
+
+### Issue tracker
+
+Issues live as GitHub issues in `joshbrooks/rakaia`, via the `gh` CLI. Issue and PR
+titles and bodies must be short and jargon-free — two paragraphs at most, with any
+technical detail appended as a comment instead. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Canonical five-label vocabulary, unmapped. See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context. Domain language lives in `docs/glossary.md` (not `CONTEXT.md`); decisions in `docs/adr/`. See `docs/agents/domain.md`.
+
 ## gstack
 
 Use the `/browse` skill from gstack for all web browsing. Never use `mcp__claude-in-chrome__*` tools.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,44 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+This repo is **single-context**: one domain, one decision log, shared across both
+packages (`src/rakaia`, the zero-dependency core, and `src/django_rakaia`, the
+Django integration). There is no `CONTEXT-MAP.md` and none is needed.
+
+## Before exploring, read these
+
+- **`docs/glossary.md`** — this repo's domain-language document. It plays the role
+  that `CONTEXT.md` plays in the skill templates: it defines the event-sourcing
+  vocabulary (stream, event, projection, handler, cursor, fencing) in the precise
+  sense Rakaia uses. Read it before naming any domain concept.
+  There is no `CONTEXT.md` at the root and none is needed — don't create one.
+- **`docs/adr/`** — read ADRs that touch the area you're about to work in.
+  Currently:
+  - ADR-0001 — ordering child collections in projections
+  - ADR-0002 — framework vs protocol server boundary
+  - ADR-0003 — handler hermeticity
+- The wider `docs/` tree is reference material, not domain definition. Reach for a
+  specific page (`protocol.md`, `subscriber-cursors.md`, `versioned-handlers.md`, …)
+  when the glossary entry points at it.
+
+If a file named above has since been removed, **proceed silently**. Don't flag its
+absence and don't suggest recreating it.
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a
+hypothesis, a test name), use the term as defined in `docs/glossary.md`. Don't drift
+to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're
+inventing language the project doesn't use (reconsider) or there's a real gap (note
+it, and add the entry to `docs/glossary.md` rather than starting a `CONTEXT.md`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0003 (handler hermeticity) — but worth reopening because…_
+
+New ADRs go in `docs/adr/` following the existing `NNNN-kebab-title.md` numbering.

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,48 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub issues. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.
+
+## Writing issues and PRs
+
+Applies to both issue bodies and pull request descriptions.
+
+- **Title**: short and jargon-free. It should tell a reader who doesn't know the
+  internals what changed or what's wrong. Prefer "bulk appends never reached live
+  subscribers" over "fan-out cursor advance skips `_notify` on batch path".
+- **Body**: at most two short paragraphs, plain language, no jargon. Say what the
+  problem or change is and why it matters. Don't paste stack traces, diffs, file
+  inventories, or design rationale into the body.
+- **Detail goes in a comment.** If technical content is genuinely needed —
+  reproduction steps, a trace, benchmark numbers, an implementation sketch —
+  append it as a follow-up comment (`gh issue comment` / `gh pr comment`), not in
+  the body. This keeps the body readable to someone skimming a list.
+
+Length is a constraint, not a target: if one paragraph says it, write one.
+
+## Repo specifics
+
+The remote is `git@github.com:joshbrooks/rakaia.git`; `gh` infers it automatically
+inside any clone or worktree of this repo.
+
+This repo also uses a `deferred` label — "intentionally deferred; action only when
+its un-defer trigger fires". It is orthogonal to the triage state machine: an issue
+can be `deferred` and still carry a triage label. Don't strip it during triage.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,29 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+Edit the right-hand column to match whatever vocabulary you actually use.
+
+## Provenance
+
+`wontfix` is a GitHub default that already existed on this repo. The other four
+labels were created as part of agent-skills setup and exist solely to drive the
+triage state machine.
+
+The repo's other labels (`bug`, `enhancement`, `documentation`, `question`,
+`duplicate`, `invalid`, `help wanted`, `good first issue`, `deferred`) are
+**not** triage states. They classify an issue's kind, not its position in the
+workflow, and an issue normally carries one of each. In particular `question`
+means "further information is requested" of the *maintainers*, which is not the
+same as `needs-info` ("waiting on the reporter") — don't substitute one for the
+other.


### PR DESCRIPTION
The engineering skills need to know where this project tracks work and what words it uses. This adds three short files under `docs/agents/` recording that issues live on GitHub, which labels drive triage, and that `docs/glossary.md` is the domain vocabulary. `CLAUDE.md` points at them.

It also sets a house rule that issue and PR titles and bodies stay short and plain, with technical detail moved to a comment. Docs only — no code changes.