### PR TITLE
Give rakaia a version number that means something

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ conformance/node_modules/
 conformance/conformance-results.json
 conformance-results.log
 conformance-server.log
+
+# Agent worktrees — transient checkouts, never part of the tree
+.claude/worktrees/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,25 @@ runnable demo for each.
 
 ## [Unreleased]
 
-Everything below has landed on `main` since the initial `0.1.0` groundwork and
-is not yet tagged in a release.
+Nothing yet.
+
+## [0.2.0] - 2026-08-15
+
+The first release that describes the library. `0.1.0` was the initial
+groundwork; everything below landed on `main` afterwards and, until now, was
+reachable only by pinning a git revision — which is what every consumer was
+doing, because the version number could not tell them what they had.
+
+Several entries are breaking. See [UPGRADING.md](UPGRADING.md) for what to do
+about each; it is organised by release from this version on.
+
+**Known limitation.** Rakaia passes the Durable Streams conformance suite except
+the stream-forking family — `Stream-Forked-From`, `Stream-Fork-Offset` and
+`Stream-Fork-Sub-Offset`, 56 tests. Forking is not implemented. The gap is
+baselined in `conformance/expected-failures.txt` so a real regression stays
+distinguishable from it, and tracked in
+[#61](https://github.com/joshbrooks/rakaia/issues/61). Everything else in the
+protocol is covered by both stores.
 
 ### Added
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -4,15 +4,22 @@ icon: lucide/arrow-up-circle
 
 # Upgrading
 
-Breaking changes, and what to do about each. Rakaia is pre-1.0 and the version
-number has not moved yet, so this file is organised by the change rather than by
-release — find the ones you are crossing and apply them in order.
+Breaking changes, and what to do about each, organised by the release that
+carries them. Find the releases you are crossing and apply their changes in
+order.
 
-If you pin rakaia to a git revision (which every current consumer does, since
-`0.1.0` predates most of what follows), the relevant question is *which
-revision*, not which version.
+If you pin rakaia to a git revision rather than a version — which every consumer
+did before `0.2.0`, since `0.1.0` predates nearly everything here — each section
+below also names the revision the change landed in, so you can work out which
+ones you are crossing.
 
 ---
+
+# 0.2.0
+
+Everything in this file so far. `0.1.0` was the initial groundwork and `0.2.0`
+is the first release describing the library, so a consumer moving off a pinned
+revision is crossing all of the below at once.
 
 ## Upgrading past `5e4a6e3` (`append_many`, 2026-08-08)
 
@@ -199,6 +206,18 @@ These are not API breaks — nothing to edit — but each changes what your code
 - **Bulk appends now reach SSE subscribers.** `append_many` was invisible to the
   channel layer. If you worked around that by also sending your own frame, you
   will now get two.
+- **A refused append to a closed stream now always carries a producer result.**
+  `AppendResult.producer_result` was `None` for anything but a retry of the
+  closing tuple; it is now `ProducerStreamClosed`. The HTTP response is
+  unchanged — the server already synthesised that result — so this only affects
+  code calling `store.append()` directly and testing the field for `None`.
+- **The dashboard views refuse a stream position they did not issue.** The JSON
+  events endpoint and the SSE `Last-Event-ID` header now answer `400` for an
+  offset in the other store's format, where they used to resolve it to an
+  unrelated position and answer `200`. An absent `Last-Event-ID` still means a
+  fresh connection. If a client of yours was passing a compound
+  `{seq}_{byte}` offset to the durable dashboard, it was already getting the
+  wrong window and will now be told so.
 - **Timestamps now compare equal to the column they were encoded from.**
   `DEFAULT_NORMALIZERS` gained `normalize_temporal`, so a `DateTimeField`,
   `DateField` or `TimeField` no longer reports a difference on every replay.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 # PyPI by an unrelated placeholder. The import name is unaffected:
 #   pip install rakaia-streams   ->   import rakaia
 name = "rakaia-streams"
-version = "0.1.0"
+version = "0.2.0"
 description = "Python server implementation of the Durable Streams protocol"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -1135,7 +1135,7 @@ wheels = [
 
 [[package]]
 name = "rakaia-streams"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
Rakaia has called itself 0.1.0 since the beginning, through about twenty-five
commits and several changes that break things for anyone upgrading. Because the
number never moved, every project using us pins a git revision instead — which
works, but means nobody can say what they are running or what changed between
two installs.

This makes 0.2.0 real: the number moves, the fifty-odd accumulated changelog
entries become a dated release, and the upgrade guide is reorganised around
releases rather than git revisions now that there is a release to organise it
around. The notes also state plainly, where a user will actually read it, the one
part of the protocol we have not implemented.

Closes #114
Closes #115
Closes #116