### PR TITLE
Write an event's envelope in one place

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -292,6 +292,29 @@ protocol is covered by both stores.
 
 ### Changed
 
+- **One writer for the enveloped event** (#131). "Write an event into the Django
+  models" was implemented twice — once in `DjangoStreamStore._write`, once in
+  `create_stream_event`, the `@stream_model` decorator's door — and the two
+  copies had drifted. The store records a labelless append under a stable
+  `"append"` sentinel that its reader inverts back to "no label"; the decorator
+  wrote the label through raw, so an event from that door could never be
+  recognised as labelless. Each also called its own offset helper and resolved
+  `metadata` its own way. `django_rakaia.envelope`'s module docstring already
+  warned that a second copy of the envelope "produces events that replay
+  differently from every other event in the same stream, and no test anywhere is
+  looking at the difference" — this was that copy.
+
+  Both doors now write through `write_enveloped_event`, which owns the sentinel,
+  the ambient-`provenance()` merge, `{}` rather than NULL metadata, `event_ts`
+  passthrough, and locking offset allocation. It takes a *list* of streams, so
+  `@stream_model`'s fan-out is still one event with one envelope shared by N
+  entries. `tests/test_django_rakaia/test_envelope_writer.py` drives both doors
+  with the same envelope and compares the rows.
+
+  Behaviour is unchanged except that a `@stream_model` event with an empty
+  action string is now stored as `"append"` rather than `""` — the same shape
+  the store has always written, and the same thing both read back as.
+
 - **One producer response table instead of three.** The five-arm `isinstance`
   ladder over `ProducerValidationResult` — duplicate → 204, stale epoch → 403,
   bad epoch opening → 400, sequence gap → 409, closed stream → 409, each with

--- a/src/django_rakaia/decorators.py
+++ b/src/django_rakaia/decorators.py
@@ -16,8 +16,8 @@ from django.db import models, transaction
 from django.db.models.signals import post_delete, post_save
 from django.dispatch import receiver
 
-from django_rakaia.models import Stream, StreamEntry, StreamEvent
-from rakaia.context import merge_provenance
+from django_rakaia.django_store import write_enveloped_event
+from django_rakaia.models import Stream, StreamEvent
 
 StreamPathResolver = (
     str
@@ -33,15 +33,6 @@ def _get_or_create_stream(stream_id: str) -> Stream:
     """Get or create a Stream record."""
     stream, _ = Stream.objects.get_or_create(stream_id=stream_id)
     return stream
-
-
-def _get_next_offset(stream: Stream) -> int:
-    """Locking offset allocation — see ``Stream.get_next_offset``.
-
-    Thin wrapper kept for backwards compatibility; the canonical, row-locking
-    implementation now lives on the model so every write path shares it.
-    """
-    return stream.get_next_offset()
 
 
 def create_stream_event(
@@ -118,45 +109,32 @@ def create_stream_event(
         json.dumps(dataclasses.asdict(dc_instance), cls=DjangoJSONEncoder)
     )
 
-    # The envelope, resolved exactly as the stores resolve it. `@stream_model`
-    # used to write `StreamEvent` rows with neither field, so `metadata` was
-    # always `{}` and `event_ts` always NULL on the busiest append path in the
-    # integration:
+    # `event_ts` is the deterministic merge key (ADR 0002 item 5), and this door
+    # always stamps one: leaving it NULL would force `merge_replay` onto
+    # transport time, which is the ordering trap that item closed. A raw
+    # protocol append is the other case — no logical time unless the producer
+    # set one — which is why the shared writer takes it as an argument rather
+    # than deciding it.
     #
-    #   * `ProvenanceMiddleware` exists to stamp actor + URL onto envelopes, and
-    #     could not reach the appends it was built for. `history.envelope_actor`
-    #     then fell back to the payload's owner FK — turning "who saved this"
-    #     into "who owns this", a different question with often a different
-    #     answer.
-    #   * `event_ts` is the deterministic merge key (ADR 0002 item 5). Leaving it
-    #     NULL forces `merge_replay` onto transport time, which is the ordering
-    #     trap that item closed.
-    #
-    # `merge_provenance(None)` returns None when no block is active, so an append
-    # outside `provenance()` still records `{}` — this is additive.
-    metadata = merge_provenance(None) or {}
+    # Everything else about the envelope — the `"append"` sentinel, merging the
+    # ambient `provenance()` block into `metadata`, `{}` rather than NULL,
+    # locking offset allocation — is `write_enveloped_event`'s to decide, shared
+    # with `DjangoStreamStore.append`. `@stream_model` used to have its own copy
+    # of those rules and the copies had drifted (#131).
     event_ts = time.time()
 
-    # Create event and entries atomically
+    # Atomic because `get_next_offset` locks the per-path high-water for the
+    # duration of the transaction. A savepoint when the caller already has one
+    # open, so the event stays inside the save that produced it.
     with transaction.atomic():
-        # Create the event (data stored once) — one envelope shared by every
-        # entry, since a fan-out is one event appearing in several streams.
-        event = StreamEvent.objects.create(
-            data=payload,
-            event_type=action,
-            metadata=metadata,
+        # One envelope shared by every entry: a fan-out is one event appearing
+        # in several streams, not several events that look alike.
+        event, _entries = write_enveloped_event(
+            [_get_or_create_stream(stream_id) for stream_id in stream_ids],
+            payload,
+            label=action,
             event_ts=event_ts,
         )
-
-        # Create an entry for each stream
-        for stream_id in stream_ids:
-            stream = _get_or_create_stream(stream_id)
-            next_offset = _get_next_offset(stream)
-            StreamEntry.objects.create(
-                stream=stream,
-                event=event,
-                offset=next_offset,
-            )
 
     return event
 

--- a/src/django_rakaia/django_store.py
+++ b/src/django_rakaia/django_store.py
@@ -129,6 +129,64 @@ def decode_payload(data: Any, payload_encoding: str | None) -> bytes:
     return json.dumps(data).encode("utf-8")
 
 
+def write_enveloped_event(
+    streams: Iterable[Stream],
+    data: Any,
+    *,
+    label: str = "",
+    metadata: Any = None,
+    event_ts: float | None = None,
+    payload_encoding: str | None = None,
+) -> tuple[StreamEvent, list[StreamEntry]]:
+    """Write one enveloped event into `streams`. The **only** writer of one.
+
+    Returns the `StreamEvent` and its `StreamEntry` rows, in `streams` order.
+
+    Every rule that turns an envelope into columns is resolved here, once:
+
+    * **the label** becomes `event_type`, with a labelless event recorded under
+      the stable `"append"` sentinel that `_read_since` inverts. `event_type` is
+      required metadata for the dashboard, so there is no "no type" to write;
+    * **the metadata** is merged with the ambient `provenance()` block —
+      explicit over ambient — and stored as `{}` rather than NULL when there is
+      none;
+    * **`event_ts`** is passed through, NULL included. NULL means "no logical
+      time was set", and readers surface the append time instead. The caller
+      decides whether to set one: a raw protocol append has none unless the
+      producer supplied it, while `@stream_model` always stamps one;
+    * **the offsets** come from `Stream.get_next_offset`, which locks the
+      per-path high-water — so this must run inside a transaction.
+
+    **Fan-out is `streams`, plural.** One event appearing in several streams is
+    one `StreamEvent` with one envelope and N `StreamEntry` rows, each with its
+    own offset in its own stream — not N events that happen to look alike. The
+    protocol store only ever passes one stream; `@stream_model` passes as many
+    as its `stream_paths` resolved to.
+
+    This exists because there were two of it. `DjangoStreamStore._write` and
+    `create_stream_event` each had a copy, and the copies disagreed about the
+    sentinel and about which offset helper to call — the drift
+    `django_rakaia.envelope`'s module docstring warns about, in the module it
+    warns about it in (#131).
+    """
+    event = StreamEvent.objects.create(
+        data=data,
+        event_type=label or _APPEND_EVENT_TYPE,
+        metadata=merge_provenance(metadata) or {},
+        event_ts=event_ts,
+        payload_encoding=payload_encoding,
+    )
+    entries = [
+        StreamEntry.objects.create(
+            stream=stream,
+            event=event,
+            offset=stream.get_next_offset(),
+        )
+        for stream in streams
+    ]
+    return event, entries
+
+
 # Long-poll poll interval. The in-memory store wakes waiters with an
 # asyncio.Event, which only works in-process; a durable stream can be appended
 # to by another process entirely, so this store polls instead. 50ms keeps
@@ -514,28 +572,27 @@ class DjangoStreamStore:
         One message per stored payload — more than one only for a JSON-mode
         array append (see `_payloads_for`). The envelope on `opts` is copied
         onto each, as the in-memory store does when it flattens.
+
+        The rows themselves are written by `write_enveloped_event`, shared with
+        `@stream_model`; what stays here is turning the written rows back into
+        protocol messages.
         """
         payloads = self._payloads_for(stream, data, is_initial_create=is_initial_create)
         if not payloads:
             return []
 
         label = getattr(opts, "label", "") or ""
-        metadata = merge_provenance(getattr(opts, "metadata", None))
         event_ts = getattr(opts, "event_ts", None)
 
         messages: list[StreamMessage] = []
         for value, encoding in payloads:
-            event = StreamEvent.objects.create(
-                data=value,
-                event_type=label or _APPEND_EVENT_TYPE,
-                metadata=metadata or {},
+            event, (entry,) = write_enveloped_event(
+                [stream],
+                value,
+                label=label,
+                metadata=getattr(opts, "metadata", None),
                 event_ts=event_ts,
                 payload_encoding=encoding,
-            )
-            entry = StreamEntry.objects.create(
-                stream=stream,
-                event=event,
-                offset=stream.get_next_offset(),
             )
             messages.append(
                 StreamMessage(
@@ -548,7 +605,7 @@ class DjangoStreamStore:
                         else entry.created_at.timestamp()
                     ),
                     label=label,
-                    metadata=metadata or None,
+                    metadata=event.metadata or None,
                 )
             )
         return messages

--- a/tests/test_django_rakaia/test_envelope_writer.py
+++ b/tests/test_django_rakaia/test_envelope_writer.py
@@ -1,0 +1,170 @@
+"""One writer for the enveloped event, whichever door you came in by (#131).
+
+There are two ways to write an event into the Django models — `store.append`
+and `@stream_model` / `create_stream_event` — and they used to be two
+*implementations* of it, each with its own copy of the envelope rules. The
+copies disagreed:
+
+* `event_type` — the store records a labelless append under the stable
+  ``"append"`` sentinel, which `read()` inverts back to ``label=""``. The
+  decorator wrote the label through raw, so an event written by that door could
+  never be recognised as labelless.
+* `event_ts` / `metadata` / offset allocation — three more rules, restated.
+
+`django_rakaia/envelope.py` opens by warning that exactly this second copy
+"produces events that replay differently from every other event in the same
+stream, and no test anywhere is looking at the difference". These tests look at
+the difference: they drive both doors with the same envelope and compare the
+rows and the read-back messages.
+
+What they deliberately do *not* pin is that the two doors choose the same
+envelope. They don't: a raw protocol append carries no `event_ts` unless the
+producer sets one, while `@stream_model` always stamps `time.time()` (ADR 0002
+item 5, `test_decorators_provenance.TestEnvelopeTimestamp`). That is a
+difference of *input*, decided by the caller. Everything below is about what
+the writer does with the input it is given.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from django_rakaia.decorators import create_stream_event
+from django_rakaia.django_store import DjangoStreamStore
+from django_rakaia.models import Stream, StreamEvent
+from rakaia import AppendOptions, provenance
+
+from .models import AreaData
+
+pytestmark = pytest.mark.django_db
+
+
+PAYLOAD = {"id": 1, "name": "a"}
+
+
+class _Instance:
+    """Stand-in for a model instance; `create_stream_event` only passes it on."""
+
+
+def _to_dataclass(_instance: object) -> AreaData:
+    return AreaData(id=PAYLOAD["id"], name=PAYLOAD["name"])
+
+
+def _store_door(path: str, *, label: str = "", **envelope: object) -> StreamEvent:
+    """Write one event through `DjangoStreamStore.append`."""
+    store = DjangoStreamStore()
+    store.create(path)
+    store.append(
+        path,
+        json.dumps(PAYLOAD).encode(),
+        AppendOptions(label=label, **envelope),  # type: ignore[arg-type]
+    )
+    return Stream.objects.get(stream_id=path).entries.get().event
+
+
+def _decorator_door(path: str, *, label: str = "") -> StreamEvent:
+    """Write one event through `create_stream_event`, the `@stream_model` door."""
+    return create_stream_event(
+        stream_paths=path,
+        to_dataclass=_to_dataclass,
+        instance=_Instance(),  # type: ignore[arg-type]
+        action=label,
+    )
+
+
+def _shape(event: StreamEvent) -> dict[str, object]:
+    """The fields the *writer* decides, as opposed to the caller."""
+    return {
+        "data": event.data,
+        "event_type": event.event_type,
+        "metadata": event.metadata,
+        "payload_encoding": event.payload_encoding,
+        "event_ts_is_set": event.event_ts is not None,
+    }
+
+
+class TestTheSentinel:
+    """A labelless event is recorded as ``"append"`` — from either door."""
+
+    def test_the_store_door_writes_the_sentinel(self):
+        assert _store_door("store/labelless").event_type == "append"
+
+    def test_the_decorator_door_writes_the_sentinel(self):
+        assert _decorator_door("decorator/labelless").event_type == "append"
+
+    def test_a_label_is_written_through_unchanged(self):
+        assert _store_door("store/labelled", label="create").event_type == "create"
+        assert _decorator_door("dec/labelled", label="create").event_type == "create"
+
+    def test_the_sentinel_inverts_on_read_from_either_door(self):
+        """`read()` maps the sentinel back to "no label". An event the decorator
+        wrote must be recognisable as labelless too, or it replays with a
+        phantom ``"append"`` label that no producer ever set."""
+        _store_door("store/invert")
+        _decorator_door("decorator/invert")
+
+        store = DjangoStreamStore()
+        for path in ("store/invert", "decorator/invert"):
+            messages, _ = store.read(path)
+            assert [m.label for m in messages] == [""], path
+
+
+class TestTheDoorsAgree:
+    """Same envelope in, same row out."""
+
+    def test_the_shape_matches_with_no_ambient_provenance(self):
+        store_event = _store_door("store/plain", label="create", event_ts=1.0)
+        decorator_event = _decorator_door("decorator/plain", label="create")
+
+        assert _shape(store_event) == _shape(decorator_event)
+
+    def test_the_shape_matches_inside_a_provenance_block(self):
+        with provenance(user=7, url="/areas/"):
+            store_event = _store_door("store/prov", label="create", event_ts=1.0)
+            decorator_event = _decorator_door("decorator/prov", label="create")
+
+        assert _shape(store_event) == _shape(decorator_event)
+        assert store_event.metadata == {"user": 7, "url": "/areas/"}
+
+    def test_metadata_is_an_empty_dict_not_null_from_either_door(self):
+        assert _store_door("store/meta").metadata == {}
+        assert _decorator_door("decorator/meta").metadata == {}
+
+    def test_an_explicit_event_ts_is_passed_through_unchanged(self):
+        assert _store_door("store/ts", event_ts=1234.5).event_ts == 1234.5
+
+    def test_offsets_start_at_one_from_either_door(self):
+        _store_door("store/offset")
+        _decorator_door("decorator/offset")
+
+        for path in ("store/offset", "decorator/offset"):
+            offsets = list(
+                Stream.objects.get(stream_id=path).entries.values_list(
+                    "offset", flat=True
+                )
+            )
+            assert offsets == [1], path
+
+
+class TestFanOut:
+    """A fan-out is one event in several streams, not several events."""
+
+    def test_one_event_shared_by_every_entry(self):
+        before = StreamEvent.objects.count()
+
+        event = create_stream_event(
+            stream_paths=["fanout/one", "fanout/two", "fanout/three"],
+            to_dataclass=_to_dataclass,
+            instance=_Instance(),  # type: ignore[arg-type]
+            action="create",
+        )
+
+        assert StreamEvent.objects.count() == before + 1
+        assert sorted(e.stream.stream_id for e in event.entries.all()) == [
+            "fanout/one",
+            "fanout/three",
+            "fanout/two",
+        ]
+        assert {e.offset for e in event.entries.all()} == {1}


### PR DESCRIPTION
There were two implementations of "write an event into the database": the durable store's append, and the `@stream_model` decorator that most Django apps actually use. They had drifted. The store records an event with no label under a stable marker that its reader knows how to undo again; the decorator wrote the label straight through, so an unlabelled event written by a model save could never be read back as unlabelled. The two also allocated offsets by different routes and worked out the metadata differently.

Both doors now go through a single writer that owns all of it — the marker, the metadata merge, the timestamp and the offset allocation. The writer takes a list of streams, so a save that fans out to several streams still records one event shared by all of them, which is what it always did. There is a new test that sends the same event in through both doors and compares what lands in the database; it failed before this change.

Closes #131
