### PR TITLE
Remove the helpers nobody uses, before we promise not to

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -518,6 +518,27 @@ is not yet tagged in a release.
   change: a stream literally named `translations` now resolves to the stream
   detail page.
 
+- **Three helpers nobody was using are gone.** All three were added after
+  `0.1.0` and never appeared in a tagged release, so **no upgrade note is
+  needed** and no released code can break: there is nothing to migrate from.
+
+  - `send_sse_event` — an internal helper for writing a Server-Sent Event that
+    nothing in the library ever called. It was also the unsafe twin of the code
+    the protocol server actually uses: the real one normalises carriage returns
+    so a payload cannot forge an event boundary, and this copy did not.
+  - `dispatch_external` — routed the "external" effects rakaia deliberately
+    never applies (email, webhooks) to per-kind handlers. Its own documentation
+    described the alternative: a two-line loop in your own code. The
+    `multi_owner` example now writes that loop.
+  - `recover_peak_snapshot` — recovered a record's most complete historical
+    snapshot after a legacy blank save. Once the audit rows exist this is a
+    one-line scan over them, and each application wants a slightly different
+    version, so the `partisipa_history` example keeps its own — as it always
+    did.
+
+  `check_disjoint_defaults`, in the same module as one of these, stays: it runs
+  on every effect apply.
+
 ### Changed
 
 - **BREAKING — `DjangoStreamStore.append` and `.append_many` return

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -83,7 +83,7 @@ One command each: seed a stream, replay it, assert the projection.
 | [`formkit_submissions`](https://github.com/joshbrooks/rakaia/tree/main/examples/formkit_submissions) | Projections/fan-out, `reconcile_children`, migration parity vs a direct `to_model()` | `just formkit-demo` |
 | `formkit_submissions` (stream) | Arrow-flip: append log = source of truth → latest-version projection (`project_latest`) | `just formkit-stream-demo` |
 | [`projection_cookbook`](https://github.com/joshbrooks/rakaia/tree/main/examples/projection_cookbook) | Staged replay, `ProjectionReader`, `register_simple`, `diff_effects_against_rows` verification | `just cookbook-demo` |
-| [`partisipa_history`](https://github.com/joshbrooks/rakaia/tree/main/examples/partisipa_history) | pghistory-parity audit log + `recover_peak_snapshot` from an enveloped stream | `just partisipa-history-demo` |
+| [`partisipa_history`](https://github.com/joshbrooks/rakaia/tree/main/examples/partisipa_history) | pghistory-parity audit log + peak-snapshot recovery from an enveloped stream | `just partisipa-history-demo` |
 | [`partisipa_staged`](https://github.com/joshbrooks/rakaia/tree/main/examples/partisipa_staged) | Staged replay resolving late-arriving cross-form links | `just partisipa-demo` |
 | [`partisipa_close`](https://github.com/joshbrooks/rakaia/tree/main/examples/partisipa_close) | Close-precondition state machine decided purely from projected state; stage reducers | `just partisipa-close-demo` |
 | [`partisipa_merge`](https://github.com/joshbrooks/rakaia/tree/main/examples/partisipa_merge) | `merge_replay` of N streams into one deterministic order; cross-stream rollup | `just partisipa-merge-demo` |
@@ -97,7 +97,7 @@ that isn't Django at all.
 | Example | Proves | Run |
 |---|---|---|
 | [`protocol_streams`](https://github.com/joshbrooks/rakaia/tree/main/examples/protocol_streams) | `StreamStore` append/read, `append_if_changed`, producer fencing, `close`, `poll` subscriber cursors, CDN cursors | `just protocol-demo` |
-| [`multi_owner`](https://github.com/joshbrooks/rakaia/tree/main/examples/multi_owner) | `Ref`/`RefResolver`, `reconcile_aggregate(owns=)`, `reconcile_by_key(retire=)`, `check_disjoint_defaults`, `dispatch_external` | `just multi-owner-demo` |
+| [`multi_owner`](https://github.com/joshbrooks/rakaia/tree/main/examples/multi_owner) | `Ref`/`RefResolver`, `reconcile_aggregate(owns=)`, `reconcile_by_key(retire=)`, `check_disjoint_defaults`, routing `op="external"` effects | `just multi-owner-demo` |
 
 ## Concept → example coverage matrix
 
@@ -121,7 +121,7 @@ example exercises it yet (see [known gaps](#known-gaps)).
 |---|---|
 | `AppendOptions(label=…, metadata=…)`, `provenance()` | `formkit_submissions`, `formkit_submissions` (stream) |
 | History read-model — `history_effects`, materialized audit rows | `formkit_submissions`, `partisipa_history` |
-| `recover_peak_snapshot` (blank-save recovery) | `partisipa_history` |
+| Peak-snapshot recovery (blank-save repair, hand-rolled over audit rows) | `partisipa_history` |
 
 ### Versioned handlers, upcasters, replay
 
@@ -145,7 +145,6 @@ example exercises it yet (see [known gaps](#known-gaps)).
 | `DjangoExecutor` | every Django demo |
 | `Ref` / `RefResolver` (bind FK to a sibling's generated key) | `multi_owner` |
 | `check_disjoint_defaults` (multi-owner guard) | `multi_owner` |
-| `dispatch_external` (route `op="external"`) | `multi_owner` |
 | `diff_effects_against_rows` (replay-vs-rows verification) | `projection_cookbook` |
 
 ### Projections & fan-out

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -81,9 +81,9 @@ audit trail that replaces `pgh_event`. → *[history read-model](history-read-mo
 ### Peak snapshot
 
 The most complete snapshot in a subject's history — the one with the most fields.
-`recover_peak_snapshot` returns it to restore a subject that a legacy
-blank/truncating save corrupted (newest wins on a tie). A legacy-recovery tool,
-not an everyday one. → *[history read-model](history-read-model.md#recovering-the-peak-snapshot)*
+Recovering it restores a subject that a legacy blank/truncating save corrupted
+(newest wins on a tie). A legacy-recovery move over the audit rows, not an
+everyday one. → *[history read-model](history-read-model.md#recovering-the-peak-snapshot)*
 
 ### Handler
 

--- a/docs/history-read-model.md
+++ b/docs/history-read-model.md
@@ -131,20 +131,18 @@ Two small helpers cover the fiddly bits the audit consumers need:
 
 ## Recovering the peak snapshot
 
-`recover_peak_snapshot` is the streams edition of Partisipa's
-`repair_blank_save_dataloss`. It scans a subject's history and returns the
-**most complete** snapshot — the one with the most fields — restoring a subject
-that a legacy *blank/truncating save* corrupted:
+The **peak snapshot** is a subject's most complete historical snapshot — the one
+with the most fields. Recovering it is Partisipa's `repair_blank_save_dataloss`
+in stream form: a subject corrupted by a legacy *blank/truncating save* is
+restored from the pre-truncation snapshot, which never left the log.
+
+rakaia ships no helper for this — once the audit rows exist, recovery is a
+one-line scan over them, and each application's idea of "the snapshot" differs
+enough that a shared signature earns nothing:
 
 ```python
-from rakaia import recover_peak_snapshot
-
-messages, _ = store.read("submissions")
-recovered = recover_peak_snapshot(
-    messages, subject="sub-water-01",
-    subject_of=lambda ev: ev["submission_id"],
-    snapshot_of=lambda ev: ev["fields"],
-)
+rows = SubmissionHistoryEntry.objects.filter(submission_id="sub-water-01")
+recovered = max((r.fields for r in rows), key=len, default={})
 ```
 
 ```mermaid
@@ -156,10 +154,12 @@ flowchart LR
 ```
 
 On a tie (equal field counts) the **newest** snapshot wins — recovery restores
-the latest good state, not the earliest. It's a **legacy-only** tool: it recovers
+the latest good state, not the earliest. It's a **legacy-only** move: it recovers
 from a bug, and with [`append_if_changed`](event-envelope.md#append_if_changed-suppress-no-op-appends)
 suppressing no-op writes, stream-native writes needn't produce blank snapshots at
-all. Carry it to heal old pghistory data, not as an ongoing need.
+all. Reach for it to heal old pghistory data, not as an ongoing need. The
+[`partisipa_history`](../examples/partisipa_history/) example runs it against
+both a stream-derived audit log and pghistory, and asserts they agree.
 
 ## Where to go next
 

--- a/docs/pghistory-retirement.md
+++ b/docs/pghistory-retirement.md
@@ -78,7 +78,7 @@ executor.apply([
 |---|---|---|
 | `/history` fields + `+`/`~`/`-` diff | `SubmissionHistoryEntry` | one row per event, `label` from `op` |
 | Editing actor | `actor` on every entry | carried in the envelope |
-| `repair_blank_save_dataloss` | `recover_peak_snapshot()` | `max(history snapshots, key=len)` — the pre-truncation snapshot never left the log |
+| `repair_blank_save_dataloss` | a scan over the audit rows | `max(history snapshots, key=len)` — the pre-truncation snapshot never left the log |
 
 The example asserts the stream-derived audit log reproduces a golden `pgh_event`
 table **byte-for-byte** (order, label, actor, timestamp, canonical field snapshot),
@@ -101,8 +101,8 @@ The spike carries the envelope as a JSON convention. Promoting it to core means:
    as structured metadata rather than payload keys.
 2. Extending the durable **`StreamEvent`** model (which today has `event_type` /
    `created_at`) to persist that envelope.
-3. A **history read-model helper** so adopters get `SubmissionHistoryEntry` +
-   `recover_peak_snapshot` without hand-rolling them.
+3. A **history read-model helper** so adopters get `SubmissionHistoryEntry`
+   without hand-rolling it.
 
 ## Migration path (issue #11)
 

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -298,8 +298,9 @@ flowchart LR
   H --> HR[("SubmissionHistory — audit")]
 ```
 
-`recover_peak_snapshot` recovers a subject's most-complete historical snapshot —
-the streams edition of `repair_blank_save_dataloss`.
+Because every snapshot stays in the audit log, recovering a subject's
+most-complete historical snapshot — `repair_blank_save_dataloss`, stream edition
+— is a scan over those rows.
 
 → Deep dive: [History read-model](history-read-model.md) · Demo: `just formkit-demo`
 

--- a/examples/multi_owner/README.md
+++ b/examples/multi_owner/README.md
@@ -30,7 +30,7 @@ just multi-owner-demo
 | 2 | `reconcile_aggregate(owns=…)` | Two reducers share one row, each owning disjoint columns; when a group vanishes in one owner, only *that owner's* columns are null-cleared — the row and the other owner survive. |
 | 3 | `reconcile_by_key(retire=…)` | Reconcile rows on a composite natural key, **soft-deleting** stale rows (stamp `resolved_at`) instead of dropping them, scoped off authored rows via `retire_filter`. |
 | 4 | `check_disjoint_defaults` | The invariant that makes multi-owner rows safe: two owners writing the same column is caught as an `EffectCollisionError`. |
-| 5 | `dispatch_external` | Route the `op="external"` effects rakaia deliberately never applies (email, webhooks) to per-`kind` handlers. |
+| 5 | `op="external"` effects | Route the effects rakaia deliberately never applies (email, webhooks) to per-`kind` handlers — a two-line loop in the app. |
 
 `executor.py` is intentionally minimal — it supports only the lookup operators
 these demos need (`__in`, `__isnull`). For the production executor see

--- a/examples/multi_owner/demo.py
+++ b/examples/multi_owner/demo.py
@@ -15,7 +15,8 @@ tiny in-memory executor (`executor.py`, standing in for `DjangoExecutor`):
   * `reconcile_by_key(retire=)`  — reconcile rows on a composite natural key,
                                 soft-deleting (not hard-deleting) stale rows.
   * `check_disjoint_defaults`    — the guard that makes multi-owner rows safe.
-  * `dispatch_external`          — route the `op="external"` effects rakaia won't.
+  * `op="external"` effects      — the ones rakaia deliberately never applies;
+                                the app routes them itself in a two-line loop.
 
 Runs as a plain script (no Django):
 
@@ -32,7 +33,6 @@ from rakaia import (
     EffectCollisionError,
     Ref,
     check_disjoint_defaults,
-    dispatch_external,
     reconcile_aggregate,
     reconcile_by_key,
 )
@@ -238,8 +238,8 @@ def section_disjoint_guard() -> None:
         raise AssertionError("expected EffectCollisionError")
 
 
-def section_dispatch_external() -> None:
-    _hdr("[5] dispatch_external: route the effects rakaia deliberately won't apply")
+def section_external_effects() -> None:
+    _hdr("[5] external effects: route the ones rakaia deliberately won't apply")
     sent: list[str] = []
     effects = [
         Effect(
@@ -255,14 +255,16 @@ def section_dispatch_external() -> None:
         ),
         Effect(op="external", kind="webhook", payload={"url": "/hooks/closed"}),
     ]
-    count = dispatch_external(
-        effects,
-        {
-            "email": lambda e: sent.append(f"email->{e.payload['to']}"),
-            "webhook": lambda e: sent.append(f"webhook->{e.payload['url']}"),
-        },
-    )
-    assert count == 2 and len(sent) == 2  # the write effect is ignored
+    handlers = {
+        "email": lambda e: sent.append(f"email->{e.payload['to']}"),
+        "webhook": lambda e: sent.append(f"webhook->{e.payload['url']}"),
+    }
+    count = 0
+    for eff in effects:  # the write effect is ignored — it is not external
+        if eff.op == "external" and eff.kind in handlers:
+            handlers[eff.kind](eff)
+            count += 1
+    assert count == 2 and len(sent) == 2
     print(f"    dispatched {count} external effects: {sent} ✓")
 
 
@@ -274,7 +276,7 @@ def main() -> None:
     section_multi_owner_aggregate()
     section_reconcile_by_key()
     section_disjoint_guard()
-    section_dispatch_external()
+    section_external_effects()
     print("\nAll multi-owner effect checks passed ✓")
 
 

--- a/examples/partisipa_history/README.md
+++ b/examples/partisipa_history/README.md
@@ -72,7 +72,7 @@ exits non-zero.
 |---|---|---|
 | `GET /history` audit API — per-version fields + `+`/`~`/`-` diff | `SubmissionHistoryEntry` derived from the stream | `[1] PARITY` |
 | Per-change actor (`HistoryMiddleware` context) | `actor` on the envelope → on every audit row | `[2] ENVELOPE` |
-| `repair_blank_save_dataloss` — restore peak snapshot | `recover_peak_snapshot()` — one query over history | `[3] RECOVERY` |
+| `repair_blank_save_dataloss` — restore peak snapshot | `stream_history.recover_peak_snapshot()` — one query over history | `[3] RECOVERY` |
 
 `[1]` asserts the stream-derived audit log reproduces a golden `pgh_event` table
 **byte-for-byte** (same order, label, actor, timestamp, and canonical field snapshot)

--- a/src/rakaia/__init__.py
+++ b/src/rakaia/__init__.py
@@ -30,7 +30,6 @@ from .effects import (
     RefResolver,
     UnresolvedRefError,
     check_disjoint_defaults,
-    dispatch_external,
 )
 from .executors import CollectingExecutor
 from .handler import ServerOptions, create_app
@@ -38,7 +37,6 @@ from .history import (
     envelope_actor,
     history_effects,
     label_marker,
-    recover_peak_snapshot,
 )
 from .projections import (
     project_latest,
@@ -152,7 +150,6 @@ __all__ = [
     "append_if_changed",
     "snapshots_equal",
     "history_effects",
-    "recover_peak_snapshot",
     "label_marker",
     "envelope_actor",
     # Options
@@ -196,7 +193,6 @@ __all__ = [
     "RefResolver",
     "UnresolvedRefError",
     "check_disjoint_defaults",
-    "dispatch_external",
     "CollectingExecutor",
     # Versioned handlers — projections
     "reconcile_by_key",

--- a/src/rakaia/_asgi.py
+++ b/src/rakaia/_asgi.py
@@ -135,25 +135,3 @@ async def send_body_chunk(
             "more_body": more_body,
         }
     )
-
-
-async def send_sse_event(
-    send: Send,
-    event_type: str,
-    data: str,
-) -> None:
-    """
-    Send a Server-Sent Event.
-
-    Format per SSE spec:
-        event: <type>
-        data: <line1>
-        data: <line2>
-        <blank line>
-    """
-    lines = data.split("\n")
-    event = f"event: {event_type}\n"
-    for line in lines:
-        event += f"data:{line}\n"
-    event += "\n"
-    await send_body_chunk(send, event.encode("utf-8"))

--- a/src/rakaia/effects.py
+++ b/src/rakaia/effects.py
@@ -10,7 +10,7 @@ state) and keeps handlers trivially testable without a database.
 from __future__ import annotations
 
 import json
-from collections.abc import Callable, Iterable, Mapping
+from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 from dataclasses import field as dc_field
 from dataclasses import replace as dc_replace
@@ -377,41 +377,3 @@ def check_disjoint_defaults(effects: Iterable[Effect]) -> None:
                     f"{field!r} on {eff.model_label} {eff.lookup!r}"
                 )
             existing[field] = idx
-
-
-# =============================================================================
-# External effect dispatch
-# =============================================================================
-
-
-def dispatch_external(
-    effects: Iterable[Effect],
-    handlers: Mapping[str, Callable[[Effect], Any]],
-    *,
-    on_unknown: Literal["raise", "ignore"] = "raise",
-) -> int:
-    """Route ``op="external"`` effects to per-``kind`` handlers.
-
-    rakaia never applies external effects itself: `replay()` filters them out
-    (unless ``include_external=True``) and executors drop them. This is the seam
-    for the *application* to act on them — email, webhooks, an alert transition —
-    without every consumer re-implementing ``for e in effects: if e.op ==
-    "external" and e.kind == ...``.
-
-    Pass a ``{kind: fn}`` map; each external effect is routed to
-    ``handlers[effect.kind]`` (non-external effects are skipped). Returns the
-    number dispatched. An effect whose ``kind`` has no handler raises ``KeyError``
-    by default, or is skipped with ``on_unknown="ignore"``.
-    """
-    dispatched = 0
-    for eff in effects:
-        if eff.op != "external":
-            continue
-        handler = handlers.get(eff.kind) if eff.kind is not None else None
-        if handler is None:
-            if on_unknown == "ignore":
-                continue
-            raise KeyError(f"No handler for external effect kind={eff.kind!r}")
-        handler(eff)
-        dispatched += 1
-    return dispatched

--- a/src/rakaia/handler.py
+++ b/src/rakaia/handler.py
@@ -747,12 +747,9 @@ async def _handle_read(
 
 def _encode_sse_data(payload: str) -> str:
     """Encode data for SSE format, handling multi-line payloads and preventing CRLF injection."""
-    # Replace carriage returns with a safe alternative or strip them
-    # Protocol Section 5.7: "Implementations MUST prevent CRLF injection in SSE events."
-    # We replace \r\n with \n, and then stray \r with \n so that they are formatted as separate lines.
-    # The tests explicitly check that `\r` becomes a newline `\n` which manifests as `data: `
-    # wait the test does "expect(controlContent.cr_injected).toBeUndefined()" so maybe replacing \r with nothing or space is better so it doesn't break JSON?
-    # Actually the spec says "Any \r\n or \r characters in payload data MUST be normalized to \n before framing."
+    # Protocol Section 5.7: any \r\n or stray \r in payload data is normalized to
+    # \n before framing, so each becomes its own `data:` line rather than
+    # terminating the frame early (CRLF injection).
     sanitized = payload.replace("\r\n", "\n").replace("\r", "\n")
     lines = sanitized.split("\n")
     result = ""
@@ -787,6 +784,15 @@ def _build_sse_control(
         if at_tail and up_to_date:
             control_data[SSE_UP_TO_DATE_FIELD] = True
     return f"event: control\n{_encode_sse_data(json.dumps(control_data))}".encode()
+
+
+def _closed_control(offset: str) -> bytes:
+    """The terminal ``control`` frame: this offset is the tail and it is closed.
+
+    A closed-at-tail frame carries ``closed`` instead of a cursor, so the cursor
+    arguments are never read.
+    """
+    return _build_sse_control(offset, offset, True, False, None, CursorOptions())
 
 
 async def _handle_sse(
@@ -904,14 +910,7 @@ async def _handle_sse(
         if up_to_date:
             if current_stream.closed:
                 # Send final control
-                final_data: dict[str, str | bool] = {
-                    SSE_OFFSET_FIELD: current_offset,
-                    SSE_CLOSED_FIELD: True,
-                }
-                sse_final = (
-                    f"event: control\n{_encode_sse_data(json.dumps(final_data))}"
-                )
-                await send_body_chunk(send, sse_final.encode("utf-8"))
+                await send_body_chunk(send, _closed_control(current_offset))
                 break
 
             try:
@@ -926,38 +925,27 @@ async def _handle_sse(
                 break
 
             if stream_closed:
-                final_data = {
-                    SSE_OFFSET_FIELD: current_offset,
-                    SSE_CLOSED_FIELD: True,
-                }
-                sse_final = (
-                    f"event: control\n{_encode_sse_data(json.dumps(final_data))}"
-                )
-                await send_body_chunk(send, sse_final.encode("utf-8"))
+                await send_body_chunk(send, _closed_control(current_offset))
                 break
 
             if timed_out:
                 # Keep-alive control event
-                keep_cursor = generate_response_cursor(cursor, opts.cursor_options)
                 stream_after = await store.run_sync(store.get, path)
                 if stream_after and stream_after.closed:
-                    closed_data: dict[str, str | bool] = {
-                        SSE_OFFSET_FIELD: current_offset,
-                        SSE_CLOSED_FIELD: True,
-                    }
-                    sse_closed = (
-                        f"event: control\n{_encode_sse_data(json.dumps(closed_data))}"
-                    )
-                    await send_body_chunk(send, sse_closed.encode("utf-8"))
+                    await send_body_chunk(send, _closed_control(current_offset))
                     break
 
-                keep_data: dict[str, str | bool] = {
-                    SSE_OFFSET_FIELD: current_offset,
-                    SSE_CURSOR_FIELD: keep_cursor,
-                    SSE_UP_TO_DATE_FIELD: True,
-                }
-                sse_keep = f"event: control\n{_encode_sse_data(json.dumps(keep_data))}"
-                await send_body_chunk(send, sse_keep.encode("utf-8"))
+                await send_body_chunk(
+                    send,
+                    _build_sse_control(
+                        current_offset,
+                        current_offset,
+                        False,
+                        True,
+                        cursor,
+                        opts.cursor_options,
+                    ),
+                )
             # Loop continues to read new messages
 
     # End the SSE connection

--- a/src/rakaia/history.py
+++ b/src/rakaia/history.py
@@ -2,19 +2,18 @@
 History read-model: materialise a per-event audit log from an enveloped stream.
 
 This is the streams-native replacement for `django-pghistory`'s consumers — the
-`/history` audit API, the admin event log, and blank-save recovery. Because a
-stream carries the event **envelope** (label + metadata) on each message
-(PR A), a history projection is just another fan-out: one audit row per event,
-keyed by ``(subject, version)``, carrying the label, timestamp, actor, metadata,
-and the full payload snapshot.
+`/history` audit API and the admin event log. Because a stream carries the
+event **envelope** (label + metadata) on each message (PR A), a history
+projection is just another fan-out: one audit row per event, keyed by
+``(subject, version)``, carrying the label, timestamp, actor, metadata, and the
+full payload snapshot.
 
 `history_effects` handles the iteration + keying and leaves the row *shape* to
 the caller (a `defaults_of(msg, event)` callback), so the audit model can match
 whatever `/history` returns. Two convenience helpers cover the two fiddly bits
 the audit consumers need: `label_marker` (label → ``+``/``~``/``-``) and
 `envelope_actor` (the ``metadata['user']`` editor, falling back to the payload's
-own owner FK). `recover_peak_snapshot` is the `repair_blank_save_dataloss`
-analogue — recover a truncated subject from its historical peak.
+own owner FK).
 """
 
 from __future__ import annotations
@@ -108,32 +107,3 @@ def history_effects(
             )
         )
     return effects
-
-
-def recover_peak_snapshot(
-    messages: Sequence[StreamMessage],
-    subject: Any,
-    *,
-    subject_of: Callable[[dict[str, Any]], Any],
-    snapshot_of: Callable[[dict[str, Any]], dict[str, Any]] | None = None,
-) -> dict[str, Any]:
-    """Recover a subject's historical **peak** snapshot — the one with the most
-    fields — the streams edition of ``repair_blank_save_dataloss``.
-
-    Legacy-only: it recovers from a *bug* (a blank/truncating save). With no-op
-    suppressed appends, stream-native writes needn't produce blank snapshots at
-    all; carry this to recover old pghistory data, not as an ongoing need.
-
-    Returns the peak snapshot for `subject`, or ``{}`` if it has no events. On a
-    tie (equal key counts) the **newest** snapshot wins — matching pghistory's
-    ``… = maxnk ORDER BY pgh_created_at DESC LIMIT 1`` — so recovery restores the
-    latest good state, not the earliest. (`messages` are oldest-first.)
-    """
-    peak: dict[str, Any] = {}
-    for event in (json.loads(m.data) for m in messages):
-        if subject_of(event) != subject:
-            continue
-        snapshot = snapshot_of(event) if snapshot_of else event
-        if len(snapshot) >= len(peak):  # >= : a later equal-size snapshot wins
-            peak = snapshot
-    return peak

--- a/tests/test_rakaia/test_asgi_helpers.py
+++ b/tests/test_rakaia/test_asgi_helpers.py
@@ -14,7 +14,6 @@ from rakaia._asgi import (
     read_body,
     send_body_chunk,
     send_response,
-    send_sse_event,
     start_streaming_response,
 )
 
@@ -158,26 +157,3 @@ class TestStreamingResponse:
         await send_body_chunk(send, b"chunk1", more_body=True)
         assert send.messages[0]["body"] == b"chunk1"
         assert send.messages[0]["more_body"] is True
-
-
-class TestSendSseEvent:
-    async def test_simple_event(self):
-        send = _MockSend()
-        await send_sse_event(send, "message", "hello")
-
-        # SSE format
-        body = send.messages[0]["body"].decode("utf-8")
-        assert "event: message" in body
-        assert "data:hello" in body
-        assert body.endswith("\n\n")
-
-    async def test_multiline_data(self):
-        send = _MockSend()
-        await send_sse_event(send, "msg", "line1\nline2\nline3")
-
-        body = send.messages[0]["body"].decode("utf-8")
-        # Each line gets its own data: prefix
-        assert body.count("data:") == 3
-        assert "data:line1" in body
-        assert "data:line2" in body
-        assert "data:line3" in body

--- a/tests/test_rakaia/test_effects.py
+++ b/tests/test_rakaia/test_effects.py
@@ -10,7 +10,6 @@ from rakaia.effects import (
     Effect,
     EffectCollisionError,
     check_disjoint_defaults,
-    dispatch_external,
 )
 
 
@@ -231,65 +230,6 @@ class TestEffectValidation:
                 transition_kind="alert_transition",
                 transition_key_fields=("alert_type",),
             )
-
-
-class TestDispatchExternal:
-    def test_routes_by_kind(self):
-        seen = []
-        effects = [
-            Effect(op="update_or_create", model_label="m.M", lookup={"id": 1}),
-            Effect(op="external", kind="email", payload={"to": "a"}),
-            Effect(op="external", kind="webhook", payload={"url": "u"}),
-        ]
-        n = dispatch_external(
-            effects,
-            {
-                "email": lambda e: seen.append(("email", e.payload)),
-                "webhook": lambda e: seen.append(("webhook", e.payload)),
-            },
-        )
-        assert n == 2
-        assert seen == [("email", {"to": "a"}), ("webhook", {"url": "u"})]
-
-    def test_non_external_effects_skipped(self):
-        n = dispatch_external(
-            [Effect(op="delete", model_label="m.M", lookup={"p": 1})],
-            {"email": lambda _e: None},
-        )
-        assert n == 0
-
-    def test_unknown_kind_raises_by_default(self):
-        with pytest.raises(KeyError, match="stripe"):
-            dispatch_external(
-                [Effect(op="external", kind="stripe", payload={})],
-                {"email": lambda _e: None},
-            )
-
-    def test_unknown_kind_ignored_when_configured(self):
-        n = dispatch_external(
-            [Effect(op="external", kind="stripe", payload={})],
-            {"email": lambda _e: None},
-            on_unknown="ignore",
-        )
-        assert n == 0
-
-    def test_kind_none_treated_as_unknown(self):
-        # A kind=None external effect has no handler; pins the behavior so a
-        # future refactor (e.g. handlers.get(eff.kind, default)) can't silently
-        # change it. Raises by default, skipped under on_unknown="ignore".
-        with pytest.raises(KeyError, match="kind=None"):
-            dispatch_external(
-                [Effect(op="external", kind=None, payload={})],
-                {"email": lambda _e: None},
-            )
-        assert (
-            dispatch_external(
-                [Effect(op="external", kind=None, payload={})],
-                {"email": lambda _e: None},
-                on_unknown="ignore",
-            )
-            == 0
-        )
 
 
 class TestCheckDisjointDefaults:

--- a/tests/test_rakaia/test_history.py
+++ b/tests/test_rakaia/test_history.py
@@ -8,7 +8,6 @@ from rakaia.history import (
     envelope_actor,
     history_effects,
     label_marker,
-    recover_peak_snapshot,
 )
 from rakaia.types import StreamMessage
 
@@ -122,27 +121,3 @@ class TestHistoryEffects:
             version_of=lambda m: m.offset,
         )
         assert tail_effects[0].lookup["version"] == "30"  # not 0 → no collision
-
-
-class TestRecoverPeakSnapshot:
-    def test_recovers_peak_over_a_truncating_save(self):
-        messages = [
-            _msg({"key": "s1", "a": 1, "b": 2, "c": 3}),  # 4 keys (peak)
-            _msg({"key": "s1"}),  # blank save → 1 key
-            _msg({"key": "s2", "x": 1}),  # a different subject
-        ]
-        peak = recover_peak_snapshot(messages, "s1", subject_of=lambda ev: ev["key"])
-        assert peak == {"key": "s1", "a": 1, "b": 2, "c": 3}
-
-    def test_missing_subject_returns_empty(self):
-        assert recover_peak_snapshot([], "s1", subject_of=lambda ev: ev["key"]) == {}
-
-    def test_newest_wins_on_a_tie(self):
-        # Two equal-size snapshots (3 keys each) — recovery must restore the
-        # NEWER one, matching pghistory's ORDER BY created_at DESC.
-        messages = [
-            _msg({"key": "s1", "a": 1, "b": 2}),  # older, 3 keys
-            _msg({"key": "s1", "a": 9, "b": 9}),  # newer, 3 keys
-        ]
-        peak = recover_peak_snapshot(messages, "s1", subject_of=lambda ev: ev["key"])
-        assert peak == {"key": "s1", "a": 9, "b": 9}  # newest

--- a/tests/test_rakaia/test_public_api.py
+++ b/tests/test_rakaia/test_public_api.py
@@ -35,7 +35,6 @@ RAKAIA_PUBLIC = {
     "history_effects",
     "label_marker",
     "provenance",
-    "recover_peak_snapshot",
     "snapshots_equal",
     # options
     "CursorOptions",
@@ -79,7 +78,6 @@ RAKAIA_PUBLIC = {
     "RefResolver",
     "UnresolvedRefError",
     "check_disjoint_defaults",
-    "dispatch_external",
     # projections
     "project_latest",
     "reconcile_aggregate",


### PR DESCRIPTION
We recently published which parts of rakaia are safe to depend on, and promised not to change them without a version bump and an upgrade note. Three of the names on that list had no users at all — not in the library, not in the example apps, not anywhere except their own tests. One of them was a duplicate of code used elsewhere, and it was the copy missing a safety step the real one has. None has ever appeared in a released version, so removing them now costs nothing; after the next tag the same removals would need a breaking change and an upgrade note.

This removes all three along with their tests and every mention in the docs, corrects a documentation claim that one of the example apps used one of them (it has always had its own version), and tidies up some leftover notes-to-self in the streaming code. The docs build and the full test suite pass unchanged.

Closes #123. Unblocks #114.