### PR TITLE
A closed stream now says so, whichever way you append

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -280,6 +280,21 @@ is not yet tagged in a release.
   duplicated `DjangoStreamStore.get_current_offset`'s watermark query verbatim.
   The store now delegates to the model property; all it adds is the expiry
   check and the absent-stream `None`.
+- **A closed stream answers the same way on both stores, whichever append door
+  you use** (#119). `append_with_producer` on the durable store ran its own
+  admission sequence — producer fencing *before* the closed check, and never
+  reading who closed the stream. A producer whose sequence had also drifted was
+  told about the gap instead of being told the stream was closed, and a producer
+  retrying its own closing append was never recognised as a duplicate; the
+  in-memory store got both right. Both doors on both stores now ask
+  `rakaia.append_decision`, the one shared admission sequence, and the shared
+  store contract drives the combination that was missing, which is why the drift
+  had gone unseen. A refusal on a closed stream now always carries a producer
+  result — `ProducerDuplicate` for a retry of the closing tuple, otherwise
+  `ProducerStreamClosed` — which is the same 409 (or 204) on the wire as before,
+  since the server already synthesised the closed result when the store gave it
+  nothing.
+
 
 - **A handler can take an injected dependency without losing drift detection.**
   A stage-0 handler is called `fn(event)`, so a dependency had nowhere to go, and

--- a/src/django_rakaia/django_store.py
+++ b/src/django_rakaia/django_store.py
@@ -51,16 +51,13 @@ from rakaia.json_mode import (
     normalize_content_type,
     process_json_append,
 )
-from rakaia.producer import validate_producer
 from rakaia.types import (
     AppendOptions,
     AppendResult,
     CloseResult,
     ContentTypeMismatch,
     ProducerAccepted,
-    ProducerDuplicate,
     ProducerState,
-    ProducerStreamClosed,
     ProducerValidationResult,
     SequenceConflict,
     StreamConfigConflict,
@@ -335,35 +332,27 @@ class DjangoStreamStore:
             if stream is None:
                 return None
 
-            if stream.closed:
-                # Mirror the in-memory store: an already-closed stream is
-                # reported, never re-closed — a different producer's close must
-                # not overwrite `closed_by`, which is what makes a retry of the
-                # *original* closing tuple recognisable as a duplicate.
-                by = stream.closed_by
-                if by is not None and (by.producer_id, by.epoch, by.seq) == (
-                    producer_id,
-                    epoch,
-                    seq,
-                ):
-                    return CloseResult(
-                        final_offset=stream.current_offset,
-                        already_closed=True,
-                        producer_result=ProducerDuplicate(last_seq=seq),
-                    )
+            # A close is admitted on the same terms as a fenced append with no
+            # body, so it asks the same question: an already-closed stream is
+            # reported, never re-closed — a different producer's close must not
+            # overwrite `closed_by`, which is what makes a retry of the
+            # *original* closing tuple recognisable as a duplicate.
+            verdict = decide_append(
+                StreamFacts(closed=stream.closed, closed_by=stream.closed_by),
+                AppendOptions(
+                    producer_id=producer_id, producer_epoch=epoch, producer_seq=seq
+                ),
+                producer_state=self._producer_state(stream, producer_id),
+                now=time.time(),
+            )
+            if not verdict.write:
                 return CloseResult(
                     final_offset=stream.current_offset,
-                    already_closed=True,
-                    producer_result=ProducerStreamClosed(),
+                    already_closed=verdict.stream_closed,
+                    producer_result=verdict.producer_result,
                 )
 
-            result = self._validate_producer(stream, producer_id, epoch, seq)
-            if not isinstance(result, ProducerAccepted):
-                return CloseResult(
-                    final_offset=stream.current_offset, producer_result=result
-                )
-
-            self._commit_producer(stream, result)
+            self._commit_producer(stream, verdict.producer_result)
             stream.closed = True
             stream.closed_at = time.time()
             stream.last_activity_at = time.time()
@@ -464,25 +453,6 @@ class DjangoStreamStore:
     # =========================================================================
     # Append helpers
     # =========================================================================
-
-    @staticmethod
-    def _check_content_type(stream: Stream, opts: Any) -> None:
-        provided = getattr(opts, "content_type", None)
-        if (
-            provided
-            and stream.content_type
-            and normalize_content_type(provided)
-            != normalize_content_type(stream.content_type)
-        ):
-            raise ContentTypeMismatch(
-                f"Content-type mismatch: expected {stream.content_type}, got {provided}"
-            )
-
-    @staticmethod
-    def _check_seq(stream: Stream, opts: Any) -> None:
-        seq = getattr(opts, "seq", None)
-        if seq is not None and stream.last_seq is not None and seq <= stream.last_seq:
-            raise SequenceConflict(f"Sequence conflict: {seq} <= {stream.last_seq}")
 
     @staticmethod
     def _close_from_append(stream: Stream, opts: Any) -> None:
@@ -587,26 +557,6 @@ class DjangoStreamStore:
     # Producer fencing
     # =========================================================================
 
-    def _validate_producer(
-        self, stream: Stream, producer_id: str, epoch: int, seq: int
-    ) -> ProducerValidationResult:
-        """Decide the outcome for one fenced write, without mutating.
-
-        The rules live in `rakaia.producer`, shared with the in-memory store,
-        so the two cannot drift. This only supplies the last known state.
-        """
-        row = StreamProducer.objects.filter(
-            stream=stream, producer_id=producer_id
-        ).first()
-        state = (
-            None
-            if row is None
-            else ProducerState(
-                epoch=row.epoch, last_seq=row.last_seq, last_updated=row.last_updated
-            )
-        )
-        return validate_producer(state, producer_id, epoch, seq, time.time())
-
     @staticmethod
     def _producer_state(
         stream: Stream, producer_id: str | None
@@ -677,27 +627,33 @@ class DjangoStreamStore:
             # per-producer asyncio.Lock is this lock's in-process analogue.)
             stream = self._require(path, for_update=True)
 
-            result = self._validate_producer(stream, producer_id, epoch, seq)
-
-            if stream.closed:
+            # The same shared sequence `append` uses. This path used to run its
+            # own: fencing first, then closed, and it never read `closed_by` —
+            # so a closed stream answered with the fencing outcome instead of
+            # the close, and a producer retrying its own closing append was
+            # never recognised.
+            verdict = decide_append(
+                StreamFacts(
+                    closed=stream.closed,
+                    closed_by=stream.closed_by,
+                    content_type=stream.content_type,
+                    last_seq=stream.last_seq,
+                ),
+                opts,
+                producer_state=self._producer_state(stream, producer_id),
+                now=time.time(),
+            )
+            if not verdict.write:
                 return AppendResult(
                     message=None,
-                    stream_closed=True,
-                    producer_result=(
-                        result
-                        if not isinstance(result, ProducerAccepted)
-                        else ProducerStreamClosed()
-                    ),
+                    stream_closed=verdict.stream_closed,
+                    producer_result=verdict.producer_result,
                 )
-
-            if not isinstance(result, ProducerAccepted):
-                return AppendResult(message=None, producer_result=result)
-
-            self._check_content_type(stream, opts)
-            self._check_seq(stream, opts)
+            result = verdict.producer_result
 
             messages = self._write(stream, data, opts)
-            self._commit_producer(stream, result)
+            if result is not None:
+                self._commit_producer(stream, result)
             if getattr(opts, "seq", None) is not None:
                 stream.last_seq = opts.seq
                 stream.save(update_fields=["last_seq"])
@@ -772,7 +728,17 @@ class DjangoStreamStore:
             last_seq = stream.last_seq
             cut = len(items)
             for i, (_data, options) in enumerate(items):
-                self._check_content_type(stream, options)
+                provided_ct = getattr(options, "content_type", None)
+                if (
+                    provided_ct
+                    and stream.content_type
+                    and normalize_content_type(provided_ct)
+                    != normalize_content_type(stream.content_type)
+                ):
+                    raise ContentTypeMismatch(
+                        f"Content-type mismatch: expected "
+                        f"{stream.content_type}, got {provided_ct}"
+                    )
                 seq = getattr(options, "seq", None)
                 if seq is not None:
                     if last_seq is not None and seq <= last_seq:

--- a/src/rakaia/append_decision.py
+++ b/src/rakaia/append_decision.py
@@ -18,10 +18,13 @@ persist — so a new backend implements *storage*, not protocol semantics.
 
 **The order is the subtle part** and is the reason this is worth centralising:
 
-1. **Closed** is checked first, and a matching `closed_by` tuple is reported as a
-   duplicate rather than a bare refusal — a producer retrying the append that
-   closed the stream must be able to tell "my close landed" from "someone else
-   closed this".
+1. **Closed** is checked first — before fencing, so a producer whose sequence is
+   also wrong is told the stream is closed rather than told to fix a sequence
+   and retry a write that can never land. A matching `closed_by` tuple is
+   reported as a duplicate rather than a bare refusal, so a producer retrying
+   the append that closed the stream can tell "my close landed" from "someone
+   else closed this"; any other tuple gets `ProducerStreamClosed`, the same
+   answer the close paths give.
 2. **Content type** next: a mismatch is a caller error regardless of fencing.
 3. **Producer fencing before Stream-Seq.** A retried append carries the same
    `Stream-Seq` it did the first time, so checking Stream-Seq first would raise
@@ -45,6 +48,7 @@ from .types import (
     ContentTypeMismatch,
     ProducerDuplicate,
     ProducerState,
+    ProducerStreamClosed,
     ProducerValidationResult,
     SequenceConflict,
 )
@@ -110,7 +114,9 @@ def decide_append(
                 stream_closed=True,
                 producer_result=ProducerDuplicate(last_seq=producer_seq or 0),
             )
-        return AppendVerdict(write=False, stream_closed=True)
+        return AppendVerdict(
+            write=False, stream_closed=True, producer_result=ProducerStreamClosed()
+        )
 
     # 2. Content type.
     provided_ct = getattr(opts, "content_type", None)

--- a/src/rakaia/handler.py
+++ b/src/rakaia/handler.py
@@ -1159,12 +1159,10 @@ async def _handle_append(
             offset=offset,
             stream_closed=True,
         )
-        if decided is None:
-            # Nothing to report about the producer — an unfenced append, or one
-            # whose fencing was fine. The closed stream is itself the answer.
-            decided = producer_response(
-                ProducerStreamClosed(), producer_epoch=producer_epoch, offset=offset
-            )
+        # A refused append on a closed stream always carries a producer result:
+        # `ProducerDuplicate` for a retry of the closing tuple, otherwise
+        # `ProducerStreamClosed` — the stores agree on that via
+        # `rakaia.append_decision`, so there is nothing left to synthesise here.
         assert decided is not None
         await _send_producer_response(send, decided, cors)
         return

--- a/src/rakaia/store.py
+++ b/src/rakaia/store.py
@@ -23,7 +23,7 @@ from .json_mode import (
     normalize_content_type,
     process_json_append,
 )
-from .producer import is_producer_state_expired, validate_producer
+from .producer import is_producer_state_expired
 from .types import (
     INITIAL_OFFSET,
     AppendOptions,
@@ -32,8 +32,6 @@ from .types import (
     ContentTypeMismatch,
     InvalidOffset,
     ProducerAccepted,
-    ProducerDuplicate,
-    ProducerStreamClosed,
     ProducerValidationResult,
     SequenceConflict,
     Stream,
@@ -432,36 +430,26 @@ class StreamStore:
             if stream is None:
                 return None
 
-            if stream.closed:
-                # Check for duplicate (same producer tuple)
-                if (
-                    stream.closed_by is not None
-                    and stream.closed_by.producer_id == producer_id
-                    and stream.closed_by.epoch == producer_epoch
-                    and stream.closed_by.seq == producer_seq
-                ):
-                    return CloseResult(
-                        final_offset=stream.current_offset,
-                        already_closed=True,
-                        producer_result=ProducerDuplicate(last_seq=producer_seq),
-                    )
-                return CloseResult(
-                    final_offset=stream.current_offset,
-                    already_closed=True,
-                    producer_result=ProducerStreamClosed(),
-                )
-
-            # Validate producer
-            producer_result = self._validate_producer(
-                stream, producer_id, producer_epoch, producer_seq
+            # A close is admitted on the same terms as a fenced append with no
+            # body: already closed is reported (as a duplicate for a retry of
+            # the closing tuple), then the producer is fenced.
+            verdict = decide_append(
+                StreamFacts(closed=stream.closed, closed_by=stream.closed_by),
+                AppendOptions(
+                    producer_id=producer_id,
+                    producer_epoch=producer_epoch,
+                    producer_seq=producer_seq,
+                ),
+                producer_state=self._producer_state(stream, producer_id),
+                now=time.time(),
             )
-
-            if producer_result.status != "accepted":
+            if not verdict.write:
                 return CloseResult(
                     final_offset=stream.current_offset,
-                    already_closed=False,
-                    producer_result=producer_result,
+                    already_closed=verdict.stream_closed,
+                    producer_result=verdict.producer_result,
                 )
+            producer_result = verdict.producer_result
 
             # Commit and close
             self._commit_producer_state(stream, producer_result)
@@ -604,28 +592,6 @@ class StreamStore:
             return None
         self._cleanup_expired_producers(stream)
         return stream.producers.get(producer_id)
-
-    def _validate_producer(
-        self,
-        stream: Stream,
-        producer_id: str,
-        epoch: int,
-        seq: int,
-    ) -> ProducerValidationResult:
-        """Validate producer state WITHOUT mutating.
-
-        The rules themselves live in `.producer` so this store and the durable
-        `DjangoStreamStore` decide identically; all this does is supply the
-        last known state and drop it if it has aged out.
-        """
-        self._cleanup_expired_producers(stream)
-        return validate_producer(
-            stream.producers.get(producer_id),
-            producer_id,
-            epoch,
-            seq,
-            time.time(),
-        )
 
     def _commit_producer_state(
         self, stream: Stream, result: ProducerValidationResult

--- a/tests/server_store_contract.py
+++ b/tests/server_store_contract.py
@@ -452,6 +452,42 @@ class ServerStoreContract:
         )
         assert isinstance(accepted.producer_result, ProducerAccepted)
 
+    async def test_append_with_producer_to_a_closed_stream_reports_closed(self, store):
+        """Closed is decided before fencing, on this door too.
+
+        Nothing drove `append_with_producer` against a closed stream, and the
+        two stores had drifted underneath: one answered with the fencing
+        outcome for a write that could never land anyway, so a producer whose
+        seq happened to be wrong learned about the gap instead of learning the
+        stream was closed.
+        """
+        await self._sync(store.create, "s")
+        await store.append_with_producer("s", b'{"id": 1}', self._producer("p", 0, 0))
+        await self._sync(store.close_stream, "s")
+
+        result = await store.append_with_producer(
+            "s", b'{"id": 2}', self._producer("p", 0, 9)
+        )
+        assert result.stream_closed is True
+        assert result.message is None
+        assert isinstance(result.producer_result, ProducerStreamClosed)
+
+    async def test_append_with_producer_retrying_a_closing_tuple_is_a_duplicate(
+        self, store
+    ):
+        """A producer that loses the response to its own closing append must be
+        able to tell "my close landed" from "someone else closed this"."""
+        await self._sync(store.create, "s")
+        opts = AppendOptions(
+            producer_id="p", producer_epoch=0, producer_seq=0, close=True
+        )
+        await store.append_with_producer("s", b'{"id": 1}', opts)
+
+        again = await store.append_with_producer("s", b'{"id": 1}', opts)
+        assert again.stream_closed is True
+        assert isinstance(again.producer_result, ProducerDuplicate)
+        assert again.message is None
+
     # =========================================================================
     # Producer options on the plain `append` path
     # =========================================================================
@@ -547,7 +583,7 @@ class ServerStoreContract:
             store.append, "s", b'{"id": 2}', self._producer("other", 0, 0)
         )
         assert other.stream_closed is True
-        assert other.producer_result is None
+        assert isinstance(other.producer_result, ProducerStreamClosed)
         assert other.message is None
 
     # =========================================================================

--- a/tests/test_rakaia/test_append_decision.py
+++ b/tests/test_rakaia/test_append_decision.py
@@ -24,6 +24,7 @@ from rakaia.types import (
     ProducerSequenceGap,
     ProducerStaleEpoch,
     ProducerState,
+    ProducerStreamClosed,
     SequenceConflict,
 )
 
@@ -58,7 +59,7 @@ class TestClosed:
         verdict = _decide(StreamFacts(closed=True))
         assert verdict.write is False
         assert verdict.stream_closed is True
-        assert verdict.producer_result is None
+        assert isinstance(verdict.producer_result, ProducerStreamClosed)
 
     def test_the_producer_that_closed_it_gets_a_duplicate(self):
         """A retry of the closing append must be distinguishable from someone
@@ -79,7 +80,9 @@ class TestClosed:
             ("p", 2, 8),  # same producer, different seq
         ],
     )
-    def test_any_other_tuple_is_a_bare_refusal(self, producer_id, epoch, seq):
+    def test_any_other_tuple_is_told_the_stream_is_closed(
+        self, producer_id, epoch, seq
+    ):
         facts = StreamFacts(closed=True, closed_by=ClosedBy("p", epoch=2, seq=7))
         verdict = _decide(
             facts,
@@ -88,7 +91,7 @@ class TestClosed:
             ),
         )
         assert verdict.stream_closed is True
-        assert verdict.producer_result is None
+        assert isinstance(verdict.producer_result, ProducerStreamClosed)
 
 
 class TestContentType:
@@ -169,6 +172,21 @@ class TestOrdering:
         )
         assert verdict.write is False
         assert verdict.stream_closed is True
+
+    def test_closed_is_checked_before_producer_fencing(self):
+        """A closed stream is the answer even when the fencing tuple is also
+        wrong — reporting the gap instead would tell a producer to fix its
+        sequence and retry a write that can never land, and it is what the
+        durable store did before this sequence was shared."""
+        state = ProducerState(epoch=0, last_seq=0, last_updated=NOW)
+        verdict = _decide(
+            StreamFacts(closed=True, closed_by=ClosedBy("p", epoch=0, seq=0)),
+            AppendOptions(producer_id="p", producer_epoch=0, producer_seq=9),
+            producer_state=state,
+        )
+        assert verdict.write is False
+        assert verdict.stream_closed is True
+        assert isinstance(verdict.producer_result, ProducerStreamClosed)
 
     def test_fencing_is_checked_before_stream_seq(self):
         """The load-bearing one. A retried append carries the same Stream-Seq it


### PR DESCRIPTION
Writing to a stream that someone has already closed gave two different answers depending on which store was underneath. On the database-backed store, a writer whose numbering had also slipped was told to fix its numbering — and retrying got the same reply forever — instead of being told the stream was closed and there was nothing left to do. A writer re-sending the very message that closed the stream, after losing the reply, was likewise not recognised as repeating itself.

Both stores now run the one shared set of admission rules, in one order, for every way of appending, and the shared test suite covers the case that had been missed. What a client sees over the wire is unchanged.

Closes #119