### PR TITLE
Say which parts of rakaia we promise not to break

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,28 @@ is not yet tagged in a release.
 
 ### Added
 
+- **A declared public API, and a contract for it.**
+  [`docs/public-api.md`](docs/public-api.md) sets out three tiers: **Tier 1**
+  (`rakaia.__all__` + the new `django_rakaia.__all__`) which does not change
+  without a major bump and an `UPGRADING.md` entry; **Tier 2**, the ORM models
+  and schema — usable, deliberately *not* exported, and free to change in a
+  minor release; and **Tier 3**, everything else. It also says plainly to depend
+  on rakaia with an **upper bound** (`>=0.2,<0.3`), because on a pre-1.0 library
+  an unbounded `>=` admits every future breaking change and takes it silently on
+  the next lockfile refresh.
+
+  `django_rakaia` previously exported **nothing** — 44 lines of docstring naming
+  a "Public API" that was not importable — so every consumer import had to name
+  an internal module, pinning the module *layout* rather than the surface. It now
+  exports 34 names, resolved lazily (PEP 562) so importing the package still does
+  not pull in the ORM, which is what made eager exports impossible and is now
+  pinned by a test. Both surfaces are pinned name-by-name, so changing one is a
+  deliberate act rather than a diff.
+
+  The examples and docs were the main offender and are converted: **72
+  submodule imports** now use the package root.
+
+
 - **`StreamServerStore` — the protocol-server store surface, named.** `create_app`
   was typed against the concrete in-memory `StreamStore`, so nothing else could
   back the protocol server. The new protocol (exported from `rakaia`) covers

--- a/docs/django-integration.md
+++ b/docs/django-integration.md
@@ -144,7 +144,7 @@ Django model and supply two callables:
 ```python
 from dataclasses import dataclass
 from django.db import models
-from django_rakaia.decorators import stream_model
+from django_rakaia import stream_model
 
 
 @dataclass
@@ -253,7 +253,7 @@ from dataclasses import dataclass
 from django.contrib.auth import get_user_model
 from django.db.models.signals import post_save
 from django.dispatch import receiver
-from django_rakaia.decorators import create_stream_event
+from django_rakaia import create_stream_event
 
 
 @dataclass
@@ -315,7 +315,7 @@ is mounted in `asgi.py` rather than in `urls.py`:
 ```python
 # asgi.py
 from django.core.asgi import get_asgi_application
-from django_rakaia.integration import get_asgi_app
+from django_rakaia import get_asgi_app
 
 django_app = get_asgi_application()
 protocol_app = get_asgi_app()  # create_app() over the configured store
@@ -359,7 +359,7 @@ inspect event payloads. To register your own concrete `StreamEvent` subclass
 in the admin, call:
 
 ```python
-from django_rakaia.admin import register_stream_event_admin
+from django_rakaia import register_stream_event_admin
 from myapp.models import MyStreamEvent
 
 register_stream_event_admin(MyStreamEvent)

--- a/docs/dry-run-and-executors.md
+++ b/docs/dry-run-and-executors.md
@@ -46,7 +46,7 @@ replication. Pass `skip_unchanged=True` to fetch the row, compare the effect's
 when nothing changed):
 
 ```python
-from django_rakaia.effect_executor import DjangoExecutor
+from django_rakaia import DjangoExecutor
 
 replay(store, "orders", DjangoExecutor(skip_unchanged=True))
 ```
@@ -60,8 +60,8 @@ To preview a replay without side effects, run it with a `CollectingExecutor` and
 inspect `.effects`:
 
 ```python
-from rakaia.executors import CollectingExecutor
-from rakaia.replay import replay
+from rakaia import CollectingExecutor
+from rakaia import replay
 
 ex = CollectingExecutor()
 replay(store, "orders", ex)          # zero writes

--- a/docs/event-envelope.md
+++ b/docs/event-envelope.md
@@ -112,7 +112,7 @@ context manager that sets **ambient** envelope metadata: every append inside the
 block merges it in automatically.
 
 ```python
-from rakaia.context import provenance
+from rakaia import provenance
 
 with provenance(user=request.user.pk, url=request.path):
     obj.save()          # any append this triggers is now attributed to the user

--- a/docs/history-read-model.md
+++ b/docs/history-read-model.md
@@ -77,7 +77,7 @@ the row with a `defaults_of(msg, event)` callback, so the audit model can match
 whatever `/history` returns:
 
 ```python
