### PR TITLE
Putting events into a stream is one call now

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,27 @@ is not yet tagged in a release.
 
 ### Added
 
+- **`rakaia.seed_stream` — putting events into a stream is one call.** Getting a
+  handful of events into a stream took four lines (create, loop, `json.dumps`,
+  `.encode()`) and rakaia never shipped a way to do it, so the test suite carried
+  six hand-rolled copies in three different shapes and the examples twelve more,
+  four of them wrapped in a locally-defined `_append`. Setup in the worst test ran
+  to sixty-eight lines before the first assertion.
+
+  `seed_stream(path, events, store=..., encoder=...)` builds an in-memory
+  `StreamStore` when no store is given, accepts any `WritableStore` when one is,
+  and returns it either way. Payloads may be dicts or pre-encoded bytes; the
+  label/metadata/`event_ts` envelope is **per event** — pair a payload with an
+  `AppendOptions` — because a batch-level label is not what the callers needed.
+  Creation is idempotent and non-destructive, so seeding an existing path appends
+  and no caller needs a `has()` guard.
+
+  The `encoder` parameter is the point: `django_rakaia.envelope.append_event` and
+  `fold_events` are now built on it, passing `DjangoJSONEncoder` in, so there is
+  exactly one `json.dumps` rule in the codebase rather than the drifting second
+  copy `envelope.py` warns about. `append_event`'s output is unchanged, byte for
+  byte, and a test pins that.
+
 - **A declared public API, and a contract for it.**
   [`docs/public-api.md`](docs/public-api.md) sets out three tiers: **Tier 1**
   (`rakaia.__all__` + the new `django_rakaia.__all__`) which does not change

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -404,6 +404,29 @@ Its sibling `fold_events` runs a batch of events through your handlers *now*,
 via a throwaway in-memory stream, so write-time projection and rebuild-time
 projection run the same code rather than two implementations that can disagree.
 
+Underneath both is `rakaia.seed_stream`, which is the same idea one tier down:
+getting a handful of events into a stream, without Django in the picture.
+
+```python
+from rakaia import AppendOptions, seed_stream
+
+store = seed_stream("submissions", [
+    ({"key": "s1", "a": 1}, AppendOptions(label="insert")),
+    ({"key": "s1", "a": 2}, AppendOptions(label="update")),
+])
+```
+
+Omit `store=` and you get a fresh in-memory one back; pass any `WritableStore`
+— the durable Django store, the `get_store()` singleton — and it is used and
+returned. Payloads may be dicts or already-encoded bytes, the envelope is per
+event rather than per batch, and the stream is created idempotently, so seeding
+the same path twice appends rather than truncating.
+
+The `encoder=` parameter is why `append_event` can be built on it without the
+core package growing a Django dependency, and it is what keeps a single
+`json.dumps` rule in the codebase instead of the drifting second copy the
+envelope docstring warns about.
+
 ---
 
 ## 13. Protocol conformance

--- a/examples/orders/orders/live.py
+++ b/examples/orders/orders/live.py
@@ -23,7 +23,6 @@ it enqueues the order for the producer to append on its next tick.
 
 from __future__ import annotations
 
-import json
 import random
 import threading
 import time
@@ -32,7 +31,7 @@ from queue import Empty, Queue
 from typing import Any
 
 from django_rakaia import DjangoExecutor, get_store
-from rakaia import replay
+from rakaia import replay, seed_stream
 
 STREAM = "orders"
 
@@ -82,7 +81,7 @@ class LiveProducer:
 
         store = get_store()
         store.delete(STREAM)
