### PR TITLE
The dashboard no longer shows the wrong events for a resumed view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -261,6 +261,26 @@ is not yet tagged in a release.
 
 ### Fixed
 
+- **The dashboard views refuse an offset the durable store never issued** (#122).
+  Two Django views parsed a client-supplied offset with bare `int()`, outside
+  any store's ownership check: `after_offset` on the JSON events endpoint, and
+  the `Last-Event-ID` header the browser sends when an `EventSource` reconnects.
+  Python reads `_` as a digit separator, so the in-memory store's compound
+  `{seq}_{byte}` offset — `int("0_5")` is `5` — resolved to an unrelated
+  position: the JSON API returned the wrong window with a `200`, and the SSE
+  endpoint resumed in the wrong place. An offset that did not parse at all fell
+  into `except ValueError: 0` and silently replayed the entire stream to a
+  client that believed it was resuming. Both now parse through the durable
+  store's own strict check and answer `400`; failing a connection is visible,
+  and neither wrong answer was.
+
+  That check has moved to `django_rakaia.offsets` alongside `format_offset`,
+  which also settles a layering inversion: `Stream.current_offset` used to
+  import `format_offset` back out of the store module for its own property, and
+  duplicated `DjangoStreamStore.get_current_offset`'s watermark query verbatim.
+  The store now delegates to the model property; all it adds is the expiry
+  check and the absent-stream `None`.
+
 - **A handler can take an injected dependency without losing drift detection.**
   A stage-0 handler is called `fn(event)`, so a dependency had nowhere to go, and
   both routes out were broken. `functools.partial` was rejected outright by

--- a/src/django_rakaia/channels_views.py
+++ b/src/django_rakaia/channels_views.py
@@ -10,11 +10,14 @@ import json
 from typing import Any
 
 from channels.layers import get_channel_layer
-from django.http import StreamingHttpResponse
+from django.http import HttpResponseBadRequest, StreamingHttpResponse
 from django.views.decorators.http import require_GET
+
+from rakaia.types import InvalidOffset
 
 from .channels_signals import _sanitize_group_name
 from .models import StreamEntry
+from .offsets import parse_offset
 
 
 @require_GET
@@ -26,13 +29,23 @@ async def stream_events_sse(_request: Any, stream_id: str) -> Any:
     auto-reconnects). On a fresh connect that header is absent, so we
     replay the full history. Each event is tagged with `id: <offset>`
     so the browser knows where to resume.
+
+    A `Last-Event-ID` this store never issued is refused with a 400 rather
+    than resumed. `int()` would read the in-memory store's compound
+    `{seq}_{byte}` offset as an unrelated number and resume in the wrong
+    place, and the old `except ValueError: 0` fallback turned an unparseable
+    resume token into a silent full replay — a client that believes it is
+    resuming would be handed duplicates it has already processed. Failing the
+    connection is visible; both alternatives are not.
     """
 
     last_event_id = _request.headers.get("Last-Event-ID", "")
     try:
-        after_offset = int(last_event_id) if last_event_id else 0
-    except ValueError:
-        after_offset = 0
+        after_offset = parse_offset(last_event_id) if last_event_id else 0
+    except InvalidOffset:
+        return HttpResponseBadRequest(
+            "Last-Event-ID is not an offset this store issued"
+        )
 
     async def event_generator():
         channel_layer = get_channel_layer()

--- a/src/django_rakaia/django_store.py
+++ b/src/django_rakaia/django_store.py
@@ -35,7 +35,6 @@ from __future__ import annotations
 import asyncio
 import base64
 import json
-import re
 import time
 from collections.abc import Iterable
 from datetime import datetime, timezone
@@ -43,7 +42,6 @@ from typing import Any
 
 from asgiref.sync import sync_to_async
 from django.db import transaction
-from django.db.models import Max
 
 from rakaia.append_decision import StreamFacts, decide_append
 from rakaia.context import merge_provenance
@@ -59,7 +57,6 @@ from rakaia.types import (
     AppendResult,
     CloseResult,
     ContentTypeMismatch,
-    InvalidOffset,
     ProducerAccepted,
     ProducerDuplicate,
     ProducerState,
@@ -76,28 +73,13 @@ from .models import (
     Stream,
     StreamEntry,
     StreamEvent,
-    StreamOffsetWatermark,
     StreamProducer,
 )
+from .offsets import format_offset, parse_offset
 
 # StreamEvent.event_type is required metadata for the dashboard; raw stream
 # appends carry no type, so they are recorded under a single stable label.
 _APPEND_EVENT_TYPE = "append"
-
-# Offsets are rendered zero-padded so they sort byte-wise lexicographically, as
-# the Durable Streams protocol requires (§3, §5.2). 20 digits covers a
-# BigAutoField's range (< 2**63). `read` still parses them numerically, so the
-# padding is transparent to filtering.
-_OFFSET_WIDTH = 20
-
-# This store's offsets, and nothing else. See `DjangoStreamStore._parse_offset`.
-_PLAIN_INTEGER_OFFSET = re.compile(r"^\d+$")
-
-
-def format_offset(value: int) -> str:
-    """Render an integer offset as the protocol's opaque, sortable string."""
-    return f"{value:0{_OFFSET_WIDTH}d}"
-
 
 # `StreamEvent.payload_encoding` values. `None` means the event's `data` is the
 # payload as a JSON value — the event-sourcing shape, and what every row written
