### PR TITLE
Stop the lockfile rewriting itself in unrelated changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,10 @@ jobs:
         uses: astral-sh/setup-uv@v9.0.0
         with:
           enable-cache: true
+          # Pin uv itself, not just the action. Unpinned, CI takes whatever is
+          # latest and rewrites uv.lock in its newer style — a version-bump PR
+          # once carried a few hundred lines of unrelated marker churn (#118).
+          version: "0.9.22"
 
       - name: Set up Python 3.12
         run: uv python install 3.12
@@ -58,6 +62,7 @@ jobs:
       - uses: astral-sh/setup-uv@v9.0.0
         with:
           enable-cache: true
+          version: "0.9.22"
 
       - name: Set up Python 3.12
         run: uv python install 3.12

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -32,6 +32,10 @@ jobs:
         uses: astral-sh/setup-uv@v9.0.0
         with:
           enable-cache: true
+          # Pin uv itself, not just the action. Unpinned, CI takes whatever is
+          # latest and rewrites uv.lock in its newer style — a version-bump PR
+          # once carried a few hundred lines of unrelated marker churn (#118).
+          version: "0.9.22"
 
       - name: Set up Python 3.12
         run: uv python install 3.12

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,6 +37,10 @@ jobs:
         uses: astral-sh/setup-uv@v9.0.0
         with:
           enable-cache: true
+          # Pin uv itself, not just the action. Unpinned, CI takes whatever is
+          # latest and rewrites uv.lock in its newer style — a version-bump PR
+          # once carried a few hundred lines of unrelated marker churn (#118).
+          version: "0.9.22"
 
       - name: Set up Python 3.12
         run: uv python install 3.12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -292,6 +292,14 @@ protocol is covered by both stores.
 
 ### Changed
 
+- **One uv version, so the lockfile stops rewriting itself.** CI pinned the
+  `setup-uv` action but not uv itself, so it installed whatever was latest and
+  reserialised `uv.lock` in the newer style — a version-bump PR arrived carrying
+  a few hundred lines of unrelated dependency-marker churn that nobody had asked
+  for. Every workflow now pins the same uv, and `[tool.uv] required-version`
+  refuses a local uv outside that range rather than quietly rewriting the lock
+  under you.
+
 - **One writer for the enveloped event** (#131). "Write an event into the Django
   models" was implemented twice — once in `DjangoStreamStore._write`, once in
   `create_stream_event`, the `@stream_model` decorator's door — and the two

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,14 @@ docs = [
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
+[tool.uv]
+# Keep everyone on one uv minor, so `uv.lock` is not rewritten in a newer
+# serialisation style by whoever happens to run `uv sync` next. A version bump
+# once carried a few hundred lines of unrelated dependency-marker churn purely
+# because CI ran a newer uv than the author (#118). CI pins the same version in
+# every workflow; this is the local half, and it refuses rather than rewrites.
+required-version = ">=0.9.22,<0.10"
+
 [tool.hatch.build.targets.wheel]
 packages = ["src/rakaia", "src/django_rakaia"]
 


### PR DESCRIPTION
A change that touched only the version number once arrived with a few hundred
lines of unrelated churn in the dependency lockfile — a newer version of our
package tool rewriting the same information in its own style, because we never
said which version anyone should use.

This names one version for continuous integration and for local work. The
practical effect is that a lockfile change now means a dependency actually
changed, rather than someone happening to run a different tool.

Closes #118