### PR TITLE
One rule for routing registrations, and a fix for handlers registered away from where they are defined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -303,17 +303,33 @@ protocol is covered by both stores.
   warned that a second copy of the envelope "produces events that replay
   differently from every other event in the same stream, and no test anywhere is
   looking at the difference" — this was that copy.
-
   Both doors now write through `write_enveloped_event`, which owns the sentinel,
   the ambient-`provenance()` merge, `{}` rather than NULL metadata, `event_ts`
   passthrough, and locking offset allocation. It takes a *list* of streams, so
   `@stream_model`'s fan-out is still one event with one envelope shared by N
   entries. `tests/test_django_rakaia/test_envelope_writer.py` drives both doors
   with the same envelope and compares the rows.
-
   Behaviour is unchanged except that a `@stream_model` event with an empty
   action string is now stored as `"append"` rather than `""` — the same shape
   the store has always written, and the same thing both read back as.
+
+- **One content-routing rule, one registration record** (#132). Handlers and
+  upcasters each answered the same question — *what string does this
+  registration's glob get tested against?* — in their own method, the second
+  carrying a comment saying it mirrored the first. `reset()` and `rehydrate()`
+  were written out twice; the "a frozenset serialises as a sorted list" rule
+  three times; and `identity` / `to_payload` / `identity_from_payload` once per
+  record type, nine methods that had to agree pairwise with nothing checking
+  that they did. Content routing is now one function both registries call, the
+  meta-stream mechanics are one base class both registries inherit, and each
+  record type declares its persisted fields once and derives the round trip from
+  the declaration. `rakaia.registration_log` made the same move one level down;
+  its module docstring says why. Routing behaviour is unchanged, and pinned
+  first by tests that put identical inputs through both registries — including
+  the two edges that carry the weight: a missing key routes as `""` and does not
+  match, and a content-routed registration matched with no event raises.
+  Content routing for upcasters (ADR 0002 item 3) is untouched; this is where
+  that decision lands rather than a walk-back of it.
 
 - **One producer response table instead of three.** The five-arm `isinstance`
   ladder over `ProducerValidationResult` — duplicate → 204, stale epoch → 403,
@@ -357,7 +373,6 @@ protocol is covered by both stores.
   service any anonymous caller could aim at any stream. Harmless while the
   server only ever ran on a laptop; not once the package is published and
   someone deploys it.
-
   The endpoint is now off unless `RAKAIA_ENABLE_FAULT_INJECTION` is set to a
   truthy value, via a new `ServerOptions.enable_fault_injection` that reads it
   the same way `long_poll_timeout` reads `LONG_POLL_TIMEOUT`. The environment
@@ -368,12 +383,29 @@ protocol is covered by both stores.
   endpoint exists. Nothing needs the flag today: the upstream conformance suite
   never calls the endpoint, so `conformance/run.sh` does not set it and the
   baseline in `conformance/expected-failures.txt` is unchanged.
-
   Six of `InjectedFault`'s ten fields were also stored and never read —
   `delayMs`, `dropConnection`, `truncateBodyBytes`, `corruptBody`, `jitterMs`
   and `injectSseEvent` — so a caller asking for a 200ms delay got no delay and
   no error either. They are gone; `count`, `status`, `retryAfter` and `method`
   are the four that ever did anything.
+
+- **A handler registered somewhere other than where it is defined comes back
+  from a restart** (#117). `rehydrate()` restores registrations by re-importing
+  modules and letting their `@register_handler` decorators run again, and it
+  worked out which modules to import by chopping the last segment off the
+  function's dotted path. That assumed the decorator ran in the module the
+  function was defined in. Binding a dependency with
+  `functools.partial(fn, **deps)` — the documented way to do it — breaks that
+  assumption by design: the partial is built in your app's `handlers.py` while
+  `fn` lives in a shared module, so rakaia imported the shared module, no
+  decorator ran, and the handler was simply absent after a restart with nothing
+  logged. The same line mis-derived a handler defined as a method, whose
+  qualname `pkg.mod.Class.method` chopped down to the *class*. A registration
+  now records `registered_in` — the module of the frame that registered it —
+  and that is what `rehydrate()` imports; `dotted_path` keeps meaning "where the
+  logic is" for drift reporting. Meta-streams written before the field existed
+  fall back to the old derivation, which is correct for exactly the cases that
+  used to work, so upgrading does not re-append an existing log.
 - **The dashboard views refuse an offset the durable store never issued** (#122).
   Two Django views parsed a client-supplied offset with bare `int()`, outside
   any store's ownership check: `after_offset` on the JSON events endpoint, and

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -137,12 +137,22 @@ registry.register(
 )
 ```
 
-**Not a closure.** A closure works and is quietly worse: its recorded path
-contains `<locals>`, which `rehydrate()` cannot import, so a registry restored
-from its meta-stream silently loses that handler — and its **drift** hash covers
-the wrapper only, so an edit to the function the wrapper calls is invisible. A
-`partial` is unwrapped, so both describe the wrapped function. A persisting
-registry warns if you use a closure anyway.
+**Not a closure.** A closure works and is quietly worse: its **drift** hash
+covers the wrapper only, so an edit to the function the wrapper calls is
+invisible, and `rehydrate()` restores it only if the module that registered it
+re-registers it on import — which a closure built inside a function does not. A
+`partial` is unwrapped, so the recorded path and the hash both describe the
+wrapped function. A persisting registry warns if you use a closure anyway.
+
+### Registration site
+
+The module that ran a registration decorator, recorded on every registration as
+`registered_in`. `rehydrate()` re-imports these and lets the decorators run
+again, so a registration comes back only if the module holding its *decorator
+call* is imported. That is not the module holding the function: bind a
+dependency with `functools.partial` and the wiring lives in your app's
+`handlers.py` while the function lives in a shared module. The `dotted_path` on
+the same record says where the *logic* is, and is what drift detection reports.
 
 ### Upcaster
 

--- a/src/rakaia/registration_log.py
+++ b/src/rakaia/registration_log.py
@@ -38,7 +38,9 @@ class RegistrationRecord(Protocol):
     Three types satisfy it — `HandlerVersion`, `ReducerVersion`,
     `UpcasterVersion`. Keeping all three parts on the type is the point: an
     identity built in one place and rebuilt in another is exactly the pair that
-    used to drift.
+    used to drift. All three now *derive* the three methods from one declared
+    field list (`rakaia.registry._MetaStreamRecord`), so the round trip is a
+    property of the declaration rather than of three methods agreeing.
 
     `to_payload` must round-trip through **JSON**, not just through a dict: a
     `frozenset` event match has to serialize as a sorted list (sorted, so the
@@ -53,12 +55,18 @@ class RegistrationRecord(Protocol):
         ...
 
     def to_payload(self) -> dict[str, Any]:
-        """The JSON-serializable form written to the meta-stream. Must include
-        ``dotted_path``, which is what `RegistrationLog.modules` re-imports."""
+        """The JSON-serializable form written to the meta-stream.
+
+        Must include ``registered_in`` — the module that made the registration,
+        which is what `RegistrationLog.modules` re-imports — and
+        ``dotted_path``, which says where the logic lives, for drift reporting.
+        They are different modules whenever a function is wired up somewhere
+        other than where it is defined.
+        """
         ...
 
-    @staticmethod
-    def identity_from_payload(payload: dict[str, Any]) -> tuple:
+    @classmethod
+    def identity_from_payload(cls, payload: dict[str, Any]) -> tuple:
         """Rebuild `identity` from a payload this type wrote.
 
         Must tolerate payloads written by older versions that predate a field —
@@ -133,17 +141,34 @@ class RegistrationLog:
         return set(self._known)
 
     def modules(self) -> set[str]:
-        """The importable module of every recorded registration.
+        """The module to re-import for every recorded registration.
 
-        Read from ``payload["dotted_path"]`` **by name**. The predecessor pulled
-        this out of the identity tuple by index, which is why two identity
-        builders carried "append new fields at the end" comments.
+        ``registered_in`` — *where the decorator ran*, which is the only thing
+        importing can re-run. This used to be derived from ``dotted_path`` by
+        chopping the last segment off, which quietly assumed the function was
+        defined in the module that registered it and had exactly one qualname
+        segment. Neither holds for a `functools.partial` wired up in an app's
+        ``handlers.py``, nor for a handler defined as a method, and the failure
+        was a registration that simply did not come back.
+
+        Payloads written before ``registered_in`` existed fall back to the old
+        derivation, which is correct for exactly the cases that used to work.
         """
         return {
-            payload["dotted_path"].rsplit(".", 1)[0]
-            for payload in self._payloads
-            if payload.get("dotted_path")
+            module
+            for module in (self._module_of(payload) for payload in self._payloads)
+            if module
         }
+
+    @staticmethod
+    def _module_of(payload: dict[str, Any]) -> str | None:
+        site = payload.get("registered_in")
+        if site:
+            return str(site)
+        dotted_path = payload.get("dotted_path")
+        if not dotted_path:
+            return None
+        return str(dotted_path).rsplit(".", 1)[0]
 
     def reset(self) -> None:
         """Forget what has been recorded, without touching the stream.

--- a/src/rakaia/registry.py
+++ b/src/rakaia/registry.py
@@ -15,10 +15,11 @@ from __future__ import annotations
 
 import fnmatch
 import importlib
+import inspect
 import warnings
 from collections.abc import Callable, Iterable
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, ClassVar
 
 from .registration_log import RegistrationLog
 from .source_hash import hash_function_source, is_importable, unwrap_handler
@@ -57,6 +58,207 @@ class HandlerDriftError(Exception):
 
 
 # =============================================================================
+# One rule per rule
+# =============================================================================
+#
+# Everything in this section exists once and is used by every registration kind.
+# Each of these used to be written out per kind — content routing twice, the
+# frozenset serialization rule three times, and identity/payload/identity-again
+# nine times across three record types. `rakaia.registration_log` did the same
+# consolidation one level down and its module docstring says why.
+
+
+def _canonical_event_match(event_match: str | Iterable[str]) -> str | frozenset[str]:
+    """Normalise an `event_match` argument to its stored form.
+
+    A plain string is kept as-is (the common single-glob case). Any other
+    iterable of strings becomes a ``frozenset`` — hashable (so it works as the
+    series key and in the identity tuple) and order-independent (so the same
+    members in a different order dedup). Raises on an empty collection or a
+    non-string member, which are always mistakes.
+
+    Also the **decoder** for a persisted `event_match`, which is a string or a
+    list: reading a payload back is the same normalisation as accepting an
+    argument, so there is no second implementation to keep in step.
+    """
+    if isinstance(event_match, str):
+        return event_match
+    members = frozenset(event_match)
+    if not members:
+        raise ValueError(
+            "event_match collection must contain at least one pattern (got empty)"
+        )
+    if not all(isinstance(m, str) for m in members):
+        raise ValueError("event_match collection members must all be strings")
+    return members
+
+
+def _event_match_payload(event_match: str | frozenset[str]) -> str | list[str]:
+    """The JSON form of a stored `event_match`.
+
+    A frozenset serializes as a **sorted** list, so the meta-stream is stable
+    regardless of set iteration order — otherwise every restart would see a
+    "new" identity and re-append the same handler. `_canonical_event_match`
+    reads it back.
+    """
+    return event_match if isinstance(event_match, str) else sorted(event_match)
+
+
+def _pattern_matches(pattern: str | frozenset[str], subject: str) -> bool:
+    """Whether `subject` matches `pattern` — a single glob, or any glob in a set."""
+    if isinstance(pattern, str):
+        return fnmatch.fnmatchcase(subject, pattern)
+    return any(fnmatch.fnmatchcase(subject, p) for p in pattern)
+
+
+def _routing_subject(
+    match_field: str | None,
+    event: dict[str, Any] | None,
+    stream_subject: str,
+    *,
+    registrant: str,
+    remedy: str,
+) -> str:
+    """The string a registration's glob is tested against — the content-routing
+    rule, for handlers and upcasters alike.
+
+    Without a `match_field` the subject is the stream/event-match string and the
+    event is irrelevant. With one, it is ``str(event[match_field])``.
+
+    Two edges carry the weight, and both are the same for both kinds:
+
+    * the field is **absent** from an event that is present → ``""``, which
+      simply does not match. A stream carrying a different form_type is normal
+      traffic, not a configuration error.
+    * the **event** is absent → `ValueError`. A caller who forgot to pass it
+      would otherwise silently leave the event unhandled or un-upcast.
+
+    `registrant` and `remedy` only shape that error, so each caller keeps the
+    wording that names the right entry point.
+    """
+    if match_field is None:
+        return stream_subject
+    if event is None:
+        raise ValueError(
+            f"{registrant} routes on match_field={match_field!r} but {remedy}"
+        )
+    return str(event.get(match_field, ""))
+
+
+def _module_prefix(dotted_path: str | None) -> str | None:
+    """The module part of a dotted path, by chopping the last segment.
+
+    Only correct when the path is ``module.function``, which is why it is no
+    longer how `rehydrate()` finds a module — see `_registration_site`. Kept as
+    the fallback for meta-stream payloads written before `registered_in`
+    existed.
+    """
+    if not dotted_path or "." not in dotted_path:
+        return dotted_path or None
+    return dotted_path.rsplit(".", 1)[0]
+
+
+def _registration_site() -> str | None:
+    """The module that made this registration — what `rehydrate()` re-imports.
+
+    Restoring a registration means re-running its **decorator**, so the module
+    that matters is the one holding the decorator call, not the one holding the
+    function. Those are different whenever a shared function is wired up
+    elsewhere — which `functools.partial(fn, **deps)` dependency binding makes
+    the normal layout, since the partial is built at the wiring site while `fn`
+    lives in a library module.
+
+    Walks out of rakaia's own frames, so it lands on the caller whether they
+    used `@register_handler`, `@register_simple`, or called `register()`
+    directly.
+    """
+    frame = inspect.currentframe()
+    try:
+        while frame is not None:
+            module = frame.f_globals.get("__name__")
+            if module is not None and not (
+                module == "rakaia" or module.startswith("rakaia.")
+            ):
+                return module
+            frame = frame.f_back
+        return None
+    finally:
+        # Frames hold references to their locals, which include this one.
+        del frame
+
+
+_REQUIRED: Any = object()
+
+
+@dataclass(frozen=True)
+class _PayloadField:
+    """One persisted field of a registration record, and how it crosses JSON.
+
+    Declaring the fields is what lets `_MetaStreamRecord` derive `identity`,
+    `to_payload` and `identity_from_payload` from a single list per record type
+    instead of three hand-written methods that had to agree.
+    """
+
+    name: str
+    encode: Callable[[Any], Any] = lambda value: value
+    decode: Callable[[Any], Any] = lambda value: value
+    default: Callable[[dict[str, Any]], Any] = _REQUIRED
+    """Value for a payload written before this field existed. Meta-streams
+    already in the wild still have to load, so every field added after the
+    format shipped needs one."""
+
+    def read(self, payload: dict[str, Any]) -> Any:
+        if self.name in payload:
+            return self.decode(payload[self.name])
+        if self.default is _REQUIRED:
+            raise KeyError(f"registration payload is missing {self.name!r}")
+        return self.default(payload)
+
+
+def _as_int(value: Any) -> int:
+    return int(value)
+
+
+def _as_int_or_none(value: Any) -> int | None:
+    return None if value is None else int(value)
+
+
+class _MetaStreamRecord:
+    """`identity` / `to_payload` / `identity_from_payload`, derived once.
+
+    Satisfies `rakaia.registration_log.RegistrationRecord` for any subclass that
+    declares `_PAYLOAD_FIELDS`. The three methods were written out per record
+    type — an identity built in one place and rebuilt in another, three times
+    over — which is exactly the pair that drifts. Here the round trip is a
+    property of the field list, so adding a field is one line in one place.
+    """
+
+    _PAYLOAD_FIELDS: ClassVar[tuple[_PayloadField, ...]] = ()
+
+    @property
+    def identity(self) -> tuple:
+        """Dedup key for the meta-stream. Excludes the callable itself (not
+        serializable, and two registrations of the same source are the same
+        registration)."""
+        return tuple(getattr(self, f.name) for f in self._PAYLOAD_FIELDS)
+
+    def to_payload(self) -> dict[str, Any]:
+        return {f.name: f.encode(getattr(self, f.name)) for f in self._PAYLOAD_FIELDS}
+
+    @classmethod
+    def identity_from_payload(cls, payload: dict[str, Any]) -> tuple:
+        return tuple(f.read(payload) for f in cls._PAYLOAD_FIELDS)
+
+
+#: The registration-site field, shared by all three record kinds. The fallback
+#: is the old derivation — right whenever the decoration site and the definition
+#: site were the same module, which is the case that used to work.
+_REGISTERED_IN = _PayloadField(
+    "registered_in", default=lambda p: _module_prefix(p.get("dotted_path"))
+)
+
+
+# =============================================================================
 # Data structures
 # =============================================================================
 
@@ -65,13 +267,16 @@ def _dotted_path(fn: Any, *, persisted: bool = False) -> str:
     """The importable path recorded for `fn`, warning when there isn't one.
 
     Taken from the *unwrapped* callable so a `functools.partial` records the
-    function it binds rather than being unrecordable.
+    function it binds rather than being unrecordable. This is "where the logic
+    is", for drift detection; "where it was registered" is a separate field
+    (`registered_in`, from `_registration_site`), because those are not the same
+    module once dependencies are bound at a wiring site.
 
-    A closure or a nested lambda has a `<locals>` qualname, which `rehydrate()`
-    cannot import — it splits the recorded path and imports the module part, and
-    `pkg.factory.<locals>` is not a module. Such a registration therefore
-    survives in memory but vanishes on a restore, and its `source_hash` covers
-    only the wrapper, so drift detection is blind to whatever it calls.
+    A closure or a nested lambda has a `<locals>` qualname. Its `source_hash`
+    then covers only the wrapper, so drift detection is blind to whatever the
+    wrapper calls — and `rehydrate()` restores it only if the module that
+    registered it re-registers it on import, which a closure built inside a
+    function does not.
 
     Warned rather than refused: a closure is legitimate in a test, and rakaia's
     own suite registers lambdas. The point is that it stops being silent. Bind
@@ -89,10 +294,11 @@ def _dotted_path(fn: Any, *, persisted: bool = False) -> str:
     path = f"{target.__module__}.{target.__qualname__}"
     if persisted and not is_importable(fn):
         warnings.warn(
-            f"Handler {path!r} is not importable, so `rehydrate()` cannot "
-            f"restore it from a meta-stream and drift detection covers only the "
-            f"wrapper, not the function it calls. Bind dependencies with "
-            f"functools.partial(fn, **deps) instead of a closure.",
+            f"Handler {path!r} is not importable: drift detection covers only "
+            f"the wrapper, not the function it calls, and `rehydrate()` can "
+            f"restore it only if the module that registered it re-registers on "
+            f"import. Bind dependencies with functools.partial(fn, **deps) "
+            f"instead of a closure.",
             UserWarning,
             stacklevel=3,
         )
@@ -100,7 +306,7 @@ def _dotted_path(fn: Any, *, persisted: bool = False) -> str:
 
 
 @dataclass(frozen=True)
-class HandlerVersion:
+class HandlerVersion(_MetaStreamRecord):
     """One registered version of a handler."""
 
     name: str
@@ -123,7 +329,8 @@ class HandlerVersion:
     """The handler callable. event -> Effect | list[Effect]."""
 
     dotted_path: str
-    """fn.__module__ + '.' + fn.__qualname__ — for persistence in Step 3."""
+    """fn.__module__ + '.' + fn.__qualname__ — *where the logic is*, taken from
+    the unwrapped callable. Used for drift reporting, not for restoring."""
 
     source_hash: str
     """SHA-256 of fn's source body — for drift detection in Step 6."""
@@ -139,66 +346,37 @@ class HandlerVersion:
     resolve facts materialised by earlier stages. Default 0 = single-stage,
     called with just the event (backward compatible)."""
 
+    registered_in: str | None = None
+    """The module that made this registration — *where the decorator ran*, which
+    is what `rehydrate()` imports. Separate from `dotted_path` because binding a
+    dependency with `functools.partial` puts the wiring in one module and the
+    function in another. Set from the calling frame; see `_registration_site`."""
+
     # -- meta-stream record (see `rakaia.registration_log`) -----------------
     #
-    # Identity and serialization live together on the type, so the round trip is
-    # a property of `HandlerVersion` rather than an agreement between two
-    # module-level functions that had to be kept mirrored by hand.
+    # Identity and serialization are derived from this list by
+    # `_MetaStreamRecord`, so adding a field is one line here rather than three
+    # methods that have to agree. Fields added after the format shipped carry a
+    # `default`, because meta-streams written without them still have to load.
+    # Order is the identity tuple's order; append, don't insert.
 
-    @property
-    def identity(self) -> tuple:
-        """Dedup key for the meta-stream. Excludes `fn` (not serializable, and
-        two registrations of the same source are the same registration)."""
-        return (
-            self.name,
-            self.event_match,
-            self.effective_from,
-            self.effective_to,
-            self.dotted_path,
-            self.source_hash,
-            self.match_field,
-            self.stage,
-        )
-
-    def to_payload(self) -> dict[str, Any]:
-        return {
-            "name": self.name,
-            # A frozenset serializes as a *sorted* list, so the meta-stream is
-            # stable regardless of set iteration order — otherwise every restart
-            # would see a "new" identity and re-append the same handler.
-            "event_match": (
-                self.event_match
-                if isinstance(self.event_match, str)
-                else sorted(self.event_match)
-            ),
-            "effective_from": self.effective_from,
-            "effective_to": self.effective_to,
-            "dotted_path": self.dotted_path,
-            "source_hash": self.source_hash,
-            "match_field": self.match_field,
-            "stage": self.stage,
-        }
-
-    @staticmethod
-    def identity_from_payload(p: dict[str, Any]) -> tuple:
-        return (
-            p["name"],
-            # Rebuild the frozenset a list-serialized set was persisted from, so
-            # a reload dedups against the live version.
-            p["event_match"]
-            if isinstance(p["event_match"], str)
-            else frozenset(p["event_match"]),
-            int(p["effective_from"]),
-            p["effective_to"] if p["effective_to"] is None else int(p["effective_to"]),
-            p["dotted_path"],
-            p["source_hash"],
-            p.get("match_field"),  # tolerate pre-match_field persisted payloads
-            int(p.get("stage", 0)),  # tolerate pre-stage persisted payloads
-        )
+    _PAYLOAD_FIELDS: ClassVar[tuple[_PayloadField, ...]] = (
+        _PayloadField("name"),
+        _PayloadField(
+            "event_match", encode=_event_match_payload, decode=_canonical_event_match
+        ),
+        _PayloadField("effective_from", decode=_as_int),
+        _PayloadField("effective_to", decode=_as_int_or_none),
+        _PayloadField("dotted_path"),
+        _PayloadField("source_hash"),
+        _PayloadField("match_field", default=lambda _p: None),
+        _PayloadField("stage", decode=_as_int, default=lambda _p: 0),
+        _REGISTERED_IN,
+    )
 
 
 @dataclass(frozen=True)
-class ReducerVersion:
+class ReducerVersion(_MetaStreamRecord):
     """A per-stage reduce step: recompute an aggregate once from the projections.
 
     Unlike a handler, a reducer is not matched or called per event. During
@@ -241,23 +419,18 @@ class ReducerVersion:
     dotted_path: str
     source_hash: str
 
+    registered_in: str | None = None
+    """The module that made this registration — see `HandlerVersion`."""
+
     # -- meta-stream record (see `rakaia.registration_log`) -----------------
 
-    @property
-    def identity(self) -> tuple:
-        return (self.name, self.stage, self.dotted_path, self.source_hash)
-
-    def to_payload(self) -> dict[str, Any]:
-        return {
-            "name": self.name,
-            "stage": self.stage,
-            "dotted_path": self.dotted_path,
-            "source_hash": self.source_hash,
-        }
-
-    @staticmethod
-    def identity_from_payload(p: dict[str, Any]) -> tuple:
-        return (p["name"], int(p["stage"]), p["dotted_path"], p["source_hash"])
+    _PAYLOAD_FIELDS: ClassVar[tuple[_PayloadField, ...]] = (
+        _PayloadField("name"),
+        _PayloadField("stage", decode=_as_int),
+        _PayloadField("dotted_path"),
+        _PayloadField("source_hash"),
+        _REGISTERED_IN,
+    )
 
 
 # =============================================================================
@@ -265,7 +438,42 @@ class ReducerVersion:
 # =============================================================================
 
 
-class HandlerRegistry:
+class _LogBackedRegistry:
+    """The meta-stream half of a registry, once for both of them.
+
+    A registry keeps one `RegistrationLog` per record kind it owns (handlers
+    keep two — handlers and reducers — upcasters keep one). Loading them,
+    clearing them and re-importing the modules they name is the same work in
+    each case, and used to be written out in each.
+    """
+
+    _logs: tuple[RegistrationLog, ...]
+
+    def _load_logs(self) -> None:
+        for log in self._logs:
+            log.load()
+
+    def _reset_logs(self) -> None:
+        for log in self._logs:
+            log.reset()
+
+    def rehydrate(self) -> None:
+        """Import the module that made each recorded registration, so its
+        `@register_*` decorator runs again and re-registers here.
+
+        No-op without a backing store. Modules are imported once (Python caches
+        imports), so calling this after some are already imported is safe — but
+        note that it therefore restores nothing for a module already imported in
+        this process, which is the normal case outside a fresh start.
+        """
+        modules: set[str] = set()
+        for log in self._logs:
+            modules |= log.modules()
+        for module_name in modules:
+            importlib.import_module(module_name)
+
+
+class HandlerRegistry(_LogBackedRegistry):
     """
     Registry of versioned handlers, optionally backed by a meta-stream.
 
@@ -301,8 +509,8 @@ class HandlerRegistry:
         self._reducer_log = RegistrationLog(
             store, self._reducer_stream_path, ReducerVersion
         )
-        self._handler_log.load()
-        self._reducer_log.load()
+        self._logs = (self._handler_log, self._reducer_log)
+        self._load_logs()
 
     def register(
         self,
@@ -354,6 +562,7 @@ class HandlerRegistry:
             fn=fn,
             dotted_path=_dotted_path(fn, persisted=self._store is not None),
             source_hash=hash_function_source(fn),
+            registered_in=_registration_site(),
             match_field=match_field,
             stage=stage,
         )
@@ -396,6 +605,7 @@ class HandlerRegistry:
             fn=fn,
             dotted_path=_dotted_path(fn, persisted=self._store is not None),
             source_hash=hash_function_source(fn),
+            registered_in=_registration_site(),
         )
 
         existing = self._reducers.get(name)
@@ -421,8 +631,7 @@ class HandlerRegistry:
         """
         self._versions.clear()
         self._reducers.clear()
-        self._handler_log.reset()
-        self._reducer_log.reset()
+        self._reset_logs()
 
     def reducers_for_stage(self, stage: int) -> list[ReducerVersion]:
         """Reducers registered for `stage`, in deterministic (name) order."""
@@ -505,27 +714,22 @@ class HandlerRegistry:
         event_match: str,
         event: dict[str, Any] | None,
     ) -> str:
-        """The string a series' pattern is tested against.
+        """The string a series' pattern is tested against — `_routing_subject`
+        for the rule, which upcasters share.
 
-        Stream-path routing (the default) returns `event_match`. Content
-        routing (a `match_field` on the series) returns `event[match_field]`.
-        match_field is consistent within a (name, pattern) series, so the first
-        version decides.
+        `match_field` is consistent within a (name, pattern) series, so the
+        first version decides. A registration that failed after `setdefault()`
+        can leave an empty series behind; that falls back to stream-path routing
+        rather than an IndexError on `versions[0]`.
         """
-        if not versions:
-            # A registration that failed after setdefault() can leave an empty
-            # series behind; fall back to stream-path routing rather than
-            # IndexError on versions[0].
-            return event_match
-        match_field = versions[0].match_field
-        if match_field is None:
-            return event_match
-        if event is None:
-            raise ValueError(
-                f"Handler {name!r} routes on match_field={match_field!r} but "
-                f"resolve() was called without an event."
-            )
-        return str(event.get(match_field, ""))
+        match_field = versions[0].match_field if versions else None
+        return _routing_subject(
+            match_field,
+            event,
+            event_match,
+            registrant=f"Handler {name!r}",
+            remedy="resolve() was called without an event.",
+        )
 
     def all_versions(self) -> list[HandlerVersion]:
         """Return every registered version (test/debug helper)."""
@@ -533,26 +737,6 @@ class HandlerRegistry:
         for series in self._versions.values():
             out.extend(series)
         return out
-
-    def rehydrate(self) -> None:
-        """
-        Import every dotted-path's module so its `@register_handler`
-        decorators run and re-register against this registry.
-
-        No-op if no backing store is configured. Modules are imported once
-        (Python caches imports), so calling this after some modules have
-        already been imported is safe.
-        """
-        for module_name in self._handler_log.modules() | self._reducer_log.modules():
-            importlib.import_module(module_name)
-
-    # ------------------------------------------------------------------
-    # Internal — persistence
-    # ------------------------------------------------------------------
-
-    # ------------------------------------------------------------------
-    # Internal — overlap check
-    # ------------------------------------------------------------------
 
     @staticmethod
     def _check_overlap(new: HandlerVersion, series: list[HandlerVersion]) -> None:
@@ -578,7 +762,7 @@ class HandlerRegistry:
 
 
 @dataclass(frozen=True)
-class UpcasterVersion:
+class UpcasterVersion(_MetaStreamRecord):
     """One registered upcaster: transforms event from `from_version` to next."""
 
     event_match: str
@@ -599,39 +783,22 @@ class UpcasterVersion:
     string — mirrors ``register_handler``, so a per-form upcaster can route on a
     per-entity stream (e.g. ``submissions:<uuid>``) whose path carries no type."""
 
+    registered_in: str | None = None
+    """The module that made this registration — see `HandlerVersion`."""
+
     # -- meta-stream record (see `rakaia.registration_log`) -----------------
 
-    @property
-    def identity(self) -> tuple:
-        return (
-            self.event_match,
-            self.from_version,
-            self.dotted_path,
-            self.source_hash,
-            self.match_field,
-        )
-
-    def to_payload(self) -> dict[str, Any]:
-        return {
-            "event_match": self.event_match,
-            "from_version": self.from_version,
-            "dotted_path": self.dotted_path,
-            "source_hash": self.source_hash,
-            "match_field": self.match_field,
-        }
-
-    @staticmethod
-    def identity_from_payload(p: dict[str, Any]) -> tuple:
-        return (
-            p["event_match"],
-            int(p["from_version"]),
-            p["dotted_path"],
-            p["source_hash"],
-            p.get("match_field"),  # tolerate pre-match_field persisted payloads
-        )
+    _PAYLOAD_FIELDS: ClassVar[tuple[_PayloadField, ...]] = (
+        _PayloadField("event_match"),
+        _PayloadField("from_version", decode=_as_int),
+        _PayloadField("dotted_path"),
+        _PayloadField("source_hash"),
+        _PayloadField("match_field", default=lambda _p: None),
+        _REGISTERED_IN,
+    )
 
 
-class UpcasterRegistry:
+class UpcasterRegistry(_LogBackedRegistry):
     """
     Registry of schema-version upcasters, keyed by (event_match, from_version,
     match_field).
@@ -650,7 +817,8 @@ class UpcasterRegistry:
         self._store = store
         self._stream_path = stream_path
         self._log = RegistrationLog(store, stream_path, UpcasterVersion)
-        self._log.load()
+        self._logs = (self._log,)
+        self._load_logs()
 
     def register(
         self,
@@ -682,6 +850,7 @@ class UpcasterRegistry:
             dotted_path=_dotted_path(fn, persisted=self._store is not None),
             source_hash=hash_function_source(fn),
             match_field=match_field,
+            registered_in=_registration_site(),
         )
 
         key = (event_match, from_version, match_field)
@@ -704,25 +873,23 @@ class UpcasterRegistry:
     def _subject(
         up: UpcasterVersion, event: dict[str, Any] | None, event_match_str: str
     ) -> str:
-        """The string an upcaster's pattern is matched against: a content field
-        when `match_field` is set (mirrors `HandlerRegistry._match_subject`), else
-        the stream/event-match string.
+        """The string an upcaster's pattern is matched against.
 
-        A content-routed upcaster matched with `event=None` raises — like handler
-        dispatch — to catch a caller who forgot to pass the event (which would
-        otherwise leave the event silently un-upcast). An event that is present
-        but lacks the field yields "" and simply does not match (a different
-        form_type on the stream is normal, not an error)."""
-        if up.match_field is not None:
-            if event is None:
-                raise ValueError(
-                    f"Upcaster (event_match={up.event_match!r}) routes on "
-                    f"match_field={up.match_field!r} but was matched without an "
-                    "event; pass the decoded event to current_version()/"
-                    "apply_chain() (or use upcast_to_current)."
-                )
-            return str(event.get(up.match_field, ""))
-        return event_match_str
+        The same content-routing rule handler dispatch uses — one function,
+        `_routing_subject`, rather than a second copy that a comment promised
+        was kept in step. ADR 0002 item 3 made content routing available to
+        upcasters; this is where that lands, not a walk-back of it.
+        """
+        return _routing_subject(
+            up.match_field,
+            event,
+            event_match_str,
+            registrant=f"Upcaster (event_match={up.event_match!r})",
+            remedy=(
+                "was matched without an event; pass the decoded event to "
+                "current_version()/apply_chain() (or use upcast_to_current)."
+            ),
+        )
 
     def current_version(
         self, event_match_str: str, event: dict[str, Any] | None = None
@@ -833,53 +1000,7 @@ class UpcasterRegistry:
         meta-stream (delete that via the store if you need to).
         """
         self._upcasters.clear()
-        self._log.reset()
-
-    def rehydrate(self) -> None:
-        for module_name in self._log.modules():
-            importlib.import_module(module_name)
-
-    # ------------------------------------------------------------------
-    # Internal — persistence (parallels HandlerRegistry)
-    # ------------------------------------------------------------------
-
-
-# =============================================================================
-# event_match helpers
-# =============================================================================
-
-
-def _canonical_event_match(event_match: str | Iterable[str]) -> str | frozenset[str]:
-    """Normalise an `event_match` argument to its stored form.
-
-    A plain string is kept as-is (the common single-glob case). Any other
-    iterable of strings becomes a ``frozenset`` — hashable (so it works as the
-    series key and in the identity tuple) and order-independent (so the same
-    members in a different order dedup). Raises on an empty collection or a
-    non-string member, which are always mistakes.
-    """
-    if isinstance(event_match, str):
-        return event_match
-    members = frozenset(event_match)
-    if not members:
-        raise ValueError(
-            "event_match collection must contain at least one pattern (got empty)"
-        )
-    if not all(isinstance(m, str) for m in members):
-        raise ValueError("event_match collection members must all be strings")
-    return members
-
-
-def _pattern_matches(pattern: str | frozenset[str], subject: str) -> bool:
-    """Whether `subject` matches `pattern` — a single glob, or any glob in a set."""
-    if isinstance(pattern, str):
-        return fnmatch.fnmatchcase(subject, pattern)
-    return any(fnmatch.fnmatchcase(subject, p) for p in pattern)
-
-
-# =============================================================================
-# Identity helpers
-# =============================================================================
+        self._reset_logs()
 
 
 # =============================================================================

--- a/tests/test_rakaia/registration_sites/__init__.py
+++ b/tests/test_rakaia/registration_sites/__init__.py
@@ -1,0 +1,21 @@
+"""Two modules that split *where a handler is defined* from *where it is
+registered* — the shape `RegistrationLog.modules()` has to survive.
+
+`logic` holds the functions and a class; `wiring` and `method_wiring` are the
+only modules that call a registration decorator. Nothing registers at
+package-import time, so importing the package is inert and a wiring module can
+be imported, dropped from `sys.modules` and re-imported to simulate the fresh
+process `rehydrate()` exists for.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from rakaia.registry import HandlerRegistry, UpcasterRegistry
+
+#: Set by a test *before* a wiring module is imported; the wiring modules
+#: register against these rather than the process-wide defaults.
+handler_registry: HandlerRegistry | None = None
+upcaster_registry: UpcasterRegistry | None = None

--- a/tests/test_rakaia/registration_sites/logic.py
+++ b/tests/test_rakaia/registration_sites/logic.py
@@ -1,0 +1,29 @@
+"""Where the logic lives. This module registers nothing."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def project_room(event: dict[str, Any], *, prefix: str = "") -> list:
+    """A handler body with a dependency to bind — the `functools.partial` case
+    `docs/versioned-handlers.md` recommends over a closure."""
+    _ = f"{prefix}{event.get('room_id', '')}"
+    return []
+
+
+def upcast_room(event: dict[str, Any]) -> dict[str, Any]:
+    return {**event, "currency": "USD"}
+
+
+def reduce_rooms(reader: Any) -> list:  # noqa: ARG001
+    return []
+
+
+class Projector:
+    """A handler defined as a method: its qualname is
+    ``…logic.Projector.project``, so splitting one segment off the dotted path
+    yields the *class*, which is not importable."""
+
+    def project(self, event: dict[str, Any]) -> list:  # noqa: ARG002
+        return []

--- a/tests/test_rakaia/registration_sites/method_wiring.py
+++ b/tests/test_rakaia/registration_sites/method_wiring.py
@@ -1,0 +1,15 @@
+"""A handler registered as a bound method — dotted path ``pkg.mod.Class.method``.
+
+Defined and registered in *different* modules as well, so this case is only
+about the extra qualname segment a method carries.
+"""
+
+from __future__ import annotations
+
+from rakaia.registry import register_handler
+
+from . import handler_registry, logic
+
+register_handler("methods", "room:*", 0, registry=handler_registry)(
+    logic.Projector().project
+)

--- a/tests/test_rakaia/registration_sites/wiring.py
+++ b/tests/test_rakaia/registration_sites/wiring.py
@@ -1,0 +1,19 @@
+"""Where the registrations happen. The functions come from `logic`.
+
+An app's `handlers.py` that wires shared functions to streams — the layout
+`functools.partial` dependency binding pushes people towards.
+"""
+
+from __future__ import annotations
+
+import functools
+
+from rakaia.registry import register_handler, register_reducer, register_upcaster
+
+from . import handler_registry, logic, upcaster_registry
+
+register_handler("room", "room:*", 0, registry=handler_registry)(
+    functools.partial(logic.project_room, prefix="p")
+)
+register_reducer("rooms", 1, registry=handler_registry)(logic.reduce_rooms)
+register_upcaster("room:*", 1, registry=upcaster_registry)(logic.upcast_room)

--- a/tests/test_rakaia/test_content_routing.py
+++ b/tests/test_rakaia/test_content_routing.py
@@ -1,0 +1,236 @@
+"""One content-routing rule, driven through both registries at once.
+
+Handlers and upcasters answer the same question — *what string does this
+registration's glob get tested against?* — and for a long time each answered it
+in its own method: `HandlerRegistry._match_subject` and
+`UpcasterRegistry._subject`, the second carrying a comment saying it mirrored
+the first. A comment is not a test. These cases put the same inputs through both
+sides so the rule is pinned as one rule:
+
+* no `match_field` → the stream/event-match string, and the event is irrelevant;
+* `match_field` set → `str(event[match_field])`;
+* `match_field` set, field **absent** → `""`, which simply does not match
+  (a different form_type on the same stream is normal, not an error);
+* `match_field` set, event **missing entirely** → `ValueError`, because a caller
+  who forgot the event would otherwise silently leave content-routed
+  registrations unmatched.
+
+Written before the two implementations were merged into one, so a silent change
+in matching behaviour would have failed here.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from rakaia.registry import HandlerRegistry, UpcasterChainError, UpcasterRegistry
+
+
+def _handler(event):  # noqa: ARG001
+    return []
+
+
+def _upcaster(event):
+    return {**event, "upcasted": True}
+
+
+@pytest.fixture
+def handlers() -> HandlerRegistry:
+    return HandlerRegistry()
+
+
+@pytest.fixture
+def upcasters() -> UpcasterRegistry:
+    return UpcasterRegistry()
+
+
+def _handler_matches(reg: HandlerRegistry, subject: str, event) -> bool:
+    """Whether the registered handler matched — the routing question, isolated
+    from sequence coverage (every handler here is registered open-ended)."""
+    return bool(reg.resolve(subject, 0, event))
+
+
+def _upcaster_matches(reg: UpcasterRegistry, subject: str, event) -> bool:
+    """Whether the registered upcaster matched. `current_version` returns 2 when
+    a v1 upcaster applies and 1 when none does."""
+    return reg.current_version(subject, event) == 2
+
+
+class TestStreamPathRoutingIgnoresTheEvent:
+    """The default: the pattern is tested against the stream/event-match string.
+    The event, present or not, has no say."""
+
+    @pytest.mark.parametrize(
+        "event",
+        [None, {}, {"form_type": "SOMETHING_ELSE"}],
+        ids=["none", "empty", "other"],
+    )
+    def test_a_handler_matches_on_the_stream_path(self, handlers, event):
+        handlers.register("h", "room:*", _handler, 0, None)
+        assert _handler_matches(handlers, "room:5", event) is True
+        assert _handler_matches(handlers, "chat:5", event) is False
+
+    @pytest.mark.parametrize(
+        "event",
+        [None, {}, {"form_type": "SOMETHING_ELSE"}],
+        ids=["none", "empty", "other"],
+    )
+    def test_an_upcaster_matches_on_the_stream_path(self, upcasters, event):
+        upcasters.register("room:*", 1, _upcaster)
+        assert _upcaster_matches(upcasters, "room:5", event) is True
+        assert _upcaster_matches(upcasters, "chat:5", event) is False
+
+
+class TestContentRoutingReadsTheField:
+    """`match_field` set → the pattern is tested against `event[match_field]`,
+    and the stream path stops mattering."""
+
+    def test_a_handler_matches_the_field_not_the_path(self, handlers):
+        handlers.register("h", "TF_*", _handler, 0, None, match_field="form_type")
+        event = {"form_type": "TF_6_1_1"}
+        assert _handler_matches(handlers, "submissions:abc", event) is True
+        assert _handler_matches(handlers, "anything-at-all", event) is True
+
+    def test_an_upcaster_matches_the_field_not_the_path(self, upcasters):
+        upcasters.register("TF_*", 1, _upcaster, match_field="form_type")
+        event = {"form_type": "TF_6_1_1"}
+        assert _upcaster_matches(upcasters, "submissions:abc", event) is True
+        assert _upcaster_matches(upcasters, "anything-at-all", event) is True
+
+    def test_a_handler_does_not_match_a_different_field_value(self, handlers):
+        handlers.register("h", "TF_*", _handler, 0, None, match_field="form_type")
+        other = {"form_type": "SF_1"}
+        assert _handler_matches(handlers, "submissions:abc", other) is False
+
+    def test_an_upcaster_does_not_match_a_different_field_value(self, upcasters):
+        upcasters.register("TF_*", 1, _upcaster, match_field="form_type")
+        other = {"form_type": "SF_1"}
+        assert _upcaster_matches(upcasters, "submissions:abc", other) is False
+
+    def test_a_handler_stringifies_a_non_string_field(self, handlers):
+        """`str()` on the value, so an integer discriminator is globbable."""
+        handlers.register("h", "42", _handler, 0, None, match_field="version_code")
+        assert _handler_matches(handlers, "s", {"version_code": 42}) is True
+
+    def test_an_upcaster_stringifies_a_non_string_field(self, upcasters):
+        upcasters.register("42", 1, _upcaster, match_field="version_code")
+        assert _upcaster_matches(upcasters, "s", {"version_code": 42}) is True
+
+
+class TestAMissingKeyIsTheEmptyString:
+    """Load-bearing: `event.get(field, "")`. An event on the stream that simply
+    carries a different shape is normal traffic, not a configuration error — so
+    the subject is `""`, which matches nothing but `""`-shaped globs, and no
+    exception is raised."""
+
+    def test_a_handler_with_the_key_absent_does_not_match(self, handlers):
+        handlers.register("h", "TF_*", _handler, 0, None, match_field="form_type")
+        assert _handler_matches(handlers, "submissions:abc", {"other": 1}) is False
+
+    def test_an_upcaster_with_the_key_absent_does_not_match(self, upcasters):
+        upcasters.register("TF_*", 1, _upcaster, match_field="form_type")
+        assert _upcaster_matches(upcasters, "submissions:abc", {"other": 1}) is False
+
+    def test_a_handler_glob_that_accepts_the_empty_string_still_matches(self, handlers):
+        """`*` matches `""`, so an absent key is genuinely routed as `""` rather
+        than being skipped — the distinction a `""`-accepting glob exposes."""
+        handlers.register("h", "*", _handler, 0, None, match_field="form_type")
+        assert _handler_matches(handlers, "submissions:abc", {"other": 1}) is True
+
+    def test_an_upcaster_glob_that_accepts_the_empty_string_still_matches(
+        self, upcasters
+    ):
+        upcasters.register("*", 1, _upcaster, match_field="form_type")
+        assert _upcaster_matches(upcasters, "submissions:abc", {"other": 1}) is True
+
+    def test_a_handler_with_an_empty_string_value_matches_like_an_absent_key(
+        self, handlers
+    ):
+        handlers.register("h", "", _handler, 0, None, match_field="form_type")
+        assert _handler_matches(handlers, "s", {"form_type": ""}) is True
+        assert _handler_matches(handlers, "s", {}) is True
+
+    def test_an_upcaster_with_an_empty_string_value_matches_like_an_absent_key(
+        self, upcasters
+    ):
+        upcasters.register("", 1, _upcaster, match_field="form_type")
+        assert _upcaster_matches(upcasters, "s", {"form_type": ""}) is True
+        assert _upcaster_matches(upcasters, "s", {}) is True
+
+
+class TestNoEventAtAllRaises:
+    """A content-routed registration matched without an event is a caller bug:
+    silently skipping it would leave the event un-handled or un-upcast with no
+    signal at all."""
+
+    def test_a_handler_raises(self, handlers):
+        handlers.register("h", "TF_*", _handler, 0, None, match_field="form_type")
+        with pytest.raises(ValueError, match="match_field"):
+            handlers.resolve("submissions:abc", 0, None)
+
+    def test_an_upcaster_raises(self, upcasters):
+        upcasters.register("TF_*", 1, _upcaster, match_field="form_type")
+        with pytest.raises(ValueError, match="match_field"):
+            upcasters.current_version("submissions:abc", None)
+
+    def test_apply_chain_always_has_an_event_so_it_reports_a_missing_link(
+        self, upcasters
+    ):
+        """`apply_chain` takes the event by value, so it can never hit the
+        no-event raise; an event that lacks the discriminator routes as `""` and
+        surfaces as a missing chain link instead."""
+        upcasters.register("TF_*", 1, _upcaster, match_field="form_type")
+        with pytest.raises(UpcasterChainError, match="Missing upcaster"):
+            upcasters.apply_chain({"schema_version": 1}, "submissions:abc", 2)
+
+    def test_the_handler_error_names_the_handler_and_the_field(self, handlers):
+        handlers.register("h", "TF_*", _handler, 0, None, match_field="form_type")
+        with pytest.raises(ValueError) as excinfo:
+            handlers.resolve("submissions:abc", 0, None)
+        assert "'h'" in str(excinfo.value)
+        assert "form_type" in str(excinfo.value)
+
+    def test_the_upcaster_error_names_the_pattern_and_the_field(self, upcasters):
+        upcasters.register("TF_*", 1, _upcaster, match_field="form_type")
+        with pytest.raises(ValueError) as excinfo:
+            upcasters.current_version("submissions:abc", None)
+        assert "TF_*" in str(excinfo.value)
+        assert "form_type" in str(excinfo.value)
+
+    def test_a_stream_routed_registration_never_raises_without_an_event(
+        self, handlers, upcasters
+    ):
+        """The raise is specific to content routing — the default path must stay
+        callable with no event, which is how most of the library calls it."""
+        handlers.register("h", "room:*", _handler, 0, None)
+        upcasters.register("room:*", 1, _upcaster)
+        assert handlers.resolve("room:5", 0) != []
+        assert upcasters.current_version("room:5") == 2
+
+
+class TestBothRegistriesAgreeOnTheSameInputs:
+    """The consolidation's actual claim: given the same pattern, field, subject
+    and event, a handler and an upcaster match or don't match together."""
+
+    CASES = [
+        ("TF_*", "form_type", "submissions:1", {"form_type": "TF_6"}, True),
+        ("TF_*", "form_type", "submissions:1", {"form_type": "SF_1"}, False),
+        ("TF_*", "form_type", "TF_6", {"form_type": "SF_1"}, False),
+        ("*", "form_type", "submissions:1", {}, True),
+        ("TF_*", "form_type", "submissions:1", {}, False),
+        ("", "form_type", "submissions:1", {"form_type": ""}, True),
+        ("42", "code", "submissions:1", {"code": 42}, True),
+    ]
+
+    @pytest.mark.parametrize(
+        ("pattern", "field", "subject", "event", "expected"),
+        CASES,
+        ids=[f"{c[0]}|{c[3]}" for c in CASES],
+    )
+    def test_the_two_registries_route_identically(
+        self, handlers, upcasters, pattern, field, subject, event, expected
+    ):
+        handlers.register("h", pattern, _handler, 0, None, match_field=field)
+        upcasters.register(pattern, 1, _upcaster, match_field=field)
+        assert _handler_matches(handlers, subject, event) is expected
+        assert _upcaster_matches(upcasters, subject, event) is expected

--- a/tests/test_rakaia/test_registration_log.py
+++ b/tests/test_rakaia/test_registration_log.py
@@ -35,17 +35,30 @@ from rakaia.store import StreamStore
 PATH = "_meta/test"
 
 
-def _handler(name="h", event_match="orders", stage=0, match_field=None):
+def _at(field: str) -> int:
+    """Position of `field` in an identity tuple, from the declared field list."""
+    return [f.name for f in HandlerVersion._PAYLOAD_FIELDS].index(field)
+
+
+def _handler(
+    name="h",
+    event_match="orders",
+    stage=0,
+    match_field=None,
+    registered_in="pkg.mod",
+    dotted_path=None,
+):
     return HandlerVersion(
         name=name,
         event_match=event_match,
         effective_from=0,
         effective_to=None,
         fn=lambda _event: [],
-        dotted_path=f"pkg.mod.{name}",
+        dotted_path=dotted_path or f"pkg.mod.{name}",
         source_hash="abc123",
         stage=stage,
         match_field=match_field,
+        registered_in=registered_in,
     )
 
 
@@ -131,6 +144,25 @@ class TestModulesAreResolvedByName:
         _log(store).record(_handler())
         assert _log(store).modules() == {"pkg.mod"}
 
+    def test_modules_names_the_registration_site_not_the_function(self):
+        """The module to re-import is the one whose decorator ran. Those differ
+        as soon as a function is wired up somewhere other than where it lives —
+        the normal shape once a dependency is bound with `functools.partial`."""
+        log = _log()
+        log.record(_handler(registered_in="app.wiring"))
+        assert log.modules() == {"app.wiring"}
+
+    def test_a_method_qualname_does_not_leak_a_class_into_the_modules(self):
+        """`pkg.mod.Class.method` chopped by one segment is `pkg.mod.Class`,
+        which is not importable — the registration site sidesteps it."""
+        log = _log()
+        log.record(
+            _handler(
+                registered_in="app.wiring", dotted_path="pkg.mod.Projector.project"
+            )
+        )
+        assert log.modules() == {"app.wiring"}
+
 
 class TestIdentityRoundTrip:
     """The bug class the hand-mirrored function pairs invited: an object's
@@ -167,12 +199,22 @@ class TestBackwardCompatibilityWithOlderPayloads:
     def test_a_payload_without_match_field_loads(self):
         payload = _handler().to_payload()
         del payload["match_field"]
-        assert HandlerVersion.identity_from_payload(payload)[6] is None
+        assert HandlerVersion.identity_from_payload(payload)[_at("match_field")] is None
 
     def test_a_payload_without_stage_loads_as_stage_zero(self):
         payload = _handler().to_payload()
         del payload["stage"]
-        assert HandlerVersion.identity_from_payload(payload)[7] == 0
+        assert HandlerVersion.identity_from_payload(payload)[_at("stage")] == 0
+
+    def test_a_payload_without_a_registration_site_falls_back_to_the_module(self):
+        """Meta-streams written before `registered_in` existed still restore —
+        via the derivation they were written under, which is right whenever the
+        function was registered where it was defined."""
+        payload = _handler().to_payload()
+        del payload["registered_in"]
+        assert HandlerVersion.identity_from_payload(payload)[_at("registered_in")] == (
+            "pkg.mod"
+        )
 
 
 class TestUnreadableMessagesAreSkipped:

--- a/tests/test_rakaia/test_registration_site.py
+++ b/tests/test_rakaia/test_registration_site.py
@@ -1,0 +1,226 @@
+"""Restoring a registration means re-importing the module that *registered* it.
+
+`rehydrate()` works by import side effect: it imports modules and lets the
+`@register_handler` decorators in them run again. So the module it has to import
+is the one holding the **decorator call**, which is not necessarily the one
+holding the function.
+
+The meta-stream used to record only `dotted_path` — the function's
+`__module__.__qualname__`, taken from the *unwrapped* callable — and derive the
+module to import by chopping the last segment off it. That silently assumed two
+things:
+
+* the decoration site and the definition site are the same module. Since
+  `functools.partial(fn, **deps)` became the documented way to bind a handler
+  dependency, they routinely are not: `fn` lives in a shared module and the
+  binding happens in an app's `handlers.py`. Importing `fn`'s module runs no
+  decorator, so the handler came back from a restart missing, with no error.
+* the qualname has exactly one segment past the module. A handler defined as a
+  method has `pkg.mod.Class.method`, so the chop yields `pkg.mod.Class` — an
+  `ImportError` on rehydrate, or worse a stale hit.
+
+A registration now records `registered_in` — the module of the frame that called
+the decorator — and that is what `rehydrate()` imports. `dotted_path` keeps
+meaning "where the logic is", which is what drift detection and the
+`<locals>` warning want from it.
+"""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+from rakaia.registry import HandlerRegistry, UpcasterRegistry
+from rakaia.store import StreamStore
+
+from . import registration_sites
+
+WIRING = "tests.test_rakaia.registration_sites.wiring"
+METHOD_WIRING = "tests.test_rakaia.registration_sites.method_wiring"
+LOGIC = "tests.test_rakaia.registration_sites.logic"
+
+
+@pytest.fixture
+def store() -> StreamStore:
+    return StreamStore()
+
+
+@pytest.fixture(autouse=True)
+def _unimported():
+    """Each test starts with the wiring modules unimported and restores that
+    afterwards, so `rehydrate()` genuinely re-runs their decorators — the fresh
+    process it exists to stand in for."""
+    for name in (WIRING, METHOD_WIRING):
+        sys.modules.pop(name, None)
+    yield
+    for name in (WIRING, METHOD_WIRING):
+        sys.modules.pop(name, None)
+    registration_sites.handler_registry = None
+    registration_sites.upcaster_registry = None
+
+
+def _wire(module: str, handlers: HandlerRegistry, upcasters: UpcasterRegistry) -> None:
+    """Import a wiring module fresh, registering against these registries."""
+    registration_sites.handler_registry = handlers
+    registration_sites.upcaster_registry = upcasters
+    sys.modules.pop(module, None)
+    __import__(module)
+
+
+class TestAHandlerRegisteredAwayFromWhereItIsDefined:
+    """The #117 case: `logic.project_room` is bound with `functools.partial` and
+    registered from `wiring`. Only `wiring` running restores the registration."""
+
+    def test_the_handler_registers_in_the_first_place(self, store):
+        handlers = HandlerRegistry(store=store)
+        _wire(WIRING, handlers, UpcasterRegistry(store=store))
+        assert [v.name for v in handlers.all_versions()] == ["room"]
+
+    def test_the_dotted_path_still_points_at_the_function(self, store):
+        """Unchanged, deliberately: drift detection and the `<locals>` warning
+        both want the function, not the wiring."""
+        handlers = HandlerRegistry(store=store)
+        _wire(WIRING, handlers, UpcasterRegistry(store=store))
+        (version,) = handlers.all_versions()
+        assert version.dotted_path == f"{LOGIC}.project_room"
+
+    def test_the_registration_site_is_recorded_separately(self, store):
+        handlers = HandlerRegistry(store=store)
+        _wire(WIRING, handlers, UpcasterRegistry(store=store))
+        (version,) = handlers.all_versions()
+        assert version.registered_in == WIRING
+
+    def test_a_fresh_registry_restores_the_handler(self, store):
+        """The bug, stated as the behaviour that was missing: a new process
+        reads the meta-stream, imports what it names, and has the handler back."""
+        _wire(WIRING, HandlerRegistry(store=store), UpcasterRegistry(store=store))
+
+        sys.modules.pop(WIRING, None)
+        restored = HandlerRegistry(store=store)
+        registration_sites.handler_registry = restored
+        registration_sites.upcaster_registry = UpcasterRegistry()
+        restored.rehydrate()
+
+        assert [v.name for v in restored.all_versions()] == ["room"]
+
+    def test_a_fresh_registry_restores_the_reducer(self, store):
+        _wire(WIRING, HandlerRegistry(store=store), UpcasterRegistry(store=store))
+
+        sys.modules.pop(WIRING, None)
+        restored = HandlerRegistry(store=store)
+        registration_sites.handler_registry = restored
+        registration_sites.upcaster_registry = UpcasterRegistry()
+        restored.rehydrate()
+
+        assert [r.name for r in restored.all_reducers()] == ["rooms"]
+
+    def test_a_fresh_upcaster_registry_restores_the_upcaster(self, store):
+        _wire(WIRING, HandlerRegistry(store=store), UpcasterRegistry(store=store))
+
+        sys.modules.pop(WIRING, None)
+        restored = UpcasterRegistry(store=store)
+        registration_sites.handler_registry = HandlerRegistry()
+        registration_sites.upcaster_registry = restored
+        restored.rehydrate()
+
+        assert [u.event_match for u in restored.all_upcasters()] == ["room:*"]
+
+    def test_importing_only_the_definition_module_restores_nothing(self, store):
+        """Why the old derivation could not work, made explicit: importing
+        `logic` runs no decorator, so a `modules()` that named it would restore
+        an empty registry however faithfully it was imported."""
+        _wire(WIRING, HandlerRegistry(store=store), UpcasterRegistry(store=store))
+
+        sys.modules.pop(WIRING, None)
+        restored = HandlerRegistry(store=store)
+        registration_sites.handler_registry = restored
+        __import__(LOGIC)
+
+        assert restored.all_versions() == []
+
+
+class TestAHandlerDefinedAsAMethod:
+    """`pkg.mod.Class.method` — chopping one segment yields the class."""
+
+    def test_the_recorded_site_is_a_module_not_the_class(self, store):
+        handlers = HandlerRegistry(store=store)
+        _wire(METHOD_WIRING, handlers, UpcasterRegistry(store=store))
+        (version,) = handlers.all_versions()
+        assert version.dotted_path == f"{LOGIC}.Projector.project"
+        assert version.registered_in == METHOD_WIRING
+
+    def test_rehydrate_does_not_try_to_import_the_class(self, store):
+        _wire(
+            METHOD_WIRING, HandlerRegistry(store=store), UpcasterRegistry(store=store)
+        )
+
+        sys.modules.pop(METHOD_WIRING, None)
+        restored = HandlerRegistry(store=store)
+        registration_sites.handler_registry = restored
+        restored.rehydrate()
+
+        assert [v.name for v in restored.all_versions()] == ["methods"]
+
+
+class TestTheRecordedSiteIsPartOfWhatIsPersisted:
+    def test_it_survives_a_reload_of_the_meta_stream(self, store):
+        _wire(WIRING, HandlerRegistry(store=store), UpcasterRegistry(store=store))
+        assert WIRING in HandlerRegistry(store=store)._handler_log.modules()
+
+    def test_the_same_registration_from_the_same_site_still_dedups(self, store):
+        """Recording the site must not make every restart re-append."""
+        from rakaia.registry import HANDLERS_META_STREAM
+
+        _wire(WIRING, HandlerRegistry(store=store), UpcasterRegistry(store=store))
+        before = len(store.read(HANDLERS_META_STREAM)[0])
+        _wire(WIRING, HandlerRegistry(store=store), UpcasterRegistry(store=store))
+        assert len(store.read(HANDLERS_META_STREAM)[0]) == before
+
+
+class TestOlderMetaStreamsStillLoad:
+    """Payloads written before `registered_in` existed have to keep working —
+    they fall back to the old derivation, which is right whenever the decoration
+    site and the definition site were the same module (the case that worked)."""
+
+    def test_a_payload_without_the_field_falls_back_to_the_dotted_path(self, store):
+        import json
+
+        from rakaia.registry import HANDLERS_META_STREAM
+
+        store.create(HANDLERS_META_STREAM)
+        store.append(
+            HANDLERS_META_STREAM,
+            json.dumps(
+                {
+                    "name": "legacy",
+                    "event_match": "x",
+                    "effective_from": 0,
+                    "effective_to": None,
+                    "dotted_path": "pkg.legacy_mod.handler",
+                    "source_hash": "deadbeef",
+                }
+            ).encode("utf-8"),
+        )
+        assert HandlerRegistry(store=store)._handler_log.modules() == {"pkg.legacy_mod"}
+
+    def test_an_old_payload_dedups_against_the_same_registration_today(self):
+        """A same-module registration reconstructs the same `registered_in` the
+        fallback produces, so upgrading does not re-append the whole log."""
+        import json
+
+        from rakaia.registry import HandlerVersion
+
+        live = HandlerVersion(
+            name="legacy",
+            event_match="x",
+            effective_from=0,
+            effective_to=None,
+            fn=lambda _e: [],
+            dotted_path="pkg.legacy_mod.handler",
+            source_hash="deadbeef",
+            registered_in="pkg.legacy_mod",
+        )
+        old_payload = json.loads(json.dumps(live.to_payload()))
+        del old_payload["registered_in"]
+        assert HandlerVersion.identity_from_payload(old_payload) == live.identity

--- a/tests/test_rakaia/test_registry_persistence.py
+++ b/tests/test_rakaia/test_registry_persistence.py
@@ -16,6 +16,13 @@ from rakaia.registry import (
 from rakaia.store import StreamStore
 
 
+def _identity_index(field: str) -> int:
+    """Position of `field` in a `HandlerVersion.identity` tuple, looked up from
+    the declared field list rather than hard-coded — adding a field must not
+    silently move an assertion onto its neighbour."""
+    return [f.name for f in HandlerVersion._PAYLOAD_FIELDS].index(field)
+
+
 def _fn(tag: str):
     def handler(event):  # noqa: ARG001
         return tag
@@ -153,7 +160,7 @@ class TestPersistence:
         store.append(HANDLERS_META_STREAM, json.dumps(payload).encode("utf-8"))
         reg = HandlerRegistry(store=store)
         ident = next(iter(reg._handler_log.known()))  # type: ignore[attr-defined]
-        assert ident[-1] == 0  # stage defaulted to 0
+        assert ident[_identity_index("stage")] == 0  # stage defaulted to 0
 
 
 class TestIdempotency:


### PR DESCRIPTION
Handlers and upcasters were each answering the same question — what text does this registration get matched against? — in their own copy of the same code, with a comment promising the two were kept in step. Three other pieces of the registration record were duplicated the same way. Each of those now exists once, and the behaviour is unchanged: tests putting identical inputs through both sides went in first, so any silent change in what matches what would have failed them.

The second fix is a real bug. Restoring registrations after a restart works by re-importing modules and letting them register themselves again, and the module to import was worked out from where the handler function was written. That is the wrong module whenever a handler is wired up somewhere other than where it is defined — which is what the recommended way of giving a handler a dependency does. The handler was quietly missing after a restart, with nothing said about it. Registrations now record where they were registered, and that is what gets re-imported.

Closes #132
Closes #117