@@ -944,23 +926,8 @@ class DjangoStreamStore:
 
     @staticmethod
     def _parse_offset(offset: str) -> int:
-        """The entry offset `offset` denotes, for this store's own format.
-
-        Strict on purpose. `int()` alone would accept far more than this store
-        ever issues — it treats underscores as digit separators, so the
-        in-memory store's compound `{seq}_{byte}` offset parses cleanly into an
-        unrelated number, and a resume read would quietly return the wrong
-        window instead of failing. `VALID_OFFSET_PATTERN` cannot catch that
-        either: it is a shared syntactic guard, and the protocol makes offsets
-        opaque rather than uniform (§6), so only the issuing store can say
-        whether a token is one of its own.
-        """
-        if not _PLAIN_INTEGER_OFFSET.match(offset):
-            raise InvalidOffset(
-                f"Not an offset this store issued: {offset!r}. Durable-store "
-                f"offsets are plain integers."
-            )
-        return int(offset)
+        """The entry offset `offset` denotes. Delegates to `parse_offset`."""
+        return parse_offset(offset)
 
     async def run_sync(self, fn: Any, *args: Any, **kwargs: Any) -> Any:
         """Run a synchronous store call for an async server, in a thread.
@@ -1090,13 +1057,9 @@ class DjangoStreamStore:
         stream = self._get_if_not_expired(path)
         if stream is None:
             return None
-        entries_max = stream.entries.aggregate(max_offset=Max("offset"))["max_offset"]
-        watermark_high = (
-            StreamOffsetWatermark.objects.filter(stream_path=path)
-            .values_list("high", flat=True)
-            .first()
-        )
-        return format_offset(max(entries_max or 0, watermark_high or 0))
+        # The head itself is `Stream.current_offset`; all this method adds is
+        # the expiry check and the absent-stream `None`.
+        return stream.current_offset
 
     def list_paths(self) -> list[str]:
         return list(Stream.objects.values_list("stream_id", flat=True))

--- a/src/django_rakaia/models.py
+++ b/src/django_rakaia/models.py
@@ -11,6 +11,8 @@ from django.db.models import Max
 
 from rakaia.types import ClosedBy
 
+from .offsets import format_offset
+
 
 class Stream(models.Model):
     """
@@ -80,8 +82,6 @@ class Stream(models.Model):
         to keep in step. Named to match the in-memory `Stream.current_offset`,
         which is what lets one protocol server read either.
         """
-        from .django_store import format_offset
-
         entries_max = self.entries.aggregate(max_offset=Max("offset"))["max_offset"]
         watermark_high = (
             StreamOffsetWatermark.objects.filter(stream_path=self.stream_id)

--- a/src/django_rakaia/offsets.py
+++ b/src/django_rakaia/offsets.py
@@ -1,0 +1,48 @@
+"""The durable store's offset format: how to render one, and how to read one.
+
+Its own module because it has three callers at two different layers — the
+store (`django_store`), the model property that reports a stream head
+(`models.Stream.current_offset`), and the dashboard views that accept an
+offset from a client. Keeping it here is what stops the model layer from
+importing out of the store layer for its own property, and stops a view from
+pulling in the whole store just to read a query parameter.
+"""
+
+from __future__ import annotations
+
+import re
+
+from rakaia.types import InvalidOffset
+
+# Offsets are rendered zero-padded so they sort byte-wise lexicographically, as
+# the Durable Streams protocol requires (§3, §5.2). 20 digits covers a
+# BigAutoField's range (< 2**63). Reads still parse them numerically, so the
+# padding is transparent to filtering.
+_OFFSET_WIDTH = 20
+
+# This store's offsets, and nothing else. See `parse_offset`.
+_PLAIN_INTEGER_OFFSET = re.compile(r"^\d+$")
+
+
+def format_offset(value: int) -> str:
+    """Render an integer offset as the protocol's opaque, sortable string."""
+    return f"{value:0{_OFFSET_WIDTH}d}"
+
+
+def parse_offset(offset: str) -> int:
+    """The entry offset `offset` denotes, in the durable store's own format.
+
+    Strict on purpose. `int()` alone would accept far more than this store
+    ever issues — it treats underscores as digit separators, so the in-memory
+    store's compound `{seq}_{byte}` offset parses cleanly into an unrelated
+    number, and a resume read would quietly return the wrong window instead of
+    failing. `VALID_OFFSET_PATTERN` cannot catch that either: it is a shared
+    syntactic guard, and the protocol makes offsets opaque rather than uniform
+    (§6), so only the issuing store can say whether a token is one of its own.
+    """
+    if not _PLAIN_INTEGER_OFFSET.match(offset):
+        raise InvalidOffset(
+            f"Not an offset this store issued: {offset!r}. Durable-store "
+            f"offsets are plain integers."
+        )
+    return int(offset)

