### PR TITLE
Turn off the testing endpoint that let anyone break a stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -326,6 +326,31 @@ protocol is covered by both stores.
 
 ### Fixed
 
+- **The fault-injection endpoint is no longer reachable on a deployed server**
+  (#130). `/_test/inject-error` was matched before any stream routing, with no
+  gate of any kind. An unauthenticated `POST` of
+  `{"path": "orders", "status": 500, "count": 999999}` made every subsequent
+  request to that path fail, indefinitely, for every client — a denial of
+  service any anonymous caller could aim at any stream. Harmless while the
+  server only ever ran on a laptop; not once the package is published and
+  someone deploys it.
+
+  The endpoint is now off unless `RAKAIA_ENABLE_FAULT_INJECTION` is set to a
+  truthy value, via a new `ServerOptions.enable_fault_injection` that reads it
+  the same way `long_poll_timeout` reads `LONG_POLL_TIMEOUT`. The environment
+  variable is what matters: `uvicorn rakaia:app` builds the module-level app
+  with default `ServerOptions()`, so a constructor argument alone could never
+  reach it. While off the path is not routed at all and answers `404` like any
+  other unknown path — deliberately not `403`, which would confirm that the
+  endpoint exists. Nothing needs the flag today: the upstream conformance suite
+  never calls the endpoint, so `conformance/run.sh` does not set it and the
+  baseline in `conformance/expected-failures.txt` is unchanged.
+
+  Six of `InjectedFault`'s ten fields were also stored and never read —
+  `delayMs`, `dropConnection`, `truncateBodyBytes`, `corruptBody`, `jitterMs`
+  and `injectSseEvent` — so a caller asking for a 200ms delay got no delay and
+  no error either. They are gone; `count`, `status`, `retryAfter` and `method`
+  are the four that ever did anything.
 - **The dashboard views refuse an offset the durable store never issued** (#122).
   Two Django views parsed a client-supplied offset with bare `int()`, outside
   any store's ownership check: `after_offset` on the JSON events endpoint, and

--- a/src/rakaia/handler.py
+++ b/src/rakaia/handler.py
@@ -240,13 +240,17 @@ class InjectedFault:
     count: int = 1
     status: int | None = None
     retry_after: int | None = None
-    delay_ms: int | None = None
-    drop_connection: bool = False
-    truncate_body_bytes: int | None = None
     method: str | None = None
-    corrupt_body: bool = False
-    jitter_ms: int | None = None
-    inject_sse_event: dict[str, str] | None = None
+
+
+def _fault_injection_enabled_by_env() -> bool:
+    """Whether ``RAKAIA_ENABLE_FAULT_INJECTION`` asks for the test endpoint."""
+    return os.environ.get("RAKAIA_ENABLE_FAULT_INJECTION", "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
 
 
 @dataclass
@@ -263,6 +267,21 @@ class ServerOptions:
 
     cursor_options: CursorOptions = field(default_factory=CursorOptions)
     """Cursor calculation options."""
+
+    enable_fault_injection: bool = field(
+        default_factory=_fault_injection_enabled_by_env
+    )
+    """Whether to route the ``/_test/inject-error`` fault-injection endpoint.
+
+    Off unless the ``RAKAIA_ENABLE_FAULT_INJECTION`` environment variable is set
+    to a truthy value (``1``/``true``/``yes``/``on``). The endpoint is
+    unauthenticated and lets any caller make an arbitrary stream path fail, so
+    it must never be reachable on a deployed server. While off the path is not
+    routed at all and answers ``404`` like any other unknown path, rather than
+    ``403``, so its existence is not advertised. The environment variable is the
+    load-bearing switch: the module-level ``rakaia:app`` is built with default
+    ``ServerOptions()``, so a constructor argument alone cannot reach it.
+    """
 
 
 def create_app(
@@ -315,8 +334,9 @@ def create_app(
             await send_response(send, 204, cors_headers)
             return
 
-        # Handle test control endpoints
-        if path == "/_test/inject-error":
+        # Handle test control endpoints. Gated off by default: when disabled the
+        # path is not routed at all, so it 404s like any other unknown path.
+        if opts.enable_fault_injection and path == "/_test/inject-error":
             await _handle_test_inject(
                 method, scope, receive, send, cors_headers, injected_faults
             )
@@ -1242,13 +1262,7 @@ async def _handle_test_inject(
             count=config.get("count", 1),
             status=config.get("status"),
             retry_after=config.get("retryAfter"),
-            delay_ms=config.get("delayMs"),
-            drop_connection=config.get("dropConnection", False),
-            truncate_body_bytes=config.get("truncateBodyBytes"),
             method=config.get("method"),
-            corrupt_body=config.get("corruptBody", False),
-            jitter_ms=config.get("jitterMs"),
-            inject_sse_event=config.get("injectSseEvent"),
         )
 
         await send_response(

--- a/tests/test_rakaia/test_handler.py
+++ b/tests/test_rakaia/test_handler.py
@@ -13,7 +13,7 @@ import pytest
 import pytest_asyncio
 
 from rakaia import StreamStore, create_app
-from rakaia.handler import ServerOptions
+from rakaia.handler import ServerOptions, _fault_injection_enabled_by_env
 from rakaia.types import INITIAL_OFFSET
 
 
@@ -285,6 +285,99 @@ class TestMethods:
     async def test_patch_returns_405(self, client: httpx.AsyncClient):
         response = await client.patch("/foo")
         assert response.status_code == 405
+
+
+# =============================================================================
+# Fault injection gate
+# =============================================================================
+
+
+def _fault_client(*, enabled: bool) -> httpx.AsyncClient:
+    """A client whose server has the fault-injection endpoint on or off."""
+    app = create_app(
+        store=StreamStore(), options=ServerOptions(enable_fault_injection=enabled)
+    )
+    transport = httpx.ASGITransport(app=app)
+    return httpx.AsyncClient(transport=transport, base_url="http://test")
+
+
+class TestFaultInjectionGate:
+    async def test_default_app_does_not_route_the_endpoint(
+        self, client: httpx.AsyncClient
+    ):
+        """Off by default, and a 404 — not a 403 that would advertise it."""
+        response = await client.post(
+            "/_test/inject-error", json={"path": "/foo", "status": 500, "count": 999}
+        )
+        assert response.status_code == 404
+
+    async def test_default_app_ignores_delete_too(self, client: httpx.AsyncClient):
+        response = await client.delete("/_test/inject-error")
+        assert response.status_code == 404
+
+    async def test_disabled_endpoint_cannot_fault_a_stream(
+        self, client: httpx.AsyncClient
+    ):
+        await client.put("/foo", headers={"content-type": "text/plain"}, content=b"hi")
+        await client.post(
+            "/_test/inject-error", json={"path": "/foo", "status": 500, "count": 999}
+        )
+        response = await client.get("/foo")
+        assert response.status_code == 200
+
+    async def test_enabled_flag_injects_a_fault(self):
+        async with _fault_client(enabled=True) as client:
+            await client.put(
+                "/foo", headers={"content-type": "text/plain"}, content=b"hi"
+            )
+            registered = await client.post(
+                "/_test/inject-error",
+                json={"path": "/foo", "status": 503, "retryAfter": 7, "count": 1},
+            )
+            assert registered.status_code == 200
+
+            faulted = await client.get("/foo")
+            assert faulted.status_code == 503
+            assert faulted.headers.get("retry-after") == "7"
+
+            # The fault is consumed after `count` responses.
+            assert (await client.get("/foo")).status_code == 200
+
+    async def test_enabled_flag_clears_faults_on_delete(self):
+        async with _fault_client(enabled=True) as client:
+            await client.put(
+                "/foo", headers={"content-type": "text/plain"}, content=b"hi"
+            )
+            await client.post(
+                "/_test/inject-error",
+                json={"path": "/foo", "status": 500, "count": 999},
+            )
+            cleared = await client.delete("/_test/inject-error")
+            assert cleared.status_code == 200
+            assert (await client.get("/foo")).status_code == 200
+
+
+class TestFaultInjectionEnvFlag:
+    """The conformance runner starts `rakaia:app`, so the env var is the only
+    way in — a constructor argument alone cannot reach the default app."""
+
+    async def test_env_var_unset_is_off(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.delenv("RAKAIA_ENABLE_FAULT_INJECTION", raising=False)
+        assert _fault_injection_enabled_by_env() is False
+
+    @pytest.mark.parametrize("value", ["1", "true", "TRUE", "yes", "on"])
+    async def test_truthy_env_values_enable_it(
+        self, monkeypatch: pytest.MonkeyPatch, value: str
+    ):
+        monkeypatch.setenv("RAKAIA_ENABLE_FAULT_INJECTION", value)
+        assert _fault_injection_enabled_by_env() is True
+
+    @pytest.mark.parametrize("value", ["", "0", "false", "no", "off"])
+    async def test_falsy_env_values_leave_it_off(
+        self, monkeypatch: pytest.MonkeyPatch, value: str
+    ):
+        monkeypatch.setenv("RAKAIA_ENABLE_FAULT_INJECTION", value)
+        assert _fault_injection_enabled_by_env() is False
 
 
 # =============================================================================


### PR DESCRIPTION
The server had a testing endpoint that anyone could call, with no password and no
check of any kind. One request could make any stream start failing, and keep it
failing, for everybody. That was harmless while the server only ever ran on
someone's laptop, but the package is being published now and people will deploy
it somewhere reachable.

The endpoint is now switched off unless you deliberately turn it on with an
environment variable. With it off the server answers as though the endpoint
simply does not exist, rather than saying "not allowed" — there is no reason to
tell a stranger it is there. Nothing we run today needs it turned on, and the
conformance results are unchanged.

Closes #130
