### PR TITLE
Make the type checker fail the build again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,10 +37,11 @@ jobs:
       - name: Format check with ruff
         run: uv run ruff format --check src/ tests/ examples/
 
-      - name: Type check with pyright (informational)
-        # Pre-existing Django ORM dynamism complaints; tracked separately.
-        # Migrate to django-stubs and flip this back to a hard failure.
-        continue-on-error: true
+      - name: Type check with pyright
+        # A hard gate since #143. Django's synthesised attributes (reverse
+        # accessors, implicit `id`, `annotate()` aliases) are declared on the
+        # models and at the query sites rather than waved through, so a new
+        # type error here is a real one. Keep it failing.
         run: uv run pyright src/
 
       - name: Run tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -409,6 +409,31 @@ protocol is covered by both stores.
   offset N fails *after* the first N-1 have been dispatched, which is the
   partial-progress behaviour replay had before staging existed.
 
+- **Type checking is a CI gate, not a report** (#143). `pyright src/` ran with
+  `continue-on-error: true`, so its 34 errors were printed and discarded on
+  every green build. That mattered more after the `Effect` split: the guarantee
+  that an invalid effect is *unconstructible* is enforced by the type system and
+  by nothing else, so a checker CI ignores is a guarantee CI does not hold. The
+  step now fails the build.
+
+  Getting to zero needed no new dependency and no loosened settings. Django's
+  synthesised attributes — reverse accessors, the implicit `id` primary key —
+  are declared on `Stream`, `StreamEvent` and `StreamEntry` under
+  `if TYPE_CHECKING`, using the `RelatedManager` stub `django-types` already
+  ships; `annotate()` aliases, which no stub can know about because the query
+  invents them, are named in a `Protocol` beside the query that produces them.
+  Neither construction runs. The old admin idiom of assigning
+  `.short_description` onto a method is now `@admin.display(description=…)`,
+  which is what Django has documented since 3.2.
+
+  Two of the errors were worth having: `HandlerRegistry.reducers_for_stage` took
+  `stage: int` while replay's non-staged pass passed `None`, working only
+  because the comparison inside it never matched — the parameter is now
+  `int | None` with the rule stated; and `@stream_model`'s check that
+  `to_dataclass` returned a dataclass accepted a dataclass *class*, which then
+  failed obscurely inside `asdict` instead of with the clear message every other
+  wrong return already got.
+
 ### Fixed
 
 - **The fault-injection endpoint is no longer reachable on a deployed server**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,12 @@
   plain `uv run` bootstraps only the zero-dependency core package, so tests fail
   with `No module named pytest` until the extras are synced.
 - CI (`.github/workflows/ci.yml`) runs `ruff check`, `ruff format --check`,
-  `pytest`, and `zensical build`; run those before pushing.
+  `pyright src/`, `pytest`, and `zensical build`; run those before pushing.
+- **pyright is a hard gate** and `src/` is expected at zero errors. Run it as
+  `PYRIGHT_PYTHON_FORCE_VERSION=latest uv run pyright src/` locally — plain
+  `uv run pyright` can object to its own pinned version. Django's synthesised
+  attributes are declared explicitly (see the `if TYPE_CHECKING` blocks in
+  `django_rakaia/models.py`) rather than waved through with ignores.
 - To reproduce the **full** CI gate locally you also need the docs extra
   (`zensical` isn't in `dev`/`django`): `uv sync --extra dev --extra django --extra docs`,
   then `uv run zensical build`. Without `--extra docs` that step fails with

--- a/src/django_rakaia/admin.py
+++ b/src/django_rakaia/admin.py
@@ -25,16 +25,14 @@ class StreamAdmin(admin.ModelAdmin):
     ordering = ["-created_at"]
     list_per_page = 50
 
+    @admin.display(description="Events")
     def event_count(self, obj):
         return obj.entries.count()
 
-    event_count.short_description = "Events"
-
+    @admin.display(description="Last Offset")
     def last_entry_offset(self, obj):
         last = obj.entries.order_by("-offset").first()
         return last.offset if last else None
-
-    last_entry_offset.short_description = "Last Offset"
 
 
 @admin.register(StreamEvent)
@@ -54,6 +52,7 @@ class StreamEventAdmin(admin.ModelAdmin):
     ordering = ["-created_at"]
     list_per_page = 50
 
+    @admin.display(description="Type")
     def event_type_badge(self, obj):
         colors = {
             "create": "#28a745",
@@ -68,8 +67,7 @@ class StreamEventAdmin(admin.ModelAdmin):
             obj.event_type.upper(),
         )
 
-    event_type_badge.short_description = "Type"
-
+    @admin.display(description="Data")
     def data_preview(self, obj: StreamEvent) -> str:
         try:
             # Explicitly type the JSONField data
@@ -81,13 +79,11 @@ class StreamEventAdmin(admin.ModelAdmin):
         except (TypeError, ValueError):
             return str(obj.data)  # type: ignore[call-overload]
 
-    data_preview.short_description = "Data"
-
+    @admin.display(description="Streams")
     def stream_count(self, obj):
         return obj.entries.count()
 
-    stream_count.short_description = "Streams"
-
+    @admin.display(description="Streams")
     def streams_list(self, obj):
         streams = obj.get_streams()
         if not streams:
@@ -95,8 +91,6 @@ class StreamEventAdmin(admin.ModelAdmin):
         return format_html_join(
             mark_safe("<br>"), "<code>{}</code>", ((s,) for s in streams)
         )
-
-    streams_list.short_description = "Streams"
 
 
 @admin.register(StreamEntry)
@@ -117,18 +111,17 @@ class StreamEntryAdmin(admin.ModelAdmin):
     list_per_page = 50
     date_hierarchy = "created_at"
 
+    @admin.display(description="Stream")
     def stream_link(self, obj):
         url = f"/admin/django_rakaia/stream/{obj.stream.id}/change/"
         return format_html('<a href="{}">{}</a>', url, obj.stream.stream_id)
 
-    stream_link.short_description = "Stream"
-
+    @admin.display(description="Event")
     def event_link(self, obj):
         url = f"/admin/django_rakaia/streamevent/{obj.event.id}/change/"
         return format_html('<a href="{}">Event #{}</a>', url, obj.event.id)
 
-    event_link.short_description = "Event"
-
+    @admin.display(description="Type")
     def event_type_badge(self, obj):
         colors = {
             "create": "#28a745",
@@ -142,8 +135,6 @@ class StreamEntryAdmin(admin.ModelAdmin):
             color,
             obj.event.event_type.upper(),
         )
-
-    event_type_badge.short_description = "Type"
 
 
 def register_stream_event_admin(event_model_class):
@@ -182,6 +173,7 @@ def register_stream_event_admin(event_model_class):
         ordering = ["-created_at"]
         list_per_page = 50
 
+        @admin.display(description="Type")
         def event_type_badge(self, obj):
             colors = {
                 "create": "#28a745",
@@ -196,8 +188,7 @@ def register_stream_event_admin(event_model_class):
                 obj.event_type.upper(),
             )
 
-        event_type_badge.short_description = "Type"
-
+        @admin.display(description="Data")
         def data_preview(self, obj):
             try:
                 data_str = json.dumps(obj.data, indent=2)
@@ -207,13 +198,11 @@ def register_stream_event_admin(event_model_class):
             except (TypeError, ValueError):
                 return str(obj.data)
 
-        data_preview.short_description = "Data"
-
+        @admin.display(description="Streams")
         def stream_count(self, obj):
             return obj.entries.count()
 
-        stream_count.short_description = "Streams"
-
+        @admin.display(description="Streams")
         def streams_list(self, obj):
             streams = obj.get_streams()
             if not streams:
@@ -221,7 +210,5 @@ def register_stream_event_admin(event_model_class):
             return format_html_join(
                 mark_safe("<br>"), "<code>{}</code>", ((s,) for s in streams)
             )
-
-        streams_list.short_description = "Streams"
 
     admin.site.register(event_model_class, StreamEventSubclassAdmin)

--- a/src/django_rakaia/decorators.py
+++ b/src/django_rakaia/decorators.py
@@ -91,9 +91,13 @@ def create_stream_event(
     # Convert to dataclass and then dict
     dc_instance = to_dataclass(instance)
 
-    if not dataclasses.is_dataclass(dc_instance):
+    # `is_dataclass` alone admits a dataclass *class* as well as an instance of
+    # one, and `asdict` accepts only the instance. Rejecting the class here
+    # turns what was an obscure `asdict` failure into the same clear message
+    # every other wrong return from `to_dataclass` already gets.
+    if not dataclasses.is_dataclass(dc_instance) or isinstance(dc_instance, type):
         raise TypeError(
-            f"to_dataclass must return a dataclass, got {type(dc_instance)}"
+            f"to_dataclass must return a dataclass instance, got {type(dc_instance)}"
         )
 
     # Encode here, not just on the way to the column. `StreamEvent.data` uses

--- a/src/django_rakaia/django_store.py
+++ b/src/django_rakaia/django_store.py
@@ -410,6 +410,10 @@ class DjangoStreamStore:
                     producer_result=verdict.producer_result,
                 )
 
+            # `decide_append` leaves `producer_result` unset only when no
+            # producer tuple was supplied. This method's producer parameters
+            # are required, so fencing always ran and a verdict always exists.
+            assert verdict.producer_result is not None
             self._commit_producer(stream, verdict.producer_result)
             stream.closed = True
             stream.closed_at = time.time()

--- a/src/django_rakaia/hermeticity.py
+++ b/src/django_rakaia/hermeticity.py
@@ -52,8 +52,8 @@ See ADR 0003 (``docs/adr/0003-handler-hermeticity.md``).
 from __future__ import annotations
 
 from collections.abc import Iterator
-from contextlib import ExitStack, contextmanager
-from typing import TYPE_CHECKING
+from contextlib import AbstractContextManager, ExitStack, contextmanager
+from typing import TYPE_CHECKING, cast
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
     from django.db.models import Model
@@ -110,7 +110,16 @@ def deny_database_access(*aliases: str) -> Iterator[None]:
 
     with ExitStack() as stack:
         for alias in aliases:
-            stack.enter_context(connections[alias].execute_wrapper(_blocker(alias)))
+            # `execute_wrapper` is a `@contextmanager` at runtime, but the
+            # django-types stub annotates the *undecorated* generator, so it
+            # advertises `Iterator[None]`. Say what the call actually returns
+            # rather than suppress the mismatch.
+            stack.enter_context(
+                cast(
+                    AbstractContextManager[None],
+                    connections[alias].execute_wrapper(_blocker(alias)),
+                )
+            )
         yield
 
 

--- a/src/django_rakaia/models.py
+++ b/src/django_rakaia/models.py
@@ -5,6 +5,8 @@ Provides a normalized model structure with Stream, StreamEvent, and StreamEntry
 for efficient querying and real-time updates via Unix sockets.
 """
 
+from typing import TYPE_CHECKING
+
 from django.core.serializers.json import DjangoJSONEncoder
 from django.db import models
 from django.db.models import Max
@@ -12,6 +14,14 @@ from django.db.models import Max
 from rakaia.types import ClosedBy
 
 from .offsets import format_offset
+
+if TYPE_CHECKING:
+    # `RelatedManager` and the implicit `id` column are synthesised by Django at
+    # class-construction time, so no static checker can see them on its own —
+    # django-types ships the stub but leaves the per-model declaration to us.
+    # These blocks are type-checker-only: nothing here runs, so Django still
+    # builds the real reverse accessors and the real AutoField primary key.
+    from django.db.models.manager import RelatedManager
 
 
 class Stream(models.Model):
@@ -34,6 +44,11 @@ class Stream(models.Model):
     on either store. Streams created purely for event-sourcing leave them at
     their defaults and behave exactly as before.
     """
+
+    if TYPE_CHECKING:
+        id: int
+        entries: RelatedManager["StreamEntry"]
+        producers: RelatedManager["StreamProducer"]
 
     stream_id = models.CharField(max_length=255, unique=True, db_index=True)
     created_at = models.DateTimeField(auto_now_add=True)
@@ -224,6 +239,10 @@ class StreamEvent(models.Model):
         created_at: When the event was created
     """
 
+    if TYPE_CHECKING:
+        id: int
+        entries: RelatedManager["StreamEntry"]
+
     data = models.JSONField(encoder=DjangoJSONEncoder)  # type: ignore[assignment]
     """The event payload. Encoded with ``DjangoJSONEncoder`` so the types Django
     models actually hold — ``UUID``, ``datetime``/``date``, ``Decimal`` — are
@@ -296,6 +315,9 @@ class StreamEntry(models.Model):
         offset: Monotonically increasing offset within the stream
         created_at: When the entry was created
     """
+
+    if TYPE_CHECKING:
+        id: int
 
     stream = models.ForeignKey(
         Stream,

--- a/src/django_rakaia/replay.py
+++ b/src/django_rakaia/replay.py
@@ -19,7 +19,7 @@ Everything else is forwarded to ``rakaia.replay.replay`` unchanged.
 from __future__ import annotations
 
 from rakaia.effects import Executor
-from rakaia.protocols import ProjectionReader
+from rakaia.protocols import ProjectionReader, ReadableStore
 from rakaia.registry import HandlerRegistry, UpcasterRegistry
 from rakaia.replay import OnDriftPolicy, ReplayResult, replay
 
@@ -39,7 +39,7 @@ def replay_stream(
     end_seq: int | None = None,
     event_match: str | None = None,
     on_drift: OnDriftPolicy = "warn",
-    store: object | None = None,
+    store: ReadableStore | None = None,
 ) -> ReplayResult:
     """Replay ``stream_path`` through the Django executor + reader by default.
 

--- a/src/django_rakaia/views.py
+++ b/src/django_rakaia/views.py
@@ -6,7 +6,9 @@ Uses the normalized Stream/StreamEvent/StreamEntry model structure.
 """
 
 import logging
-from typing import Any
+from collections.abc import Iterable
+from datetime import datetime
+from typing import Any, Protocol, cast
 
 from django.contrib.auth.decorators import login_required
 from django.db.models import Count, Max, Min
@@ -20,6 +22,23 @@ from .models import Stream, StreamEntry, StreamEvent
 from .offsets import parse_offset
 
 _log = logging.getLogger("django_rakaia.views")
+
+
+class _AnnotatedStream(Protocol):
+    """A ``Stream`` row as it comes back from the statistics ``annotate()``.
+
+    ``QuerySet.annotate()`` attaches its aliases to each row at runtime, so they
+    exist on the instance but not on the model class, and no static checker can
+    infer them. Naming the shape here — rather than reaching for ``Any`` — keeps
+    the aliases and their types written down next to the query that produces
+    them, so a rename in one place is caught in the other.
+    """
+
+    stream_id: str
+    event_count: int
+    min_offset: int | None
+    max_offset: int | None
+    last_event: datetime | None
 
 
 @login_required
@@ -257,7 +276,9 @@ def streams_api(_request: Any) -> Any:
             "max_offset": s.max_offset,
             "last_event": s.last_event.isoformat() if s.last_event else None,
         }
-        for s in streams
+        # `cast` is a no-op at runtime; it only records that `annotate()` put
+        # the alias attributes on each row.
+        for s in cast(Iterable[_AnnotatedStream], streams)
     ]
 
     return JsonResponse(

--- a/src/rakaia/registry.py
+++ b/src/rakaia/registry.py
@@ -633,8 +633,14 @@ class HandlerRegistry(_LogBackedRegistry):
         self._reducers.clear()
         self._reset_logs()
 
-    def reducers_for_stage(self, stage: int) -> list[ReducerVersion]:
-        """Reducers registered for `stage`, in deterministic (name) order."""
+    def reducers_for_stage(self, stage: int | None) -> list[ReducerVersion]:
+        """Reducers registered for `stage`, in deterministic (name) order.
+
+        `stage=None` is the single, non-staged pass, and it is a defined input
+        rather than an accident: a reducer always registers against a numbered
+        stage, so a non-staged pass has no reducers and this returns an empty
+        list. Callers on that path (``replay._run_stage_reducers``) rely on it.
+        """
         return sorted(
             (r for r in self._reducers.values() if r.stage == stage),
             key=lambda r: r.name,

--- a/src/rakaia/store.py
+++ b/src/rakaia/store.py
@@ -457,6 +457,10 @@ class StreamStore:
                     producer_result=verdict.producer_result,
                 )
             producer_result = verdict.producer_result
+            # `decide_append` leaves `producer_result` unset only when no
+            # producer tuple was supplied. This method's producer parameters
+            # are required, so fencing always ran and a verdict always exists.
+            assert producer_result is not None
 
             # Commit and close
             self._commit_producer_state(stream, producer_result)


### PR DESCRIPTION
The type checker was set to report its complaints and let the build pass anyway. Thirty-four of them had piled up that way, unnoticed, because nothing ever failed. That was fine when they were all noise about Django, but it stopped being fine once the library started relying on the type system to make invalid values impossible to write down — a check nobody is required to pass is not a guarantee.

All thirty-four are cleared and the step now fails the build. Most were Django attributes that a checker cannot see on its own, and those are now written down where they are used. Two were real problems worth fixing on their own: a function that could be handed a value it said it would never accept, and a check that let a wrong kind of value through to fail later with a confusing message.

Closes #143