--- a/src/django_rakaia/views.py
+++ b/src/django_rakaia/views.py
@@ -14,7 +14,10 @@ from django.http import HttpResponse, JsonResponse
 from django.shortcuts import render
 from django.views.decorators.http import require_GET
 
+from rakaia.types import InvalidOffset
+
 from .models import Stream, StreamEntry, StreamEvent
+from .offsets import parse_offset
 
 _log = logging.getLogger("django_rakaia.views")
 
@@ -182,9 +185,13 @@ def stream_events_api(_request: Any, stream_id: str) -> Any:
     query = stream.entries.select_related("event").order_by("offset")
 
     if after_offset:
+        # Parsed by the durable store's own strict check, not `int()`: this
+        # endpoint reads durable rows, and `int("0_5")` is 5 in Python, so an
+        # in-memory-store offset would resolve to an unrelated position and
+        # return the wrong window with a 200.
         try:
-            after_offset_int = int(after_offset)
-        except (TypeError, ValueError):
+            after_offset_int = parse_offset(after_offset)
+        except InvalidOffset:
             return JsonResponse(
                 {"error": "after_offset must be an integer"}, status=400
             )

--- a/tests/test_django_rakaia/test_channels.py
+++ b/tests/test_django_rakaia/test_channels.py
@@ -235,6 +235,32 @@ class TestChannelLayerSSEViews:
         assert chunks[0]["event"]["data"] == {"from": "mine"}
         assert "stream_id" not in chunks[0], "routing field must not leak to clients"
 
+    async def test_sse_foreign_last_event_id_is_refused(self):
+        """A ``Last-Event-ID`` this store never issued must not resume.
+
+        ``int("0_5")`` is 5 in Python, so the in-memory store's compound
+        ``{seq}_{byte}`` offset parses into an unrelated resume point; a
+        foreign offset that does not parse at all used to fall back to 0 and
+        replay the whole stream. Both are wrong: refuse instead.
+        """
+        from django_rakaia.channels_views import stream_events_sse
+
+        stream = await Stream.objects.acreate(stream_id="foreign-offset")
+        event = await StreamEvent.objects.acreate(event_type="create", data={"n": 1})
+        await StreamEntry.objects.acreate(stream=stream, event=event, offset=1)
+
+        from django.test import RequestFactory
+
+        factory = RequestFactory()
+        request = factory.get(
+            "/api/streams/foreign-offset/sse/", HTTP_LAST_EVENT_ID="0_5"
+        )
+
+        response = await stream_events_sse(request, "foreign-offset")
+
+        assert response.status_code == 400
+        assert not getattr(response, "streaming", False)
+
     async def test_sse_response_headers(self):
         """SSE response has correct content-type and cache headers."""
         from django_rakaia.channels_views import stream_events_sse

--- a/tests/test_django_rakaia/test_views.py
+++ b/tests/test_django_rakaia/test_views.py
@@ -190,3 +190,22 @@ class TestStreamEventsApi:
             {"after_offset": "abc"},
         )
         assert resp.status_code == 400
+
+    def test_foreign_after_offset_is_refused(self, auth_client: Client) -> None:
+        """An offset in the other store's format must fail, not resolve.
+
+        Python reads ``_`` as a digit separator, so ``int("0_5")`` is 5: the
+        in-memory store's compound ``{seq}_{byte}`` offset would silently
+        resolve to an unrelated position and return the wrong window with a
+        200. Only the store that issued an offset can say whether it owns it,
+        and this view serves durable (plain-integer) offsets.
+        """
+        for off in (1, 2, 3, 4, 5, 6):
+            _make_entry("s:1", off)
+        resp = auth_client.get(
+            reverse("django_rakaia:stream_events_api", args=["s:1"]),
+            {"after_offset": "0_5"},
+        )
+        assert resp.status_code == 400, (
+            f"foreign offset resolved instead of being refused: {resp.content!r}"
+        )


### PR DESCRIPTION
The dashboard's event list and its live feed both accepted a position marker from the browser and trusted it without checking it belonged to them. A marker issued by the other kind of stream store looked close enough to a valid one to be read as a completely different position, so the page could quietly show the wrong slice of a stream and still report success. In one case an unrecognised marker was treated as "start from the beginning", so a page that thought it was picking up where it left off was handed the whole history again.

Both entry points now check the marker is one they issued and reject it with a clear error if it isn't. Being told the request is bad is far easier to notice than being shown plausible but wrong events.

Closes #122