### PR TITLE
Compare Stream-Seq the way the protocol says

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -636,12 +636,22 @@ protocol is covered by both stores.
   broadcast, after the write had landed. Anything outside the channel layer's
   allowed set is now replaced, and over-long names are truncated.
 
-- **Stream-Seq was compared as text, not as a number.** The header reached the
-  store unparsed, so the conflict check `opts.seq <= stream.last_seq` compared
-  strings: sending `Stream-Seq: 10` after `9` was rejected with a 409, because
-  `"10" < "9"` lexicographically. Every producer broke on reaching double
-  digits. The header is now parsed strictly (400 on a non-integer, matching the
-  producer headers) and both fields are typed `int | None`.
+- **`Stream-Seq` is an opaque string, compared byte-wise**
+  ([#137](https://github.com/joshbrooks/rakaia/issues/137)). Rakaia spent part
+  of this cycle parsing the header as a decimal integer, comparing it
+  numerically, and returning `400 Bad Request` for anything that was not one.
+  The protocol specifies none of that: `Stream-Seq` values are opaque strings
+  that **MUST** compare using simple byte-wise lexicographic ordering, so any
+  value is well-formed and a ULID is as valid as a digit string.
+
+  **If you send unpadded decimals, pad them.** Byte-wise, `"10"` sorts below
+  `"9"`, so `Stream-Seq: 10` after `9` is a `409 Conflict` — correctly. Send
+  `"09"` then `"10"`, at whatever fixed width your writer will reach; rakaia's
+  own offsets zero-pad for exactly this reason. Nothing else in the header's
+  behaviour changed, and a writer already padding or using a ULID is unaffected.
+
+  Seven conformance tests were failing on the numeric comparison. They pass now,
+  leaving the stream-forking family as the only known gap.
 
 - **`@stream_model` no longer appends phantom events for fixture loads** (#80).
   `handle_post_save` now honours Django's `raw` kwarg, so `manage.py loaddata`
@@ -744,8 +754,10 @@ protocol is covered by both stores.
   Both changes need the accompanying migration (`0007`), which adds the
   lifecycle columns to `Stream` and the `StreamProducer` table.
 
-- **BREAKING — `AppendOptions.seq` and `Stream.last_seq` are `int | None`,** not
-  `str | None`. See the Stream-Seq fix under Fixed.
+- **BREAKING — `AppendOptions.seq` and `Stream.last_seq` are `str | None`,** and
+  the durable `Stream.last_seq` column is text rather than an integer. See the
+  `Stream-Seq` entry under Fixed. Needs migration `0009`, which widens the
+  column; the values it held were decimal digits and survive unchanged.
 
 - **BREAKING — `StreamServerStore` requires `run_sync`.** The protocol server
   is async but most of the store surface is synchronous, and how that sync work

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -117,9 +117,15 @@ consumer was — nothing changes. The entry is still reachable via `read()`.
 `create()` gained keyword-only options (`content_type`, `ttl_seconds`,
 `expires_at`, `initial_data`, `closed`). `create(path)` is unchanged.
 
-`StreamMessage.seq` and `Stream.last_seq` are now `int | None` where they were
-`str | None`. The header is parsed strictly, which is what fixed `Stream-Seq: 10`
-being rejected after `9` because `"10" < "9"` as text.
+`AppendOptions.seq` and `Stream.last_seq` are `str | None`, and the durable
+`Stream.last_seq` column is text — migration `0009` widens it. `Stream-Seq` is
+an opaque string compared byte-wise, as the protocol requires, so any value is
+accepted and none is rejected as malformed.
+
+**If your writer sends unpadded decimals, pad them.** Byte-wise, `"10"` sorts
+below `"9"`, so `Stream-Seq: 10` after `9` is a `409 Conflict`. Send `"09"` then
+`"10"` — zero-padded to whatever width your writer will reach — or use a ULID.
+A writer already padding, or not sending `Stream-Seq` at all, needs no change.
 
 ---
 

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -216,10 +216,10 @@ Servers that do not support appends for a given stream **SHOULD** return `405 Me
 - `Transfer-Encoding: chunked` (optional)
   - Indicates a streaming body. Servers **SHOULD** support HTTP/1.1 chunked encoding and HTTP/2 streaming semantics.
 
-- `Stream-Seq: <integer>` (optional)
-  - A monotonic, numeric writer sequence number for coordination.
-  - `Stream-Seq` values are non-negative decimal integers that **MUST** compare numerically. Servers **MUST** reject a non-integer value with `400 Bad Request`. (An earlier revision of this document specified opaque strings under byte-wise lexicographic ordering; that ordering rejects `10` after `9`, so any writer reaching double digits started failing. Numeric comparison is the behaviour servers implement.) Sequence numbers are scoped per authenticated writer identity (or per stream, depending on implementation). Servers **MUST** document the scope they enforce.
-  - If provided and numerically less than or equal to the last appended sequence, the server **MUST** return `409 Conflict`. Sequence numbers **MUST** be strictly increasing.
+- `Stream-Seq: <string>` (optional)
+  - A monotonic, lexicographic writer sequence number for coordination.
+  - `Stream-Seq` values are opaque strings that **MUST** compare using simple byte-wise lexicographic ordering. Sequence numbers are scoped per authenticated writer identity (or per stream, depending on implementation). Servers **MUST** document the scope they enforce.
+  - If provided and less than or equal to the last appended sequence (as determined by lexicographic comparison), the server **MUST** return `409 Conflict`. Sequence numbers **MUST** be strictly increasing.
 
 - `Stream-Closed: true` (optional)
   - When present with value `true`, the stream is **closed** after the append completes. This is an atomic operation: the body (if any) is appended as the final data, and the stream transitions to the closed state in the same step.
@@ -274,7 +274,7 @@ Durable Streams supports Kafka-style idempotent producers for exactly-once write
 - **Per-batch sequence numbers**: Separate from `Stream-Seq`, used for retry safety
 - **Two-layer sequence design**:
   - Transport layer: `Producer-Id` + `Producer-Epoch` + `Producer-Seq` (retry safety)
-  - Application layer: `Stream-Seq` (cross-restart ordering, numeric)
+  - Application layer: `Stream-Seq` (cross-restart ordering, lexicographic)
 
 #### Request Headers
 
@@ -1004,7 +1004,7 @@ This document requests registration of the following HTTP headers in the "Perman
 
 - `Stream-TTL`: Relative time-to-live for streams (seconds)
 - `Stream-Expires-At`: Absolute expiry time for streams (RFC 3339 timestamp)
-- `Stream-Seq`: Writer sequence number for coordination (decimal integer)
+- `Stream-Seq`: Writer sequence number for coordination (opaque string)
 - `Stream-Cursor`: Cursor for CDN collapsing (opaque string)
 - `Stream-Next-Offset`: Next offset for subsequent reads (opaque string)
 - `Stream-Up-To-Date`: Indicates up-to-date response (presence header)

--- a/src/django_rakaia/migrations/0009_alter_stream_last_seq.py
+++ b/src/django_rakaia/migrations/0009_alter_stream_last_seq.py
@@ -1,0 +1,23 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    """Store `Stream-Seq` as text, because the protocol says it is a string.
+
+    `Stream-Seq` values are opaque strings compared byte-wise lexicographically
+    (PROTOCOL.md), so an integer column could not hold a conforming value such
+    as a ULID. The column is only written by the protocol server and only ever
+    held decimal digits, which survive the widening unchanged.
+    """
+
+    dependencies = [
+        ("django_rakaia", "0008_alter_translatable_unique_together_and_more"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="stream",
+            name="last_seq",
+            field=models.CharField(blank=True, max_length=255, null=True),
+        ),
+    ]

--- a/src/django_rakaia/models.py
+++ b/src/django_rakaia/models.py
@@ -51,8 +51,12 @@ class Stream(models.Model):
     last_activity_at = models.FloatField(default=0.0)
     """Unix time of the last TTL-extending activity (read/write/close)."""
 
-    last_seq = models.IntegerField(null=True, blank=True)
-    """Last `Stream-Seq` accepted, for writer coordination."""
+    last_seq = models.CharField(max_length=255, null=True, blank=True)
+    """Last `Stream-Seq` accepted, for writer coordination.
+
+    Text, not a number: the protocol makes `Stream-Seq` an opaque string
+    compared byte-wise lexicographically.
+    """
 
     closed = models.BooleanField(default=False)
     """Whether the stream is closed to further appends."""

--- a/src/rakaia/append_decision.py
+++ b/src/rakaia/append_decision.py
@@ -65,7 +65,7 @@ class StreamFacts:
     closed: bool = False
     closed_by: ClosedBy | None = None
     content_type: str | None = None
-    last_seq: int | None = None
+    last_seq: str | None = None
 
 
 @dataclass(frozen=True)
@@ -144,7 +144,9 @@ def decide_append(
         if producer_result.status != "accepted":
             return AppendVerdict(write=False, producer_result=producer_result)
 
-    # 4. Stream-Seq monotonicity.
+    # 4. Stream-Seq monotonicity. The values are opaque strings and `<=` on
+    #    `str` is Python's byte-wise lexicographic comparison, which is exactly
+    #    what the protocol asks for — no numeric interpretation anywhere.
     seq = getattr(opts, "seq", None)
     if seq is not None and facts.last_seq is not None and seq <= facts.last_seq:
         raise SequenceConflict(f"Sequence conflict: {seq} <= {facts.last_seq}")

--- a/src/rakaia/handler.py
+++ b/src/rakaia/handler.py
@@ -1060,18 +1060,12 @@ async def _handle_append(
     cors: dict[str, str],
 ) -> None:
     content_type = get_header(scope, "content-type")
-    # Stream-Seq is a number, and must be parsed as one. It used to be passed
-    # through as the raw header string, so the store's `opts.seq <=
-    # stream.last_seq` compared text: seq=10 after seq=9 was rejected as a
-    # conflict, because "10" < "9" lexicographically. Any producer reaching
-    # double digits started failing.
-    seq_str = get_header(scope, STREAM_SEQ_HEADER)
-    seq: int | None = None
-    if seq_str is not None:
-        if not STRICT_INTEGER_PATTERN.match(seq_str):
-            await _send_error(send, 400, b"Invalid Stream-Seq", cors)
-            return
-        seq = int(seq_str)
+    # Stream-Seq is an opaque string, compared byte-wise lexicographically
+    # (PROTOCOL.md). Any value is well-formed, so there is nothing to validate
+    # and nothing to parse — pass the header through untouched. A writer that
+    # needs its values to order pads them or uses a ULID, the same way rakaia's
+    # own offsets zero-pad (see `store.py`).
+    seq = get_header(scope, STREAM_SEQ_HEADER)
     closed_header = get_header(scope, STREAM_CLOSED_HEADER)
     close_stream = closed_header == "true"
 

--- a/src/rakaia/types.py
+++ b/src/rakaia/types.py
@@ -211,8 +211,12 @@ class Stream:
     current_offset: str = INITIAL_OFFSET
     """Current offset (next offset to write to)."""
 
-    last_seq: int | None = None
-    """Last sequence number for writer coordination (Stream-Seq)."""
+    last_seq: str | None = None
+    """Last `Stream-Seq` accepted, for writer coordination.
+
+    An opaque string, compared byte-wise lexicographically as the protocol
+    requires — never parsed as a number.
+    """
 
     ttl_seconds: int | None = None
     """TTL in seconds."""
@@ -313,7 +317,8 @@ ProducerValidationResult = (
 class AppendOptions:
     """Options for append operations."""
 
-    seq: int | None = None
+    seq: str | None = None
+    """`Stream-Seq`: an opaque string compared byte-wise lexicographically."""
     content_type: str | None = None
     producer_id: str | None = None
     producer_epoch: int | None = None

--- a/tests/server_store_contract.py
+++ b/tests/server_store_contract.py
@@ -240,15 +240,21 @@ class ServerStoreContract:
 
     def test_seq_conflict_raises(self, store):
         store.create("s")
-        store.append("s", b'{"id": 1}', AppendOptions(seq=5))
+        store.append("s", b'{"id": 1}', AppendOptions(seq="5"))
         with pytest.raises(SequenceConflict):
-            store.append("s", b'{"id": 2}', AppendOptions(seq=5))
+            store.append("s", b'{"id": 2}', AppendOptions(seq="5"))
 
-    def test_seq_advances_numerically(self, store):
-        """10 follows 9. Compared as text it would not."""
+    def test_seq_advances_lexicographically(self, store):
+        """`Stream-Seq` is an opaque string compared byte-wise, so "10" after
+        "9" is a conflict and a writer that wants ordering pads its values."""
         store.create("s")
-        store.append("s", b'{"id": 1}', AppendOptions(seq=9))
-        result = store.append("s", b'{"id": 2}', AppendOptions(seq=10))
+        store.append("s", b'{"id": 1}', AppendOptions(seq="9"))
+        with pytest.raises(SequenceConflict):
+            store.append("s", b'{"id": 2}', AppendOptions(seq="10"))
+
+        store.create("padded")
+        store.append("padded", b'{"id": 1}', AppendOptions(seq="09"))
+        result = store.append("padded", b'{"id": 2}', AppendOptions(seq="10"))
         assert result.message is not None
 
     def test_append_with_close_closes_the_stream(self, store):
@@ -290,21 +296,21 @@ class ServerStoreContract:
 
     def test_append_many_validates_seq_per_item(self, store):
         store.create("s")
-        store.append("s", b'{"id": 1}', AppendOptions(seq=5))
+        store.append("s", b'{"id": 1}', AppendOptions(seq="5"))
         with pytest.raises(SequenceConflict):
-            store.append_many("s", [(b'{"id": 2}', AppendOptions(seq=5))])
+            store.append_many("s", [(b'{"id": 2}', AppendOptions(seq="5"))])
 
     def test_append_many_advances_seq_like_a_loop_of_append(self, store):
         store.create("s")
         store.append_many(
             "s",
             [
-                (b'{"id": 1}', AppendOptions(seq=1)),
-                (b'{"id": 2}', AppendOptions(seq=2)),
+                (b'{"id": 1}', AppendOptions(seq="1")),
+                (b'{"id": 2}', AppendOptions(seq="2")),
             ],
         )
         with pytest.raises(SequenceConflict):
-            store.append("s", b'{"id": 3}', AppendOptions(seq=2))
+            store.append("s", b'{"id": 3}', AppendOptions(seq="2"))
 
     def test_append_many_close_item_refuses_the_rest(self, store):
         """A batch is a loop of `append`: an item with `close=True` closes the

--- a/tests/test_django_rakaia/test_django_store.py
+++ b/tests/test_django_rakaia/test_django_store.py
@@ -127,16 +127,22 @@ class TestDjangoStreamStore:
     def test_seq_conflict_raises(self):
         store = DjangoStreamStore()
         store.create("s")
-        store.append("s", b'{"id": 1}', AppendOptions(seq=5))
+        store.append("s", b'{"id": 1}', AppendOptions(seq="5"))
         with pytest.raises(SequenceConflict):
-            store.append("s", b'{"id": 2}', AppendOptions(seq=5))
+            store.append("s", b'{"id": 2}', AppendOptions(seq="5"))
 
-    def test_seq_compares_numerically(self):
+    def test_seq_compares_lexicographically(self):
+        """Seq values are opaque strings compared byte-wise, so "10" after "9"
+        is a conflict. Padded, "10" follows "09"."""
         store = DjangoStreamStore()
         store.create("s")
-        store.append("s", b'{"id": 1}', AppendOptions(seq=9))
-        # 10 follows 9. Compared as text it would not.
-        result = store.append("s", b'{"id": 2}', AppendOptions(seq=10))
+        store.append("s", b'{"id": 1}', AppendOptions(seq="9"))
+        with pytest.raises(SequenceConflict):
+            store.append("s", b'{"id": 2}', AppendOptions(seq="10"))
+
+        store.create("padded")
+        store.append("padded", b'{"id": 1}', AppendOptions(seq="09"))
+        result = store.append("padded", b'{"id": 2}', AppendOptions(seq="10"))
         assert result.message is not None
 
     def test_get_current_offset(self):

--- a/tests/test_rakaia/test_append_decision.py
+++ b/tests/test_rakaia/test_append_decision.py
@@ -116,19 +116,36 @@ class TestContentType:
 class TestStreamSeq:
     def test_a_replayed_seq_conflicts(self):
         with pytest.raises(SequenceConflict):
-            _decide(StreamFacts(last_seq=5), AppendOptions(seq=5))
+            _decide(StreamFacts(last_seq="5"), AppendOptions(seq="5"))
 
     def test_a_lower_seq_conflicts(self):
         with pytest.raises(SequenceConflict):
-            _decide(StreamFacts(last_seq=5), AppendOptions(seq=4))
+            _decide(StreamFacts(last_seq="5"), AppendOptions(seq="4"))
 
     def test_a_higher_seq_is_allowed(self):
-        assert _decide(StreamFacts(last_seq=5), AppendOptions(seq=6)).write is True
+        assert _decide(StreamFacts(last_seq="5"), AppendOptions(seq="6")).write is True
 
-    def test_seq_is_compared_as_a_number(self):
-        """`"10" < "9"` lexicographically — the bug that broke every producer on
-        reaching double digits."""
-        assert _decide(StreamFacts(last_seq=9), AppendOptions(seq=10)).write is True
+    def test_seq_is_compared_lexicographically(self):
+        """`Stream-Seq` is an opaque string compared byte-wise, so `"10"` after
+        `"9"` is a conflict — `"10" < "9"`. That is the protocol's rule, not a
+        bug: a writer that needs its values to order pads them to a fixed width
+        or uses a ULID. Rakaia's own offsets zero-pad for exactly this reason
+        (`src/rakaia/store.py`), so `"09"` then `"10"` is accepted below."""
+        with pytest.raises(SequenceConflict):
+            _decide(StreamFacts(last_seq="9"), AppendOptions(seq="10"))
+        assert (
+            _decide(StreamFacts(last_seq="09"), AppendOptions(seq="10")).write is True
+        )
+
+    def test_a_non_numeric_seq_is_a_valid_opaque_string(self):
+        """ULIDs are the idiomatic conforming value; nothing may reject them."""
+        assert (
+            _decide(
+                StreamFacts(last_seq="01ARZ3NDEKTSV4RRFFQ69G5FAV"),
+                AppendOptions(seq="01ARZ3NDEKTSV4RRFFQ69G5FAW"),
+            ).write
+            is True
+        )
 
 
 class TestProducerFencing:
@@ -194,8 +211,8 @@ class TestOrdering:
         SequenceConflict on exactly the retry that fencing exists to absorb."""
         state = ProducerState(epoch=0, last_seq=3, last_updated=NOW)
         verdict = _decide(
-            StreamFacts(last_seq=9),
-            AppendOptions(producer_id="p", producer_epoch=0, producer_seq=3, seq=9),
+            StreamFacts(last_seq="9"),
+            AppendOptions(producer_id="p", producer_epoch=0, producer_seq=3, seq="9"),
             producer_state=state,
         )
         # Reported as a duplicate, not raised as a sequence conflict.

--- a/tests/test_rakaia/test_store.py
+++ b/tests/test_rakaia/test_store.py
@@ -702,7 +702,7 @@ class TestClosedStreamAppend:
         store.append("s", b"a")
         store.close_stream("s")
 
-        result = store.append("s", b"b", AppendOptions(seq=5))
+        result = store.append("s", b"b", AppendOptions(seq="5"))
         assert result.stream_closed is True
         assert result.message is None
 

--- a/tests/test_rakaia/test_store_failures.py
+++ b/tests/test_rakaia/test_store_failures.py
@@ -144,9 +144,9 @@ class TestStoreRaisesTheNamedFailure:
 
         store = StreamStore()
         store.create("s")
-        store.append("s", b"a", AppendOptions(seq=5))
+        store.append("s", b"a", AppendOptions(seq="5"))
         with pytest.raises(SequenceConflict):
-            store.append("s", b"b", AppendOptions(seq=5))
+            store.append("s", b"b", AppendOptions(seq="5"))
 
     def test_invalid_json(self) -> None:
         store = StreamStore()
@@ -214,62 +214,58 @@ class TestFailureBecomesStatus:
         assert r.status_code == 409
 
     @pytest.mark.asyncio
-    async def test_seq_compares_numerically_not_textually(
+    async def test_seq_compares_lexicographically_not_numerically(
         self, client: httpx.AsyncClient
     ) -> None:
-        """Stream-Seq 10 follows 9.
+        """Stream-Seq "10" after "9" is a conflict, as the protocol requires.
 
-        The header used to reach the store unparsed, so `opts.seq <=
-        stream.last_seq` compared text and "10" < "9" made seq=10 a conflict.
-        Every producer broke on reaching double digits.
-        """
-        await client.put("/s", headers={"content-type": "text/plain"})
-        first = await client.post(
-            "/s",
-            content=b"a",
-            headers={"content-type": "text/plain", "stream-seq": "9"},
-        )
-        second = await client.post(
-            "/s",
-            content=b"b",
-            headers={"content-type": "text/plain", "stream-seq": "10"},
-        )
-        assert first.status_code in (200, 204)
-        assert second.status_code in (200, 204), "seq=10 must follow seq=9"
-
-    @pytest.mark.asyncio
-    async def test_seq_regression_across_digit_lengths_is_409(
-        self, client: httpx.AsyncClient
-    ) -> None:
-        """Stream-Seq 9 after 10 is a conflict.
-
-        The other half of the numeric-parse fix: text comparison put "9" above
-        "10", so this regression was wrongly *accepted*. Without this test a
-        revert to string comparison would keep the sibling test green and only
-        lose this one.
+        The values are opaque strings compared byte-wise, and "10" < "9". A
+        writer that wants its values to order pads them to a fixed width — the
+        same idiom rakaia's own offsets use — so "09" then "10" is accepted.
         """
         await client.put("/s", headers={"content-type": "text/plain"})
         await client.post(
             "/s",
             content=b"a",
-            headers={"content-type": "text/plain", "stream-seq": "10"},
+            headers={"content-type": "text/plain", "stream-seq": "9"},
         )
         r = await client.post(
             "/s",
             content=b"b",
-            headers={"content-type": "text/plain", "stream-seq": "9"},
+            headers={"content-type": "text/plain", "stream-seq": "10"},
         )
         assert r.status_code == 409
 
+        await client.put("/padded", headers={"content-type": "text/plain"})
+        first = await client.post(
+            "/padded",
+            content=b"a",
+            headers={"content-type": "text/plain", "stream-seq": "09"},
+        )
+        second = await client.post(
+            "/padded",
+            content=b"b",
+            headers={"content-type": "text/plain", "stream-seq": "10"},
+        )
+        assert first.status_code in (200, 204)
+        assert second.status_code in (200, 204), '"10" must follow padded "09"'
+
     @pytest.mark.asyncio
-    async def test_non_numeric_seq_is_400(self, client: httpx.AsyncClient) -> None:
+    async def test_a_non_numeric_seq_is_accepted(
+        self, client: httpx.AsyncClient
+    ) -> None:
+        """The header is an opaque string, so a ULID is a conforming value and
+        must not be refused as malformed."""
         await client.put("/s", headers={"content-type": "text/plain"})
         r = await client.post(
             "/s",
             content=b"a",
-            headers={"content-type": "text/plain", "stream-seq": "not-a-number"},
+            headers={
+                "content-type": "text/plain",
+                "stream-seq": "01ARZ3NDEKTSV4RRFFQ69G5FAV",
+            },
         )
-        assert r.status_code == 400
+        assert r.status_code in (200, 204)
 
     @pytest.mark.asyncio
     async def test_invalid_json_is_400(self, client: httpx.AsyncClient) -> None:


### PR DESCRIPTION
The Durable Streams spec says the `Stream-Seq` header holds an opaque string, compared byte by byte. We stopped doing that in August, after a writer that sent 9 and then 10 was turned away. Comparing byte by byte, "10" comes before "9", so the refusal was right — but we changed rakaia to read the header as a number instead, and we also edited our copy of the spec to say numbers, crediting a revision that was never written. This puts both back.

If you send `Stream-Seq` as plain counting numbers, pad them: send "09" then "10", to whatever width you will reach, or use a ULID. Anything already padded, or not sending the header at all, is unaffected. Seven conformance tests were failing on this and now pass, taking us from 269 to 276.

Closes #137