-from django_rakaia.history import materialize_history
+from django_rakaia import materialize_history
 from rakaia import label_marker, envelope_actor
 
 materialize_history(

--- a/docs/index.md
+++ b/docs/index.md
@@ -91,7 +91,7 @@ CHANNEL_LAYERS = {
 # models.py
 from dataclasses import dataclass
 from django.db import models
-from django_rakaia.decorators import stream_model
+from django_rakaia import stream_model
 
 @dataclass
 class RoomData:

--- a/docs/multi-stream-merge.md
+++ b/docs/multi-stream-merge.md
@@ -8,9 +8,9 @@
 ## Using it
 
 ```python
-from rakaia.replay import merge_replay, ENVELOPE_TS
-from django_rakaia.effect_executor import DjangoExecutor
-from django_rakaia.projection_reader import DjangoProjectionReader
+from rakaia import merge_replay, ENVELOPE_TS
+from django_rakaia import DjangoExecutor
+from django_rakaia import DjangoProjectionReader
 
 merge_replay(
     store,

--- a/docs/projection-cookbook.md
+++ b/docs/projection-cookbook.md
@@ -95,9 +95,9 @@ Point `replay()` at the stream with a real executor and reader. It requires
 is a single pass and no reader is needed (backward compatible).
 
 ```python
-from rakaia.replay import replay
-from django_rakaia.effect_executor import DjangoExecutor
-from django_rakaia.projection_reader import DjangoProjectionReader
+from rakaia import replay
+from django_rakaia import DjangoExecutor
+from django_rakaia import DjangoProjectionReader
 
 replay(store, "cookbook", DjangoExecutor(), reader=DjangoProjectionReader())
 ```
@@ -114,7 +114,7 @@ each write effect's `defaults` against the live rows.
 
 ```python
 from rakaia import CollectingExecutor
-from django_rakaia.verification import diff_effects_against_rows
+from django_rakaia import diff_effects_against_rows
 
 ex = CollectingExecutor()
 replay(store, "cookbook", ex, reader=DjangoProjectionReader())
@@ -166,7 +166,7 @@ bulk-fetches every lookup up front, one query per `(model, lookup-shape)` group,
 then serves each `get` from an in-memory snapshot:
 
 ```python
-from django_rakaia.verification import (
+from django_rakaia import (
     PreloadedProjectionReader,
     diff_effects_against_rows,
 )

--- a/docs/public-api.md
+++ b/docs/public-api.md
@@ -1,0 +1,139 @@
+---
+icon: lucide/file-signature
+---
+
+# The public API
+
+What rakaia promises not to break, what it reserves the right to change, and how
+to depend on it.
+
+This exists because the first production consumer accumulated 178 imports and 84
+direct database queries against rakaia, and neither side could say which of those
+were supported. Some were. Some worked only by accident. The library had never
+said which was which — `django_rakaia` exported *nothing*, so every consumer
+import was forced to name an internal module.
+
+## Three tiers
+
+### Tier 1 — Stable
+
+**`rakaia.__all__` and `django_rakaia.__all__`.** Import these from the package
+root:
+
+```python
+from rakaia import replay, Effect, HandlerRegistry, AppendOptions
+from django_rakaia import DjangoExecutor, DjangoProjectionReader, get_store
+```
+
+These names will not be removed or change meaning without a **major** version
+bump and an entry in [`UPGRADING.md`](https://github.com/joshbrooks/rakaia/blob/main/UPGRADING.md).
+
+`django_rakaia`'s names resolve lazily, so importing the package does not pull in
+the ORM — that would raise `AppRegistryNotReady` during Django's own startup, and
+is why the package exported nothing for so long.
+
+!!! warning "Import from the package, not the module it lives in"
+
+    `from rakaia.replay import replay` works and will keep working, but it pins
+    the module **layout** rather than the surface. Splitting a file internally
+    would break you even though `__all__` never changed. Prefer
+    `from rakaia import replay`.
+
+    Older docs and examples used the submodule form for names that are exported;
+    that was our inconsistency, not a second sanctioned spelling.
+
+### Tier 2 — Provisional: the ORM models and the database schema
+
+`django_rakaia.models` — `Stream`, `StreamEvent`, `StreamEntry`,
+`StreamProducer`, `StreamOffsetWatermark`, `ConsumerCursor` — plus the table
+shape behind them.
+
+**These are usable, and deliberately not in `__all__`.** Importing them from
+`django_rakaia.models` keeps the weaker guarantee visible at the import site
+instead of hiding it among the stable names.
+
+What "provisional" means here:
+
+- The models may gain fields in a minor release (they have, repeatedly).
+- The *relationships* between them — that a `StreamEvent` is joined to a `Stream`
+  through a `StreamEntry`, that `StreamEntry.offset` is an orderable integer
+  column, that `StreamEvent.data` is a queryable `JSONField` — are not promised.
+  A future storage change could denormalise them.
+- Every change will appear in `UPGRADING.md` with the migration.
+
+**Why they are available at all.** Because the alternative today is worse. The
+store protocol offers `read(path, offset)` and nothing else: no filter, no limit,
+no "the latest event matching this predicate". A consumer that needs to ask the
+log a question — the canonical case being *"has this already been recorded?"*,
+which a producer must ask of the log rather than the projection — has to read the
+whole stream and filter in Python, which is O(stream) on a write path. Querying
+`StreamEntry` with a JSON predicate is O(index). We are not going to pretend
+that choice is unreasonable while offering no alternative.
+
+If you are on Tier 2, say so in your own code, and expect to read `UPGRADING.md`
+on every bump.
+
+### Tier 3 — Internal
+
+Everything else:
+
+- any name beginning with `_`, in either package;
+- any submodule of `django_rakaia` not listed in `_EXPORTS`;
+- `rakaia`'s submodules as *import paths* — the names they hold may be public,
+  the layout is not;
+- the templates, URLs, views and admin registrations, unless you have registered
+  them yourself.
+
+These change without notice, in any release.
+
+## Versioning
+
+rakaia is **pre-1.0**. Semantic versioning gives a `0.x` release no compatibility
+guarantee at all, so the tiers above are the promise, and the version number is
+how we signal it:
+
+| Bump | Means |
+|---|---|
+| `0.x.Y` → `0.x.Y+1` | Tier 1 unchanged. Bug fixes, new names. |
+| `0.X` → `0.X+1` | Tier 1 may change. Tier 2 may change. Read `UPGRADING.md`. |
+
+### Depend on us with an upper bound
+
+```toml
+# pyproject.toml
+dependencies = ["rakaia-streams>=0.2,<0.3"]
+```
+
+**Not `>=0.2`.** On a pre-1.0 library an unbounded lower bound admits every
+future breaking change, and takes it silently on the next lockfile refresh. This
+is not hypothetical — it is the exact exposure the first consumer is carrying as
+this is written.
+
+Note the distribution is `rakaia-streams`; the import names are `rakaia` and
+`django_rakaia` (plain `rakaia` was already taken on PyPI).
+
+## Contracts inside Tier 1
+
+Being in `__all__` is not the whole promise. Three behavioural contracts are
+documented where they are declared, and are worth naming here because breaking
+them is easy and the failure is quiet:
+
+- **Offsets are opaque.** Pass one back to `read()`; compare offsets *from the
+  same store* lexicographically. Never parse one — no `int(offset)`. The format
+  is store-specific by design ([`protocols.py`](https://github.com/joshbrooks/rakaia/blob/main/src/rakaia/protocols.py)).
+- **Handlers are hermetic.** A handler reads only through the injected reader
+  ([ADR 0003](adr/0003-handler-hermeticity.md)). Bind dependencies with
+  `functools.partial`, not a closure — see the *Handler dependencies* entry in
+  [the glossary](glossary.md).
+- **`store.get()` returns metadata**, not your backend's row. It is a
+  `rakaia.types.Stream` from every store.
+
+## What is *not* a promise
+
+- The wire format of the channel-layer SSE frame.
+- The meta-stream payload shape (`__rakaia__:handlers` and friends). It is
+  versioned by tolerance — old payloads keep loading — but not by contract.
+- The in-memory `StreamStore`'s offset format, or the durable store's. Both are
+  opaque tokens (see above).
+- Anything in `examples/`. Those are demonstrations; copy from them freely, but
+  they are not an interface.

--- a/docs/research/handler-types.md
+++ b/docs/research/handler-types.md
@@ -1,0 +1,503 @@
+# What handler types does a durable-stream event-sourcing library actually need?
+
+**Status:** research notes, 2026-08-15. Not a decision — no ADR is implied by this
+file, and nothing here changes source.
+
+**Where this lives and why.** `docs/` holds prose docs that are listed in
+`zensical.toml`'s explicit `nav`; `docs/adr/` holds decisions; `okf/` holds the
+machine-readable bundle. None of those is right for a research note: this is not
+a decision (so not `adr/`), not a user-facing manual page (so not a `nav` entry),
+and not part of the concept bundle (so not `okf/`). A new `docs/research/`
+directory keeps it inside the docs tree — searchable, versioned with the code it
+argues about — without claiming any of those three roles. It is deliberately
+**not added to `zensical.toml`'s nav**; see the "Docs build" section at the end
+for what that costs.
+
+---
+
+## The question, and why now
+
+rakaia names three extension points:
+
+| Concept | Shape | Registration | Selection |
+|---|---|---|---|
+| **handler** | `event -> Effect` (stage 0) / `event, reader -> Effect` (stage > 0) | `register_handler(name, event_match, effective_from, effective_to, match_field=, stage=)` | seq-bracketed version series; glob on stream path *or* on `event[match_field]` (`src/rakaia/registry.py:268`) |
+| **reducer** | `reader -> Effect` / `reader, touched -> Effect` | `register_reducer(name, stage)` | one current definition per name, last-write-wins, **not** seq-versioned (`src/rakaia/registry.py:161`) |
+| **upcaster** | `event -> event` | `register_upcaster(event_match, from_version, match_field=)` | chained by `from_version` (`src/rakaia/registry.py:595`) |
+
+Its first real production consumer, `partisipa-import`, has grown five app-side
+shapes that rakaia does not name: edge/relation binders, thin attribute folds,
+correction folds, derivation folds, and producers. The question is whether any of
+those is a genuinely distinct **handler type** that deserves first-class support,
+or whether each is a composition of what already exists.
+
+The question is live now because the consumer is at the point of flipping the
+durable log to authoritative, and because ADR 0002 already committed rakaia to
+bringing its *framework-tier extension seams* up to the protocol tier's standard.
+If a sixth registration shape is coming, this is the moment to know.
+
+---
+
+## The headline finding, up front
+
+**Four of the five candidates are the same thing: a content-routed stage-1
+handler.** Not "similar to" — literally the same three-line registration, varying
+only in the value of `event_match`:
+
+```python
+# relations.py            location_correction.py      project_status.py           status.py
+reg.register(             reg.register(               reg.register(               reg.register(
+  name="project_edge_…",    name="location_correc…",    name="project_status_…",    name="status_binding",
+  event_match="project",    event_match="location_…",   event_match="project_st…",  event_match="status_ch…",
+  fn=…, effective_from=0,   fn=…, effective_from=0,     fn=…, effective_from=0,     fn=…, effective_from=0,
+  match_field="relation",   match_field="relation",     match_field="relation",     match_field="relation",
+  stage=1,                  stage=1,                    stage=1,                    stage=1,
+)                         )                           )                           )
+```
+
+(`backend/ida_forms/streams/{relations,location_correction,project_status,status}.py`,
+each in its own `build_registry()`.)
+
+What differs between them is entirely inside the function body — which projection
+they read, which column they write, and what rule decides. That is application
+logic, which is what a handler body is *for*. The variety the consumer perceives
+is domain variety, not mechanism variety.
+
+The one candidate that is **not** a handler at all is the producer, and it is the
+only one where rakaia genuinely has a hole. That hole is narrower than "rakaia
+needs a producer concept", and is discussed under Question 2.
+
+---
+
+## The five candidates
+
+| Candidate | What it does | Distinct? | Covered by | Verdict |
+|---|---|---|---|---|
+| **1. Edge / relation binder** (`relations.py`) | Binds a link between two existing subjects; `LINK`/`UNLINK` lifecycle; must not materialise a node | **No** | Content-routed stage-1 handler + `Effect(op="update")` / `op="delete"`. The "must not materialise a node" rule (their ADR-0005) is *already* rakaia's `op="update"` semantics — "the update-if-exists primitive a secondary owner of a multi-owned projection row uses instead of a hand-rolled exists-guard" (`src/rakaia/effects.py:79`) | **Build nothing.** Their ADR-0008 declined to upstream; still correct — see Q3. Worth telling them `op="update"` replaces their hand-rolled `reader.get(...) is None` guard |
+| **2. Thin attribute fold** (`status.py`) | A `submissions/status` stream carrying identity + form_type + status only, folded over the content stream | **No** | Content-routed stage-1 handler emitting `op="update"`. There is no rakaia-side concept in the *fold* at all — the event is thin because the **producer** made it thin | **Build nothing on the read side.** The real content of this candidate is a write-side decision (see below), and rakaia already ships the primitive for it: `append_if_changed` (`src/rakaia/append.py`) |
+| **3. Correction fold** (`location_correction.py`, their ADR-0016) | A later stream whose events override an earlier stream's projection; precedence by fold order | **No** as a handler; the *precedence mechanism* is the real question | Handler: identical stage-1 shape. Precedence: today an unwritten convention (call order of `replay()` in `rebuild_tf611.py:170-193`). rakaia has two mechanisms that could carry it — `stage=` and `merge_replay(order_key=)` | **Build nothing; name something.** See Q1 |
+| **4. Derivation fold** (`project_status.py`) | Recomputes a value from another aggregate; a user-authored terminal status beats a derived one regardless of arrival order | **No** | Content-routed stage-1 handler. "Discriminated authority" is four lines of `if` in the handler body (`project_status.py`, `_TERMINAL` check before deriving) | **Build nothing.** A library concept for "not last-write-wins" would be a DSL for one `if` statement |
+| **5. Producer** (`produce.py`, `dual_write.py`, `_envelope.py`) | Decides *what to emit*: classify the save, choose the stream, build the envelope, append, then fold | **Yes — genuinely absent** | Partially: `AppendOptions` + `provenance()` (envelope), `append_if_changed` (no-op suppression), `rakaia.producer` (fencing only — epoch/seq, *not* "what to emit") | **Build a little, and name a rule.** Not a `Producer` abstraction — see Q2 |
+
+### Note on the naming collision inside rakaia
+
+`src/rakaia/producer.py` exists and is about **producer fencing**: `(Producer-Id,
+Producer-Epoch, Producer-Seq)` → accept / duplicate / stale epoch / gap. It is a
+protocol-tier concept (ADR 0002 Tier 2), not a framework-tier one, and it says
+nothing about *what* to emit. So "rakaia has no producer concept" is not quite
+right — rakaia has the word, spent on something else. Any framework-tier
+write-side concept must not be called `Producer` without resolving that.
+
+---
+
+## Question 1 — Is "fold order between stream families" first-class, or emergent?
+
+### What is actually there today
+
+Emergent, and *doubly* so. In `rebuild_tf611.py` the whole precedence rule is four
+consecutive statements:
+
+```python
+result   = replay(store, TF611_STREAM,          executor, handler_registry=build_tf611_authoritative_registry(...), reader=reader)
+if store.has(LOCATION_STREAM):
+             replay(store, LOCATION_STREAM,      executor, handler_registry=location_registry(),        reader=reader)
+status_result = replay(store, PROJECT_STATUS_STREAM, executor, handler_registry=project_status_registry(), reader=reader)
+if store.has(STATUS_STREAM):
+             replay(store, STATUS_STREAM,        executor, handler_registry=status_registry(),          reader=reader)
+```
+
+Two separate things are emergent here, and they should not be conflated:
+
+1. **Order between families** is the caller's statement order. Nothing declares it,
+   nothing checks it, and a reordering is a silent correctness change.
+2. **The registries are disjoint.** Each family builds its *own fresh*
+   `HandlerRegistry()`. So `stage=1` in `location_registry()` and `stage=1` in
+   `status_registry()` are unrelated numbers in unrelated registries. Even if
+   someone wanted to express precedence as a stage, today's structure cannot: a
+   stage only orders passes *within one `replay()` call*.
+
+`merge_replay` is used **nowhere** in the consumer (grep: zero hits across the
+worktree). So the multi-stream merge primitive rakaia built is, on this evidence,
+not the thing the consumer reached for; four sequential single-stream replays is.
+
+### Is correction-precedence expressible in `merge_replay`?
+
+**Not by time, no — and this is the decisive point.** `merge_replay` orders by an
+order key: a payload field, or `ENVELOPE_TS` (the envelope's `event_ts`,
+`src/rakaia/replay.py:67`). Their ADR-0016 requires that a `location_corrected`
+event beat the base coordinate **and any later re-import's coordinate**. A later
+re-import has a later `event_ts`. So under `merge_replay(order_key=ENVELOPE_TS)`,
+the re-import wins and the correction is lost — precisely the failure the whole
+ADR exists to prevent, and precisely the alternative ADR-0016 already rejected
+("Same event type, last-write-wins vs the base coord … A later re-import would
+revert the fix").
+
+Correction precedence is therefore **not a temporal fact**. It is a *typed
+authority* fact: this class of event outranks that class, forever, independent of
+when either happened. Ordering by `event_ts` vs append order is the wrong axis to
+argue about — both are time, and time is not what decides this.
+
+`stage=` **is** the right axis: it is rakaia's existing name for "this pass runs
+after that one, regardless of event order". Expressing correction-precedence as
+`stage` would need one composed registry over merged streams, i.e.
+`merge_replay(paths, order_key=ENVELOPE_TS)` with content-routed handlers at
+stages 0/1/2 — base content at the lower stage, corrections at the higher.
+
+That is available today with no new API. It has one real cost, documented in
+`merge_replay`'s own docstring (`src/rakaia/replay.py:506`): merged `seq` is the
+position in the *merged* order, so any handler with a **closed** `effective_to`
+sized to one stream raises `HandlerGapError`. The consumer's folds all use
+`effective_from=0, effective_to=None`, so they would survive — but this is a
+constraint a migration must state, not discover.
+
+### Recommendation
+
+**Name it; do not build it.**
+
+1. Add **fold order** to `docs/glossary.md` as a named concept, defined as: *when
+   several stream families project into one read model, the order in which they
+   are folded is part of the projection's definition, not an implementation
+   detail of the rebuild command.*
+2. Document the two ways rakaia already expresses it, and when each applies:
+   - **`stage=` within one replay (or one `merge_replay`)** — for precedence that
+     is *typed*: correction-beats-base, derived-beats-nothing. Declared in the
+     registration, visible to `stages()`, checkable.
+   - **`merge_replay(order_key=…)`** — for precedence that is *temporal*: several
+     streams that genuinely interleave and where "later wins" is the rule.
+   State plainly that correction-precedence is the first kind and **must not** be
+   modelled as the second.
+3. Do **not** add a cross-replay ordering API. A list of `(stream, registry)` run
+   in order is a `for` loop; wrapping it buys a name and nothing else, and the
+   composed-registry route gives the same name for free with real checking behind
+   it.
+
+**Prior art supports this.** Axon draws the line in exactly the same place: within
+one processor, "the order in which components are registered … is guiding" and can
+be made explicit with `@Order`; but "it is **not possible** to order event handlers
+belonging to different Event Processors" — and the docs warn that ordering at all
+"means those components are inclined to interact with one another, introducing a
+form of coupling". rakaia's `stage` is the intra-replay `@Order`; the four
+sequential `replay()` calls are four processors with no ordering contract, which
+is the arrangement Axon says has none to offer.
+
+---
+
+## Question 2 — Does a producer belong in the library at all?
+
+### The asymmetry argument, examined
+
+The claim is: rakaia has the read-side hermeticity rule (ADR 0003 →
+`django_rakaia.hermeticity.deny_database_access`) but no write-side twin, and the
+consumer had to invent one (their ADR-0021, "a producer must not consult the
+projection to decide whether to emit — ask the log").
+
+The asymmetry is real but it does **not** argue for a producer *abstraction*. Look
+at what the read-side twin actually is: `deny_database_access` is not an
+abstraction over handlers — it is an **enforcement seam**. It works because the
+rule it enforces is mechanically decidable: "no statement may reach the `default`
+alias during handler dispatch". A Django `execute_wrapper` can see every such
+statement.
+
+ADR-0021's rule is **not** mechanically decidable, and their own ADR says so:
+
+> "Reading the projection for the *payload* of an event remains fine and
+> unavoidable (the producer must read the rows it is describing). The rule is
+> about **control flow**: what decides whether an event exists at all."
+
+A query wrapper cannot distinguish a read that shaped a payload from a read that
+decided an emission. So the read-side pattern — *ship the guard, not the
+abstraction* — does not transfer. There is no guard to ship.
+
+### Be skeptical: ADR-0021 is ahead of its code
+
+The lead flagged this and it checks out.
+
+- `ranked_priority_ids` and `RANK_STREAM` **do not exist** on this branch. Grep
+  finds them only inside ADR-0021's own text; `streams/sf23.py` has neither, and
+  its docstring still says `PriorityOrder.order` "is maintained by a pgtrigger
+  group-rank … not by the handler, so it is a derived column excluded from
+  projection parity". The ADR names its own status honestly ("validated on
+  `spike/priority-fractional-rank` @ `4e7b7983`"), but the flagship
+  implementation is on a different branch.
+- The live edge producer **does** consult the projection to decide whether to
+  emit. `produce.bind_project_edge` reads `SeparatedSubmissionProject.objects
+  .filter(...).exists()` and the typed row's resolved `project` FK, and skips the
+  append on that basis. It is a *hybrid* — `_latest_project_edge` asks the log
+  first, and the SSP query is described in the code as "a fast negative" — but the
+  ORM read is still in the emit/skip control flow, which is what ADR-0021
+  forbids. Its own comment concedes the shape: "the SSP row is a fast negative
+  (already linked, incl. by a prior produce of this same resolver)".
+- `location_correction.py`'s producer side does not exist at all: "The producer
+  side (append on the admin/GIS edit) … [is] the follow-on (Phase 3)".
+
+So: **one recorded decision, zero conforming producers on this branch, and one
+producer that violates it.** That is not evidence of a validated pattern. It is
+evidence of a rule someone learned the hard way once, in a spike, and wrote down.
+Upstreaming a producer abstraction on that basis would be abstracting from a
+single unshipped data point.
+
+### What *is* worth taking
+
+Two concrete things, both small, both already asking to be upstreamed by name:
+
+1. **The append envelope + scratch-fold ritual.** `streams/_envelope.py` is 79
+   lines wrapping `append_event(store, path, payload, label=, actor=, event_ts=)`
+   and `fold_events(events, registry, reader=)`. Its docstring is explicit that
+   its location is a dependency-management accident, not a design choice:
+
+   > "These helpers live app-side deliberately: `rakaia`/`django_rakaia` are an
+   > external dependency, so upstreaming is a later version bump, not a blocker
+   > (ADR-0020, alternatives)."
+
+   And its stated motivation is exactly the drift a library exists to prevent:
+   "~37 appends across 18 files, 11 scratch rituals" hand-rolled, with the warning
+   "a second write path which re-implements the envelope is a path no gate
+   covers." That is a library-shaped problem. `fold_events` in particular — seed a
+   scratch `StreamStore`, replay one subject's events through a registry with a
+   live reader — is *the* live-projection primitive, and it is currently
+   reimplemented per adopter.
+
+2. **`append_if_changed` needs to be findable.** rakaia already ships no-op
+   suppression (`src/rakaia/append.py`), the glossary already names it, and the
+   consumer's candidate #2 — the thin-attribute-fold, motivated by "62% of
+   re-saves re-carry the blob for nothing" — is a bespoke reimplementation of the
+   same idea (`fields_fingerprint` + a `_PRIOR_STATE` pre-save stash + a
+   three-way save classification in `dual_write.py`). Grep confirms the consumer
+   never imports `append_if_changed`. Their version does more (it *routes* to a
+   different stream rather than just suppressing), so this is not "they missed
+   it" — but a library whose flagship consumer independently rebuilds its
+   write-side change-detection has a discoverability problem, and possibly a
+   generality one: `append_if_changed` returns `bool` (append or not), where the
+   consumer needed a three-way classification (content / status-only / no change).
+
+### Recommendation
+
+- **Yes, narrowly — and it is already done.** ~~Upstream~~ the envelope +
+  scratch-fold helpers (`append_event` / `fold_events`) shipped in
+  `src/django_rakaia/envelope.py` in PR #94 (2026-08-14), pinned byte-for-byte
+  against the longhand they replace. **Correction to this section's premise:** the
+  consumer still carries `streams/_envelope.py` only because it is pinned to PyPI
+  `rakaia-streams 0.1.0`, which predates the upstream. Deleting their copy needs a
+  release, not a design decision. `SCRATCH_PATH` was also renamed
+  `"produce/submission"` → `"_scratch/fold"` (#100) precisely because the
+  consumer's domain vocabulary had no business being the library default.
+- **Write the ADR-0021 rule into rakaia's docs** as a stated contract next to
+  ADR 0003, on the strength of the reasoning (which is sound) rather than the
+  evidence (which is one branch-local spike). Say plainly it is not enforceable.
+- **No `Producer` type, no producer registry, no emit-decision framework.** The
+  read/write asymmetry is real, but it argues for a *documented rule*, not a
+  mechanism: the read side got a mechanism only because a mechanism was possible
+  there.
+- **Do not name any of it `Producer`** — `rakaia.producer` is taken by fencing.
+
+---
+
+## Question 3 — Is an edge/relation binder just a stage-1 handler?
+
+**Yes, and their ADR-0008 is still right.** Three reasons, in increasing order of
+weight:
+
+1. **Still one adopter.** ADR-0008's own extraction trigger — "if a second adopter
+   needs edges, *then* consider extracting a rakaia helper … with two real call
+   sites to design against" — has not fired. Nothing has changed on that axis.
+2. **The pattern got *smaller*, not larger, since the ADR.** ADR-0008 was written
+   when edges looked like a subsystem: "the edge model (`relations.py`, the
+   binder, the commands)". What is actually load-bearing today is one handler
+   registration and a ~40-line function body. There is less to extract now than
+   when they declined to extract it.
+3. **The one genuinely general bit is already in rakaia, and they are not using
+   it.** ADR-0005 ("an edge annotates an existing node — never materialises one")
+   is implemented as a hand-rolled guard:
+
+   ```python
+   if reader.get(label, submission_id=source) is None:
+       return []
+   ```
+
+   followed by `Effect(op="update_or_create", …)`. That is exactly what
+   `Effect(op="update", …)` does natively — rows matching `lookup` are "updated in
+   place and **never** inserted" (`src/rakaia/effects.py:79`), and rakaia's own
+   docstring pitches it as the alternative to "a hand-rolled exists-guard". Their
+   other three folds already use `op="update"`; `relations.py` is the one that
+   didn't, because it also needs the existence answer to decide about the
+   `SeparatedSubmissionProject` row.
+
+**Recommendation:** decline again, and close the loop by telling them about
+`op="update"`. If a second adopter ever appears, the thing to extract is not "an
+edge primitive" — it is a documented *recipe* in `docs/projection-cookbook.md`:
+edge event shape (`{relation, source, target, action}`), content-routing on
+`relation`, stage 1 for the reader, `op="update"` so a missing node is a no-op,
+`op="delete"` for `UNLINK`, and last-write-wins by append order. Recipes cost
+nothing to be wrong about.
+
+Note also that `relations.py`'s own docstring still says **"Spike status
+(read-only). … Nothing durable / on the live path here"**, even though
+`produce.bind_project_edge` now appends to `RELATIONS_STREAM` and folds through
+`relations.build_registry()` on the live save path. The docstring is stale. That is
+a small thing, but it is the same class of problem as ADR-0021: the written record
+and the code disagree, in both directions, and neither can be trusted alone.
+
+---
+
+## Prior art — what other frameworks call these things
+
+Sources are official docs only; each row is what that project's own documentation
+says, not a community summary.
+
+| | per-event projector | cross-aggregate / multi-stream projector | schema-upgrade step | write-side component |
+|---|---|---|---|---|
+| **rakaia** | **handler** (`event -> Effect`) | **reducer** (per-stage, `reader -> Effect`); **`merge_replay`** (k-way merge by order key) | **upcaster** (`from_version` chain) | — (framework tier); `rakaia.producer` = protocol-tier **fencing** only |
+| **EventStoreDB / KurrentDB** | **projection** — but it means something else entirely (below) | `fromAll()` / `fromStreams([])` + `partitionBy` inside a user-defined projection | — (no equivalent; events are immutable JSON, versioning is the client's problem) | `emit()` / `linkTo()` **inside** a projection |
+| **Axon Framework** | **event handler** ("a method that is capable of handling an `EventMessage`"), grouped into an **event handling component**, assigned to an **event processor** (subscribing / streaming / pooled streaming) | **saga** (long-running, cross-aggregate process); handler ordering via `@Order` **within** one processor only | **upcaster** — `EventUpcaster`, `SingleEventUpcaster`, `EventUpcasterChain`; "transforms events from their original stored structure to a new structure" | command handler + aggregate |
+| **Marten** | **single-stream projection** / **aggregation** (`Apply`, `Create`); **event projection** (`Project`, `Create`) for ad-hoc document ops | **multi-stream projection** — "a view is aggregated over events between streams", with `Identity<T>` / `Identities<T>` / a custom `IAggregateGrouper` / a custom `IEventSlicer` | **upcasting** — "transforming the old JSON schema into the new one … performed on the fly each time the event is read"; `EventUpcaster<T>`, `MapEventType()` | append (`Quick` / `Rich` append modes) |
+| **Eventide** | **entity projection** — "applies one event to one entity"; `apply` blocks per event type | — (no named multi-stream projector; consumers/handlers compose) | — | **handler**, run by a **consumer** in a **component** |
+| **Akka** | **Projection** — "you process a stream of events or records from a source to a projected model or external system"; **Handler**; **SourceProvider**; **offset store** | (same Projection machinery over a tagged/sliced source) | **event adapter** — `WriteEventAdapter` / `ReadEventAdapter`, for schema evolution between journal and domain representation | persist / event handler in an `EventSourcedBehavior` |
+
+### Where rakaia's names agree, and where they clash
+
+**Agree, safely:**
+
+- **upcaster** is the near-universal term for the schema-upgrade step (Axon,
+  Marten). Akka calls it an *event adapter*; the concept is the same. rakaia's
+  `from_version` chain matches Axon's `EventUpcasterChain` closely. **No change
+  needed and none available — this is the settled word.**
+- **handler** as "the per-event function" matches Axon and Eventide directly.
+- **projection** as "a derived read model" matches Marten, Akka, and Eventide.
+
+**Clash, and worth knowing about:**
+
+- **"projection" means the opposite thing in EventStoreDB/KurrentDB.** There, a
+  projection is a *server-side, event-producing* subsystem: it "let[s] you append
+  new events or link existing events to streams", via `emit()` and `linkTo()`, and
+  its documented cost is "write amplification because emitting new events or link
+  events creates additional load on the server IO". Read models there are built by
+  *subscriptions*, not projections. Anyone arriving at rakaia from EventStoreDB
+  will read "projection" backwards. This is not a reason to rename — Marten, Akka
+  and Eventide are all on rakaia's side — but the glossary entry could say so in
+  one clause.
+- **"reducer" is rakaia's own coinage.** Nobody else uses it for this. The closest
+  named equivalents are Marten's **multi-stream projection** (a view aggregated
+  across streams) and Akka's **grouped handler**. rakaia's reducer is genuinely a
+  bit different from both — it runs once per stage over *committed projections
+  via the reader*, not over a slice of events — so a rename would trade a unique
+  word for an inexact one. **Keep it**, but note in the glossary that Marten users
+  will look for "multi-stream projection" and Axon users for "saga".
+- **rakaia has no word for the write side, and the obvious word is taken.** Every
+  other framework names this: Axon *command handler*, Eventide *handler +
+  consumer*, Marten *append modes*, EventStoreDB *emit*. rakaia's `producer` means
+  fencing. If a framework-tier write-side concept ever lands, the vocabulary
+  question has to be settled first.
+- **Nobody names "fold order between families".** Axon comes closest and its
+  answer is a *prohibition* ("not possible to order event handlers belonging to
+  different Event Processors") plus a warning that ordering is coupling. This is
+  weak support for making it a first-class rakaia concept — and good support for
+  the Q1 recommendation of expressing it as a stage inside one replay, which is
+  the arrangement Axon *does* support.
+
+---
+
+## What NOT to build
+
+Each of these was considered and rejected. The reason matters more than the
+verdict, because a future adopter will propose them again.
+
+1. **An edge / graph primitive** (`register_edge`, an edge event type, an edge
+   reducer). One adopter; the pattern is one `register(..., match_field="relation",
+   stage=1)` call; the only generalisable part (`op="update"` as "annotate, never
+   materialise") already exists and the adopter isn't using it. Their ADR-0008 got
+   this right in 2026-07 and nothing has changed since.
+
+2. **A correction-fold primitive** (`register_correction`, `overrides=`). A
+   correction fold is a stage-1 handler. What is special about corrections is the
+   *precedence*, and precedence is already spelled `stage=`. A dedicated
+   registration kwarg would be a second, weaker spelling of an existing concept.
+
+3. **A "discriminated authority" mechanism** (declarative precedence, a
+   non-last-write-wins registration flag). The consumer's implementation is:
+
+   ```python
+   if current is not None and current.value in _TERMINAL:
+       return []
+   ```
+
+   Four lines in a handler body, reading a projection through the reader. A
+   library concept for this would be a configuration language for `if`. The rule
+   is *domain* knowledge (which status values are user-authored terminals), and
+   domain knowledge in a general library is exactly what ADR-0008 warns against.
+
+4. **A "thin event" / attribute-fold concept.** There is nothing thin about the
+   *fold* — it is a normal handler over a normal event. Thinness is a property of
+   what the producer chose to emit. Building a read-side concept for it would name
+   the wrong end of the pipe.
+
+5. **A `Producer` class / producer registry / emit-decision framework.** See Q2:
+   the rule that motivates it (ADR-0021) is not mechanically enforceable by its
+   authors' own account, has zero conforming implementations on the branch under
+   review, and is contradicted by the one live producer that faces the same
+   decision. Abstracting now would canonise an unvalidated pattern — and the name
+   is already spent on fencing.
+
+6. **A cross-replay fold-ordering API** (`replay_families([...])`,
+   `run_in_order([...])`). It is a `for` loop over `(stream, registry)` pairs. The
+   version with real value — one composed registry where family precedence *is*
+   the stage — needs no new API at all, only `merge_replay` and a doc page.
+
+7. **A rakaia-side "one fact, one derivation" conflict check.** Tempting: their
+   ADR-0018 found the same column computed by a stage-1 fold and a stage-2 reducer
+   under *different rules*, live, in two different gates. A registry that knew both
+   writers targeted `Tf_6_1_1.project_status` could in principle warn. Rejected for
+   now — a handler's target column is only knowable from its returned `Effect`s,
+   i.e. at replay time, not registration time, so the check would be a runtime
+   warning on a legitimate pattern (multi-owner projections are explicitly
+   supported; `op="update"` exists to serve them). Listed below as an open
+   question rather than a rejection, because the failure it would have caught was
+   real and expensive.
+
+---
+
+## Open questions / what would change the answer
+
+- **A second adopter of edges.** This is ADR-0008's own stated trigger and the
+  single cleanest thing that would flip candidate #1. Two real call sites would
+  make the shape designable; one still makes it guesswork.
+
+- **Does the composed-registry route actually work at their scale?** The Q1
+  recommendation (one registry, families as stages, `merge_replay(ENVELOPE_TS)`)
+  is sound on paper and **untested by anyone** — `merge_replay` has zero call
+  sites in the consumer. A prototype rebuild of TF611 + corrections + status +
+  derivations as one merged, staged replay is the experiment. If it fails on
+  `HandlerGapError`, memory, or the `seq`-semantics change, the answer to Q1
+  becomes "the sequential-replay convention is the design, so document *that*
+  instead".
+
+- **Do multi-owner projections need a declared owner-per-column?** ADR-0018's
+  defect (two live derivations of one fact, disagreeing at the edges, each wired
+  into a different gate) is the most expensive bug in the consumer's whole ADR
+  record, and it is a *composition* failure, not a handler-type failure. If a
+  second consumer hits the same class, "who owns this column" may deserve to be
+  declarable. That would be a new kind of registration metadata, not a new handler
+  type.
+
+- **Is `append_if_changed` general enough?** The consumer needed a three-way
+  classification (content-changed / status-only / no-change) and got a `bool`.
+  Whether the primitive should return a verdict rather than a boolean is worth
+  asking before a second consumer rebuilds it a second time.
+
+- **Does ADR-0021 survive contact with its own codebase?** The rule has one
+  spike-branch implementation and one live counter-example. When
+  `spike/priority-fractional-rank` lands (or doesn't), and when
+  `bind_project_edge` is either reconciled with the rule or explicitly excepted
+  from it, there will be real evidence. Revisit Q2 then, not before. A recorded
+  decision is not evidence of a working pattern.
+
+---
+
+## Docs build
+
+`uv run zensical build` with this file present: **`No issues found`, build clean.**
+An un-navigated page under `docs/` neither breaks nor warns — zensical uses an
+explicit `nav`, so a file absent from it is simply not published. This file is
+**not** added to
+`zensical.toml`'s `nav`, deliberately — research notes are not part of the
+published manual, and adding one would set a precedent for the nav that a future
+`docs/research/` directory of ten files would not survive.

--- a/docs/staged-replay.md
+++ b/docs/staged-replay.md
@@ -12,10 +12,10 @@ Declare a handler's stage; replay runs stages in ascending order, and a stage > 
 handler is called `fn(event, reader)` with a read-only projection reader:
 
 ```python
-from rakaia.registry import register_handler
-from rakaia.replay import replay
-from django_rakaia.effect_executor import DjangoExecutor
-from django_rakaia.projection_reader import DjangoProjectionReader
+from rakaia import register_handler
+from rakaia import replay
+from django_rakaia import DjangoExecutor
+from django_rakaia import DjangoProjectionReader
 
 @register_handler(name="project", event_match="TF_6_1_1",
                   match_field="form_type", stage=0)
@@ -50,7 +50,7 @@ projections and returning idempotent Effects (typically via
 [`reconcile_aggregate`](projections-and-fan-out.md)):
 
 ```python
-from rakaia.registry import register_reducer
+from rakaia import register_reducer
 from rakaia import reconcile_aggregate
 
 @register_reducer(name="balance", stage=1)

--- a/docs/subscriber-cursors.md
+++ b/docs/subscriber-cursors.md
@@ -76,8 +76,8 @@ cursor.
 (`(consumer_id, stream_path) → offset`) so a consumer survives restarts:
 
 ```python
-from django_rakaia.django_store import DjangoStreamStore
-from django_rakaia.subscription import poll_consumer, commit_cursor
+from django_rakaia import DjangoStreamStore
+from django_rakaia import poll_consumer, commit_cursor
 
 store = DjangoStreamStore()
 result = poll_consumer(store, consumer_id="reporting", stream_path="submissions")

--- a/docs/versioned-handlers.md
+++ b/docs/versioned-handlers.md
@@ -87,8 +87,8 @@ Two real changes from Partisipa's recent history are easy to express:
 Django autodiscovery picks up this module on app `ready()`.
 
 ```python
-from rakaia.effects import Effect
-from rakaia.registry import register_handler, register_upcaster
+from rakaia import Effect
+from rakaia import register_handler, register_upcaster
 
 
 # ---------------------------------------------------------------------------
@@ -180,7 +180,7 @@ upcasters will normalise on read.
 
 ```python
 import json
-from rakaia.store import StreamStore   # or your durable store of choice
+from rakaia import StreamStore   # or your durable store of choice
 
 store: StreamStore = ...               # singleton
 

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -259,7 +259,7 @@ payload — a change **label** (create/update/delete → `+`/`~`/`-`) and an ope
 shipped middleware opens the block for you.
 
 ```python
-from rakaia.context import provenance
+from rakaia import provenance
 
 with provenance(user=request.user.pk, url=request.path):
     obj.save()          # every append inside is attributed to this user
@@ -390,7 +390,7 @@ drifted produced events that replay differently from their neighbours, with
 nothing looking at the difference. `append_event` is those four lines:
 
 ```python
-from django_rakaia.envelope import append_event
+from django_rakaia import append_event
 
 append_event(store, "submissions", payload, label="create", actor=user_id)
 ```

--- a/examples/chat/chat/models.py
+++ b/examples/chat/chat/models.py
@@ -16,7 +16,7 @@ from dataclasses import dataclass
 from django.contrib.auth import get_user_model
 from django.db import models
 
-from django_rakaia.decorators import stream_model
+from django_rakaia import stream_model
 
 User = get_user_model()
 

--- a/examples/formkit_submissions/submission_stream/stream.py
+++ b/examples/formkit_submissions/submission_stream/stream.py
@@ -25,9 +25,8 @@ from typing import Any
 
 from django.db import transaction
 
-from django_rakaia.django_store import DjangoStreamStore
-from django_rakaia.effect_executor import DjangoExecutor
-from django_rakaia.history import materialize_history as _materialize_history
+from django_rakaia import DjangoExecutor, DjangoStreamStore
+from django_rakaia import materialize_history as _materialize_history
 from rakaia import (
     AppendOptions,
     envelope_actor,

--- a/examples/formkit_submissions/submissions/handlers.py
+++ b/examples/formkit_submissions/submissions/handlers.py
@@ -27,9 +27,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from rakaia import reconcile_children
-from rakaia.effects import Effect
-from rakaia.registry import register_handler
+from rakaia import Effect, reconcile_children, register_handler
 
 from . import mapping
 from .seed import POLICY_CHANGE_SEQ

--- a/examples/formkit_submissions/submissions/management/commands/demo_submissions.py
+++ b/examples/formkit_submissions/submissions/management/commands/demo_submissions.py
@@ -28,17 +28,15 @@ from typing import Any
 from django.core.management import call_command
 from django.core.management.base import BaseCommand, CommandError, CommandParser
 
-from django_rakaia.effect_executor import DjangoExecutor
-from django_rakaia.envelope import append_event
-from django_rakaia.store import get_store
+from django_rakaia import DjangoExecutor, append_event, get_store
 from rakaia import (
     CollectingExecutor,
     envelope_actor,
     history_effects,
     label_marker,
+    replay,
     upcast,
 )
-from rakaia.replay import replay
 from submissions import reference
 from submissions.models import ActivityProgress, MonitoringVisit, SubmissionHistory
 from submissions.seed import POLICY_CHANGE_SEQ, SAMPLE_SUBMISSIONS

--- a/examples/formkit_submissions/submissions/upcasters.py
+++ b/examples/formkit_submissions/submissions/upcasters.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from rakaia.registry import register_upcaster
+from rakaia import register_upcaster
 
 
 def _rename_pct(activity: dict[str, Any]) -> dict[str, Any]:

--- a/examples/orders/orders/handlers.py
+++ b/examples/orders/orders/handlers.py
@@ -29,8 +29,7 @@ Handlers are pure: they take an (already upcasted) event dict and return an
 
 from decimal import Decimal
 
-from rakaia.effects import Effect
-from rakaia.registry import register_handler
+from rakaia import Effect, register_handler
 
 from .seed import TAX_CHANGE_SEQ
 

--- a/examples/orders/orders/live.py
+++ b/examples/orders/orders/live.py
@@ -31,9 +31,8 @@ from collections import deque
 from queue import Empty, Queue
 from typing import Any
 
-from django_rakaia.effect_executor import DjangoExecutor
-from django_rakaia.store import get_store
-from rakaia.replay import replay
+from django_rakaia import DjangoExecutor, get_store
+from rakaia import replay
 
 STREAM = "orders"
 

--- a/examples/orders/orders/management/commands/demo_orders.py
+++ b/examples/orders/orders/management/commands/demo_orders.py
@@ -20,12 +20,10 @@ from typing import Any
 from django.core.management import call_command
 from django.core.management.base import BaseCommand, CommandError, CommandParser
 
-from django_rakaia.effect_executor import DjangoExecutor
-from django_rakaia.store import get_store
+from django_rakaia import DjangoExecutor, get_store
 from orders.models import OrderSummary
 from orders.seed import SAMPLE_BONUSES, SAMPLE_ORDERS, TAX_CHANGE_SEQ
-from rakaia import CollectingExecutor
-from rakaia.replay import replay
+from rakaia import CollectingExecutor, replay
 
 STREAM = "orders"
 

--- a/examples/orders/orders/templates/orders/info.html
+++ b/examples/orders/orders/templates/orders/info.html
@@ -214,7 +214,7 @@ def _update(eff):
     </p>
     {% verbatim %}
     <pre><code>from rakaia.replay import replay
-from django_rakaia.effect_executor import DjangoExecutor
+from django_rakaia import DjangoExecutor
 
 replay(store=store, stream_path="orders", executor=DjangoExecutor())
 # start_seq=N replays only the tail — that's what the live producer does each tick.

--- a/examples/orders/orders/upcasters.py
+++ b/examples/orders/orders/upcasters.py
@@ -5,7 +5,7 @@ Autodiscovered by django_rakaia on app ready(): importing this module runs the
 UpcasterRegistry.
 """
 
-from rakaia.registry import register_upcaster
+from rakaia import register_upcaster
 
 
 def _rename_qty(item: dict) -> dict:

--- a/examples/partisipa_close/lifecycle/handlers.py
+++ b/examples/partisipa_close/lifecycle/handlers.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 from decimal import Decimal
 from typing import Any
 
-from rakaia.effects import Effect
+from rakaia import Effect
 
 PROJECT = "lifecycle.Project"
 MEETING = "lifecycle.Meeting"

--- a/examples/partisipa_close/lifecycle/management/commands/demo_close.py
+++ b/examples/partisipa_close/lifecycle/management/commands/demo_close.py
@@ -30,7 +30,7 @@ from typing import Any
 from django.core.management import call_command
 from django.core.management.base import BaseCommand, CommandError
 
-from django_rakaia.store import get_store
+from django_rakaia import get_store
 from lifecycle import staged_replay as sr
 from lifecycle.handlers import STAGES
 from lifecycle.models import (

--- a/examples/partisipa_close/lifecycle/staged_replay.py
+++ b/examples/partisipa_close/lifecycle/staged_replay.py
@@ -20,7 +20,7 @@ from typing import Any
 
 from django.apps import apps
 
-from django_rakaia.effect_executor import DjangoExecutor
+from django_rakaia import DjangoExecutor
 from rakaia import upcast
 
 

--- a/examples/partisipa_history/history/management/commands/demo_history.py
+++ b/examples/partisipa_history/history/management/commands/demo_history.py
@@ -28,7 +28,7 @@ from typing import Any
 from django.core.management import call_command
 from django.core.management.base import BaseCommand, CommandError
 
-from django_rakaia.store import get_store
+from django_rakaia import get_store
 from history import pghistory_today, stream_history
 from history.envelope import PGH_TO_LABEL, canonical
 from history.models import (

--- a/examples/partisipa_history/history/stream_history.py
+++ b/examples/partisipa_history/history/stream_history.py
@@ -26,8 +26,8 @@ from __future__ import annotations
 import json
 from typing import Any
 
-from django_rakaia.effect_executor import DjangoExecutor
-from rakaia.effects import Effect
+from django_rakaia import DjangoExecutor
+from rakaia import Effect
 
 from .envelope import OP_TO_LABEL, canonical, make_event
 from .models import SubmissionHistoryEntry

--- a/examples/partisipa_merge/subproject/handlers.py
+++ b/examples/partisipa_merge/subproject/handlers.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 from decimal import Decimal
 from typing import Any
 
-from rakaia.effects import Effect
+from rakaia import Effect
 
 PROJECT = "subproject.Project"
 MEETING = "subproject.Meeting"

--- a/examples/partisipa_merge/subproject/management/commands/demo_merge.py
+++ b/examples/partisipa_merge/subproject/management/commands/demo_merge.py
@@ -27,7 +27,7 @@ from typing import Any
 from django.core.management import call_command
 from django.core.management.base import BaseCommand, CommandError
 
-from django_rakaia.store import get_store
+from django_rakaia import get_store
 from subproject import merge_replay as mr
 from subproject.handlers import STAGES
 from subproject.models import (

--- a/examples/partisipa_merge/subproject/merge_replay.py
+++ b/examples/partisipa_merge/subproject/merge_replay.py
@@ -24,7 +24,7 @@ from typing import Any
 
 from django.apps import apps
 
-from django_rakaia.effect_executor import DjangoExecutor
+from django_rakaia import DjangoExecutor
 from rakaia import upcast
 
 

--- a/examples/partisipa_repeaters/repeaters/management/commands/demo_repeaters.py
+++ b/examples/partisipa_repeaters/repeaters/management/commands/demo_repeaters.py
@@ -25,7 +25,7 @@ from typing import Any
 from django.core.management import call_command
 from django.core.management.base import BaseCommand, CommandError
 
-from django_rakaia.store import get_store
+from django_rakaia import get_store
 from repeaters import tree_replay as tr
 from repeaters.models import Node, Total
 from repeaters.seed import (

--- a/examples/partisipa_repeaters/repeaters/tree_replay.py
+++ b/examples/partisipa_repeaters/repeaters/tree_replay.py
@@ -24,8 +24,8 @@ from __future__ import annotations
 import json
 from typing import Any
 
-from django_rakaia.effect_executor import DjangoExecutor
-from rakaia.effects import Effect
+from django_rakaia import DjangoExecutor
+from rakaia import Effect
 
 NODE = "repeaters.Node"
 TOTAL = "repeaters.Total"

--- a/examples/partisipa_staged/partisipa/handlers.py
+++ b/examples/partisipa_staged/partisipa/handlers.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from rakaia.effects import Effect
+from rakaia import Effect
 
 PROJECT_MODEL = "partisipa.Project"
 SF12_MODEL = "partisipa.Sf12"

--- a/examples/partisipa_staged/partisipa/management/commands/demo_staged.py
+++ b/examples/partisipa_staged/partisipa/management/commands/demo_staged.py
@@ -24,7 +24,7 @@ from typing import Any
 from django.core.management import call_command
 from django.core.management.base import BaseCommand, CommandError
 
-from django_rakaia.store import get_store
+from django_rakaia import get_store
 from partisipa import staged_replay as sr
 from partisipa.handlers import ALL_ONE_STAGE, STAGED
 from partisipa.models import Project, Sf12

--- a/examples/partisipa_staged/partisipa/staged_replay.py
+++ b/examples/partisipa_staged/partisipa/staged_replay.py
@@ -28,7 +28,7 @@ from typing import Any
 
 from django.apps import apps
 
-from django_rakaia.effect_executor import DjangoExecutor
+from django_rakaia import DjangoExecutor
 from rakaia import upcast
 
 Handler = Callable[[dict[str, Any], "Refs"], Any]

--- a/examples/polyglot/polyglot/signals.py
+++ b/examples/polyglot/polyglot/signals.py
@@ -19,7 +19,7 @@ from django.db import models
 from django.db.models.signals import post_delete, post_save
 from django.dispatch import receiver
 
-from django_rakaia.decorators import create_stream_event
+from django_rakaia import create_stream_event
 from polyglot.models import Translatable
 
 

--- a/examples/projection_cookbook/cookbook/management/commands/demo_cookbook.py
+++ b/examples/projection_cookbook/cookbook/management/commands/demo_cookbook.py
@@ -19,17 +19,16 @@ from django.core.management.base import BaseCommand, CommandError
 
 from cookbook.models import Project, Task
 from cookbook.seed import SAMPLE_EVENTS
-from django_rakaia.effect_executor import DjangoExecutor
-from django_rakaia.hermeticity import assert_no_live_writes
-from django_rakaia.projection_reader import DjangoProjectionReader
-from django_rakaia.store import get_store
-from django_rakaia.verification import (
+from django_rakaia import (
     VACUOUS,
+    DjangoExecutor,
+    DjangoProjectionReader,
     VacuousVerification,
+    assert_no_live_writes,
     diff_effects_against_rows,
+    get_store,
 )
-from rakaia import CollectingExecutor
-from rakaia.replay import replay
+from rakaia import CollectingExecutor, replay
 
 STREAM = "cookbook"
 

--- a/src/django_rakaia/__init__.py
+++ b/src/django_rakaia/__init__.py
@@ -37,8 +37,89 @@ Public API:
       imported here because it pulls in the ORM before apps are ready)
 """
 
-# We intentionally do not eager import models here
-# to avoid AppRegistryNotReady errors during Django's initialization.
-# Models should be imported directly from django_rakaia.models after Django is setup.
-
 default_app_config = "django_rakaia.apps.DjangoRakaiaConfig"
+
+# =============================================================================
+# Public API
+# =============================================================================
+#
+# Resolved lazily (PEP 562). Eager imports here would pull the ORM in at package
+# import time and raise `AppRegistryNotReady` during Django's own startup, which
+# is why this package exported nothing at all for so long — and why every
+# consumer import was forced to name a submodule, pinning the module *layout*
+# rather than the surface.
+#
+# Lazy resolution gets both: `from django_rakaia import DjangoExecutor` works,
+# and nothing is imported until the name is actually touched. Importing the
+# package stays free.
+#
+# See `docs/public-api.md` for what these guarantees mean and what they exclude.
+
+#: name -> the module that defines it.
+_EXPORTS: dict[str, str] = {
+    # -- emitting events ----------------------------------------------------
+    "stream_model": "django_rakaia.decorators",
+    "create_stream_event": "django_rakaia.decorators",
+    "append_event": "django_rakaia.envelope",
+    "fold_events": "django_rakaia.envelope",
+    "SCRATCH_PATH": "django_rakaia.envelope",
+    # -- stores -------------------------------------------------------------
+    "get_store": "django_rakaia.store",
+    "DjangoStreamStore": "django_rakaia.django_store",
+    # -- replaying ----------------------------------------------------------
+    "DjangoExecutor": "django_rakaia.effect_executor",
+    "DjangoProjectionReader": "django_rakaia.projection_reader",
+    "replay_stream": "django_rakaia.replay",
+    # -- verifying a rebuild -------------------------------------------------
+    "diff_effects_against_rows": "django_rakaia.verification",
+    "PreloadedProjectionReader": "django_rakaia.verification",
+    "DiffReport": "django_rakaia.verification",
+    "RowDiff": "django_rakaia.verification",
+    "FieldDiff": "django_rakaia.verification",
+    "VerificationError": "django_rakaia.verification",
+    "VacuousVerification": "django_rakaia.verification",
+    "canonical_value": "django_rakaia.verification",
+    "DEFAULT_NORMALIZERS": "django_rakaia.verification",
+    "GREEN": "django_rakaia.verification",
+    "RED": "django_rakaia.verification",
+    "VACUOUS": "django_rakaia.verification",
+    # -- rebuild isolation ---------------------------------------------------
+    "deny_database_access": "django_rakaia.hermeticity",
+    "assert_no_live_writes": "django_rakaia.hermeticity",
+    "AmbientDatabaseAccess": "django_rakaia.hermeticity",
+    "LiveWriteLeaked": "django_rakaia.hermeticity",
+    # -- reading -------------------------------------------------------------
+    "ModelStreamReader": "django_rakaia.streams",
+    "materialize_history": "django_rakaia.history",
+    # -- subscriber cursors --------------------------------------------------
+    "poll_consumer": "django_rakaia.subscription",
+    "load_cursor": "django_rakaia.subscription",
+    "commit_cursor": "django_rakaia.subscription",
+    # -- mounting ------------------------------------------------------------
+    "get_asgi_app": "django_rakaia.integration",
+    "register_stream_event_admin": "django_rakaia.admin",
+    "ProvenanceMiddleware": "django_rakaia.middleware",
+}
+
+__all__ = sorted(_EXPORTS)
+
+
+def __getattr__(name: str):
+    """Resolve a public name on first use (PEP 562).
+
+    Deliberately does **not** cover the ORM models. They are usable and
+    documented, but at a weaker stability tier than this surface — see
+    `docs/public-api.md`. Import them from `django_rakaia.models`, which makes
+    the weaker guarantee visible at the import site rather than hiding it among
+    the stable names.
+    """
+    module_path = _EXPORTS.get(name)
+    if module_path is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    from importlib import import_module
+
+    return getattr(import_module(module_path), name)
+
+
+def __dir__() -> list[str]:
+    return sorted([*__all__, *globals()])

--- a/tests/test_rakaia/test_public_api.py
+++ b/tests/test_rakaia/test_public_api.py
@@ -1,0 +1,256 @@
+"""The public surface is pinned, so changing it is a decision rather than a diff.
+
+`docs/public-api.md` promises that Tier 1 — the names in `rakaia.__all__` and
+`django_rakaia.__all__` — does not change without a major bump and an
+`UPGRADING.md` entry. A promise nothing checks is a promise that gets broken by
+an unrelated refactor, so the full list is written out below.
+
+**When this test fails, that is the test working.** Adding a name is fine: add it
+here too. Removing or renaming one is a breaking change — do it deliberately,
+with the changelog and upgrade note that go with it.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import rakaia
+
+RAKAIA_PUBLIC = {
+    # app factory
+    "app",
+    "create_app",
+    # store
+    "StreamStore",
+    # extension protocols
+    "CursorStore",
+    "ProjectionReader",
+    "ReadableStore",
+    "StreamServerStore",
+    "WritableStore",
+    # envelope / provenance
+    "append_if_changed",
+    "envelope_actor",
+    "get_provenance",
+    "history_effects",
+    "label_marker",
+    "provenance",
+    "recover_peak_snapshot",
+    "snapshots_equal",
+    # options
+    "CursorOptions",
+    "ServerOptions",
+    # types
+    "AppendOptions",
+    "AppendResult",
+    "ClosedBy",
+    "CloseResult",
+    "ProducerState",
+    "Stream",
+    "StreamMessage",
+    # producer validation
+    "ProducerAccepted",
+    "ProducerDuplicate",
+    "ProducerInvalidEpochSeq",
+    "ProducerSequenceGap",
+    "ProducerStaleEpoch",
+    "ProducerStreamClosed",
+    "ProducerValidationResult",
+    # named store failures
+    "ContentTypeMismatch",
+    "EmptyJsonArray",
+    "InvalidJson",
+    "InvalidOffset",
+    "SequenceConflict",
+    "StreamConfigConflict",
+    "StreamError",
+    "StreamNotFound",
+    # cursors
+    "calculate_cursor",
+    "generate_response_cursor",
+    # effects
+    "CollectingExecutor",
+    "DuplicateProducesError",
+    "Effect",
+    "EffectCollisionError",
+    "EffectOp",
+    "Executor",
+    "Ref",
+    "RefResolver",
+    "UnresolvedRefError",
+    "check_disjoint_defaults",
+    "dispatch_external",
+    # projections
+    "project_latest",
+    "reconcile_aggregate",
+    "reconcile_by_key",
+    "reconcile_children",
+    "reconcile_tree",
+    # registry
+    "HANDLERS_META_STREAM",
+    "REDUCERS_META_STREAM",
+    "UPCASTERS_META_STREAM",
+    "HandlerDriftError",
+    "HandlerGapError",
+    "HandlerOverlapError",
+    "HandlerRegistry",
+    "HandlerVersion",
+    "ReducerVersion",
+    "UpcasterChainError",
+    "UpcasterConflictError",
+    "UpcasterRegistry",
+    "UpcasterVersion",
+    "get_default_registry",
+    "get_default_upcaster_registry",
+    "register_handler",
+    "register_reducer",
+    "register_simple",
+    "register_upcaster",
+    "reset_default_registries",
+    "upcast",
+    # replay
+    "ENVELOPE_TS",
+    "ReplayResult",
+    "TouchedSubject",
+    "merge_replay",
+    "replay",
+    # subscriptions
+    "Poll",
+    "PollStatus",
+    "poll",
+    # version
+    "__version__",
+}
+
+DJANGO_RAKAIA_PUBLIC = {
+    "AmbientDatabaseAccess",
+    "DEFAULT_NORMALIZERS",
+    "DiffReport",
+    "DjangoExecutor",
+    "DjangoProjectionReader",
+    "DjangoStreamStore",
+    "FieldDiff",
+    "GREEN",
+    "LiveWriteLeaked",
+    "ModelStreamReader",
+    "PreloadedProjectionReader",
+    "ProvenanceMiddleware",
+    "RED",
+    "RowDiff",
+    "SCRATCH_PATH",
+    "VACUOUS",
+    "VacuousVerification",
+    "VerificationError",
+    "append_event",
+    "assert_no_live_writes",
+    "canonical_value",
+    "commit_cursor",
+    "create_stream_event",
+    "deny_database_access",
+    "diff_effects_against_rows",
+    "fold_events",
+    "get_asgi_app",
+    "get_store",
+    "load_cursor",
+    "materialize_history",
+    "poll_consumer",
+    "register_stream_event_admin",
+    "replay_stream",
+    "stream_model",
+}
+
+
+class TestRakaiaSurface:
+    def test_all_is_exactly_the_pinned_set(self):
+        assert set(rakaia.__all__) == RAKAIA_PUBLIC
+
+    def test_every_exported_name_resolves(self):
+        """`__all__` listing a name that isn't there breaks `import *` and every
+        documentation example that uses it."""
+        for name in rakaia.__all__:
+            assert hasattr(rakaia, name), f"rakaia.__all__ lists missing {name!r}"
+
+    def test_no_private_name_is_exported(self):
+        assert [n for n in rakaia.__all__ if n.startswith("_")] == ["__version__"]
+
+
+class TestDjangoRakaiaSurface:
+    def test_all_is_exactly_the_pinned_set(self):
+        import django_rakaia
+
+        assert set(django_rakaia.__all__) == DJANGO_RAKAIA_PUBLIC
+
+    def test_every_exported_name_resolves(self):
+        import django_rakaia
+
+        for name in django_rakaia.__all__:
+            assert getattr(django_rakaia, name) is not None
+
+    def test_an_unknown_name_raises_attribute_error(self):
+        """The lazy `__getattr__` must not turn a typo into an ImportError from
+        somewhere unrelated."""
+        import django_rakaia
+
+        with pytest.raises(AttributeError, match="no attribute"):
+            _ = django_rakaia.definitely_not_exported
+
+    def test_dir_includes_the_public_names(self):
+        """So tab-completion and `help()` show the surface."""
+        import django_rakaia
+
+        assert set(dir(django_rakaia)) >= DJANGO_RAKAIA_PUBLIC
+
+
+class TestImportingTheDjangoPackageStaysCheap:
+    """The reason this package exported nothing for so long: eager imports pull
+    the ORM in at package-import time and raise `AppRegistryNotReady` during
+    Django's own startup. Lazy resolution is what makes a declared surface
+    possible at all, so the laziness is part of the contract."""
+
+    def test_the_models_module_is_not_imported_as_a_side_effect(self):
+        import subprocess
+        import sys
+
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                "import sys, django_rakaia; "
+                "print('django_rakaia.models' in sys.modules)",
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        assert result.stdout.strip() == "False", (
+            "importing django_rakaia pulled in the ORM — that raises "
+            "AppRegistryNotReady during Django startup"
+        )
+
+
+class TestTierTwoIsDeliberatelyNotExported:
+    """The ORM models are usable but weaker than Tier 1 (`docs/public-api.md`).
+    Keeping them out of `__all__` is what makes the weaker guarantee visible at
+    the import site."""
+
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "Stream",
+            "StreamEvent",
+            "StreamEntry",
+            "StreamProducer",
+            "StreamOffsetWatermark",
+            "ConsumerCursor",
+        ],
+    )
+    def test_a_model_is_not_in_the_stable_surface(self, model):
+        import django_rakaia
+
+        assert model not in django_rakaia.__all__
+
+    def test_models_remain_importable_from_their_module(self):
+        """Not exported is not the same as not supported — Tier 2 is usable."""
+        from django_rakaia.models import Stream, StreamEntry, StreamEvent
+
+        assert Stream and StreamEntry and StreamEvent

--- a/zensical.toml
+++ b/zensical.toml
@@ -21,6 +21,7 @@ nav = [
     { "What's new" = "whats-new.md" },
     { "Examples & concept coverage" = "examples.md" },
     { "Glossary" = "glossary.md" },
+    { "The public API" = "public-api.md" },
     { "Framework vs. protocol server" = "framework-vs-protocol-server.md" },
     { "Django integration" = "django-integration.md" },
     { "Versioned handlers" = "versioned-handlers.md" },


### PR DESCRIPTION
Until now rakaia never told anyone which bits of it were safe to depend on. The
Django half was the worst of it: its documentation listed a "Public API" of four
things, none of which were actually importable from the package. So every project
using it had to reach into internal file names instead, which quietly means that
splitting a file in two breaks them, even though nothing they were promised
changed. The first project using rakaia ended up with 178 imports and 84 direct
database queries against us, and neither side could say which of those were
supported.

This declares the answer in three levels. The top level is the names you can
import straight from `rakaia` and `django_rakaia`, and those won't move without a
major version and an upgrade note. The middle level is the database tables — real,
usable, and deliberately not in the top level, so that depending on them is a
visible decision rather than an accident. The bottom level is everything else,
which can change at any time. It also spells out how to depend on us safely,
which right now our only real user isn't doing.

I audited the example apps against it. They were already clean on everything that
matters — nothing pokes at the database tables, nothing takes apart an offset,
nothing uses a private name. The only gap was import style, so those are updated
to show the supported form. All eleven demos still pass.