-        store.create(STREAM)
+        seed_stream(STREAM, store=store)
         OrderSummary.objects.all().delete()
         self._thread = threading.Thread(
             target=self._run, name="orders-live-producer", daemon=True
@@ -123,7 +122,7 @@ class LiveProducer:
         store = get_store()
         start = self._seq
         for event in batch:
-            store.append(STREAM, json.dumps(event).encode("utf-8"))
+            seed_stream(STREAM, [event], store=store)
             self._seq += 1
             # Track placed PAID orders (invented *or* browser-submitted) so a
             # later bonus can target a real row; do this before _note_event so

--- a/examples/orders/orders/management/commands/demo_orders.py
+++ b/examples/orders/orders/management/commands/demo_orders.py
@@ -14,7 +14,6 @@ today. That is the time-correctness guarantee.
 
 from __future__ import annotations
 
-import json
 from typing import Any
 
 from django.core.management import call_command
@@ -23,7 +22,7 @@ from django.core.management.base import BaseCommand, CommandError, CommandParser
 from django_rakaia import DjangoExecutor, get_store
 from orders.models import OrderSummary
 from orders.seed import SAMPLE_BONUSES, SAMPLE_ORDERS, TAX_CHANGE_SEQ
-from rakaia import CollectingExecutor, replay
+from rakaia import CollectingExecutor, replay, seed_stream
 
 STREAM = "orders"
 
@@ -60,12 +59,10 @@ class Command(BaseCommand):
         store.delete(STREAM)
         OrderSummary.objects.all().delete()
 
-        store.create(STREAM)
         # Orders first, then the loyalty-bonus events — so each bonus carries a
         # higher seq than the order it decorates and finds the row already
         # materialised when op="update" applies.
-        for event in [*SAMPLE_ORDERS, *SAMPLE_BONUSES]:
-            store.append(STREAM, json.dumps(event).encode("utf-8"))
+        seed_stream(STREAM, [*SAMPLE_ORDERS, *SAMPLE_BONUSES], store=store)
         self.stdout.write(
             f"Seeded {len(SAMPLE_ORDERS)} order events "
             f"(tax rule changes at seq {TAX_CHANGE_SEQ}) "

--- a/examples/partisipa_close/lifecycle/management/commands/demo_close.py
+++ b/examples/partisipa_close/lifecycle/management/commands/demo_close.py
@@ -23,7 +23,6 @@ Four checks, each asserted hard (a failure raises CommandError):
 
 from __future__ import annotations
 
-import json
 from decimal import Decimal
 from typing import Any
 
@@ -41,6 +40,7 @@ from lifecycle.models import (
     Project,
 )
 from lifecycle.seed import EXPECTED_INITIAL, HEAL_EVENTS, SAMPLE_EVENTS
+from rakaia import seed_stream
 
 STREAM = "subproject-lifecycle"
 
@@ -48,10 +48,6 @@ STREAM = "subproject-lifecycle"
 def _reset() -> None:
     for model in (CycleClose, Balance, FinanceLine, Meeting, Project):
         model.objects.all().delete()
-
-
-def _append(store: Any, event: dict) -> None:
-    store.append(STREAM, json.dumps(event).encode("utf-8"))
 
 
 def _close_state() -> dict[str, tuple[str, list]]:
@@ -73,9 +69,7 @@ class Command(BaseCommand):
         call_command("migrate", verbosity=0, interactive=False)
         store = get_store()
         store.delete(STREAM)
-        store.create(STREAM)
-        for event in SAMPLE_EVENTS:
-            _append(store, event)
+        seed_stream(STREAM, SAMPLE_EVENTS, store=store)
         _reset()
         sr.staged_replay(store, STREAM, STAGES)
         self.stdout.write(
@@ -109,8 +103,7 @@ class Command(BaseCommand):
     # -- [2] self-heal ------------------------------------------------------
 
     def _check_self_heal(self, store: Any) -> None:
-        for event in HEAL_EVENTS:
-            _append(store, event)
+        seed_stream(STREAM, HEAL_EVENTS, store=store)
         _reset()
         sr.staged_replay(store, STREAM, STAGES)
         state = _close_state()

--- a/examples/partisipa_history/history/management/commands/demo_history.py
+++ b/examples/partisipa_history/history/management/commands/demo_history.py
@@ -72,7 +72,6 @@ class Command(BaseCommand):
         store = get_store()
         for path in (STREAM, NAIVE_STREAM):
             store.delete(path)
-            store.create(path)
 
         # The "today" path: pghistory records the golden audit table.
         pghistory_today.simulate(SAVES)

--- a/examples/partisipa_history/history/stream_history.py
+++ b/examples/partisipa_history/history/stream_history.py
@@ -27,7 +27,7 @@ import json
 from typing import Any
 
 from django_rakaia import DjangoExecutor
-from rakaia import Effect
+from rakaia import Effect, seed_stream
 
 from .envelope import OP_TO_LABEL, canonical, make_event
 from .models import SubmissionHistoryEntry
@@ -41,15 +41,16 @@ HISTORY_MODEL = "history.SubmissionHistoryEntry"
 
 def append_saves(store: Any, stream: str, saves: list[dict[str, Any]]) -> None:
     """Write each save to the stream as a full envelope event."""
-    for save in saves:
-        store.append(stream, json.dumps(make_event(save)).encode("utf-8"))
+    seed_stream(stream, [make_event(save) for save in saves], store=store)
 
 
 def naive_append(store: Any, stream: str, saves: list[dict[str, Any]]) -> None:
     """The strawman: append only the fields — no actor, no op, no timestamp."""
-    for save in saves:
-        payload = {"key": save["key"], "fields": save["fields"]}
-        store.append(stream, json.dumps(payload).encode("utf-8"))
+    seed_stream(
+        stream,
+        [{"key": save["key"], "fields": save["fields"]} for save in saves],
+        store=store,
+    )
 
 
 # -- replaying into projections ---------------------------------------------

--- a/examples/partisipa_merge/subproject/management/commands/demo_merge.py
+++ b/examples/partisipa_merge/subproject/management/commands/demo_merge.py
@@ -21,13 +21,13 @@ Four checks, each asserted hard (a failure raises CommandError):
 
 from __future__ import annotations
 
-import json
 from typing import Any
 
 from django.core.management import call_command
 from django.core.management.base import BaseCommand, CommandError
 
 from django_rakaia import get_store
+from rakaia import seed_stream
 from subproject import merge_replay as mr
 from subproject.handlers import STAGES
 from subproject.models import (
@@ -52,10 +52,6 @@ from subproject.seed import (
 def _reset() -> None:
     for model in (Readiness, Balance, Claim, FinanceLine, Meeting, Project):
         model.objects.all().delete()
-
-
-def _append(store: Any, path: str, event: dict) -> None:
-    store.append(path, json.dumps(event).encode("utf-8"))
 
 
 def _snapshot() -> dict[str, Any]:
@@ -114,16 +110,14 @@ class Command(BaseCommand):
 
     def _build_single(self, store: Any, events: list[dict]) -> None:
         store.delete(SINGLE_STREAM)
-        store.create(SINGLE_STREAM)
-        for event in events:
-            _append(store, SINGLE_STREAM, event)
+        seed_stream(SINGLE_STREAM, events, store=store)
 
     def _build_three(self, store: Any, events: list[dict]) -> None:
         for path in THREE_STREAMS:
             store.delete(path)
-            store.create(path)
+            seed_stream(path, store=store)
         for event in events:
-            _append(store, STREAMS[event["form_type"]], event)
+            seed_stream(STREAMS[event["form_type"]], [event], store=store)
 
     # -- [1] parity ---------------------------------------------------------
 
@@ -214,8 +208,8 @@ class Command(BaseCommand):
     def _check_self_heal(self, store: Any) -> None:
         # Each fix lands on its own pipeline (and on the combined stream).
         for event in HEAL_EVENTS:
-            _append(store, STREAMS[event["form_type"]], event)
-            _append(store, SINGLE_STREAM, event)
+            seed_stream(STREAMS[event["form_type"]], [event], store=store)
+            seed_stream(SINGLE_STREAM, [event], store=store)
 
         baseline = _replay_baseline(store)
         merged = _replay_merged(store)

--- a/examples/partisipa_repeaters/repeaters/management/commands/demo_repeaters.py
+++ b/examples/partisipa_repeaters/repeaters/management/commands/demo_repeaters.py
@@ -19,13 +19,13 @@ Four checks, each asserted hard (a failure raises CommandError):
 
 from __future__ import annotations
 
-import json
 from typing import Any
 
 from django.core.management import call_command
 from django.core.management.base import BaseCommand, CommandError
 
 from django_rakaia import get_store
+from rakaia import seed_stream
 from repeaters import tree_replay as tr
 from repeaters.models import Node, Total
 from repeaters.seed import (
@@ -79,7 +79,7 @@ class Command(BaseCommand):
         call_command("migrate", verbosity=0, interactive=False)
         store = get_store()
         store.delete(STREAM)
-        store.create(STREAM)
+        seed_stream(STREAM, store=store)
         self.stdout.write(f"Submission {SUBMISSION}: v1 tree, then a pruned v2.\n")
 
         self._check_build(store)
@@ -89,13 +89,10 @@ class Command(BaseCommand):
 
         self.stdout.write(self.style.SUCCESS("\nAll tree-reconcile checks passed ✓"))
 
-    def _append(self, store: Any, event: dict) -> None:
-        store.append(STREAM, json.dumps(event).encode("utf-8"))
-
     # -- [1] build ----------------------------------------------------------
 
     def _check_build(self, store: Any) -> None:
-        self._append(store, V1_EVENT)
+        seed_stream(STREAM, [V1_EVENT], store=store)
         _reset()
         tr.replay_tree(store, STREAM)
         ids, total, dangling = _node_ids(), _total(), _dangling_parents()
@@ -113,7 +110,7 @@ class Command(BaseCommand):
     # -- [2] naive orphans --------------------------------------------------
 
     def _check_naive(self, store: Any) -> None:
-        self._append(store, V2_EVENT)  # the resubmission
+        seed_stream(STREAM, [V2_EVENT], store=store)  # the resubmission
         _reset()
         tr.replay_naive(store, STREAM)
         ids, total = _node_ids(), _total()

--- a/examples/partisipa_staged/partisipa/management/commands/demo_staged.py
+++ b/examples/partisipa_staged/partisipa/management/commands/demo_staged.py
@@ -18,7 +18,6 @@ Three checks, each asserted hard (a failure raises CommandError):
 
 from __future__ import annotations
 
-import json
 from typing import Any
 
 from django.core.management import call_command
@@ -29,6 +28,7 @@ from partisipa import staged_replay as sr
 from partisipa.handlers import ALL_ONE_STAGE, STAGED
 from partisipa.models import Project, Sf12
 from partisipa.seed import LATE_SF, LATE_TF, SAMPLE_SUBMISSIONS
+from rakaia import seed_stream
 
 STREAM = "submissions"
 
@@ -48,10 +48,6 @@ def _link_state() -> tuple[list, list]:
     return links, projects
 
 
-def _append(store: Any, event: dict) -> None:
-    store.append(STREAM, json.dumps(event).encode("utf-8"))
-
-
 class Command(BaseCommand):
     help = "Demonstrate staged replay resolving late-arriving cross-form links."
 
@@ -62,9 +58,7 @@ class Command(BaseCommand):
         call_command("migrate", verbosity=0, interactive=False)
         store = get_store()
         store.delete(STREAM)
-        store.create(STREAM)
-        for event in SAMPLE_SUBMISSIONS:
-            _append(store, event)
+        seed_stream(STREAM, SAMPLE_SUBMISSIONS, store=store)
         self.stdout.write(
             f"Seeded {len(SAMPLE_SUBMISSIONS)} submissions "
             f"(every SF_1_2 precedes its TF_6_1_1 in the stream).\n"
@@ -122,7 +116,7 @@ class Command(BaseCommand):
 
     def _check_self_heal(self, store: Any) -> None:
         # A new SF whose TF has NOT been submitted yet.
-        _append(store, LATE_SF)
+        seed_stream(STREAM, [LATE_SF], store=store)
         _reset_projections()
         sr.staged_replay(store, STREAM, STAGED)
         late = Sf12.objects.get(submission_id=LATE_SF["key"])
@@ -136,7 +130,7 @@ class Command(BaseCommand):
         )
 
         # The TF finally arrives. Re-run staged — no bespoke backfill task.
-        _append(store, LATE_TF)
+        seed_stream(STREAM, [LATE_TF], store=store)
         _reset_projections()
         sr.staged_replay(store, STREAM, STAGED)
         healed = Sf12.objects.get(submission_id=LATE_SF["key"])

--- a/examples/projection_cookbook/cookbook/management/commands/demo_cookbook.py
+++ b/examples/projection_cookbook/cookbook/management/commands/demo_cookbook.py
@@ -11,7 +11,6 @@ non-zero on failure, so it doubles as a smoke test.
 
 from __future__ import annotations
 
-import json
 from typing import Any
 
 from django.core.management import call_command
@@ -28,7 +27,7 @@ from django_rakaia import (
     diff_effects_against_rows,
     get_store,
 )
-from rakaia import CollectingExecutor, replay
+from rakaia import CollectingExecutor, replay, seed_stream
 
 STREAM = "cookbook"
 
@@ -49,9 +48,7 @@ class Command(BaseCommand):
         store.delete(STREAM)
         Task.objects.all().delete()
         Project.objects.all().delete()
-        store.create(STREAM)
-        for event in SAMPLE_EVENTS:
-            store.append(STREAM, json.dumps(event).encode("utf-8"))
+        seed_stream(STREAM, SAMPLE_EVENTS, store=store)
         self.stdout.write(
             f"Seeded {len(SAMPLE_EVENTS)} events "
             "(the P-100 tasks arrive before the P-100 project)."
@@ -127,7 +124,7 @@ class Command(BaseCommand):
         and the sweep has no evidence either way.
         """
         renamed = f"{STREAM}-renamed"
-        store.create(renamed)
+        seed_stream(renamed, store=store)
 
         ex = CollectingExecutor()
         replay(store, renamed, ex, reader=DjangoProjectionReader())

--- a/src/django_rakaia/envelope.py
+++ b/src/django_rakaia/envelope.py
@@ -25,13 +25,12 @@ models. The core package stays dependency-free.
 
 from __future__ import annotations
 
-import json
 from collections.abc import Sequence
 from typing import Any
 
 from django.core.serializers.json import DjangoJSONEncoder
 
-from rakaia import AppendOptions, StreamStore
+from rakaia import AppendOptions, seed_stream
 from rakaia.protocols import ProjectionReader, WritableStore
 from rakaia.registry import HandlerRegistry
 from rakaia.replay import replay
@@ -78,21 +77,32 @@ def append_event(
     * ``event_ts`` is passed through. ``None`` means "order by append time",
       which is the pre-existing default, not a silent loss of ordering.
 
+    The create-and-append itself is `rakaia.seed_stream`, handed the Django
+    encoder: this module's whole warning is about a second `json.dumps` rule
+    drifting from the first, so there is one and it lives in the core package.
+    What stays here is the Django-shaped part — which encoder, and where an
+    actor goes.
+
     ``create()`` is called unconditionally rather than guarded by ``has()``:
     creation is idempotent by contract and — as
     ``tests/store_contract.py::test_create_on_an_existing_stream_preserves_its_messages``
     pins — a redundant create cannot truncate a populated stream or rewind its
     offsets. One round trip instead of two.
     """
-    store.create(stream_path)
-    store.append(
+    seed_stream(
         stream_path,
-        json.dumps(payload, cls=DjangoJSONEncoder).encode(),
-        AppendOptions(
-            label=label,
-            metadata={"user": actor} if actor is not None else None,
-            event_ts=event_ts,
-        ),
+        [
+            (
+                payload,
+                AppendOptions(
+                    label=label,
+                    metadata={"user": actor} if actor is not None else None,
+                    event_ts=event_ts,
+                ),
+            )
+        ],
+        store=store,
+        encoder=DjangoJSONEncoder,
     )
 
 
@@ -132,14 +142,11 @@ def fold_events(
 
     from .effect_executor import DjangoExecutor
 
-    scratch = StreamStore()
-    scratch.create(scratch_path)
-    for event in events:
-        scratch.append(
-            scratch_path,
-            json.dumps(event, cls=DjangoJSONEncoder).encode(),
-            AppendOptions(label=label),
-        )
+    scratch = seed_stream(
+        scratch_path,
+        [(event, AppendOptions(label=label)) for event in events],
+        encoder=DjangoJSONEncoder,
+    )
 
     replay(
         scratch,

--- a/src/rakaia/__init__.py
+++ b/src/rakaia/__init__.py
@@ -76,6 +76,7 @@ from .registry import (
     upcast,
 )
 from .replay import ENVELOPE_TS, ReplayResult, TouchedSubject, merge_replay, replay
+from .seed import seed_stream
 from .store import StreamStore
 from .subscription import Poll, PollStatus, poll
 from .types import (
@@ -139,6 +140,7 @@ __all__ = [
     "app",
     # Store
     "StreamStore",
+    "seed_stream",
     # Extension protocols (storage / projection seams)
     "ReadableStore",
     "WritableStore",

--- a/src/rakaia/seed.py
+++ b/src/rakaia/seed.py
@@ -1,0 +1,117 @@
+"""Putting events into a stream — the first thing anyone does, in one call.
+
+Getting a handful of events into a stream took four lines and rakaia never
+shipped a way to do it, so everyone wrote the four lines: create the stream,
+loop, `json.dumps`, `.encode()`. Our own suite had six hand-rolled copies in
+three different shapes and our examples had twelve more, four of them wrapped in
+a locally-defined `_append`. The cost lands hardest on tests, where setup ran to
+sixty-eight lines before the first assertion and the reader could not see what
+the test was about.
+
+The shape here is the union of what those call sites actually needed, and
+nothing else:
+
+* **The store is optional.** Omit it and you get a fresh in-memory `StreamStore`;
+  pass one and it is used. Either way it is returned, so both the
+  ``seed_stream(...)`` and ``store = seed_stream(...)`` styles read naturally.
+* **Any `WritableStore` works** — `DjangoStreamStore` and a process-wide
+  singleton are as valid as an in-memory store.
+* **The envelope is per event, not per batch.** A batch-level ``label=`` would
+  have been shorter and wrong: real callers want a different label on each event
+  with metadata on only the first, or a different ``event_ts`` on each. An event
+  may therefore be given as ``(payload, AppendOptions(...))``, reusing the
+  vocabulary `append` already speaks rather than inventing a parallel one.
+* **Payloads may be dicts or already-encoded bytes**, because callers pinning an
+  exact on-the-wire shape pass bytes.
+* **Creation is unconditional.** `create()` is idempotent by store contract and,
+  as ``tests/store_contract.py::test_create_on_an_existing_stream_preserves_its_messages``
+  pins, cannot truncate a populated stream — so seeding the same path twice
+  appends, and no caller needs a ``has()`` guard.
+
+The ``encoder`` hook is the load-bearing part. Django payloads need
+`DjangoJSONEncoder` so a `UUID`, `datetime` or `Decimal` survives, and a
+dependency-free core package cannot import it. Taking the encoder as a parameter
+keeps **one** `json.dumps` call in the codebase: `django_rakaia.envelope.append_event`
+passes its encoder in rather than repeating the rule. `envelope.py` warns that a
+drifting second copy "produces events that replay differently from every other
+event in the same stream, and no test anywhere is looking at the difference" —
+a hook is how that stays a warning about the past.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable
+from typing import Any, TypeVar, Union, overload
+
+from .protocols import WritableStore
+from .store import StreamStore
+from .types import AppendOptions
+
+#: One event to seed: a JSON-encodable payload, pre-encoded bytes, or either of
+#: those paired with the `AppendOptions` envelope to record on it.
+SeedEvent = Union[
+    "dict[str, Any]",
+    bytes,
+    "tuple[dict[str, Any] | bytes, AppendOptions | None]",
+]
+
+_S = TypeVar("_S", bound=WritableStore)
+
+
+@overload
+def seed_stream(
+    path: str,
+    events: Iterable[SeedEvent] = ...,
+    *,
+    store: _S,
+    encoder: type[json.JSONEncoder] | None = ...,
+) -> _S: ...
+
+
+@overload
+def seed_stream(
+    path: str,
+    events: Iterable[SeedEvent] = ...,
+    *,
+    store: None = ...,
+    encoder: type[json.JSONEncoder] | None = ...,
+) -> StreamStore: ...
+
+
+def seed_stream(
+    path: str,
+    events: Iterable[SeedEvent] = (),
+    *,
+    store: _S | None = None,
+    encoder: type[json.JSONEncoder] | None = None,
+) -> _S | StreamStore:
+    """Create ``path`` and append ``events`` to it, in list order.
+
+    ``events`` are payloads — dicts, which are JSON-encoded, or ``bytes``, which
+    are appended untouched. Pair one with `AppendOptions` to give it an envelope::
+
+        store = seed_stream("submissions", [
+            ({"key": "s1", "a": 1}, AppendOptions(label="insert",
+                                                  metadata={"user": 42})),
+            ({"key": "s1", "a": 2}, AppendOptions(label="update")),
+        ])
+
+    ``store`` defaults to a fresh in-memory `StreamStore` and is returned either
+    way. ``encoder`` is a `json.JSONEncoder` subclass passed straight to
+    `json.dumps`; it never touches a ``bytes`` payload.
+
+    Seeding is additive: the stream is created unconditionally, which is
+    idempotent and non-destructive, so seeding an existing path appends to it.
+    """
+    target: Any = StreamStore() if store is None else store
+    target.create(path)
+    for event in events:
+        payload, options = event if isinstance(event, tuple) else (event, None)
+        data = (
+            payload
+            if isinstance(payload, bytes)
+            else json.dumps(payload, cls=encoder).encode("utf-8")
+        )
+        target.append(path, data, options)
+    return target

--- a/tests/test_django_rakaia/test_alerts.py
+++ b/tests/test_django_rakaia/test_alerts.py
@@ -12,7 +12,6 @@ never touches authored alerts.
 
 from __future__ import annotations
 
-import json
 from typing import Any
 
 import pytest
@@ -23,7 +22,7 @@ from rakaia.effects import Effect
 from rakaia.projections import reconcile_by_key
 from rakaia.registry import HandlerRegistry
 from rakaia.replay import replay
-from rakaia.store import StreamStore
+from rakaia.seed import seed_stream
 
 from .models import Alert
 
@@ -385,14 +384,6 @@ class TestMachineResolutionTransitions:
     by default, delivered when ``include_external=True``, never re-spammed."""
 
     @staticmethod
-    def _seed_stream(events: list[dict]) -> StreamStore:
-        store = StreamStore()
-        store.create("sub:1")
-        for ev in events:
-            store.append("sub:1", json.dumps(ev).encode("utf-8"))
-        return store
-
-    @staticmethod
     def _registry() -> HandlerRegistry:
         reg = HandlerRegistry()
 
@@ -419,7 +410,7 @@ class TestMachineResolutionTransitions:
         ]
 
     def test_one_transition_per_real_resolution(self):
-        store = self._seed_stream(self._events)
+        store = seed_stream("sub:1", self._events)
         ex = _CapturingDjangoExecutor()
         replay(
             store, "sub:1", ex, handler_registry=self._registry(), include_external=True
@@ -437,7 +428,7 @@ class TestMachineResolutionTransitions:
         assert t.payload["resolved_at"] == "t2"
 
     def test_still_violating_key_emits_no_transition(self):
-        store = self._seed_stream(self._events)
+        store = seed_stream("sub:1", self._events)
         ex = _CapturingDjangoExecutor()
         replay(
             store, "sub:1", ex, handler_registry=self._registry(), include_external=True
@@ -446,14 +437,14 @@ class TestMachineResolutionTransitions:
         assert "ff4_operational_exceeds_ksp" not in fired  # A stayed open
 
     def test_transition_skipped_on_replay_by_default(self):
-        store = self._seed_stream(self._events)
+        store = seed_stream("sub:1", self._events)
         ex = _CapturingDjangoExecutor()
         result = replay(store, "sub:1", ex, handler_registry=self._registry())
         assert ex.externals == []  # not delivered
         assert result.external_effects_skipped == 1  # but counted
 
     def test_rebuild_is_silent_by_default(self):
-        store = self._seed_stream(self._events)
+        store = seed_stream("sub:1", self._events)
         reg = self._registry()
         for _ in range(2):  # a rebuild replays from scratch at the default gate
             ex = _CapturingDjangoExecutor()
@@ -589,10 +580,7 @@ def _staged_registry() -> HandlerRegistry:
 
 
 def _run(events: list[dict], **kw: Any):
-    store = StreamStore()
-    store.create("sub:1")
-    for e in events:
-        store.append("sub:1", json.dumps(e).encode("utf-8"))
+    store = seed_stream("sub:1", events)
     return replay(
         store,
         "sub:1",

--- a/tests/test_django_rakaia/test_django_store.py
+++ b/tests/test_django_rakaia/test_django_store.py
@@ -19,7 +19,7 @@ from rakaia import CollectingExecutor
 from rakaia.effects import Effect
 from rakaia.registry import HandlerRegistry
 from rakaia.replay import replay
-from rakaia.store import StreamStore
+from rakaia.seed import seed_stream
 from rakaia.types import AppendOptions, SequenceConflict, StreamConfigConflict
 
 
@@ -392,17 +392,11 @@ class TestDjangoStreamStoreReplay:
         events = [{"id": 1, "name": "a"}, {"id": 2, "name": "b"}]
         reg = self._register()
 
-        mem = StreamStore()
-        mem.create("s")
-        for ev in events:
-            mem.append("s", json.dumps(ev).encode("utf-8"))
+        mem = seed_stream("s", events)
         mem_ex = CollectingExecutor()
         replay(mem, "s", mem_ex, handler_registry=reg)
 
-        dj = DjangoStreamStore()
-        dj.create("s")
-        for ev in events:
-            dj.append("s", json.dumps(ev).encode("utf-8"))
+        dj = seed_stream("s", events, store=DjangoStreamStore())
         dj_ex = CollectingExecutor()
         replay(dj, "s", dj_ex, handler_registry=reg)
 

--- a/tests/test_django_rakaia/test_hermeticity.py
+++ b/tests/test_django_rakaia/test_hermeticity.py
@@ -11,8 +11,6 @@ lie. See ADR 0003.
 
 from __future__ import annotations
 
-import json
-
 import pytest
 
 from django_rakaia.effect_executor import DjangoExecutor
@@ -21,6 +19,7 @@ from django_rakaia.projection_reader import DjangoProjectionReader
 from rakaia.effects import Effect
 from rakaia.registry import HandlerRegistry, UpcasterRegistry
 from rakaia.replay import replay
+from rakaia.seed import seed_stream
 from rakaia.store import StreamStore
 
 # A *plain* model (no `@stream_model`): saving it fires no post_save append, so
@@ -53,11 +52,7 @@ def _impure_handler(event):
 def _mem_store(events: list[dict]) -> StreamStore:
     """An in-memory log so the *event source* never touches a guarded alias —
     only the handlers' own reads can trip the guard."""
-    store = StreamStore()
-    store.create("s")
-    for event in events:
-        store.append("s", json.dumps(event).encode("utf-8"))
-    return store
+    return seed_stream("s", events)
 
 
 def _replay(store: StreamStore, registry: HandlerRegistry) -> None:

--- a/tests/test_django_rakaia/test_history_materializer.py
+++ b/tests/test_django_rakaia/test_history_materializer.py
@@ -11,6 +11,7 @@ import pytest
 from django_rakaia.django_store import DjangoStreamStore
 from django_rakaia.history import materialize_history
 from rakaia.history import envelope_actor, label_marker
+from rakaia.seed import seed_stream
 from rakaia.types import AppendOptions
 
 from .models import History
@@ -26,19 +27,18 @@ def _defaults(msg, event):
 
 
 def _seed() -> DjangoStreamStore:
-    store = DjangoStreamStore()
-    store.create("submissions")
-    store.append(
+    return seed_stream(
         "submissions",
-        b'{"key": "s1", "user_id": 9, "a": 1}',
-        AppendOptions(label="insert", metadata={"user": 42}),
+        [
+            (
+                b'{"key": "s1", "user_id": 9, "a": 1}',
+                AppendOptions(label="insert", metadata={"user": 42}),
+            ),
+            # no context -> actor falls back to owner
+            (b'{"key": "s1", "user_id": 9, "a": 2}', AppendOptions(label="update")),
+        ],
+        store=DjangoStreamStore(),
     )
-    store.append(
-        "submissions",
-        b'{"key": "s1", "user_id": 9, "a": 2}',
-        AppendOptions(label="update"),  # no context -> actor falls back to owner
-    )
-    return store
 
 
 def _materialize(store, **kw):

--- a/tests/test_django_rakaia/test_projection_reader.py
+++ b/tests/test_django_rakaia/test_projection_reader.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import json
-
 import pytest
 
 from django_rakaia.effect_executor import DjangoExecutor
@@ -12,6 +10,7 @@ from django_rakaia.store import get_store
 from rakaia.effects import Effect
 from rakaia.registry import HandlerRegistry, UpcasterRegistry
 from rakaia.replay import merge_replay, replay
+from rakaia.seed import seed_stream
 
 from .models import Area
 
@@ -64,9 +63,7 @@ class TestStagedReplayOverOrm:
     def test_stage1_reads_stage0_committed_rows(self):
         store = get_store()
         store.delete("s")
-        store.create("s")
-        for event in _EVENTS:
-            store.append("s", json.dumps(event).encode("utf-8"))
+        seed_stream("s", _EVENTS, store=store)
 
         reg = HandlerRegistry()
         reg.register("ref", "REF", _ref_handler, 0, None, match_field="kind", stage=0)
@@ -117,6 +114,18 @@ _FINANCE_EVENTS = [
 ]
 
 
+def _line(key: str, suku: str, delta: int, hour: str) -> dict:
+    """A finance line with an explicit `ts`, for the merge ordering test."""
+    return {
+        "schema_version": 1,
+        "kind": "FINANCE",
+        "key": key,
+        "suku": suku,
+        "delta": delta,
+        "ts": f"2026-01-01T{hour}:00:00Z",
+    }
+
+
 @pytest.mark.django_db
 class TestReducerOverOrm:
     def test_reducer_recomputes_aggregate_via_reconcile_aggregate(self):
@@ -124,9 +133,7 @@ class TestReducerOverOrm:
 
         store = get_store()
         store.delete("s")
-        store.create("s")
-        for event in _FINANCE_EVENTS:
-            store.append("s", json.dumps(event).encode("utf-8"))
+        seed_stream("s", _FINANCE_EVENTS, store=store)
 
         reg = HandlerRegistry()
         reg.register(
@@ -215,45 +222,11 @@ class TestMergeReplayOverOrm:
         store = get_store()
         for path in ("fin/a", "fin/b"):
             store.delete(path)
-            store.create(path)
-        store.append(
-            "fin/a",
-            json.dumps(
-                {
-                    "schema_version": 1,
-                    "kind": "FINANCE",
-                    "key": "f1",
-                    "suku": "A",
-                    "delta": 100,
-                    "ts": "2026-01-01T00:00:00Z",
-                }
-            ).encode("utf-8"),
-        )
-        store.append(
+        seed_stream("fin/a", [_line("f1", "A", 100, "00")], store=store)
+        seed_stream(
             "fin/b",
-            json.dumps(
-                {
-                    "schema_version": 1,
-                    "kind": "FINANCE",
-                    "key": "f2",
-                    "suku": "A",
-                    "delta": -30,
-                    "ts": "2026-01-01T01:00:00Z",
-                }
-            ).encode("utf-8"),
-        )
-        store.append(
-            "fin/b",
-            json.dumps(
-                {
-                    "schema_version": 1,
-                    "kind": "FINANCE",
-                    "key": "f3",
-                    "suku": "B",
-                    "delta": 50,
-                    "ts": "2026-01-01T02:00:00Z",
-                }
-            ).encode("utf-8"),
+            [_line("f2", "A", -30, "01"), _line("f3", "B", 50, "02")],
+            store=store,
         )
 
         reg = HandlerRegistry()

--- a/tests/test_django_rakaia/test_replay_command.py
+++ b/tests/test_django_rakaia/test_replay_command.py
@@ -3,13 +3,13 @@
 from __future__ import annotations
 
 import io
-import json
 
 import pytest
 from django.core.management import call_command
 
 from django_rakaia.store import get_store
 from rakaia.registry import HandlerDriftError
+from rakaia.seed import seed_stream
 
 # Importing handlers for the side effect of registering the autodiscovered
 # handler that the management command tests dispatch against.
@@ -18,12 +18,9 @@ from .models import Area
 
 
 def _seed(stream_path: str, events: list[dict]) -> None:
-    store = get_store()
-    # The store is a process-wide singleton; tolerate the stream already existing.
-    if not store.has(stream_path):
-        store.create(stream_path)
-    for ev in events:
-        store.append(stream_path, json.dumps(ev).encode("utf-8"))
+    # The store is a process-wide singleton, and seeding is additive: `create()`
+    # is idempotent and cannot truncate, so an existing stream needs no guard.
+    seed_stream(stream_path, events, store=get_store())
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_django_rakaia/test_replay_helper.py
+++ b/tests/test_django_rakaia/test_replay_helper.py
@@ -4,14 +4,13 @@ not fail with "stage > 0 but no reader" (#68 minor)."""
 
 from __future__ import annotations
 
-import json
-
 import pytest
 
 from django_rakaia.replay import replay_stream
 from django_rakaia.store import get_store
 from rakaia.effects import Effect
 from rakaia.registry import HandlerRegistry, UpcasterRegistry
+from rakaia.seed import seed_stream
 
 from .models import Area
 
@@ -41,14 +40,16 @@ class TestReplayStream:
     def test_staged_replay_defaults_the_reader(self):
         store = get_store()
         store.delete("s")
-        store.create("s")
         # Dependent arrives before the reference it needs — only a staged replay
         # with a reader resolves it.
-        for event in (
-            {"schema_version": 1, "kind": "DEP", "key": "d1", "ref": "the-ref"},
-            {"schema_version": 1, "kind": "REF", "key": "r1", "name": "the-ref"},
-        ):
-            store.append("s", json.dumps(event).encode("utf-8"))
+        seed_stream(
+            "s",
+            [
+                {"schema_version": 1, "kind": "DEP", "key": "d1", "ref": "the-ref"},
+                {"schema_version": 1, "kind": "REF", "key": "r1", "name": "the-ref"},
+            ],
+            store=store,
+        )
 
         reg = HandlerRegistry()
         reg.register("ref", "REF", _ref, 0, None, match_field="kind", stage=0)
@@ -67,10 +68,10 @@ class TestReplayStream:
     def test_returns_replay_result(self):
         store = get_store()
         store.delete("s2")
-        store.create("s2")
-        store.append(
+        seed_stream(
             "s2",
-            json.dumps({"schema_version": 1, "kind": "REF", "name": "solo"}).encode(),
+            [{"schema_version": 1, "kind": "REF", "name": "solo"}],
+            store=store,
         )
 
         reg = HandlerRegistry()

--- a/tests/test_django_rakaia/test_subscription.py
+++ b/tests/test_django_rakaia/test_subscription.py
@@ -7,19 +7,17 @@ with the Django store's non-zero-padded integer offsets.
 
 from __future__ import annotations
 
-import json
-
 import pytest
 
 from django_rakaia.django_store import DjangoStreamStore
 from django_rakaia.subscription import commit_cursor, load_cursor, poll_consumer
+from rakaia.seed import seed_stream
 
 CONSUMER = "reporting"
 
 
 def _append(store: DjangoStreamStore, path: str, n: int) -> None:
-    for i in range(n):
-        store.append(path, json.dumps({"i": i}).encode())
+    seed_stream(path, [{"i": i} for i in range(n)], store=store)
 
 
 @pytest.mark.django_db

--- a/tests/test_django_rakaia/test_using_seam.py
+++ b/tests/test_django_rakaia/test_using_seam.py
@@ -9,8 +9,6 @@ instead of a bespoke in-memory engine.
 
 from __future__ import annotations
 
-import json
-
 import pytest
 
 from django_rakaia.effect_executor import DjangoExecutor
@@ -19,6 +17,7 @@ from django_rakaia.store import get_store
 from rakaia.effects import Effect, Ref
 from rakaia.registry import HandlerRegistry, UpcasterRegistry
 from rakaia.replay import replay
+from rakaia.seed import seed_stream
 
 from .models import Area, FinanceLine
 
@@ -114,9 +113,7 @@ class TestFromScratchRebuildProof:
     def test_staged_rebuild_links_in_overlay_leaving_default_empty(self):
         store = get_store()
         store.delete("s")
-        store.create("s")
-        for event in _EVENTS:
-            store.append("s", json.dumps(event).encode("utf-8"))
+        seed_stream("s", _EVENTS, store=store)
 
         reg = HandlerRegistry()
         reg.register("ref", "REF", _ref_handler, 0, None, match_field="kind", stage=0)

--- a/tests/test_django_rakaia/test_verification.py
+++ b/tests/test_django_rakaia/test_verification.py
@@ -8,7 +8,6 @@ issue #68 item #1.
 
 from __future__ import annotations
 
-import json
 import uuid
 from decimal import Decimal
 
@@ -23,6 +22,7 @@ from rakaia.effects import Effect
 from rakaia.executors import CollectingExecutor
 from rakaia.registry import HandlerRegistry, UpcasterRegistry
 from rakaia.replay import replay
+from rakaia.seed import seed_stream
 
 from .models import FinanceLine, Measure
 
@@ -196,24 +196,26 @@ class TestEndToEndCollectingExecutorProof:
 
         store = get_store()
         store.delete("s")
-        store.create("s")
-        for event in (
-            {
-                "schema_version": 1,
-                "kind": "FINANCE",
-                "key": "f1",
-                "suku": "A",
-                "delta": 100,
-            },
-            {
-                "schema_version": 1,
-                "kind": "FINANCE",
-                "key": "f2",
-                "suku": "B",
-                "delta": 50,
-            },
-        ):
-            store.append("s", json.dumps(event).encode("utf-8"))
+        seed_stream(
+            "s",
+            [
+                {
+                    "schema_version": 1,
+                    "kind": "FINANCE",
+                    "key": "f1",
+                    "suku": "A",
+                    "delta": 100,
+                },
+                {
+                    "schema_version": 1,
+                    "kind": "FINANCE",
+                    "key": "f2",
+                    "suku": "B",
+                    "delta": 50,
+                },
+            ],
+            store=store,
+        )
 
         reg = HandlerRegistry()
         reg.register(

--- a/tests/test_rakaia/test_alerts.py
+++ b/tests/test_rakaia/test_alerts.py
@@ -9,11 +9,10 @@ upsert is idempotent.
 
 from __future__ import annotations
 
-import json
-
 from rakaia.effects import Effect
 from rakaia.registry import HandlerRegistry
 from rakaia.replay import replay
+from rakaia.seed import seed_stream
 from rakaia.store import StreamStore
 
 ALERT = "app.Alert"
@@ -66,12 +65,6 @@ class CaptureExecutor:
         return [e for b in self.batches for e in b]
 
 
-def _seed(store: StreamStore, path: str, events: list[dict]) -> None:
-    store.create(path)
-    for ev in events:
-        store.append(path, json.dumps(ev).encode("utf-8"))
-
-
 def _registry() -> HandlerRegistry:
     reg = HandlerRegistry()
     reg.register("alert_authored", "sub:1:alerts", alert_authored, 0, None)
@@ -99,7 +92,7 @@ _EVENTS = [
 class TestAuthoredAlertReplayDiscipline:
     def test_transitions_skipped_on_replay_by_default(self):
         store = StreamStore()
-        _seed(store, "sub:1:alerts", _EVENTS)
+        seed_stream("sub:1:alerts", _EVENTS, store=store)
         ex = CaptureExecutor()
 
         result = replay(store, "sub:1:alerts", ex, handler_registry=_registry())
@@ -112,7 +105,7 @@ class TestAuthoredAlertReplayDiscipline:
 
     def test_transitions_delivered_when_included(self):
         store = StreamStore()
-        _seed(store, "sub:1:alerts", _EVENTS)
+        seed_stream("sub:1:alerts", _EVENTS, store=store)
         ex = CaptureExecutor()
 
         replay(
@@ -128,7 +121,7 @@ class TestAuthoredAlertReplayDiscipline:
 
     def test_rereplay_is_idempotent_and_silent(self):
         store = StreamStore()
-        _seed(store, "sub:1:alerts", _EVENTS)
+        seed_stream("sub:1:alerts", _EVENTS, store=store)
         reg = _registry()
 
         first = replay(store, "sub:1:alerts", CaptureExecutor(), handler_registry=reg)

--- a/tests/test_rakaia/test_executors.py
+++ b/tests/test_rakaia/test_executors.py
@@ -2,14 +2,13 @@
 
 from __future__ import annotations
 
-import json
-
 import pytest
 
 from rakaia.effects import Effect
 from rakaia.executors import CollectingExecutor
 from rakaia.registry import HandlerRegistry
 from rakaia.replay import replay
+from rakaia.seed import seed_stream
 from rakaia.store import StreamStore
 
 
@@ -45,9 +44,7 @@ class TestCollectingExecutor:
             )
 
         reg.register("h", "s", h, 0, None)
-        store.create("s")
-        for ev in [{"id": 1, "name": "a"}, {"id": 2, "name": "b"}]:
-            store.append("s", json.dumps(ev).encode("utf-8"))
+        seed_stream("s", [{"id": 1, "name": "a"}, {"id": 2, "name": "b"}], store=store)
 
         ex = CollectingExecutor()
         result = replay(store, "s", ex, handler_registry=reg)

--- a/tests/test_rakaia/test_public_api.py
+++ b/tests/test_rakaia/test_public_api.py
@@ -22,6 +22,7 @@ RAKAIA_PUBLIC = {
     "create_app",
     # store
     "StreamStore",
+    "seed_stream",
     # extension protocols
     "CursorStore",
     "ProjectionReader",

--- a/tests/test_rakaia/test_replay.py
+++ b/tests/test_rakaia/test_replay.py
@@ -20,6 +20,7 @@ from rakaia.replay import (
     merge_replay,
     replay,
 )
+from rakaia.seed import seed_stream
 from rakaia.store import StreamStore
 from rakaia.types import AppendOptions
 
@@ -46,12 +47,6 @@ def store() -> StreamStore:
     return StreamStore()
 
 
-def _seed_stream(store: StreamStore, path: str, events: list[dict]) -> None:
-    store.create(path)
-    for ev in events:
-        store.append(path, json.dumps(ev).encode("utf-8"))
-
-
 # ---------------------------------------------------------------------------
 # Basic dispatch + apply
 # ---------------------------------------------------------------------------
@@ -70,7 +65,7 @@ class TestBasicReplay:
             )
 
         reg.register("h", "stream", h, 0, None)
-        _seed_stream(store, "stream", [{"id": 1, "name": "alice"}])
+        seed_stream("stream", [{"id": 1, "name": "alice"}], store=store)
         ex = CaptureExecutor()
 
         result = replay(store, "stream", ex, handler_registry=reg)
@@ -91,7 +86,7 @@ class TestBasicReplay:
 
         reg.register("h1", "stream", h1, 0, None)
         reg.register("h2", "stream", h2, 0, None)
-        _seed_stream(store, "stream", [{"id": 1}])
+        seed_stream("stream", [{"id": 1}], store=store)
         ex = CaptureExecutor()
 
         result = replay(store, "stream", ex, handler_registry=reg)
@@ -113,7 +108,7 @@ class TestBasicReplay:
             ]
 
         reg.register("h", "stream", h, 0, None)
-        _seed_stream(store, "stream", [{"id": 1}])
+        seed_stream("stream", [{"id": 1}], store=store)
         ex = CaptureExecutor()
 
         replay(store, "stream", ex, handler_registry=reg)
@@ -126,7 +121,7 @@ class TestBasicReplay:
             return None
 
         reg.register("h", "stream", h, 0, None)
-        _seed_stream(store, "stream", [{"id": 1}])
+        seed_stream("stream", [{"id": 1}], store=store)
         ex = CaptureExecutor()
 
         result = replay(store, "stream", ex, handler_registry=reg)
@@ -152,10 +147,10 @@ class TestVersioning:
 
         reg.register("h", "s", h_v1, 0, 3)
         reg.register("h", "s", h_v2, 3, None)
-        _seed_stream(
-            store,
+        seed_stream(
             "s",
             [{"id": 0}, {"id": 1}, {"id": 2}, {"id": 3}, {"id": 4}],
+            store=store,
         )
         ex = CaptureExecutor()
 
@@ -179,7 +174,7 @@ class TestIdempotency:
             )
 
         reg.register("h", "s", h, 0, None)
-        _seed_stream(store, "s", [{"id": 1, "name": "a"}, {"id": 2, "name": "b"}])
+        seed_stream("s", [{"id": 1, "name": "a"}, {"id": 2, "name": "b"}], store=store)
 
         ex1 = CaptureExecutor()
         replay(store, "s", ex1, handler_registry=reg)
@@ -206,7 +201,7 @@ class TestExternalEffects:
             ]
 
         reg.register("h", "s", h, 0, None)
-        _seed_stream(store, "s", [{"x": 1}])
+        seed_stream("s", [{"x": 1}], store=store)
         ex = CaptureExecutor()
 
         result = replay(store, "s", ex, handler_registry=reg)
@@ -222,7 +217,7 @@ class TestExternalEffects:
             return Effect(op="external", kind="email", payload={"to": "x"})
 
         reg.register("h", "s", h, 0, None)
-        _seed_stream(store, "s", [{"x": 1}])
+        seed_stream("s", [{"x": 1}], store=store)
         ex = CaptureExecutor()
 
         result = replay(store, "s", ex, handler_registry=reg, include_external=True)
@@ -254,7 +249,7 @@ class TestUpcasting:
             return None
 
         handlers.register("h", "s", h, 0, None)
-        _seed_stream(store, "s", [{"id": 1, "schema_version": 1}])
+        seed_stream("s", [{"id": 1, "schema_version": 1}], store=store)
         ex = CaptureExecutor()
 
         replay(
@@ -285,7 +280,7 @@ class TestRangeBounds:
             return None
 
         reg.register("h", "s", h, 0, None)
-        _seed_stream(store, "s", [{"id": i} for i in range(5)])
+        seed_stream("s", [{"id": i} for i in range(5)], store=store)
 
         result = replay(
             store, "s", CaptureExecutor(), handler_registry=reg, start_seq=2
@@ -304,7 +299,7 @@ class TestRangeBounds:
             return None
 
         reg.register("h", "s", h, 0, None)
-        _seed_stream(store, "s", [{"id": i} for i in range(5)])
+        seed_stream("s", [{"id": i} for i in range(5)], store=store)
 
         replay(store, "s", CaptureExecutor(), handler_registry=reg, end_seq=3)
 
@@ -325,7 +320,7 @@ class TestErrors:
 
         reg.register("h", "s", h, 0, 2)
         reg.register("h", "s", h, 5, None)
-        _seed_stream(store, "s", [{"id": i} for i in range(6)])
+        seed_stream("s", [{"id": i} for i in range(6)], store=store)
 
         with pytest.raises(HandlerGapError):
             replay(store, "s", CaptureExecutor(), handler_registry=reg)
@@ -355,7 +350,7 @@ class TestErrors:
 class TestNoHandlers:
     def test_replay_with_no_handlers_just_counts_events(self, store: StreamStore):
         reg = HandlerRegistry()
-        _seed_stream(store, "s", [{"id": 1}, {"id": 2}])
+        seed_stream("s", [{"id": 1}, {"id": 2}], store=store)
         ex = CaptureExecutor()
 
         result = replay(store, "s", ex, handler_registry=reg)
@@ -378,7 +373,7 @@ class TestDrift:
             return None
 
         reg.register("h", "s", h, 0, None)
-        _seed_stream(store, "s", [{"id": 1}])
+        seed_stream("s", [{"id": 1}], store=store)
 
         result = replay(store, "s", CaptureExecutor(), handler_registry=reg)
 
@@ -395,7 +390,7 @@ class TestDrift:
         # Tamper with the stored hash to simulate the live source having drifted
         object.__setattr__(version, "source_hash", "deadbeef" * 8)
 
-        _seed_stream(store, "s", [{"id": 1}, {"id": 2}])
+        seed_stream("s", [{"id": 1}, {"id": 2}], store=store)
 
         result = replay(store, "s", CaptureExecutor(), handler_registry=reg)
 
@@ -415,7 +410,7 @@ class TestDrift:
         version = reg.register("h", "s", h, 0, None)
         object.__setattr__(version, "source_hash", "deadbeef" * 8)
 
-        _seed_stream(store, "s", [{"id": 1}])
+        seed_stream("s", [{"id": 1}], store=store)
 
         with pytest.raises(HandlerDriftError, match="handler='h'"):
             replay(
@@ -440,7 +435,7 @@ class TestDrift:
         up_version = upcasters.register("s", 1, upcast)
         object.__setattr__(up_version, "source_hash", "deadbeef" * 8)
 
-        _seed_stream(store, "s", [{"id": 1, "schema_version": 1}])
+        seed_stream("s", [{"id": 1, "schema_version": 1}], store=store)
 
         result = replay(
             store,
@@ -467,7 +462,7 @@ class TestDrift:
         up_version = upcasters.register("s", 1, upcast)
         object.__setattr__(up_version, "source_hash", "deadbeef" * 8)
 
-        _seed_stream(store, "s", [{"id": 1, "schema_version": 1}])
+        seed_stream("s", [{"id": 1, "schema_version": 1}], store=store)
 
         with pytest.raises(HandlerDriftError, match="upcaster"):
             replay(
@@ -498,7 +493,7 @@ class TestDeleteEffects:
             )
 
         reg.register("h", "stream", h, 0, None)
-        _seed_stream(store, "stream", [{"id": 1, "keep": [0, 1]}])
+        seed_stream("stream", [{"id": 1, "keep": [0, 1]}], store=store)
         ex = CaptureExecutor()
 
         result = replay(store, "stream", ex, handler_registry=reg)
@@ -540,14 +535,14 @@ class TestMatchFieldRouting:
         reg.register("tf", "tf_*", tf, 0, None, match_field="form_type")
         reg.register("sf", "sf_*", sf, 0, None, match_field="form_type")
 
-        _seed_stream(
-            store,
+        seed_stream(
             "submissions",
             [
                 {"id": 1, "form_type": "tf_611"},
                 {"id": 2, "form_type": "sf_12"},
                 {"id": 3, "form_type": "tf_611"},
             ],
+            store=store,
         )
         ex = CaptureExecutor()
         replay(store, "submissions", ex, handler_registry=reg)
@@ -684,7 +679,7 @@ def _staged_registry():
 
 class TestStagedReplay:
     def test_late_reference_still_links(self, store: StreamStore):
-        _seed_stream(store, "s", _STAGED_EVENTS)
+        seed_stream("s", _STAGED_EVENTS, store=store)
         reg = _staged_registry()
         proj = DictProjections()
         result = replay(
@@ -702,7 +697,7 @@ class TestStagedReplay:
         assert result.events_processed == 2  # counted once, not per stage
 
     def test_missing_reader_raises(self, store: StreamStore):
-        _seed_stream(store, "s", _STAGED_EVENTS)
+        seed_stream("s", _STAGED_EVENTS, store=store)
         reg = _staged_registry()
         with pytest.raises(ValueError, match="reader"):
             replay(
@@ -715,7 +710,7 @@ class TestStagedReplay:
 
     def test_self_heals_on_re_replay(self, store: StreamStore):
         # Only the SF exists: its project is unresolved.
-        _seed_stream(store, "s", [_STAGED_EVENTS[0]])
+        seed_stream("s", [_STAGED_EVENTS[0]], store=store)
         reg = _staged_registry()
         proj = DictProjections()
         replay(
@@ -743,7 +738,7 @@ class TestStagedReplay:
 
     def test_stage_zero_only_is_single_pass_without_reader(self, store: StreamStore):
         # A registry with only stage-0 handlers needs no reader (backward compat).
-        _seed_stream(store, "s", [_STAGED_EVENTS[1]])
+        seed_stream("s", [_STAGED_EVENTS[1]], store=store)
         reg = HandlerRegistry()
         reg.register(
             "project",
@@ -822,7 +817,7 @@ def _finance_registry(reducer=_balance_reducer):
 
 class TestReducers:
     def test_reducer_recomputes_aggregate(self, store: StreamStore):
-        _seed_stream(store, "s", _FINANCE_EVENTS)
+        seed_stream("s", _FINANCE_EVENTS, store=store)
         proj = DictProjections()
         replay(
             store,
@@ -836,7 +831,7 @@ class TestReducers:
         assert proj.get("app.Balance", suku="B").total == 50
 
     def test_reducer_runs_once_per_stage_not_per_event(self, store: StreamStore):
-        _seed_stream(store, "s", _FINANCE_EVENTS)  # 3 events
+        seed_stream("s", _FINANCE_EVENTS, store=store)  # 3 events
         calls: list[int] = []
 
         def counting(reader):  # noqa: ARG001
@@ -855,7 +850,7 @@ class TestReducers:
         assert len(calls) == 1  # once for stage 1, not 3x (per event)
 
     def test_reducer_requires_reader(self, store: StreamStore):
-        _seed_stream(store, "s", _FINANCE_EVENTS)
+        seed_stream("s", _FINANCE_EVENTS, store=store)
         with pytest.raises(ValueError, match="reader"):
             replay(
                 store,
@@ -866,7 +861,7 @@ class TestReducers:
             )  # no reader=
 
     def test_reducer_recompute_is_replay_safe(self, store: StreamStore):
-        _seed_stream(store, "s", _FINANCE_EVENTS)
+        seed_stream("s", _FINANCE_EVENTS, store=store)
         reg = _finance_registry()
         proj = DictProjections()
         replay(
@@ -890,7 +885,7 @@ class TestReducers:
 
     def test_reducer_sees_only_committed_stage0_rows(self, store: StreamStore):
         # A reducer at stage 1 reads FinanceLine rows all built in stage 0.
-        _seed_stream(store, "s", _FINANCE_EVENTS)
+        seed_stream("s", _FINANCE_EVENTS, store=store)
         proj = DictProjections()
         replay(
             store,
@@ -918,7 +913,7 @@ class TestReducerTouchedSubjects:
     of subjects the pass's per-event handlers wrote (#51)."""
 
     def test_two_arg_reducer_receives_touched_subjects(self, store: StreamStore):
-        _seed_stream(store, "s", _FINANCE_EVENTS)  # keys f1, f2, f3
+        seed_stream("s", _FINANCE_EVENTS, store=store)  # keys f1, f2, f3
         sink: list = []
         proj = DictProjections()
         replay(
@@ -941,7 +936,7 @@ class TestReducerTouchedSubjects:
 
     def test_one_arg_reducer_is_called_unchanged(self, store: StreamStore):
         # A legacy fn(reader) reducer keeps working — no touched arg is forced.
-        _seed_stream(store, "s", _FINANCE_EVENTS)
+        seed_stream("s", _FINANCE_EVENTS, store=store)
         proj = DictProjections()
         replay(
             store,
@@ -956,7 +951,7 @@ class TestReducerTouchedSubjects:
     def test_touched_is_incremental_on_a_tail_replay(self, store: StreamStore):
         # Replaying only the tail touches only the tail's subjects — the same
         # reducer scopes to what the pass changed, no code change at the reducer.
-        _seed_stream(store, "s", _FINANCE_EVENTS)
+        seed_stream("s", _FINANCE_EVENTS, store=store)
         sink: list = []
         proj = DictProjections()
         replay(
@@ -976,7 +971,7 @@ class TestReducerTouchedSubjects:
         # reducer at the same stage emitted. Two stage-1 reducers, name-ordered:
         # "a_writes" recomputes app.Balance; "b_captures" runs after and must not
         # see app.Balance in its touched set.
-        _seed_stream(store, "s", _FINANCE_EVENTS)
+        seed_stream("s", _FINANCE_EVENTS, store=store)
         sink: list = []
         reg = HandlerRegistry()
         reg.register(
@@ -1015,7 +1010,7 @@ class TestReducerTouchedSubjects:
                 "delta": 5,
             },
         ]
-        _seed_stream(store, "s", events)
+        seed_stream("s", events, store=store)
         sink: list = []
         proj = DictProjections()
         replay(
@@ -1032,8 +1027,7 @@ class TestReducerTouchedSubjects:
     def test_touched_flows_through_merge_replay(self, store: StreamStore):
         # merge_replay shares the same pipeline; a two-arg reducer gets the
         # touched subjects merged across streams, in merged order.
-        _seed_stream(
-            store,
+        seed_stream(
             "fin/a",
             [
                 {
@@ -1045,9 +1039,9 @@ class TestReducerTouchedSubjects:
                     "ts": "2026-01-01T00:00:00Z",
                 }
             ],
+            store=store,
         )
-        _seed_stream(
-            store,
+        seed_stream(
             "fin/b",
             [
                 {
@@ -1059,6 +1053,7 @@ class TestReducerTouchedSubjects:
                     "ts": "2026-01-01T01:00:00Z",
                 }
             ],
+            store=store,
         )
         sink: list = []
         proj = DictProjections()
@@ -1114,8 +1109,8 @@ _CANONICAL = [_A[0], _B[0], _A[1], _B[1]]
 
 class TestMergeReplay:
     def _seed_two(self, store: StreamStore):
-        _seed_stream(store, "forms/a", _A)
-        _seed_stream(store, "forms/b", _B)
+        seed_stream("forms/a", _A, store=store)
+        seed_stream("forms/b", _B, store=store)
 
     def test_tie_resolved_by_stream_path(self, store: StreamStore):
         self._seed_two(store)
@@ -1154,7 +1149,7 @@ class TestMergeReplay:
             upcaster_registry=UpcasterRegistry(),
         )
 
-        _seed_stream(store, "combined", _CANONICAL)
+        seed_stream("combined", _CANONICAL, store=store)
         single = DictProjections()
         replay(
             store,
@@ -1171,10 +1166,10 @@ class TestMergeReplay:
         )
 
     def test_missing_order_key_raises(self, store: StreamStore):
-        _seed_stream(
-            store,
+        seed_stream(
             "forms/a",
             [{"schema_version": 1, "form_type": "TOUCH", "key": "x", "slot": "S"}],
+            store=store,
         )  # no ts
         with pytest.raises(ValueError, match="order_key"):
             merge_replay(
@@ -1186,7 +1181,7 @@ class TestMergeReplay:
             )
 
     def test_duplicate_stream_paths_raise(self, store: StreamStore):
-        _seed_stream(store, "forms/a", _A)
+        seed_stream("forms/a", _A, store=store)
         with pytest.raises(ValueError, match="duplicate"):
             merge_replay(
                 store,
@@ -1199,8 +1194,7 @@ class TestMergeReplay:
     def test_incomparable_order_key_raises_clearly(self, store: StreamStore):
         # One stream's ts is an int, the other's a str -> sort would TypeError;
         # merge_replay should surface a clear ValueError, not the bare crash.
-        _seed_stream(
-            store,
+        seed_stream(
             "forms/a",
             [
                 {
@@ -1211,9 +1205,9 @@ class TestMergeReplay:
                     "ts": 1,
                 }
             ],
+            store=store,
         )
-        _seed_stream(
-            store,
+        seed_stream(
             "forms/b",
             [
                 {
@@ -1224,6 +1218,7 @@ class TestMergeReplay:
                     "ts": "2026-01-01T00:00:00Z",
                 }
             ],
+            store=store,
         )
         with pytest.raises(ValueError, match="not mutually comparable"):
             merge_replay(
@@ -1235,7 +1230,7 @@ class TestMergeReplay:
             )
 
     def test_requires_reader_when_staged(self, store: StreamStore):
-        _seed_stream(store, "forms/a", _A)
+        seed_stream("forms/a", _A, store=store)
         reg = _touch_registry()
         reg.register(
             "dep", "TOUCH", lambda *_: None, 0, None, match_field="form_type", stage=1
@@ -1250,8 +1245,7 @@ class TestMergeReplay:
             )
 
     def test_reducer_runs_over_merged_streams(self, store: StreamStore):
-        _seed_stream(
-            store,
+        seed_stream(
             "fin/a",
             [
                 {
@@ -1263,9 +1257,9 @@ class TestMergeReplay:
                     "ts": "2026-01-01T00:00:00Z",
                 }
             ],
+            store=store,
         )
-        _seed_stream(
-            store,
+        seed_stream(
             "fin/b",
             [
                 {
@@ -1285,6 +1279,7 @@ class TestMergeReplay:
                     "ts": "2026-01-01T02:00:00Z",
                 },
             ],
+            store=store,
         )
         proj = DictProjections()
         merge_replay(
@@ -1302,25 +1297,19 @@ class TestMergeReplay:
         # Backfill scenario: events are appended in an order that differs from
         # their logical event order, and the payloads carry NO "ts" field — so
         # ordering can only come from the producer-set envelope event_ts.
-        def _seed(path, rows):
-            store.create(path)
-            for key, logical_ts in rows:
-                ev = {
-                    "schema_version": 1,
-                    "form_type": "TOUCH",
-                    "key": key,
-                    "slot": "S",
-                }
-                store.append(
-                    path,
-                    json.dumps(ev).encode("utf-8"),
-                    AppendOptions(event_ts=logical_ts),
-                )
+        def _touch(key: str, logical_ts: float):
+            event = {
+                "schema_version": 1,
+                "form_type": "TOUCH",
+                "key": key,
+                "slot": "S",
+            }
+            return event, AppendOptions(event_ts=logical_ts)
 
         # Append order (transport) would make b1 the last write; but by logical
         # envelope ts the last event is a1 (400), so a1 must win the slot.
-        _seed("forms/a", [("a0", 100.0), ("a1", 400.0)])
-        _seed("forms/b", [("b0", 200.0), ("b1", 300.0)])
+        seed_stream("forms/a", [_touch("a0", 100.0), _touch("a1", 400.0)], store=store)
+        seed_stream("forms/b", [_touch("b0", 200.0), _touch("b1", 300.0)], store=store)
 
         proj = DictProjections()
         merge_replay(

--- a/tests/test_rakaia/test_seed.py
+++ b/tests/test_rakaia/test_seed.py
@@ -1,0 +1,161 @@
+"""Tests for `rakaia.seed_stream` — the four lines everyone was retyping.
+
+Every case here is forced by a call site that existed before the helper did:
+the byte-identical pair in `test_replay.py`/`test_alerts.py` (store passed in,
+plain dicts), the Django-side pair that builds its own store and returns it,
+the one that passes pre-encoded bytes with a per-event label and metadata, the
+management-command one that seeds the process-wide singleton twice, and the
+closure in `test_replay.py` that needs a different `event_ts` per event.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from rakaia import AppendOptions, StreamStore, seed_stream
+
+
+class TestTheStore:
+    def test_it_builds_an_in_memory_store_when_none_is_given(self):
+        store = seed_stream("p", [{"n": 1}])
+        assert isinstance(store, StreamStore)
+        messages, _ = store.read("p")
+        assert [json.loads(m.data)["n"] for m in messages] == [1]
+
+    def test_it_uses_the_store_it_is_given_and_returns_it(self):
+        mine = StreamStore()
+        returned = seed_stream("p", [{"n": 1}], store=mine)
+        assert returned is mine
+
+    def test_it_seeds_any_writable_store(self):
+        """The Django backend and the `get_store()` singleton are `WritableStore`
+        implementations, not `StreamStore` — the helper must not assume either."""
+
+        class Recording:
+            def __init__(self):
+                self.created: list[str] = []
+                self.appended: list[tuple[str, bytes]] = []
+
+            def has(self, path: str) -> bool:
+                return path in self.created
+
+            def create(self, path: str) -> None:
+                self.created.append(path)
+
+            def append(self, path: str, data: bytes, options=None) -> None:  # noqa: ARG002
+                self.appended.append((path, data))
+
+        backend = Recording()
+        assert seed_stream("p", [{"n": 1}], store=backend) is backend
+        assert backend.created == ["p"]
+        assert backend.appended == [("p", b'{"n": 1}')]
+
+    def test_seeding_twice_appends_rather_than_truncating(self):
+        """`create()` is idempotent by store contract, so the `has()` guard the
+        management-command helper carried is not needed."""
+        store = seed_stream("p", [{"n": 1}])
+        seed_stream("p", [{"n": 2}], store=store)
+        messages, _ = store.read("p")
+        assert [json.loads(m.data)["n"] for m in messages] == [1, 2]
+
+    def test_no_events_still_creates_the_stream(self):
+        store = seed_stream("p", [])
+        assert store.has("p")
+
+
+class TestThePayloads:
+    def test_dicts_are_json_encoded(self):
+        store = seed_stream("p", [{"n": 1}, {"n": 2}])
+        messages, _ = store.read("p")
+        assert [m.data for m in messages] == [b'{"n": 1}', b'{"n": 2}']
+
+    def test_pre_encoded_bytes_are_appended_untouched(self):
+        raw = b'{"key": "s1", "user_id": 9, "a": 1}'
+        store = seed_stream("p", [raw])
+        (msg,), _ = store.read("p")
+        assert msg.data == raw
+
+    def test_dicts_and_bytes_can_be_mixed(self):
+        store = seed_stream("p", [{"n": 1}, b'{"n": 2}'])
+        messages, _ = store.read("p")
+        assert [json.loads(m.data)["n"] for m in messages] == [1, 2]
+
+    def test_the_events_land_in_list_order(self):
+        store = seed_stream("p", [{"n": i} for i in range(5)])
+        messages, _ = store.read("p")
+        assert [json.loads(m.data)["n"] for m in messages] == [0, 1, 2, 3, 4]
+
+
+class TestThePerEventEnvelope:
+    """Label, metadata and `event_ts` are per event, not per batch — the history
+    materializer needs a different label on each event with metadata on only the
+    first, and the backfill test needs a different `event_ts` on each."""
+
+    def test_an_event_can_carry_its_own_append_options(self):
+        store = seed_stream(
+            "p",
+            [
+                ({"a": 1}, AppendOptions(label="insert", metadata={"user": 42})),
+                ({"a": 2}, AppendOptions(label="update")),
+            ],
+        )
+        first, second = store.read("p")[0]
+        assert (first.label, first.metadata) == ("insert", {"user": 42})
+        assert second.label == "update"
+        assert second.metadata in (None, {})
+
+    def test_bytes_can_carry_options_too(self):
+        store = seed_stream("p", [(b'{"a": 1}', AppendOptions(label="insert"))])
+        (msg,), _ = store.read("p")
+        assert (msg.data, msg.label) == (b'{"a": 1}', "insert")
+
+    def test_per_event_event_ts_is_recorded(self):
+        store = seed_stream(
+            "p",
+            [
+                ({"k": "a0"}, AppendOptions(event_ts=100.0)),
+                ({"k": "a1"}, AppendOptions(event_ts=400.0)),
+            ],
+        )
+        messages, _ = store.read("p")
+        assert [m.event_ts for m in messages] == [100.0, 400.0]
+
+    def test_enveloped_and_bare_events_can_be_mixed(self):
+        store = seed_stream("p", [{"a": 1}, ({"a": 2}, AppendOptions(label="x"))])
+        first, second = store.read("p")[0]
+        assert (first.label, second.label) == ("", "x")
+
+
+class TestTheEncoderHook:
+    """A core-tier helper cannot import `DjangoJSONEncoder`, and a second
+    `json.dumps` rule is the drift `django_rakaia/envelope.py` warns about — so
+    the encoder is a parameter and there is exactly one `dumps` call."""
+
+    def test_the_encoder_class_is_used_for_dict_payloads(self):
+        class Shouty(json.JSONEncoder):
+            def default(self, o):
+                return str(o).upper()
+
+        store = seed_stream("p", [{"v": object.__new__(_Thing)}], encoder=Shouty)
+        (msg,), _ = store.read("p")
+        assert json.loads(msg.data)["v"] == "THING"
+
+    def test_without_an_encoder_an_unserialisable_payload_raises(self):
+        with pytest.raises(TypeError):
+            seed_stream("p", [{"v": object.__new__(_Thing)}])
+
+    def test_the_encoder_is_not_applied_to_pre_encoded_bytes(self):
+        class Exploding(json.JSONEncoder):
+            def default(self, o):  # noqa: ARG002  # pragma: no cover
+                raise AssertionError("bytes must not be re-encoded")
+
+        store = seed_stream("p", [b'{"v": 1}'], encoder=Exploding)
+        (msg,), _ = store.read("p")
+        assert msg.data == b'{"v": 1}'
+
+
+class _Thing:
+    def __str__(self) -> str:
+        return "thing"


### PR DESCRIPTION
Getting a handful of events into a stream used to take four lines, and rakaia
never shipped a way to do it — so everyone wrote the four lines. Our test suite
had six copies of them and our examples twelve more, with small differences
between them. The cost landed hardest on tests, where the setup could run to
sixty-eight lines before the first thing was actually checked.

There is now one call that does it, and every copy has been replaced with it.
The worst test setup drops from sixty-eight lines to thirty-five, and the Django
helper that already did this for its own users is now built on the same code, so
there is one rule for turning an event into bytes rather than two that can drift
apart.

Closes #120