### PR TITLE
Rewrite the docs around what the reader is trying to do

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,25 @@
   then `uv run zensical build`. Without `--extra docs` that step fails with
   `Failed to spawn: zensical`.
 
+## Documentation
+
+- **`docs/api-reference.md` is generated. Do not hand-edit it.** It is produced
+  from `rakaia.__all__` / `django_rakaia.__all__` by
+  `scripts/gen_api_reference.py`. Run `just api-reference` and commit the result;
+  `just api-reference-check` fails if it has drifted. To move a name into a
+  different section, edit `GROUPS` in that script, not the Markdown.
+- **The nav in `zensical.toml` is grouped by reader intent** — *Start here*,
+  *How do I…*, *How it works*, *Look it up*, *Experiments* — not by subsystem.
+  The four Diátaxis modes were used to work out what each page is *for*; the
+  section names are the plain-English version. When adding a page, decide which
+  question the reader is asking and put it there.
+- **Main pages stay plain-language; technical detail goes in a trailing
+  `## Appendix` section on the same page.** Keeping the detail next to what it
+  qualifies is deliberate — it is what stops the caveats rotting away from the
+  claims they modify.
+- Research notes live in `docs/research/` and are deliberately **not** in the
+  nav. They are dated and are not decisions; decisions go in `docs/adr/`.
+
 ## Agent skills
 
 ### Issue tracker

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,0 +1,227 @@
+---
+icon: lucide/list
+---
+
+# Python API reference
+
+Every name the two packages export, with its signature. This page is generated
+from `rakaia.__all__` and `django_rakaia.__all__`, so it lists exactly what is
+importable and nothing else.
+
+For *what these names promise* — which are stable, which may change, and how to
+pin a version — see [the public API](public-api.md). This page is the index; that
+page is the contract.
+
+!!! note "Generated file"
+
+    Do not edit by hand. Run `just api-reference` and commit the result.
+
+
+## Running a server
+
+| Name | Import from | Signature | What it does |
+|---|---|---|---|
+| `app` | `rakaia` | `(scope: 'Scope', receive: 'Receive', send: 'Send') -> 'None'` | — |
+| `create_app` | `rakaia` | `(store: 'StreamServerStore \| None' = None, options: 'ServerOptions \| None' = None) -> 'Any'` | Create a plain ASGI application implementing the Durable Streams protocol. |
+| `get_asgi_app` | `django_rakaia` | `(options: rakaia.handler.ServerOptions \| None = None) -> object` | Get the Rakaia ASGI application configured with the store `RAKAIA_STORE` names. |
+| `ServerOptions` | `rakaia` | `(long_poll_timeout: 'float' = 3.0, cursor_options: 'CursorOptions' = <factory>, enable_fault_injection: 'bool' = <factory>) -> None` | Configuration for the ASGI handler. |
+| `get_store` | `django_rakaia` | `() -> Any` | Get the configured stream store. |
+
+## Reading and writing streams
+
+| Name | Import from | Signature | What it does |
+|---|---|---|---|
+| `Stream` | `rakaia` | `(path: 'str', content_type: 'str \| None' = None, current_offset: 'str' = '0000000000000000_0000000000000000', last_seq: 'str \| None' = None, ttl_seconds: 'int \| None' = None, expires_at: 'str \| None' = None, created_at: 'float' = 0.0, last_activity_at: 'float' = 0.0, producers: 'dict[str, ProducerState]' = <factory>, closed: 'bool' = False, closed_by: 'ClosedBy \| None' = None) -> None` | Stream metadata. |
+| `StreamStore` | `rakaia` | `() -> 'None'` | In-memory store for durable streams. |
+| `DjangoStreamStore` | `django_rakaia` | `()` | A durable store backed by the django_rakaia ORM models. |
+| `ReadableStore` | `rakaia` | `(*args, **kwargs)` | A store `replay()` can read events from. |
+| `WritableStore` | `rakaia` | `(*args, **kwargs)` | A store the event-sourcing framework both writes to and reads from. |
+| `StreamServerStore` | `rakaia` | `(*args, **kwargs)` | A store that can back a Durable Streams **protocol server**. |
+| `append_event` | `django_rakaia` | `(store: 'WritableStore', stream_path: 'str', payload: 'dict[str, Any]', *, label: 'str', actor: 'Any' = None, event_ts: 'float \| None' = None) -> 'None'` | Append one enveloped event to ``stream_path``, creating the stream if absent. |
+| `append_if_changed` | `rakaia` | `(store: 'Any', path: 'str', data: 'bytes', *, current: 'Any', options: 'Any' = None, snapshot_of: 'Callable[[dict[str, Any]], Any] \| None' = None) -> 'bool'` | Append `data` to `path` only if its snapshot differs from `current`. |
+| `seed_stream` | `rakaia` | `(path: 'str', events: 'Iterable[SeedEvent]' = (), *, store: '_S \| None' = None, encoder: 'type[json.JSONEncoder] \| None' = None) -> '_S \| StreamStore'` | Create ``path`` and append ``events`` to it, in list order. |
+| `create_stream_event` | `django_rakaia` | `(stream_paths: str \| list[str] \| collections.abc.Callable[[django.db.models.base.Model], str \| list[str]], to_dataclass: collections.abc.Callable[[django.db.models.base.Model], typing.Any], instance: django.db.models.base.Model, action: str) -> django_rakaia.models.StreamEvent` | Create a stream event for the given model instance. |
+| `AppendOptions` | `rakaia` | `(seq: 'str \| None' = None, content_type: 'str \| None' = None, producer_id: 'str \| None' = None, producer_epoch: 'int \| None' = None, producer_seq: 'int \| None' = None, close: 'bool' = False, label: 'str' = '', metadata: 'dict \| None' = None, event_ts: 'float \| None' = None) -> None` | Options for append operations. |
+| `AppendResult` | `rakaia` | `(message: 'StreamMessage \| None' = None, producer_result: 'ProducerValidationResult \| None' = None, stream_closed: 'bool' = False) -> None` | Result of an append operation. |
+| `CloseResult` | `rakaia` | `(final_offset: 'str' = '', already_closed: 'bool' = False, producer_result: 'ProducerValidationResult \| None' = None) -> None` | Result of a close operation. |
+| `ClosedBy` | `rakaia` | `(producer_id: 'str', epoch: 'int', seq: 'int') -> None` | Tracks which producer tuple closed a stream (for idempotent close). |
+| `StreamMessage` | `rakaia` | `(data: 'bytes', offset: 'str', timestamp: 'float', event_ts: 'float \| None' = None, label: 'str' = '', metadata: 'dict \| None' = None) -> None` | A single message in a stream. |
+| `Poll` | `rakaia` | `(messages: 'list[StreamMessage]', cursor: 'str \| None', status: 'PollStatus') -> None` | The result of polling a stream from a cursor. |
+| `PollStatus` | `rakaia` | — | — |
+| `poll` | `rakaia` | `(store: 'CursorStore', path: 'str', cursor: 'str \| None') -> 'Poll'` | Read `path` forward from `cursor`, detecting a rewound log. |
+| `poll_consumer` | `django_rakaia` | `(store: 'CursorStore', consumer_id: 'str', stream_path: 'str') -> 'Poll'` | Load this consumer's cursor and poll `stream_path` for the delta. |
+
+## Rebuilding tables (replay)
+
+| Name | Import from | Signature | What it does |
+|---|---|---|---|
+| `replay` | `rakaia` | `(store: 'ReadableStore', stream_path: 'str', executor: 'Executor', *, handler_registry: 'HandlerRegistry \| None' = None, upcaster_registry: 'UpcasterRegistry \| None' = None, start_seq: 'int' = 0, end_seq: 'int \| None' = None, event_match: 'str \| None' = None, on_drift: 'OnDriftPolicy' = 'warn', reader: 'ProjectionReader \| None' = None) -> 'ReplayResult'` | Replay events in `stream_path` from `start_seq` (inclusive) to `end_seq` (exclusive) through the registered handlers, applying produced effects via `executor`. |
+| `replay_stream` | `django_rakaia` | `(stream_path: 'str', *, executor: 'Executor \| None' = None, reader: 'ProjectionReader \| None' = None, handler_registry: 'HandlerRegistry \| None' = None, upcaster_registry: 'UpcasterRegistry \| None' = None, start_seq: 'int' = 0, end_seq: 'int \| None' = None, event_match: 'str \| None' = None, on_drift: 'OnDriftPolicy' = 'warn', store: 'ReadableStore \| None' = None) -> 'ReplayResult'` | Replay ``stream_path`` through the Django executor + reader by default. |
+| `merge_replay` | `rakaia` | `(store: 'ReadableStore', stream_paths: 'list[str]', executor: 'Executor', *, order_key: 'str \| _EnvelopeTs' = 'ts', handler_registry: 'HandlerRegistry \| None' = None, upcaster_registry: 'UpcasterRegistry \| None' = None, event_match: 'str \| None' = None, on_drift: 'OnDriftPolicy' = 'warn', reader: 'ProjectionReader \| None' = None) -> 'ReplayResult'` | Replay several streams merged into one deterministic total order. |
+| `ReplayResult` | `rakaia` | `(events_processed: 'int' = 0, effects_applied: 'int' = 0, external: 'list[ExternalEffect]' = <factory>, warnings: 'list[str]' = <factory>, drift_detected: 'list[str]' = <factory>) -> None` | Summary of a single replay() invocation. |
+| `fold_events` | `django_rakaia` | `(events: 'Sequence[dict[str, Any]]', registry: 'HandlerRegistry', *, reader: 'ProjectionReader \| None' = None, executor: 'Any' = None, label: 'str' = 'import', scratch_path: 'str' = '_scratch/fold') -> 'None'` | Project ``events`` now, through the handlers a replay would use. |
+| `project_latest` | `rakaia` | `(messages: 'Sequence[StreamMessage]', model_label: 'str', *, subject_of: 'Callable[[dict[str, Any]], Any]', defaults_of: 'Callable[[StreamMessage, dict[str, Any]], dict[str, Any]]', subject_field: 'str' = 'subject', tombstone_labels: 'Sequence[str]' = ('delete',)) -> 'list[Effect]'` | Project each subject's **latest** snapshot into one row — the current-state read model behind an event log. |
+
+## Describing changes (effects)
+
+| Name | Import from | Signature | What it does |
+|---|---|---|---|
+| `Effect` | `rakaia` | — | — |
+| `AnyEffect` | `rakaia` | — | — |
+| `Upsert` | `rakaia` | `(model_label: 'str', lookup: 'dict[str, Any]', defaults: 'dict[str, Any] \| None' = None, produces: 'str \| None' = None) -> None` | Create the row matching ``lookup``, or update it in place — the replay-safe write. Re-applying converges to the same row. |
+| `Update` | `rakaia` | `(model_label: 'str', lookup: 'dict[str, Any]', defaults: 'dict[str, Any] \| None' = None) -> None` | Update-if-exists: the rows matching ``lookup`` are updated in place and **never** inserted (a no-op when nothing matches or ``defaults`` is empty). |
+| `Delete` | `rakaia` | `(model_label: 'str', lookup: 'dict[str, Any]', spare: 'Exclude \| SpareKeys \| None' = None) -> None` | Hard-delete the rows matching ``lookup``, minus any ``spare``. |
+| `Retire` | `rakaia` | `(model_label: 'str', lookup: 'dict[str, Any]', patch: 'dict[str, Any]', spare: 'SpareKeys \| None' = None, transition: 'Transition \| None' = None) -> None` | Soft-delete: the rows matching ``lookup`` (minus ``spare``) are UPDATEd with ``patch`` instead of DELETEd, e.g. ``{"resolved_at": <event ts>}``. |
+| `Exclude` | `rakaia` | `(lookup: 'dict[str, Any]') -> None` | Spare rows from a delete via a single flat lookup. |
+| `RowEffect` | `rakaia` | `(model_label: 'str', lookup: 'dict[str, Any]') -> None` | The row identity every database effect shares. |
+| `ExternalEffect` | `rakaia` | `(kind: 'str', payload: 'dict[str, Any]') -> None` | An application-level side effect: an email, a webhook, a payment. |
+| `Ref` | `rakaia` | `(produces: 'str', field: 'str' = 'pk') -> None` | A batch-local reference to a row a *sibling* effect materialises. |
+| `RefResolver` | `rakaia` | `() -> 'None'` | Resolves `Ref` placeholders against rows produced earlier in one batch. |
+| `UnresolvedRefError` | `rakaia` | — | A `Ref` names a `produces` id no earlier effect in the batch produced (a forward reference or a typo). |
+| `Transition` | `rakaia` | `(kind: 'str', key_fields: 'tuple[str, ...]') -> None` | A retire's opt-in request for per-flip notifications. |
+| `TouchedSubject` | `rakaia` | `(model_label: 'str', lookup: 'dict[str, Any]') -> None` | One subject a replay pass's per-event handlers wrote: the target model and the ``lookup`` identifying the affected row(s), taken straight from the applied Effect. |
+
+## Registering rules (handlers, reducers, upcasters)
+
+| Name | Import from | Signature | What it does |
+|---|---|---|---|
+| `register_handler` | `rakaia` | `(name: 'str', event_match: 'str \| Iterable[str]', effective_from: 'int', effective_to: 'int \| None' = None, *, match_field: 'str \| None' = None, stage: 'int' = 0, registry: 'HandlerRegistry \| None' = None) -> 'Callable[[Callable[..., Any]], Callable[..., Any]]'` | Decorator that registers a handler version with the default registry. |
+| `register_reducer` | `rakaia` | `(name: 'str', stage: 'int', *, registry: 'HandlerRegistry \| None' = None) -> 'Callable[[Callable[..., Any]], Callable[..., Any]]'` | Decorator that registers a per-stage reduce step with the default registry. |
+| `register_simple` | `rakaia` | `(name: 'str', event_match: 'str \| Iterable[str]', *, match_field: 'str \| None' = None, stage: 'int' = 0, registry: 'HandlerRegistry \| None' = None) -> 'Callable[[Callable[..., Any]], Callable[..., Any]]'` | Register an always-on handler — the common "just project" case. |
+| `register_upcaster` | `rakaia` | `(event_match: 'str', from_version: 'int', *, match_field: 'str \| None' = None, registry: 'UpcasterRegistry \| None' = None) -> 'Callable[[Callable[[dict[str, Any]], dict[str, Any]]], Callable[[dict[str, Any]], dict[str, Any]]]'` | Decorator that registers an upcaster from `from_version` to `from_version+1`. |
+| `upcast` | `rakaia` | `(event: 'dict[str, Any]', event_match: 'str', *, registry: 'UpcasterRegistry \| None' = None) -> 'dict[str, Any]'` | Normalise `event` to the current schema for `event_match`. |
+| `HandlerRegistry` | `rakaia` | `(store: 'StreamStore \| None' = None, *, stream_path: 'str' = '__rakaia__:handlers') -> 'None'` | Registry of versioned handlers, optionally backed by a meta-stream. |
+| `UpcasterRegistry` | `rakaia` | `(store: 'StreamStore \| None' = None, *, stream_path: 'str' = '__rakaia__:upcasters') -> 'None'` | Registry of schema-version upcasters, keyed by (event_match, from_version, match_field). |
+| `HandlerVersion` | `rakaia` | `(name: 'str', event_match: 'str \| frozenset[str]', effective_from: 'int', effective_to: 'int \| None', fn: 'Callable[..., Any]', dotted_path: 'str', source_hash: 'str', match_field: 'str \| None' = None, stage: 'int' = 0, registered_in: 'str \| None' = None) -> None` | One registered version of a handler. |
+| `ReducerVersion` | `rakaia` | `(name: 'str', stage: 'int', fn: 'Callable[..., Any]', dotted_path: 'str', source_hash: 'str', registered_in: 'str \| None' = None) -> None` | A per-stage reduce step: recompute an aggregate once from the projections. |
+| `UpcasterVersion` | `rakaia` | `(event_match: 'str', from_version: 'int', fn: 'Callable[[dict[str, Any]], dict[str, Any]]', dotted_path: 'str', source_hash: 'str', match_field: 'str \| None' = None, registered_in: 'str \| None' = None) -> None` | One registered upcaster: transforms event from `from_version` to next. |
+| `get_default_registry` | `rakaia` | `() -> 'HandlerRegistry'` | Return the process-wide default handler registry. |
+| `get_default_upcaster_registry` | `rakaia` | `() -> 'UpcasterRegistry'` | Return the process-wide default upcaster registry. |
+| `reset_default_registries` | `rakaia` | `() -> 'None'` | Reset both process-wide default registries (handlers + upcasters). |
+| `check_disjoint_defaults` | `rakaia` | `(effects: 'Iterable[Effect]') -> 'None'` | Raise EffectCollisionError if two write effects targeting the same (model_label, lookup) row share any key in their `defaults`. |
+
+## Applying changes (executors and readers)
+
+| Name | Import from | Signature | What it does |
+|---|---|---|---|
+| `Executor` | `rakaia` | `(*args, **kwargs)` | Applies a batch of effects to durable storage. |
+| `CollectingExecutor` | `rakaia` | `() -> 'None'` | An Executor that records effects instead of applying them. |
+| `DjangoExecutor` | `django_rakaia` | `(*, skip_unchanged: 'bool' = False, using: 'str \| None' = None) -> 'None'` | Apply Effects via Django's ORM. |
+| `InMemoryProjections` | `rakaia` | `() -> 'None'` | An in-memory `Executor` **and** `ProjectionReader` over dict-backed tables. |
+| `ProjectionReader` | `rakaia` | `(*args, **kwargs)` | Read-only view over materialised projections. |
+| `DjangoProjectionReader` | `django_rakaia` | `(*, using: 'str \| None' = None) -> 'None'` | Read-only projection accessor over `apps.get_model(...).objects`. |
+| `PreloadedProjectionReader` | `django_rakaia` | `(effects: 'Iterable[Effect]', *, using: 'str \| None' = None) -> 'None'` | A :class:`DjangoProjectionReader` that bulk-fetches, up front, the rows a batch of effects will look up — so each :meth:`get` serves from an in-memory snapshot instead of issuing one ``SELECT``… |
+| `ModelStreamReader` | `django_rakaia` | `(*, queryset_for: 'Callable[[str], QuerySet[Any]]', order_by: 'str', to_payload: 'Callable[[Any], dict[str, Any]]', chunk_size: 'int' = 1000) -> 'None'` | A read-only adapter that satisfies the subset of the `StreamStore` interface that `rakaia.replay.replay` uses. |
+
+## Rehearsing a rebuild safely
+
+| Name | Import from | Signature | What it does |
+|---|---|---|---|
+| `deny_database_access` | `django_rakaia` | `(*aliases: 'str') -> 'Iterator[None]'` | Raise :class:`AmbientDatabaseAccess` on any query to ``aliases`` in the block. |
+| `assert_no_live_writes` | `django_rakaia` | `(*models: 'type[Model]', using: 'str' = 'default') -> 'Iterator[None]'` | Assert the ``using`` row counts of ``models`` are unchanged across the block. |
+| `AmbientDatabaseAccess` | `django_rakaia` | — | A guarded connection alias was queried inside ``deny_database_access`` — a handler (or a helper it calls) read the database directly instead of through the injected reader. |
+| `LiveWriteLeaked` | `django_rakaia` | — | A guarded model's row count changed inside ``assert_no_live_writes`` — a rebuild mutated the live database it was only supposed to reconstruct. |
+| `diff_effects_against_rows` | `django_rakaia` | `(effects: 'Iterable[Effect]', *, reader: 'DjangoProjectionReader \| None' = None, normalizers: 'Sequence[Normalizer] \| None' = None, kinds: 'tuple[type, ...]' = (<class 'rakaia.effects.Upsert'>, <class 'rakaia.effects.Update'>)) -> 'DiffReport'` | Diff each write effect's ``defaults`` against its live projection row. |
+| `DiffReport` | `django_rakaia` | `(rows: 'list[RowDiff]') -> None` | Aggregate result of :func:`diff_effects_against_rows`. |
+| `RowDiff` | `django_rakaia` | `(model_label: 'str', lookup: 'dict[str, Any]', missing: 'bool', field_diffs: 'list[FieldDiff]' = <factory>) -> None` | The verification outcome for one write effect's target row. |
+| `FieldDiff` | `django_rakaia` | `(field: 'str', expected: 'Any', actual: 'Any') -> None` | One field whose stored value disagrees with the effect's ``defaults``. |
+| `snapshots_equal` | `rakaia` | `(a: 'Any', b: 'Any') -> 'bool'` | Whether two decoded snapshots are equal. |
+| `GREEN` | `django_rakaia` | — | — |
+| `RED` | `django_rakaia` | — | — |
+| `VACUOUS` | `django_rakaia` | — | — |
+| `VacuousVerification` | `django_rakaia` | `(report: 'DiffReport') -> 'None'` | Raised by :meth:`DiffReport.raise_if_diff` when nothing was compared. |
+| `VerificationError` | `django_rakaia` | `(report: 'DiffReport') -> 'None'` | Raised by :meth:`DiffReport.raise_if_diff` when a projection disagrees. |
+
+## Audit trails and provenance
+
+| Name | Import from | Signature | What it does |
+|---|---|---|---|
+| `provenance` | `rakaia` | `(**fields: 'Any') -> 'Iterator[None]'` | Set ambient envelope metadata for appends within this block. |
+| `get_provenance` | `rakaia` | `() -> 'dict[str, Any]'` | The current ambient provenance (a copy; empty dict if none is set). |
+| `ProvenanceMiddleware` | `django_rakaia` | `(get_response: 'Callable[[Any], Any]') -> 'None'` | Stamp the acting user + request path onto envelope metadata per request. |
+| `envelope_actor` | `rakaia` | `(msg: 'StreamMessage', event: 'dict[str, Any]', *, owner_key: 'str' = 'user_id') -> 'Any'` | The acting user: the envelope's ``metadata['user']`` (the editor), falling back to the payload's own owner FK (``event[owner_key]``) when there is no request-context actor (bulk import, management… |
+| `label_marker` | `rakaia` | `(label: 'str') -> 'str'` | Map an envelope label to the `/history` diff marker `+` / `~` / `-`. |
+| `materialize_history` | `django_rakaia` | `(store: 'Any', path: 'str', model_label: 'str', *, subject_of: 'Callable[[dict[str, Any]], Any]', defaults_of: 'Callable[[Any, dict[str, Any]], dict[str, Any]]', subject_field: 'str' = 'subject', version_field: 'str' = 'version', version_of: 'Callable[[Any], Any] \| None' = None, executor: 'Any \| None' = None) -> 'list[Effect]'` | Read `path` and materialise its `/history` audit rows into `model_label`. |
+| `history_effects` | `rakaia` | `(messages: 'Sequence[StreamMessage]', model_label: 'str', *, subject_of: 'Callable[[dict[str, Any]], Any]', defaults_of: 'Callable[[StreamMessage, dict[str, Any]], dict[str, Any]]', subject_field: 'str' = 'subject', version_field: 'str' = 'version', version_of: 'Callable[[StreamMessage], Any] \| None' = None) -> 'list[Effect]'` | One idempotent audit-row upsert per event in `messages`. |
+| `ENVELOPE_TS` | `rakaia` | — | — |
+
+## Keeping child rows in step
+
+| Name | Import from | Signature | What it does |
+|---|---|---|---|
+| `reconcile_children` | `rakaia` | `(model_label: 'str', parent_lookup: 'dict[str, Any]', child_key: 'str', items: 'Sequence[Any]', defaults_fn: 'Callable[[Any], dict[str, Any]]') -> 'list[Effect]'` | Return Effects that materialise `items` as child rows without orphans. |
+| `reconcile_tree` | `rakaia` | `(model_label: 'str', scope_lookup: 'dict[str, Any]', node_key: 'str', nodes: 'Sequence[Any]', id_fn: 'Callable[[Any], Any]', defaults_fn: 'Callable[[Any], dict[str, Any]]') -> 'list[Effect]'` | Materialise an unbounded nested tree without orphans at any depth. |
+| `reconcile_aggregate` | `rakaia` | `(model_label: 'str', scope_lookup: 'dict[str, Any]', group_key: 'str', groups: 'Mapping[Any, dict[str, Any]]', *, owns: 'Sequence[str] \| None' = None, retire_filter: 'dict[str, Any] \| None' = None, allow_full_clear: 'bool' = False) -> 'list[Effect]'` | Materialise one recomputed aggregate row per group, without stale rows. |
+| `reconcile_by_key` | `rakaia` | `(model_label: 'str', scope: 'dict[str, Any]', key_fields: 'tuple[str, ...]', items: 'Sequence[Any]', key_fn: 'Callable[[Any], dict[str, Any]]', defaults_fn: 'Callable[[Any], dict[str, Any]]', *, retire_filter: 'dict[str, Any] \| None' = None, retire: "Literal['delete'] \| dict[str, Any]" = 'delete', transition_kind: 'str \| None' = None) -> 'list[Effect]'` | Reconcile a set of rows keyed by a *composite natural key*. |
+
+## Consumer cursors
+
+| Name | Import from | Signature | What it does |
+|---|---|---|---|
+| `CursorStore` | `rakaia` | `(*args, **kwargs)` | A `ReadableStore` that also exposes its current head offset — what a subscriber (`poll()`) needs to detect new messages and a rewound log. |
+| `CursorOptions` | `rakaia` | `(interval_seconds: 'int' = 20, epoch: 'float' = 1728432000.0) -> None` | Configuration for cursor calculation. |
+| `calculate_cursor` | `rakaia` | `(options: 'CursorOptions \| None' = None) -> 'str'` | Calculate the current cursor value based on time intervals. |
+| `generate_response_cursor` | `rakaia` | `(client_cursor: 'str \| None', options: 'CursorOptions \| None' = None) -> 'str'` | Generate a cursor for a response, ensuring monotonic progression. |
+| `commit_cursor` | `django_rakaia` | `(consumer_id: 'str', stream_path: 'str', offset: 'str') -> 'None'` | Persist `offset` as the consumer's watermark for `stream_path`. |
+| `load_cursor` | `django_rakaia` | `(consumer_id: 'str', stream_path: 'str') -> 'str \| None'` | The consumer's last committed offset for `stream_path`, or None. |
+
+## Producer fencing
+
+| Name | Import from | Signature | What it does |
+|---|---|---|---|
+| `ProducerState` | `rakaia` | `(epoch: 'int', last_seq: 'int', last_updated: 'float') -> None` | Producer state for idempotent writes. Tracks epoch and sequence number per producer ID for deduplication. |
+| `ProducerAccepted` | `rakaia` | `(status: "Literal['accepted']" = 'accepted', is_new: 'bool' = False, producer_id: 'str' = '', proposed_state: 'ProducerState \| None' = None) -> None` | Producer validation: append accepted. |
+| `ProducerDuplicate` | `rakaia` | `(status: "Literal['duplicate']" = 'duplicate', last_seq: 'int' = 0) -> None` | Producer validation: duplicate append (idempotent success). |
+| `ProducerStaleEpoch` | `rakaia` | `(status: "Literal['stale_epoch']" = 'stale_epoch', current_epoch: 'int' = 0) -> None` | Producer validation: stale epoch (zombie fencing). |
+| `ProducerSequenceGap` | `rakaia` | `(status: "Literal['sequence_gap']" = 'sequence_gap', expected_seq: 'int' = 0, received_seq: 'int' = 0) -> None` | Producer validation: sequence gap detected. |
+| `ProducerInvalidEpochSeq` | `rakaia` | `(status: "Literal['invalid_epoch_seq']" = 'invalid_epoch_seq') -> None` | Producer validation: new epoch must start at seq=0. |
+| `ProducerStreamClosed` | `rakaia` | `(status: "Literal['stream_closed']" = 'stream_closed') -> None` | Producer validation: stream is already closed. |
+| `ProducerValidationResult` | `rakaia` | — | — |
+
+## Django model integration
+
+| Name | Import from | Signature | What it does |
+|---|---|---|---|
+| `stream_model` | `django_rakaia` | `(stream_paths: str \| collections.abc.Callable[[django.db.models.base.Model], str] \| list[str] \| collections.abc.Callable[[django.db.models.base.Model], list[str]], to_dataclass: collections.abc.Callable[[django.db.models.base.Model], typing.Any], on_delete: Optional[Literal['delete', 'update']] = 'delete', delete_to_dataclass: collections.abc.Callable[[django.db.models.base.Model], typing.Any] \| None = None) -> collections.abc.Callable[[type[django.db.models.base.Model]], type[django.db.models.base.Model]]` | Decorator to automatically stream Django model changes to stream events. |
+| `register_stream_event_admin` | `django_rakaia` | `(event_model_class)` | Register a concrete StreamEvent subclass with the admin. |
+| `canonical_value` | `django_rakaia` | `(model: 'type', field_name: 'str', value: 'Any', normalizers: 'tuple[Normalizer, ...]' = (<function normalize_uuid>, <function normalize_decimal>, <function normalize_temporal>)) -> 'Any'` | Coerce ``value`` into the comparable form the column stores. |
+| `DEFAULT_NORMALIZERS` | `django_rakaia` | — | — |
+
+## Constants
+
+| Name | Import from | Signature | What it does |
+|---|---|---|---|
+| `__version__` | `rakaia` | — | — |
+| `HANDLERS_META_STREAM` | `rakaia` | — | — |
+| `REDUCERS_META_STREAM` | `rakaia` | — | — |
+| `UPCASTERS_META_STREAM` | `rakaia` | — | — |
+| `SCRATCH_PATH` | `django_rakaia` | — | — |
+
+## Errors
+
+| Name | Import from | Signature | What it does |
+|---|---|---|---|
+| `StreamError` | `rakaia` | — | Base for store failures a protocol server maps to a status. |
+| `StreamNotFound` | `rakaia` | — | The stream does not exist, or has expired. |
+| `SequenceConflict` | `rakaia` | — | An append's `Stream-Seq` is not above the stream's last seq. |
+| `ContentTypeMismatch` | `rakaia` | — | An append's content type disagrees with the stream's. |
+| `InvalidJson` | `rakaia` | — | A JSON-mode payload did not parse. |
+| `InvalidOffset` | `rakaia` | — | An offset is syntactically valid but not one this store can read. |
+| `EmptyJsonArray` | `rakaia` | — | A JSON-mode append carried an empty array. |
+| `SpareKeys` | `rakaia` | `(keys: 'list[dict[str, Any]]') -> None` | Spare rows from a delete or retire by composite natural key. |
+| `StreamConfigConflict` | `rakaia` | — | A create names an existing stream with a different configuration. |
+| `HandlerDriftError` | `rakaia` | — | A handler/upcaster's source body differs from its registered hash. |
+| `HandlerGapError` | `rakaia` | — | No registered version of a handler covers the requested sequence. |
+| `HandlerOverlapError` | `rakaia` | — | Two versions of the same handler claim overlapping sequence ranges. |
+| `EffectCollisionError` | `rakaia` | — | Two sibling effects target the same (model_label, lookup) row with overlapping keys in `defaults`, violating the disjoint-defaults invariant. |
+| `DuplicateProducesError` | `rakaia` | — | Two effects in one batch declare the same `produces` id. The id would silently bind to the second producer's row, orphaning the first — always a bug, so it is rejected rather than resolved to the… |
+| `UpcasterChainError` | `rakaia` | — | Cannot upcast: missing or ambiguous link in the upcaster chain. |
+| `UpcasterConflictError` | `rakaia` | — | Two upcasters were registered for the same (event_match, from_version). |
+
+---
+
+## Appendix — coverage
+
+131 exported names across 14 sections. 116 carry a docstring; 15 do not and show `—` above.
+
+Undocumented: `AnyEffect`, `DEFAULT_NORMALIZERS`, `ENVELOPE_TS`, `Effect`, `GREEN`, `HANDLERS_META_STREAM`, `PollStatus`, `ProducerValidationResult`, `RED`, `REDUCERS_META_STREAM`, `SCRATCH_PATH`, `UPCASTERS_META_STREAM`, `VACUOUS`, `__version__`, `app`.

--- a/docs/django-integration.md
+++ b/docs/django-integration.md
@@ -353,9 +353,8 @@ The semantics follow the [protocol specification](protocol.md).
 
 ## Admin
 
-`django_rakaia.admin` registers `Stream`, `StreamEvent`, `StreamEntry`, and
-`Translatable` with the Django admin so you can browse stored streams and
-inspect event payloads. To register your own concrete `StreamEvent` subclass
+`django_rakaia.admin` registers `Stream`, `StreamEvent`, and `StreamEntry` with
+the Django admin so you can browse stored streams and inspect event payloads. To register your own concrete `StreamEvent` subclass
 in the admin, call:
 
 ```python

--- a/docs/dry-run-and-executors.md
+++ b/docs/dry-run-and-executors.md
@@ -110,6 +110,62 @@ dry-run count matches the real `effects_applied`. This is the primitive behind:
 - **"What will this replay do?"** — see the writes a `--from/--to` window would
   make before running it for real.
 
+## Make "no writes" enforced rather than assumed
+
+A `CollectingExecutor` writes nothing *because it has no code that writes*. That
+is a property of the executor, not a guarantee about the run: a handler that
+reaches around it and touches the ORM directly would still write, and the dry run
+would still look clean.
+
+Two guards in `django_rakaia` turn the assumption into a check.
+
+**`deny_database_access(*aliases)`** blocks the connection outright. Any query on
+a named alias — read or write — raises `AmbientDatabaseAccess`:
+
+```python
+from django_rakaia import deny_database_access
+
+with deny_database_access("default"):
+    replay(store, "orders", CollectingExecutor())   # a stray query now raises
+```
+
+**`assert_no_live_writes(*models, using="default")`** is the narrower one: it
+watches specific tables and raises `LiveWriteLeaked` if a row was written while
+the block was open.
+
+```python
+from django_rakaia import assert_no_live_writes
+from orders.models import OrderSummary
+
+with assert_no_live_writes(OrderSummary):
+    replay(store, "orders", CollectingExecutor())
+```
+
+!!! warning "The two guards differ in kind"
+
+    `deny_database_access` **prevents** the query — nothing reaches the database.
+    `assert_no_live_writes` **detects** afterwards, so outside a transaction the
+    offending row has already landed by the time it raises. Use it inside
+    `transaction.atomic()` if you need the write undone as well as reported, and
+    prefer `deny_database_access` when you want prevention.
+
+    Both install themselves on the calling thread's connection. A write issued on
+    another thread — including ORM work handed off by the durable store's
+    `run_sync` — is **not** caught. See
+    [ADR 0003](adr/0003-handler-hermeticity.md).
+
+### A rebuild that changes nothing is not a pass
+
+When you diff a rehearsal against existing rows, the result is one of three
+verdicts, not two: `GREEN` (compared, and matched), `RED` (compared, and
+differed), or `VACUOUS` — *nothing was compared at all*.
+
+`VACUOUS` exists because a run over an empty population passes every assertion
+you can write about it, and that is the most common way a verification quietly
+certifies nothing. `DiffReport.certified` is true only for `GREEN`, and
+`raise_if_diff()` refuses a zero population with `VacuousVerification` unless you
+pass `allow_empty`.
+
 ## From the command line
 
 The bundled `manage.py replay` command wires this up for you: `--dry-run` swaps in

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,153 +2,79 @@
 icon: lucide/waves
 ---
 
-# Rakaia Documentation
+# Rakaia
 
-**Rakaia** is a Python implementation of the [Durable Streams protocol](protocol.md) — an
-HTTP-based protocol for append-only, ordered, durable byte streams.
+**Build your Django tables from a record of what happened, so you can rebuild
+them when the code was wrong.**
 
-The project ships two installable packages:
+Most projects write to a table and keep a change log beside it. Rakaia turns that
+around: the log is the original, and your tables are produced by reading it back.
+When you find a bug in how a table was filled in, you fix the code and re-run —
+no repair script, no guessing what the row should have been.
 
-- **`rakaia`** — A zero-dependency ASGI application implementing the protocol. Run
-  it standalone with `uvicorn`/`daphne`/`granian`, or mount it inside Django,
-  FastAPI, or Starlette.
-- **`django_rakaia`** — A Django app that stores stream events in your database
-  via normalized `Stream` / `StreamEvent` / `StreamEntry` models, broadcasts
-  changes over Django Channels, and provides a `@stream_model` decorator for
-  emitting events from your own Django models.
+It also lets you *rehearse* that rebuild against real data and see exactly what it
+would write, without writing anything.
 
-!!! tip "New here?"
-    Start with the **[guided tour of what's new](whats-new.md)** — every recent
-    feature with a one-command demo you can run to prove it. New to the
-    vocabulary (*projection*, *handler*, *upcaster*, *replay*)? See the
-    **[glossary](glossary.md)**.
+!!! tip "Start here"
 
-Beyond the raw protocol server, `django_rakaia` derives your database tables from
-an append-only log of events — so you can replay history and rebuild them:
+    - **[Tutorial](tutorial.md)** — ten minutes from nothing to a table you
+      rebuild after fixing a bug in it.
+    - **[Why Rakaia exists](why-rakaia.md)** — what this buys you, what it costs
+      you, and when to use something simpler.
+    - **[Glossary](glossary.md)** — every term used here, in plain language.
+    - **[API reference](api-reference.md)** — all 131 exported names.
+
+## Install
+
+```bash
+pip install "rakaia-streams[django]"
+```
+
+The distribution is `rakaia-streams`; you import `rakaia` and `django_rakaia`.
+
+## What you get
 
 ```mermaid
 flowchart LR
-  W["Your model<br/>.save()"] -->|emit| S[("Stream<br/>append-only log")]
-  S -->|replay| U["Upcasters<br/>normalise old events"]
-  U --> H["Versioned handlers<br/>pure: event → Effect"]
-  H --> X{Executor}
-  X -->|"update_or_create / delete"| P[("Projection<br/>your tables")]
-  X -.->|dry-run| C["CollectingExecutor<br/>records, zero writes"]
+  W["Your model<br/>.save()"] -->|records| S[("The log<br/>append-only")]
+  S -->|replay| H["Your rules<br/>event → change"]
+  H --> X{Apply}
+  X -->|for real| P[("Your tables")]
+  X -.->|rehearsal| C["Reports every change,<br/>writes nothing"]
 ```
 
-## Installation
+Two packages, either usable on its own:
 
-```bash
-# Core protocol server only (zero runtime dependencies)
-pip install rakaia-streams
+- **`django_rakaia`** — the part most people want. Records changes to your Django
+  models, rebuilds tables from those records, and can rehearse a rebuild without
+  touching the database.
+- **`rakaia`** — a standalone server speaking the
+  [Durable Streams protocol](protocol.md), with no dependencies at all. Run it
+  with `uvicorn`, or mount it inside Django, FastAPI, or Starlette.
 
-# With the Django integration
-pip install "rakaia-streams[django]"
+## Try it without installing anything
 
-# With Redis-backed channel layer (for multi-process SSE)
-pip install "rakaia-streams[django,redis]"
-```
+Four sample Django projects, each proving one thing. They assert their own claims
+and fail loudly if the library stops delivering, so they double as tests:
 
-## Quick Start (standalone server)
-
-```bash
-pip install rakaia-streams uvicorn
-uvicorn rakaia:app --port 4437
-```
-
-That gives you a fully functional Durable Streams server backed by an
-in-memory store.
-
-```python
-from rakaia import create_app, StreamStore
-
-# Default in-memory store
-app = create_app()
-
-# Or supply your own store
-app = create_app(store=StreamStore())
-```
-
-## Quick Start (Django integration)
-
-See [`django-integration.md`](django-integration.md) for the full guide.
-
-```python
-# settings.py
-INSTALLED_APPS = [
-    "daphne",
-    "channels",
-    "django_rakaia",
-    # ...
-]
-ASGI_APPLICATION = "myproject.asgi.application"
-CHANNEL_LAYERS = {
-    "default": {"BACKEND": "channels.layers.InMemoryChannelLayer"},
-}
-```
-
-```python
-# models.py
-from dataclasses import dataclass
-from django.db import models
-from django_rakaia import stream_model
-
-@dataclass
-class RoomData:
-    id: int
-    name: str
-
-@stream_model(
-    stream_paths=lambda obj: f"room:{obj.id}:messages",
-    to_dataclass=lambda obj: RoomData(id=obj.id, name=obj.name),
-)
-class ChatRoom(models.Model):
-    name = models.CharField(max_length=100)
-```
-
-Every save/delete now emits a `StreamEvent` and a `StreamEntry` against the
-relevant stream(s), automatically broadcast to any connected SSE consumers via
-the channel layer.
-
-## Documentation index
-
-- [What's new — a guided tour](whats-new.md) — recent features, each with a demo.
-- [Glossary](glossary.md) — plain-language definitions of the event-sourcing terms.
-- [Framework vs. protocol server](framework-vs-protocol-server.md) — the package
-  boundary and the "what needs Django / what is pure" matrix.
-- [Django integration](django-integration.md) — Models, decorator, admin, SSE,
-  and adopting the durable store.
-- [Versioned handlers](versioned-handlers.md) — Time-correct replay, handler
-  versions, upcasters, drift detection.
-- [Projections & fan-out](projections-and-fan-out.md) — One event into many
-  rows, orphan-free with `reconcile_children`.
-- [The event envelope & provenance](event-envelope.md) — Attach the actor,
-  label, and no-op suppression on append.
-- [History read-model](history-read-model.md) — Latest-state vs a queryable
-  audit trail, both derived from one log.
-- [Subscriber cursors](subscriber-cursors.md) — Incremental per-consumer reads
-  over a stream's offsets, with rewind detection and durable watermarks.
-- [Alerts projection](alerts-projection.md) — Human judgment and machine rules
-  in one projection, without clobber.
-- [Dry-run & executors](dry-run-and-executors.md) — Preview a replay's writes
-  with zero side effects.
-- [Translations](translations.md) — the `polyglot` example: live-editable
-  translations over SSE.
-- [Deployment](deployment.md) — Production setup, ASGI servers, Redis channel
-  layer, scaling.
-- [Protocol specification](protocol.md) — Wire format, headers, semantics.
-- [Backend storage](streams-backend-storage.md) — Browser-side stream persistence.
-
-## Sample applications
-
-Four standalone Django projects each demonstrate one feature area. Run them all
-with `just demo`, or individually:
-
-| Example | Demonstrates | Run |
+| Example | Shows | Run |
 |---|---|---|
-| [`orders`](../examples/orders/) | Versioned handlers, upcasters, replay, dry-run | `just orders-demo` |
-| [`formkit_submissions`](../examples/formkit_submissions/) | Projections/fan-out, `reconcile_children`, migration parity | `just formkit-demo` |
-| [`chat`](../examples/chat/) | `@stream_model`, multi-stream events, live SSE | `just dev` |
-| [`polyglot`](../examples/polyglot/) | Language-scoped streams, live-editable translations | `just polyglot-dev` |
+| [`partisipa_history`](../examples/partisipa_history/) | Reproducing an audit log exactly, and recovering a truncated record | `just partisipa-history-demo` |
+| [`orders`](../examples/orders/) | Rules that changed over time, replayed correctly | `just orders-demo` |
+| [`formkit_submissions`](../examples/formkit_submissions/) | One change updating many rows without orphans | `just formkit-demo` |
+| [`chat`](../examples/chat/) | Recording changes on `save()`, live updates over SSE | `just dev` |
 
-The [guided tour](whats-new.md) narrates what each one proves.
+## Where to go next
+
+- **New here?** [The tutorial](tutorial.md), then
+  [why Rakaia exists](why-rakaia.md).
+- **Evaluating it?** [Why Rakaia exists](why-rakaia.md) is written for you and is
+  honest about the limits. Then [the public API](public-api.md) for what is and
+  isn't promised before 1.0.
+- **Already using it?** [What's new](whats-new.md) tours recent features, each
+  with a command that demonstrates it.
+
+!!! warning "Pre-1.0"
+
+    Pin an upper bound — `rakaia-streams>=0.2,<0.3`. See
+    [the public API](public-api.md) for which names are stable and which are not.

--- a/docs/pghistory-retirement.md
+++ b/docs/pghistory-retirement.md
@@ -1,8 +1,15 @@
-# pghistory retirement (design spike)
+# pghistory parity — the design notes
 
-> Status: **design spike** for [issue #11](https://github.com/joshbrooks/rakaia/issues/11).
-> Prototyped in [`examples/partisipa_history`](../examples/partisipa_history); not yet
-> part of rakaia core. This page is the design; the example is the proof.
+> **Plain-language version:** [Why Rakaia exists](why-rakaia.md). This page is
+> the detailed design behind it and assumes the vocabulary.
+>
+> Status: originally a design spike for
+> [issue #11](https://github.com/joshbrooks/rakaia/issues/11), proved in
+> [`examples/partisipa_history`](../examples/partisipa_history). **The envelope
+> and the history read-model have since landed in core** — see
+> [the event envelope](event-envelope.md) and
+> [the history read-model](history-read-model.md). The "what making it
+> first-class requires" list below is kept as a record and is now complete.
 
 ## The problem: the audit log is load-bearing
 
@@ -93,16 +100,21 @@ and that stream recovery returns the same peak snapshot pghistory recovery does.
   the create/update/delete events remain as history — the row goes away, its audit
   trail does not. That is exactly pghistory's behaviour and what an audit log must do.
 
-## What making it first-class requires
+## What making it first-class required — all since done
 
-The spike carries the envelope as a JSON convention. Promoting it to core means:
+The spike carried the envelope as a JSON convention. Promoting it to core meant
+three things, each of which has since landed:
 
-1. An **append surface** that accepts `actor` / `label` / `ts` / optional `causation`
-   as structured metadata rather than payload keys.
-2. Extending the durable **`StreamEvent`** model (which today has `event_type` /
-   `created_at`) to persist that envelope.
-3. A **history read-model helper** so adopters get `SubmissionHistoryEntry`
-   without hand-rolling it.
+1. ~~An **append surface** that accepts `actor` / `label` / `ts` / optional
+   `causation` as structured metadata rather than payload keys.~~ Shipped as
+   `provenance()`, `label_marker()` and `append_if_changed()` — see
+   [the event envelope](event-envelope.md).
+2. ~~Extending the durable **`StreamEvent`** model (which today has `event_type` /
+   `created_at`) to persist that envelope.~~ Shipped: `StreamEvent.metadata` and
+   `StreamEvent.event_ts` (`src/django_rakaia/models.py:262,265`).
+3. ~~A **history read-model helper** so adopters get `SubmissionHistoryEntry`
+   without hand-rolling it.~~ Shipped as `materialize_history()` /
+   `history_effects()` — see [the history read-model](history-read-model.md).
 
 ## Migration path (issue #11)
 

--- a/docs/research/demonstrating-value.md
+++ b/docs/research/demonstrating-value.md
@@ -1,0 +1,685 @@
+# How can this project's value best be demonstrated to a potential user?
+
+**Status:** research notes, 2026-08-15. Not a decision — no ADR is implied by this
+file, and nothing here changes source.
+
+> **Correction, 2026-08-16.** This note repeatedly claims PyPI serves only
+> `rakaia-streams 0.1.0`. **That is wrong.** 0.2.0 was published on
+> 2026-08-15T15:58:51Z (wheel and sdist), verified against
+> `https://pypi.org/pypi/rakaia-streams/json`. The note was written against a
+> stale view of the index. Everything below that reasons from "PyPI is a version
+> behind" — the "Problem 1 — you get 0.1.0" walkthrough, the `ImportError`
+> failure mode in the friction table, and the first half of Option 1 — is void.
+> The rest of Option 1 (publish the docs site, fix the 404ing URLs) still
+> stands, and so does the observation that `partisipa-import` is *itself* still
+> pinned to 0.1.0, which is a different problem with a different fix.
+
+**Where this lives and why.** Same reasoning as
+[`handler-types.md`](handler-types.md): `docs/` holds prose listed in
+`zensical.toml`'s explicit `nav`, `docs/adr/` holds decisions, `okf/` holds the
+machine-readable bundle. This is none of those — it is not a decision, not a
+user-facing manual page, and not part of the concept bundle. It sits in
+`docs/research/` so it is searchable and versioned alongside the code it argues
+about, and it is deliberately **not added to `zensical.toml`'s nav**.
+
+A note on method: every claim about rakaia below is either a `path:line` citation
+or something I ran on this checkout at this commit, and the transcript is quoted.
+Every claim about another project is a link to that project's own documentation.
+Where I am inferring rather than reporting, it says **inference**.
+
+---
+
+## The question, and why now
+
+rakaia is 101 commits old (first commit 2026-03-13), has one production consumer,
+**zero GitHub stars, no repository description, and no homepage URL** (`gh repo
+view`, 2026-08-15). It has 1,372 passing tests in 17 seconds, twelve runnable
+examples, twenty-five docs pages, four ADRs, and an independent protocol
+conformance harness. The engineering is far ahead of the presentation.
+
+So the question is not "is there value" — it is "which single artifact would make
+a stranger believe it in under ten minutes", and the honest answer depends on
+which stranger.
+
+---
+
+## The headline finding, up front
+
+**Three things, in this order.**
+
+1. **The strongest demonstration already exists in the repo and is mislabelled.**
+   `just partisipa-history-demo` proves, with assertions, that a rakaia stream
+   reproduces a `pgh_event` audit table byte-for-byte, recovers the same peak
+   snapshot pghistory recovery does, and survives re-replay. It is the only
+   artifact in the project that argues against a named incumbent. It appears in
+   the nav as **"pghistory retirement (spike)"** (`zensical.toml:35`), is absent
+   from the four-example table on the front page (`docs/index.md:147-152`), and is
+   absent from the top table of the guided tour (`docs/whats-new.md:46-51`). A
+   reader following the documented "start here" path never sees it.
+
+2. **The first five minutes are broken in a way nobody has run.** The README
+   quickstart (`README.md:30-42`) ends at `uvicorn rakaia:app`. The obvious next
+   two commands — `PUT` a stream, `POST` an event — return **`409 Conflict:
+   Content-type mismatch`** on a clean install, because the `PUT` must carry the
+   content type the later `POST` will use. That is documented nowhere in the
+   quickstart. Worse: **PyPI serves 0.1.0 while this repo is 0.2.0**
+   (`pyproject.toml:6`), so `pip install rakaia-streams` gives a version that
+   predates `django_rakaia.envelope`, the public-API tiers, and most of what the
+   docs describe.
+
+3. **The sharpest differentiator is not event sourcing — it is the rebuild
+   gate.** Nothing else in the Python or Django field lets you replay a log into a
+   throwaway database, *prove* the replay read nothing but the log and wrote
+   nothing live, and diff the result against production before you trust it. Every
+   competitor surveyed below has zero of the three. That is the argument that
+   answers the actual objection to adopting event sourcing, which is not "is it
+   elegant" but "how do I know the rebuild is right".
+
+---
+
+## Who the plausible user actually is
+
+The docs are unusually forthcoming about this, because they were written
+alongside a real adopter rather than for an imagined one.
+
+### The evidenced user: a Django team with a load-bearing audit log
+
+The consumer is `partisipa-import`, named directly in the docs
+(`docs/versioned-handlers.md:13-18`, `docs/adr/0004-handler-types-and-fold-order.md:12`,
+`docs/research/handler-types.md:28`). What we know about it from primary sources
+in this repo:
+
+| Evidence | Citation |
+|---|---|
+| It accumulated **178 imports and 84 direct database queries** against rakaia before the public API existed | `docs/public-api.md:11-13` |
+| Its `Submission` table is tracked by `django-pghistory`, with three live consumers: a `/history` audit API, per-change actor context, and a `repair_blank_save_dataloss` recovery command | `docs/pghistory-retirement.md:14-21` |
+| It carried a "re-save the row so newer signals fire" backfill pattern (`_task_sf12_backfill_project_ids`, `_task_ff4_backfill`) — the workaround versioned handlers replace | `docs/versioned-handlers.md:13-18` |
+| It hit four distinct seam failures in one rebuild command: a dormant upcaster, a `merge_replay` with no `ts` to order on, a hand-rolled `pgh_id` watermark, and stale internal docs | `docs/adr/0002-framework-vs-protocol-server-boundary.md:39-52` |
+| A shared projection helper silently read the **live** database from inside a rebuild that claimed to be log-only | `docs/adr/0003-handler-hermeticity.md:38-45` |
+| It is still pinned to PyPI `rakaia-streams 0.1.0` and carries a duplicate of an upstreamed helper because of it | `docs/research/handler-types.md:280-283` |
+| Adoption is still open as issue #11, "Partisipa still has to adopt the streams work we finished" | `gh issue list` |
+
+That is a very specific person: **a Django team, several years in, with forms or
+submissions, an audit trail somebody depends on, and a folder of backfill scripts
+they are ashamed of.** They are not shopping for an event store. They have a
+concrete pain — "our history table and our current table disagree", "we cannot
+re-run last year's rules", "our backfill re-saved 40,000 rows and we do not know
+what it wrote".
+
+Every one of those failures has a rakaia feature named after it, which is the
+strongest evidence that this is who the library is for.
+
+### The user the front door addresses
+
+Not that person. `README.md:3` opens with:
+
+> **Rakaia** is a Python implementation of the Durable Streams protocol — an
+> HTTP-based protocol for append-only, ordered, durable byte streams.
+
+`docs/index.md:7` is the same sentence. The Django integration is introduced as
+the *second* of two packages (`README.md:8-12`). The word "audit" does not appear
+in the README; "pghistory" does not appear in the README; "replay" first appears
+at `README.md:91`, past the fold on any screen.
+
+**Inference:** the README describes what the code *is* (a protocol
+implementation) rather than what it *fixes* (a Django team's audit and backfill
+problem). Those are two different products with two different buyers, and the
+repo currently leads with the one that has the smaller, more sophisticated
+audience.
+
+### A third, real but thin, user
+
+There is genuinely no Durable Streams server implementation in Python. Upstream
+lists a Node reference server, a Caddy plugin, a Cloudflare server, and two
+community servers (Go, Java) — no Python
+(https://github.com/durable-streams/durable-streams). rakaia is therefore the
+only way to serve this protocol from a Python process, which is a real and
+uncontested niche.
+
+The niche is also nine months old. The spec is a self-published **DRAFT** from a
+single vendor: `docs/protocol.md:1-8` reproduces its own header —
+
+> `# DRAFT: The Durable Streams Protocol` … **Date:** 2025-01-XX … **Author:**
+> ElectricSQL
+
+— with the date still an unfilled placeholder. The conformance package is at
+`0.3.6`. ElectricSQL announced it 2025-12-09
+(https://electric-sql.com/blog/2025/12/09/announcing-durable-streams).
+
+**Inference:** the protocol audience is real but small and speculative today; the
+Django audience is small but *evidenced*. Weighting the demonstration toward the
+evidenced one is the lower-variance bet.
+
+---
+
+## What is genuinely differentiated
+
+All rows are from the project's own documentation. Nothing here is sourced from a
+comparison post.
+
+### The field
+
+| | Append-only log | Rebuild by replay | Time-correct (versioned) handlers | Schema evolution | Live stream to a client | HTTP wire protocol | Dry-run rebuild |
+|---|---|---|---|---|---|---|---|
+| **rakaia** | yes (`StreamStore` / `DjangoStreamStore`) | yes (`replay`, `merge_replay`) | **yes** (`effective_from`/`effective_to`) | yes (upcasters) | yes (SSE via Channels) | **yes** (Durable Streams) | **yes** (`CollectingExecutor`) |
+| **eventsourcing** (pyeventsourcing) | yes | yes | no — `upcast_vX_vY` migrates *data forward* to one current handler | yes | no (Python iterator; Postgres/POPO only) | no | no |
+| **eventsourcing-django** | yes (storage adapter only) | inherits | no | inherits | no | no | no |
+| **django-eventstream** | no — 24-hour buffer | no | no | no | yes (SSE) | yes (SSE) | no |
+| **django-pghistory** | yes (row snapshots, trigger-enforced) | no — per-object `revert` only | no | no | no | no | no |
+| **django-simple-history** | yes, but bypassable | no — `as_of` + revert-by-save | no | no | no | no | no |
+| **KurrentDB / EventStoreDB** | yes | yes | no | no | yes (subscriptions) | yes (gRPC) | no |
+
+Sources, in order: https://eventsourcing.readthedocs.io/en/stable/topics/domain.html#versioning ·
+https://github.com/pyeventsourcing/eventsourcing-django ·
+https://github.com/fanout/django-eventstream ·
+https://django-pghistory.readthedocs.io/en/stable/basics/ and
+https://django-pghistory.readthedocs.io/en/stable/reversion/ ·
+https://django-simple-history.readthedocs.io/en/latest/common_issues.html ·
+https://docs.kurrent.io/server/v25.0/features/projections/
+
+### Four claims that survive contact with the primary sources
+
+**1. Time-correct handlers are unique.** The nearest thing in the field is
+`eventsourcing`'s upcasting: *"Static methods of the form `upcast_vX_vY()` will be
+called to update the state of a stored aggregate event or snapshot from a lower
+version X to the next higher version Y"*
+(https://eventsourcing.readthedocs.io/en/stable/topics/domain.html#versioning).
+That is the opposite move — migrate the old *data* into the shape today's single
+handler expects. rakaia keeps every historical *rule* in source and dispatches by
+seq range (`docs/whats-new.md:68-105`), so an event from before a tax change still
+gets the pre-change answer. The distinction is easy to state and easy to
+demonstrate, and no surveyed project offers it.
+
+Rakaia also has upcasters *as well*, for the schema-shape case
+(`docs/whats-new.md:113-130`) — so it is a superset, not a substitute.
+
+**2. The rebuild gate is unique, and is the strongest argument.** Three primitives
+compose into something no competitor has:
+
+- `deny_database_access(*aliases)` — "Raise `AmbientDatabaseAccess` on any query
+  to `aliases` in the block" (`src/django_rakaia/hermeticity.py:80`)
+- `assert_no_live_writes(...)` — raises `LiveWriteLeaked` if a guarded model's row
+  count moves (`src/django_rakaia/hermeticity.py:155,68-70`)
+- `diff_effects_against_rows(...)` → a `DiffReport` with a `verdict` that
+  distinguishes `GREEN` from `VACUOUS`, and a `VacuousVerification` error for a
+  sweep that compared nothing (`src/django_rakaia/verification.py:110,210,408`;
+  narrated at `docs/whats-new.md:348-381`)
+
+ADR 0003 states the motivating incident plainly: a shared helper computed a
+dangling-FK check with an un-aliased `.objects.filter(...).exists()` *from inside
+a rebuild running under `using="rebuild"`* — "the rebuild silently consults
+production, so its 'clean rebuild' verdict is not actually log-only"
+(`docs/adr/0003-handler-hermeticity.md:38-45`).
+
+Nothing in the Python/Django field addresses this. pghistory's revert
+`RuntimeError`s rather than degrade
+(https://django-pghistory.readthedocs.io/en/stable/reversion/); simple-history's
+revert is a plain `.save()` that mutates production immediately
+(https://django-simple-history.readthedocs.io/en/latest/quick_start.html). Neither
+has a dry run.
+
+**3. Against the two Django audit libraries, the differentiator is *derivation*,
+not history.** Both incumbents store **row snapshots**, not domain events —
+pghistory's own basics page defines an event as "a historical version of a model"
+(https://django-pghistory.readthedocs.io/en/stable/basics/). They can tell you
+what the row looked like; they cannot recompute what it *should* look like under a
+corrected rule. rakaia inverts the arrow: the table is the derived thing
+(`docs/glossary.md:67-71`).
+
+The counter-argument is worth stating because a competent evaluator will make it:
+**pghistory's trigger-based capture is strictly more reliable than anything
+signal- or ORM-based**, by its own account — capture "includes bulk methods and
+even changes that happen in raw SQL"
+(https://django-pghistory.readthedocs.io/en/stable/). rakaia's `@stream_model`
+sits in the ORM, so it inherits exactly the bypass hole django-simple-history
+documents against itself: "for certain bulk operations, such as `bulk_create`,
+`bulk_update`, and queryset updates, signals are not sent, and the history is not
+saved automatically"
+(https://django-simple-history.readthedocs.io/en/latest/common_issues.html). Any
+honest before/after must concede this, and the honest rakaia answer is that the
+log is *the write path*, not a mirror of one — which is a bigger architectural
+commitment than dropping in a decorator, and should be sold as such.
+
+**4. Log-plus-wire-protocol in one package is unoccupied.** `eventsourcing` has
+the log and no protocol — its interface page still carries the banner "this page
+is under development — please check back soon"
+(https://eventsourcing.readthedocs.io/en/stable/topics/interface.html).
+`django-eventstream` has the protocol (SSE) and a 24-hour buffer, not a log: "When
+storage is enabled, events are written to the database before they are published,
+and they persist for 24 hours"
+(https://github.com/fanout/django-eventstream). KurrentDB has both but is a
+separate server you deploy, under a source-available licence with a hosted-service
+restriction (https://github.com/kurrent-io/KurrentDB/blob/master/LICENSE.md) and a
+license key for some features
+(https://docs.kurrent.io/server/v25.0/quick-start/installation.html). rakaia is
+MIT, `pip install`, and runs inside the Django process you already have.
+
+**Inference:** this is the most *interesting* differentiator and the least
+*persuasive* one, because the buyer who wants it does not exist in quantity yet.
+
+### One claim that needs softening
+
+`README.md:186-188` says rakaia "passes the full protocol surface today except the
+stream **forking** family". Measured on this checkout:
+
+```
+276 passed, 56 failed, 6 skipped (of 338)
+0 NEW failure(s) · 0 newly passing · 56 expected (known gap)
+```
+
+The statement is true — all 56 failures are the baselined forking family
+(`conformance/expected-failures.txt`, 56 non-comment lines) — but "except forking"
+reads as a footnote when it is 17% of the suite. **A reader who runs
+`just conformance` and sees `56 failed` before reading the regression summary will
+draw the wrong conclusion.** Fifteen words in the README fixes it, and the honest
+framing is stronger than the current one: *276 of 338 upstream conformance tests,
+with the entire remaining gap tracked as one named family (#61).*
+
+---
+
+## What a newcomer hits in the first five minutes today
+
+Everything in this section was run against this checkout on 2026-08-15.
+
+### Path A — the README quickstart, on a clean machine
+
+`README.md:30-42` and `docs/index.md:52-70` both offer:
+
+```bash
+pip install rakaia-streams uvicorn
+uvicorn rakaia:app --port 4437
+```
+
+I ran exactly that in a fresh venv:
+
+```
+rakaia-streams 0.1.0
+INFO:     Uvicorn running on http://127.0.0.1:4437
+```
+
+**Problem 1 — you get 0.1.0.** PyPI has one release; `pyproject.toml:6` says
+`version = "0.2.0"`. So the installed package predates `django_rakaia.envelope`
+(`append_event` / `fold_events`, `docs/whats-new.md:385-405`), the Tier-1/2/3
+public API contract (`docs/public-api.md`), and the rename of `SCRATCH_PATH`. This
+is not speculative: it is already the reason the production consumer carries a
+duplicate helper (`docs/research/handler-types.md:280-283`). **Every code sample
+in the docs is written against a version a stranger cannot install.**
+
+**Problem 2 — the quickstart stops before anything happens.** It starts a server
+and says nothing about how to use it. The obvious next moves fail:
+
+```
+$ curl -X PUT  http://127.0.0.1:4437/hello                                  → 201
+$ curl -X POST http://127.0.0.1:4437/hello -H 'Content-Type: application/json' -d '{"a":1}'
+409 Conflict
+Content-type mismatch
+```
+
+The `PUT` with no body created the stream as `application/octet-stream`; the
+`POST` declared JSON; the server correctly refused. The working sequence is:
+
+```
+$ curl -X PUT  http://127.0.0.1:4437/h2 -H 'Content-Type: application/json'   → 201
+$ curl -X POST http://127.0.0.1:4437/h2 -H 'Content-Type: application/json' -d '{"a":1}'  → 204
+$ curl -X POST http://127.0.0.1:4437/h2 -H 'Content-Type: application/json' -d '{"a":2}'  → 204
+$ curl        http://127.0.0.1:4437/h2
+[{"a":1},{"a":2}]
+```
+
+Four lines. They are not in the README, not in `docs/index.md`, and not in
+`docs/protocol.md`'s quickstart (there isn't one). **The single highest
+value-per-byte edit available to this project is pasting those four lines into
+`README.md:36`.** The payoff line — `[{"a":1},{"a":2}]` — is a durable append-only
+log answering a plain `curl`, which is the whole pitch in one screenful.
+
+### Path B — the guided tour, in a git checkout
+
+`docs/index.md:20-24` says "New here? Start with the guided tour of what's new",
+and `docs/whats-new.md:37-40` says:
+
+```bash
+just install     # sync all dependency groups
+just demo        # runs the scripted demos end-to-end, with narration
+```
+
+This works, and works well. `just orders-demo` completed in **1.9 seconds** with
+assertion-backed output ending `Replayed again: 6 -> 6 rows — idempotent ✓`.
+`just cookbook-demo` printed five numbered checks including
+`[3] vacuous green: a sweep that compared 0 rows reports VACUOUS and refuses to
+certify ✓`. The demos are genuinely excellent, and `docs/examples.md:196-202`
+("Assertion-backed … there is no 'looks right' path") is an accurate description
+of them.
+
+Three frictions:
+
+- **`just` is a hard prerequisite for every published command.** Every table in
+  every doc gives the run instruction as `just <name>-demo`. `README.md:149`
+  hedges ("If you have `just` and `podman`") but that hedge is under *Running it*,
+  after the sample-application table that already used `just`. The direct form
+  (`cd examples/orders && uv run python manage.py demo_orders`) is mentioned once,
+  in passing, at `docs/examples.md:197-199`.
+- **`just install` syncs four extras** (`justfile:54`: `dev`, `django`, `docs`,
+  `prod`) — 58 packages including `daphne`, `channels-redis`, `hypercorn`,
+  `whitenoise`, and `zensical` — to run a demo that needs none of them.
+- **The demo you most want is not in the tour.** `just demo` runs `orders` then
+  `formkit_submissions` (`justfile:62-80`). `partisipa_history` — the pghistory
+  parity proof — is not in it.
+
+### Path C — the docs site
+
+There isn't one. `/site/` is gitignored, there is no Pages workflow (only
+`ci.yml`, `conformance.yml`, `publish.yml`), and `zensical.toml:12` sets
+`site_url = "https://github.com/joshbrooks/durable-streams"` — which **404s**, as
+does the social link at `zensical.toml:88`. The repo is `joshbrooks/rakaia`.
+
+So the twenty-five-page documentation set, which is the project's largest asset,
+is readable only as GitHub Markdown by someone who has already found the repo.
+
+### What the nav says about the project
+
+`zensical.toml:19-53` lists 22 top-level entries. Five are labelled **"(spike)"**
+— pghistory retirement, staged replay, close preconditions, multi-stream merge,
+tree-reconcile — and one "(example)". Nearly a third of the published manual
+announces itself as provisional, and one of the five is the best demonstration in
+the repo.
+
+Reading it against Diátaxis (https://diataxis.fr/), which splits documentation
+into tutorials, how-to guides, reference, and explanation
+(https://diataxis.fr/foundations/): rakaia has excellent **reference**
+(`public-api.md`, `protocol.md`, `glossary.md`), excellent **explanation** (the
+ADRs, `framework-vs-protocol-server.md`), decent **how-to** (`django-integration.md`,
+`deployment.md`) — and **no tutorial at all**. Diátaxis names this exact pattern:
+
+> Tutorials are rarely done well, partly because they are genuinely difficult to
+> do well, and partly because they are not well understood. In software, many
+> products lack good tutorials, or lack tutorials completely; tutorials are often
+> conflated with how-to guides. (https://diataxis.fr/tutorials/)
+
+`whats-new.md` is the closest candidate and is not one: it is a feature tour
+organised by *what shipped recently*, whose reader is assumed to already want the
+features. A tutorial in the Diátaxis sense is "a practical activity, in which the
+student learns by doing something meaningful, towards some achievable goal… Its
+purpose is not to help the user get something done, but to help them learn"
+(https://diataxis.fr/tutorials/), and its craft rules — "deliver visible results
+early and often", "ruthlessly minimise explanation" — are precisely what the
+current front door does not do.
+
+### Where a newcomer is lost, ranked
+
+| # | Loss point | Evidence | Recoverable by |
+|---|---|---|---|
+| 1 | Installs 0.1.0, follows 0.2.0 docs, hits `ImportError` | PyPI vs `pyproject.toml:6` | a release |
+| 2 | Two curls after the quickstart return `409 Content-type mismatch` | run above | four lines in `README.md` |
+| 3 | Reads a protocol tagline, is a Django person with an audit problem | `README.md:3` | a second sentence |
+| 4 | Cannot find the docs site; `site_url` 404s | `zensical.toml:12,88` | a Pages workflow |
+| 5 | Must install `just` before any documented demo | every docs table | one direct-invocation line per table |
+| 6 | Never sees the pghistory demo | `docs/index.md:147-152`, `zensical.toml:35` | promote it |
+| 7 | Sees `56 failed` from `just conformance` | run above | reword `README.md:186-188` |
+
+Items 1–4 are not documentation problems. They are **distribution** problems, and
+no amount of new demo material routes around them.
+
+---
+
+## Demonstration options
+
+Seven options. Each states what it proves, who it converts, what it costs, and
+what it risks. They are not exclusive, and roughly half are prerequisites for the
+other half mattering.
+
+### Option 1 — Ship the thing (release 0.2.0; publish the docs; fix the URLs)
+
+**Proves:** nothing. **Enables:** everything else.
+
+- Tag and publish 0.2.0 (`publish.yml` already exists and checks the tag against
+  the project version).
+- Add a Pages job for `zensical build`; fix `site_url` and the social link
+  (`zensical.toml:12,88`).
+- Set the GitHub repo description and homepage — both are currently empty.
+
+**Cost:** hours. **Risk:** near zero, except that publishing commits you to the
+Tier-1 surface in `docs/public-api.md` — which is the point of having written it.
+
+**Note:** `docs/public-api.md:104` already tells adopters to pin
+`rakaia-streams>=0.2,<0.3`, a version that does not exist on PyPI. That is the
+clearest evidence the release is overdue.
+
+### Option 2 — A 60-second curl tutorial in the README
+
+**Proves:** the protocol layer works, immediately, with no Python and no Django.
+**Converts:** the protocol-curious, and every skimmer.
+
+The four curl lines from Path B above, plus the `[{"a":1},{"a":2}]` payoff, placed
+at `README.md:36`. Optionally a fifth line showing SSE tailing.
+
+**Cost:** under an hour, including a test that runs it in CI so it cannot rot.
+**Risk:** essentially none. It is also the only option that helps *all three*
+candidate users.
+
+This is the highest ratio of value to cost on the list, and it should probably
+happen regardless of what else does.
+
+### Option 3 — Promote and harden the pghistory before/after
+
+**Proves:** rakaia replaces a named incumbent, with byte-for-byte parity, on the
+incumbent's own ground. **Converts:** the evidenced user, directly.
+
+Three moves of increasing cost:
+
+1. **Relabel and promote** (hours). Drop "(spike)" from `zensical.toml:35`; add
+   `partisipa_history` to `docs/index.md:147-152` and `docs/whats-new.md:46-51`;
+   add it to `just demo` (`justfile:62`).
+2. **Run against real pghistory** (a day or two). Today the parity target is
+   `PghEventGolden`, a hand-written model — its own docstring says "Not a live
+   pghistory instance; a golden reference the stream must reproduce"
+   (`examples/partisipa_history/history/models.py:58-65`), and
+   `docs/pghistory-retirement.md:115-117` repeats the caveat. A sceptical
+   evaluator will find that in thirty seconds and discount the whole demo.
+   Installing `django-pghistory` as an example-only dependency and diffing against
+   its real `pgh_event` table turns "we modelled their output" into "we matched
+   their output". Note pghistory requires Postgres
+   (https://django-pghistory.readthedocs.io/en/stable/), so the example would need
+   a Postgres service — a real cost, and the reason to keep it example-scoped.
+3. **Write the migration guide** (a week). A how-to: what you keep, what you
+   delete, what breaks. `docs/pghistory-retirement.md:107-113` already sketches
+   the three-step path.
+
+**Risk, and it is real.** A head-to-head invites the comparison rakaia loses:
+pghistory captures at the database, "includes bulk methods and even changes that
+happen in raw SQL" (https://django-pghistory.readthedocs.io/en/stable/), whereas
+`@stream_model` is ORM-level and inherits the bulk-operation blind spot
+django-simple-history documents against itself
+(https://django-simple-history.readthedocs.io/en/latest/common_issues.html).
+**Conceding this up front is stronger than being caught by it** — the honest frame
+is that rakaia is not a better audit *mirror*, it is a different write path, and
+you adopt it when you want the tables *derived*, not when you want them watched.
+
+### Option 4 — One worked application instead of twelve feature demos
+
+**Proves:** rakaia composes into something whole. **Converts:** the evaluator who
+believes each feature and doubts the sum.
+
+Today `examples/` has twelve projects, each proving one concept
+(`docs/examples.md:71-101`), and `docs/examples.md:167-176` honestly lists four
+public APIs with no example at all. What does not exist is one application a
+reader recognises — with forms, an audit page, a rule that changed last quarter,
+and a rebuild command — where the reader can break a rule, replay, and watch the
+tables converge.
+
+**Cost:** the largest on this list — one to three weeks, plus permanent
+maintenance in `just demos` (`justfile:90`).
+**Risk:** high. A thirteenth example dilutes rather than concentrates unless it
+*replaces* several. And the twelve existing demos are a genuine asset —
+assertion-backed, CI-gated, fast — so this is a restructuring, not an addition.
+
+**Inference:** worth doing eventually; wrong to do before options 1–3.
+
+### Option 5 — A benchmark
+
+**Proves:** replay is fast enough. **Converts:** almost nobody.
+
+**Cost:** days, plus permanent flakiness in CI.
+**Risk:** high and asymmetric. The competitors are not competing on throughput —
+pghistory is a Postgres trigger and will win any write-path microbenchmark by
+construction; KurrentDB is a purpose-built database. rakaia's claim is
+*correctness under change*, and a benchmark answers a question nobody asked while
+inviting one that goes badly.
+
+The one number that *would* help is not a benchmark but a scale statement: how
+long a replay of N events takes on the production consumer's real log. That is one
+sentence of evidence, not a harness. **Evidence for that number does not exist in
+this repo** — flagged under open questions.
+
+### Option 6 — A tutorial (Diátaxis sense), not another explanation
+
+**Proves:** a stranger can succeed. **Converts:** the evidenced user, at the point
+where they are deciding whether to spend an afternoon.
+
+One page, one goal, guaranteed success: start from an ordinary Django model with
+no streams; emit events; replay into a projection; change a rule; replay again;
+watch the old events keep their old answer. Ninety per cent of it already exists
+inside `examples/orders`; what is missing is the narrative frame and the promise
+that following it works.
+
+Diátaxis's craft rules apply directly: "deliver visible results early and often",
+"maintain a narrative of the expected", "ruthlessly minimise explanation"
+(https://diataxis.fr/tutorials/) — the last being the discipline this project's
+docs would find hardest, since their instinct is to explain, and they explain very
+well.
+
+**Cost:** two to four days including a CI test that executes it.
+**Risk:** low, but it is wasted effort while option 1 is outstanding — a tutorial
+whose first line is `pip install rakaia-streams` currently installs 0.1.0 and
+fails at step three.
+
+### Option 7 — A full Diátaxis restructure of the nav
+
+**Proves:** nothing on its own. **Converts:** by removing friction rather than
+adding evidence.
+
+Split `zensical.toml`'s 22 flat entries into Tutorial / How-to / Reference /
+Explanation, move the five "(spike)" pages and the four ADRs under Explanation,
+and stop leading the manual with provisional material.
+
+**Cost:** a day of moving files, plus every existing inbound link and every
+`docs/*.md` cross-reference.
+**Risk:** moderate — churn with no user-visible new capability, and the current
+nav, while flat, is at least honest. The mapping is also imperfect: `whats-new.md`
+is a genuine fifth thing (a release-oriented tour) that Diátaxis has no slot for,
+and forcing it into one would lose it.
+
+**Inference:** do the cheap 80% — a tutorial section at the top (option 6),
+"(spike)" pages demoted below the fold — and skip the taxonomy purity.
+
+### Ranked, with the reasoning rather than the verdict
+
+| | Option | Cost | Risk | Converts |
+|---|---|---|---|---|
+| 1 | Ship 0.2.0 + publish docs + fix URLs | hours | none | prerequisite for all |
+| 2 | Four curl lines in the README | <1 hour | none | everyone |
+| 3a | Relabel/promote the pghistory demo | hours | none | the evidenced user |
+| 3b | Real pghistory in the example | 1–2 days | low | the sceptic |
+| 6 | A tutorial | 2–4 days | low | the evaluator |
+| 3c | Migration guide | ~1 week | low | the committed adopter |
+| 7 | Nav restructure | ~1 day | moderate | nobody directly |
+| 4 | One worked application | 1–3 weeks | high | the doubter of the sum |
+| 5 | Benchmark | days | high | nobody |
+
+The shape of that table is the real finding: **the four cheapest items are all
+distribution and framing, and none of them is a demo.** The project's problem is
+not that it lacks proof. It has more proof than most libraries ten times its size.
+The proof is unshipped, unpublished, mislabelled, and behind a tagline aimed at a
+different reader.
+
+---
+
+## What NOT to do
+
+Each was considered and rejected; the reason matters more than the verdict.
+
+1. **Do not write more explanation.** `docs/` is 25 pages, 5,600 lines, and the
+   ADRs are excellent. Adding a page has never been this project's bottleneck.
+   `docs/whats-new.md` is already 449 lines of "here is why this is good", which
+   is roughly the length at which an evaluator stops reading.
+
+2. **Do not lead with the protocol.** It is the most technically distinctive thing
+   here and the least evidenced demand. The spec is a vendor DRAFT with a
+   placeholder date (`docs/protocol.md:1-8`), the conformance tooling is `0.3.6`,
+   and there are five server implementations in the world. Keep it as the second
+   sentence and the reason the library is trustworthy; do not make it the reason
+   to install.
+
+3. **Do not benchmark against pghistory.** See option 5. It is a trigger; it wins;
+   the comparison is not about speed.
+
+4. **Do not build a thirteenth example.** `docs/examples.md:167-176` already lists
+   four public APIs with no example (`register_reducer`, `reconcile_tree`,
+   `replay_stream`, `DjangoExecutor(skip_unchanged=True)`). Filling those gaps is
+   maintenance, not demonstration, and doing it will not move a single evaluator.
+
+5. **Do not vendor a newer copy of the upstream spec into `docs/protocol.md`
+   as a demonstration move.** The copy is stale — 1,043 lines and 12 sections
+   here, against ~1,560 lines and 13 sections upstream (forking as §4.2, Reserved
+   Subscription APIs, webhook signatures, IANA header registrations). That is
+   worth *fixing*, and it explains why the forking family is the conformance gap
+   (#61) — but it is a correctness chore, not a way to demonstrate value, and it
+   should not compete for the same week.
+
+6. **Do not rename or reposition the library.** "rakaia" is fine; the distribution
+   rename to `rakaia-streams` is already documented (`README.md:22-28`,
+   `UPGRADING.md`). A second identity change would cost the one thing the project
+   has accumulated, which is internal consistency.
+
+---
+
+## Open questions / where the evidence is thin
+
+- **We have one user and no user research.** Everything in "who the plausible user
+  is" is inferred from one consumer's failure modes as recorded in this repo's own
+  ADRs. That consumer is the author's other project. It may be representative; we
+  have no evidence either way, and `partisipa-import` is not in this checkout, so
+  even its side of the story is second-hand here.
+
+- **No scale evidence exists.** Nothing in this repo states how many events a real
+  replay covers, how long it takes, or how large the durable store gets. The demos
+  seed six events. Issue #138 ("Our stream positions have a size limit we chose by
+  hand") suggests the limits are chosen rather than measured. A single honest
+  sentence — "the production log is N events; a full rebuild takes T" — would be
+  worth more than option 5's entire harness, and **cannot currently be written.**
+
+- **Is the pghistory story the *general* pitch, or one adopter's pitch?** It is
+  overwhelmingly the sharpest artifact in the repo, and it is entirely derived from
+  `partisipa-import`'s specific situation (`docs/pghistory-retirement.md:14-21`).
+  Whether "retire your audit library" generalises to other Django teams, or whether
+  most of them are happy with pghistory and would read the pitch as a solution to a
+  problem they do not have, is unknown. A second adopter would settle it — the same
+  trigger `handler-types.md` names for the edge-primitive question.
+
+- **Does the ORM-level capture hole matter in practice?** Section "one claim that
+  needs softening" argues it must be conceded. Whether it is *disqualifying* for
+  the target user — a team that does bulk imports, which by the sound of
+  `partisipa-import` is exactly what that team does — is not answered anywhere in
+  this repo, and it is the single most likely reason a well-informed evaluator
+  bounces. Worth a documented answer before option 3b invites the question.
+
+- **Zensical is alpha.** Its own about page says "While currently in alpha, it's
+  already compatible with Material for MkDocs" (https://zensical.org/about/), and
+  `ci.yml` gates on `zensical build`. Committing to a published docs site (option
+  1) inherits that. Probably fine; worth knowing it is a choice.
+
+- **Would a released 0.2.0 actually be adopted?** Issue #11 has been open since the
+  early days and `docs/research/handler-types.md:280-283` records the consumer
+  still pinned to 0.1.0. If the one user who wants this most has not upgraded, the
+  release may not be the unlock this note assumes it is — or the release may be
+  precisely what is blocking them. Nothing in this repo distinguishes those.
+
+---
+
+## Docs build
+
+`uv run zensical build` is part of the CI gate (`.github/workflows/ci.yml:51`) and
+uses an explicit `nav`, so a file absent from `zensical.toml`'s `nav` is simply not
+published — it neither breaks nor warns. This file is **not** added to the nav, on
+the same reasoning as `handler-types.md`: research notes are not part of the
+published manual, and a `docs/research/` directory of ten of them would not survive
+being in it.

--- a/docs/research/django-integration-testing.md
+++ b/docs/research/django-integration-testing.md
@@ -1,0 +1,613 @@
+# How can rakaia's Django integration be tested and improved?
+
+**Status:** research notes, 2026-08-15. Not a decision — no ADR is implied by
+this file, and nothing here changes source.
+
+**Where this lives and why.** Same reasoning as
+[`handler-types.md`](handler-types.md): `docs/` holds prose docs listed in
+`zensical.toml`'s explicit `nav`, `docs/adr/` holds decisions, `okf/` holds the
+machine-readable bundle. A research note is none of those. It sits in
+`docs/research/` — inside the docs tree, searchable, versioned with the code it
+argues about — and is deliberately **not** added to `zensical.toml`'s `nav`.
+
+---
+
+## The question, and why now
+
+`django_rakaia` is 5,058 lines — 25 top-level modules, 9 migrations, one
+management command. It has 521 tests and **94% line coverage** (measured
+2026-08-15,
+`uv run pytest tests/test_django_rakaia --cov=src/django_rakaia`). By the usual
+metric it is well tested.
+
+The question is whether that number means what it looks like it means. The
+answer is no, and the reason is stated in the source itself, four times:
+
+| Where | What it says |
+|---|---|
+| `src/django_rakaia/django_store.py:248` | "a no-op on backends without row locks (SQLite)" |
+| `src/django_rakaia/django_store.py:311` | "SQLite has no row locks, so a missing transaction here is **invisible to the test suite** but a guaranteed 500 in production" |
+| `src/django_rakaia/effect_executor.py:206` | "No-op on SQLite, which serialises writers anyway" |
+| `src/django_rakaia/django_store.py:752` | "backends with `INSERT ... RETURNING` (Postgres, and the modern SQLite used in CI)" |
+
+And once in the test suite, as a test written for a CI leg that does not exist
+(`tests/server_store_contract.py:205`):
+
+> This is also the durable store's only write path that ever ran outside a
+> transaction — invisible on SQLite (no row locks), a guaranteed
+> `TransactionManagementError` 500 on Postgres. **The case exists so a Postgres
+> CI leg fails** if the `transaction.atomic()` around create is ever removed.
+
+There is no Postgres CI leg (`.github/workflows/ci.yml`, `conformance.yml`,
+`publish.yml` — the only three workflows). So the codebase has already written
+down, in five places, that its most safety-critical behaviour is not exercised.
+This note takes that seriously and asks what else is in the same category.
+
+---
+
+## What the Django surface actually is
+
+`django_rakaia` is not a thin wrapper. It touches most of Django's stateful
+machinery. Enumerated from source:
+
+| Django facility | Where | What depends on it |
+|---|---|---|
+| **Models / ORM** | `models.py` — 6 models (`Stream:27`, `StreamOffsetWatermark:175`, `StreamProducer:196`, `StreamEvent:228`, `StreamEntry:305`, `ConsumerCursor:348`) | The whole durable log |
+| **`transaction.atomic()`** | `django_store.py:317,388,466,681,779`; `decorators.py:133`; `effect_executor.py:90` | Offset allocation, producer fencing, batch append, effect application |
+| **`select_for_update()`** | `models.py:161` (offset watermark), `django_store.py:250` (stream row), `effect_executor.py:211` (retire transition capture) | Concurrent-writer serialization; the entire correctness argument for offsets and fencing |
+| **`post_save` / `post_delete` signals** | `decorators.py:236,259` (`@stream_model`); `channels_signals.py:95` (SSE fan-out) | Model-driven event emission; live broadcast |
+| **`raw=True` signal guard** | `decorators.py:247`, `channels_signals.py:110` | `loaddata` / `serialized_rollback` must not append phantom events |
+| **Migrations** | `migrations/0001`–`0009` | Schema; `0007` has a data migration (2 uncovered lines) |
+| **Multi-DB / `using=`** | `effect_executor.py:73,81,90`; `projection_reader.py`; `verification.py:480` | Disposable-DB rebuild verification (ADR 0003) |
+| **`connection.execute_wrapper`** | `hermeticity.py:120` | `deny_database_access` — the read-side hermeticity gate |
+| **System checks** | `checks.py:26` (`rakaia.E001`, `rakaia.W001`) | Store misconfiguration caught at `manage.py check` |
+| **`AppConfig.ready()`** | `apps.py:10` | Handler autodiscovery, conditional Channels wiring |
+| **Middleware** | `middleware.py:32` — sync-only, `ContextVar`-based provenance | Envelope `metadata` stamping |
+| **Async ORM bridge** | `django_store.py:959` (`sync_to_async(thread_sensitive=True)`), `:1043`, `:1053`, `:1058` | Serving the Durable Streams protocol over the durable store |
+| **Async querysets** | `channels_views.py:64` (`async for entry in entries_qs`) | SSE catch-up |
+| **`StreamingHttpResponse`** | `channels_views.py:105` | SSE |
+| **Channels channel layer** | `channels_signals.py:85,90`; `channels_views.py:51-55,80` | Cross-process broadcast |
+| **Management command** | `management/commands/replay.py` | Operator-facing replay |
+| **Admin** | `admin.py:18,38,96` (3 registrations) + `register_stream_event_admin:140` | Browsing |
+| **Settings** | `RAKAIA_STORE`, `RAKAIA_ENABLE_SSE` (`store.py:61`, `apps.py:41`) | Backend selection, optional-extra gating |
+
+Two structural facts matter for testing:
+
+1. **The store is a process-wide singleton behind a module-level dict**
+   (`store.py:19-20`, `_stores` + `_store_lock`). It is not reset by any Django
+   or pytest-django fixture, because it holds no DB state — the in-memory
+   variant holds *all* its state.
+2. **Every offset the durable store issues goes through one locked
+   read-modify-write** (`models.py:131-172`,
+   `Stream.get_next_offset_block`). The docstring says "Must be called inside a
+   transaction". Nothing in the test suite can check that claim (see below).
+
+---
+
+## What is currently tested
+
+521 tests in `tests/test_django_rakaia/` (36 `test_*.py` modules), plus four shared contract
+suites at `tests/` root (`store_contract.py`, `server_store_contract.py`,
+`executor_contract.py`, `projection_reader_contract.py`) that are run against
+**both** the in-memory and the Django store — a genuinely good pattern, and the
+strongest thing in the harness. `tests/test_django_rakaia/test_store_contract.py`
+and `test_server_store_contract.py` are three-line adapters that bind the shared
+suite to `DjangoStreamStore`.
+
+Per-module line coverage (same run):
+
+| Module | Cov | Uncovered |
+|---|---|---|
+| `integration.py` | **0%** | all of it — the documented ASGI mount |
+| `admin.py` | 84% | 79-80, 160, 178-184, 193-199, 203, 207-210 |
+| `management/commands/replay.py` | 87% | 77, 79-80, 82 |
+| `channels_signals.py` | 89% | 83, 87, 113 |
+| `django_store.py` | 92% | 25 lines |
+| `verification.py` | 94% | 15 lines |
+| `models.py` | 95% | 6 lines |
+| everything else | 98–100% | |
+
+Transaction-mode usage is deliberate and documented where used. Only 6 of 36
+test modules opt into `pytest.mark.django_db(transaction=True)`:
+`test_channels.py:48,117`, `test_protocol_server.py:26`,
+`test_publish_on_append.py:35`, `test_server_store_contract.py:21`,
+`test_django_store.py:442`. `test_server_store_contract.py:7` explains why:
+"because the async cases reach the database through …". The other ~59
+`django_db` marks are the default (transaction-wrapped) mode.
+
+Two test modules declare a second database:
+`pytest.mark.django_db(databases=["default", "overlay"])` —
+`test_using_seam.py:24` and `test_hermeticity.py:37`, against an `overlay`
+alias defined at `tests/test_django_rakaia/settings.py:6`.
+
+---
+
+## The gaps
+
+### Gap 1 — one backend, and it is the one that cannot express the invariants
+
+`tests/test_django_rakaia/settings.py:1-7` configures two SQLite `:memory:`
+aliases and nothing else. Every one of the eleven `examples/*/settings.py`
+files is also SQLite (`grep -rn ENGINE examples/`). There is no
+`psycopg`/`postgres` string anywhere in `.github/workflows/`.
+
+This is not a coverage quibble — it silently disarms three mechanisms. From
+Django's own source (6.0.3, as installed in `.venv`;
+`django/db/models/sql/compiler.py:840`):
+
+```python
+if self.query.select_for_update and features.has_select_for_update:
+    if (
+        self.connection.get_autocommit()
+        # Don't raise an exception when database doesn't
+        # support transactions, as it's a noop.
+        and features.supports_transactions
+    ):
+        raise TransactionManagementError(
+            "select_for_update cannot be used outside of a transaction."
+        )
+```
+
+`has_select_for_update` defaults to `False`
+(`django/db/backends/base/features.py:50`) and the SQLite backend does not
+override it. So on SQLite the *entire* branch is skipped. Two consequences,
+both load-bearing here:
+
+- **No lock is taken.** `models.py:161`, `django_store.py:250` and
+  `effect_executor.py:211` are no-ops. The concurrency argument for
+  monotonic offsets, for producer fencing ("the row lock is what makes fencing
+  fence", `django_store.py:682`), and for the retire-transition capture
+  ("without the lock, under READ COMMITTED the reported flip set could
+  diverge", `effect_executor.py:205`) is **entirely unexercised**.
+- **The "must be inside a transaction" contract is unenforced.** The
+  `TransactionManagementError` that would catch a missing `atomic()` is inside
+  the skipped branch. This is precisely the failure mode
+  `django_store.py:309-314` and `tests/server_store_contract.py:205` warn about
+  in prose, having no way to assert it.
+
+Django's QuerySet reference states the same thing from the outside:
+
+> Using `select_for_update()` on backends which do not support `SELECT ... FOR
+> UPDATE` (such as SQLite) will have no effect. `SELECT ... FOR UPDATE` will not
+> be added to the query, and an error isn't raised if `select_for_update()` is
+> used in autocommit mode.
+
+and lists the backends that do: "The `postgresql`, `oracle`, and `mysql`
+database backends support `select_for_update()`"
+(<https://docs.djangoproject.com/en/5.2/ref/models/querysets/#select-for-update>).
+
+**And a Postgres CI leg alone would not be enough.** The same page carries the
+warning that closes the loop with Gap 3:
+
+> Although `select_for_update()` normally fails in autocommit mode, since
+> `TestCase` automatically wraps each test in a transaction, calling
+> `select_for_update()` in a `TestCase` even outside an `atomic()` block will
+> (perhaps unexpectedly) pass without raising a `TransactionManagementError`.
+> **To properly test `select_for_update()` you should use
+> `TransactionTestCase`.**
+
+So the guard is disarmed twice over, independently: once by the backend, once by
+the test-case class. Switching to Postgres without also switching those tests to
+`transaction=True` would move the needle less than it looks.
+
+The library's own docs point deployments at Postgres
+(`django_store.py:753`: "The durable store targets Postgres"). The gap between
+"targets Postgres" and "tested only on SQLite" is the single widest one here.
+
+### Gap 2 — one Django version, one Python version
+
+`pyproject.toml` declares `requires-python = ">=3.10"`, `django>=4.2.0`, and
+classifiers for Python 3.10/3.11/3.12/3.13. CI installs exactly one
+combination: `uv python install 3.12` (`ci.yml:26`, `conformance.yml:43`,
+`demos` job) resolved through `uv.lock`, which pins **Django 5.2.12** for
+`python_full_version < '3.12'` and **Django 6.0.3** for `>= 3.12`
+(`uv.lock:526-547`). On Python 3.12 that is Django 6.0.3.
+
+So of the declared support matrix, exactly one cell is ever built, and
+**Django 4.2 is never installed by anything** — not by CI, not by the lockfile
+on any Python the project supports. The `django>=4.2.0` floor is an untested
+assertion.
+
+Worse, it is an assertion about a version Django itself no longer supports. The
+Django download page currently lists **5.2 LTS** ("End of mainstream support:
+December 3, 2025", "End of extended support: April 2028"), **6.0** ("End of
+mainstream support: August 4, 2026") and **6.1** as the supported series, with
+6.1 as "the latest official version"
+(<https://www.djangoproject.com/download/>). 4.2 is not on that list. Meanwhile
+the lockfile's own split is forced by Django's Python floor: per Django's
+install FAQ, 5.2 runs on Python 3.10–3.14 and **6.0 requires Python 3.12+**
+(<https://docs.djangoproject.com/en/dev/faq/install/#what-python-version-can-i-use-with-django>).
+That is exactly why `uv.lock` carries two Django versions.
+
+Net: the project claims a floor Django has retired, and tests a ceiling one
+minor behind Django's latest. There is also no `--resolution lowest-direct`
+job, which is the packaging-level way to test a declared floor at all.
+
+One smaller inconsistency falls out of the same table. Django's install FAQ
+gives 4.2 → Python 3.8–3.12 and 5.2 → 3.10–3.14, so the intersection of
+`django>=4.2` with `requires-python = ">=3.10"` is Python **3.10–3.12**. The
+`Programming Language :: Python :: 3.13` classifier (`pyproject.toml:21`)
+therefore advertises a combination that cannot include the declared floor. It is
+harmless in practice — a 3.13 resolve simply picks a newer Django — but it is
+another line in the metadata that nothing checks.
+
+### Gap 3 — `TestCase` vs `TransactionTestCase` semantics are load-bearing here and mostly unstated
+
+pytest-django's plain `django_db` mark maps to Django's `TestCase`;
+`transaction=True` maps to `TransactionTestCase`, and "will allow the test to use
+real transactions" (<https://pytest-django.readthedocs.io/en/latest/helpers.html>).
+Django's own testing docs draw the line precisely:
+
+> A `TransactionTestCase` resets the database after the test runs by truncating
+> all tables. A `TransactionTestCase` may call commit and rollback and observe
+> the effects of these calls on the database. A `TestCase`, on the other hand,
+> does not truncate tables after a test. Instead, it encloses the test code in a
+> database transaction that is rolled back at the end of the test.
+
+and, decisively for this codebase:
+
+> A consequence of this, however, is that some database behaviors cannot be
+> tested within a Django `TestCase` class. For instance, **you cannot test that a
+> block of code is executing within a transaction, as is required when using
+> `select_for_update()`**. In those cases, you should use
+> `TransactionTestCase`.
+
+(<https://docs.djangoproject.com/en/5.2/topics/testing/tools/>, emphasis added.)
+
+So the 30 or so `django_db` marks covering the durable store's write paths are
+running in the one mode Django's docs name as unable to test the thing those
+write paths are built around — on top of the backend (Gap 1) that removes the
+lock entirely. The two effects compound.
+
+Three behaviours in this codebase turn on that distinction and are only tested
+in one mode:
+
+- **`transaction.on_commit` is never used** (`grep -rn "on_commit" src/` — zero
+  hits), even though `django_store.py:849` broadcasts to the channel layer
+  **inside** `transaction.atomic()`, with the comment "Inside the transaction,
+  matching the receiver's existing timing on the `append` path." That means a
+  transaction that rolls back after an append has already told every SSE
+  subscriber about an event that does not exist. Under the default `django_db`
+  mode *every* test rolls back, so the suite has been running the phantom-frame
+  scenario continuously without an assertion pointed at it. Django ships the
+  tool for testing exactly this without paying for `TransactionTestCase` —
+  `TestCase.captureOnCommitCallbacks()`, which "[r]eturns a context manager that
+  captures `transaction.on_commit()` callbacks for the given database
+  connection" and with `execute=True` "emulates a commit after the wrapped block
+  of code" (<https://docs.djangoproject.com/en/5.2/topics/testing/tools/>) — and
+  it is inapplicable here, because there are no `on_commit` callbacks to
+  capture.
+- **`select_for_update()` inside `django_db` (non-transactional)** is inside the
+  outer atomic block Django opened, so even on a locking backend it would not
+  reproduce cross-connection contention. Concurrency needs
+  `transaction=True` *and* real threads/connections *and* a locking backend.
+- **`raw=True` / `serialized_rollback`.** `decorators.py:244-248` and
+  `channels_signals.py:110` guard against fixture loads, and
+  `test_decorators_consumer_contract.py:6` names `serialized_rollback` as one of
+  the two paths that produce them — but nothing in the suite actually runs with
+  `serialized_rollback=True`. The guard is tested via `loaddata`-shaped calls,
+  not via the mechanism it names. (pytest-django's own docs are blunt about the
+  price: "Note that this will slow down that test suite by approximately 3x" —
+  <https://pytest-django.readthedocs.io/en/latest/helpers.html>. One targeted
+  test, not a suite-wide flag.)
+
+### Gap 4 — the broadcast/commit ordering has no test either way
+
+Related to Gap 3 but worth separating, because it is an *integration* defect
+candidate rather than a harness one. Both broadcast paths fire pre-commit:
+
+- `channels_signals.py:95` — a `post_save` receiver on `StreamEntry`;
+- `django_store.py:849` — an explicit `self._publish(...)` inside
+  `transaction.atomic()`, added because `bulk_create` does not fire `post_save`
+  (issue #82).
+
+The second deliberately copies the first's timing. Neither has a test asserting
+what a subscriber sees when the enclosing transaction rolls back. The
+`ProvenanceMiddleware` case makes this concrete: a view that appends and then
+raises broadcasts an event whose row is gone.
+
+### Gap 5 — multi-DB is half-wired, and the untested half is the `@stream_model` door
+
+The `using=` seam is real and well tested for the **replay** path
+(`test_using_seam.py`, `test_hermeticity.py`, both with
+`databases=["default", "overlay"]`). It is absent from the **write** path:
+
+- `decorators.py:133` opens `transaction.atomic()` with **no `using=`**, and
+  `decorators.py:250` calls `create_stream_event(...)` without forwarding
+  `kwargs["using"]` — which Django's `post_save` always supplies. So a model
+  saved on a non-default alias emits its stream event onto `default`, in a
+  transaction on `default`, splitting the write.
+- `subscription.py:67,78` (`load_cursor`, `commit_cursor`) and
+  `store.py` (`get_store()`) take no alias at all.
+- `management/commands/replay.py:19-46` exposes `stream`, `--from`, `--to`,
+  `--strict-drift`, `--dry-run` — **no `--database`/`--using`**, despite
+  `replay_stream` being the documented entry point for the disposable-DB
+  rebuild that the `using=` seam exists to enable.
+
+There is also no `DATABASE_ROUTERS` anywhere in `src/`, `tests/` or `examples/`
+(`grep -rn "DATABASE_ROUTERS"` → zero hits), so router interaction — the normal
+way a real deployment splits reads and writes — is untested. Django's multi-DB
+docs note that routers reach into migrations too: "`makemigrations` always
+creates migrations for model changes, but if `allow_migrate()` returns `False`,
+any migration operations for the `model_name` will be silently skipped when
+running `migrate` on the `db`"
+(<https://docs.djangoproject.com/en/5.2/topics/db/multi-db/#allow_migrate>).
+For a library that ships its own migrations, "silently skipped" is the operative
+phrase.
+
+Worth noting that the two-alias tests are correctly written: Django's docs
+warn that "By default, only the `default` database will be wrapped in a
+transaction during a `TestCase`'s execution and attempts to query other
+databases will result in assertion errors to prevent state leaking between
+tests" (<https://docs.djangoproject.com/en/5.2/topics/testing/tools/>), which is
+why `test_using_seam.py:24` and `test_hermeticity.py:37` declare
+`databases=["default", "overlay"]`. The gap is coverage, not correctness.
+
+### Gap 6 — no migration-drift check
+
+`grep -rn "makemigrations" .github/ tests/ justfile` returns only
+`ruff format --check` hits. Nothing runs `makemigrations --check`, and nothing
+tests that the 9 migrations actually build the schema the models describe.
+Django's own answer is one flag: `--check` "[m]akes `makemigrations` exit with a
+non-zero status when model changes without migrations are detected. Implies
+`--dry-run`"
+(<https://docs.djangoproject.com/en/5.2/ref/django-admin/#cmdoption-makemigrations-check>).
+The `--dry-run` implication is a 4.2-and-later guarantee — 4.2's own release
+note says "In older versions, the missing migrations were also created when
+using the `--check` option" — so it is safe for this project's declared floor,
+which is one of the few places that floor helps rather than costs.
+
+Coverage reports 100% on most migration files only because they are
+*imported* during test-database creation, not because their forward/backward
+behaviour is asserted. `0007_stream_closed_stream_closed_at_and_more.py` is at
+80% with lines 15-16 uncovered — those are inside its data-migration function.
+
+For a library that ships migrations into other people's projects, a model change
+landing without its migration is a defect that reaches consumers as a runtime
+`ProgrammingError`, and it is the single cheapest gate to add.
+
+A live instance of the drift this invites: `0008_alter_translatable_unique_together_and_more.py`
+drops the `Translatable` model ("demo domain, not library surface … **every**
+consumer got the table whether or not they ever used it"), and `grep -rn "class
+Translatable" src/` now returns nothing — but `docs/django-integration.md`'s
+Admin section still tells readers that `django_rakaia.admin` "registers
+`Stream`, `StreamEvent`, `StreamEntry`, and `Translatable`". `admin.py` has
+three registrations (`:18`, `:38`, `:96`). Nothing checks the docs against the
+code, so the manual describes a model that was deleted on the same day this note
+was written.
+
+### Gap 7 — async/ASGI is tested at the protocol layer but not at the connection layer
+
+What *is* tested: `test_protocol_server.py` drives `create_app(store=DjangoStreamStore())`
+over `httpx.ASGITransport` under `django_db(transaction=True)`, and
+`test_channels.py` exercises the SSE view including `Last-Event-ID` handling and
+group-mate filtering. That is real async coverage.
+
+What is not:
+
+- **The documented composition.** `integration.py` is at **0% coverage**. Its
+  docstring (`integration.py:15-27`) and `docs/django-integration.md`
+  ("Protocol HTTP API") both give a prefix-stripping `asgi.py` recipe, and
+  `tests/test_django_rakaia/asgi.py` is a bare `get_asgi_application()` — the
+  composed app the docs tell users to build is never assembled, so the
+  prefix-stripping instruction is unverified.
+- **Connection lifetime in the long-lived generator.**
+  `channels_views.py:50-103` opens a queryset (`async for entry in entries_qs`,
+  line 64), then loops on `channel_layer.receive()` forever. Nothing closes the
+  DB connection for the life of the SSE response. Django's databases reference
+  states the rule directly:
+
+  > If a connection is created in a long-running process, outside of Django's
+  > request-response cycle, the connection will remain open until explicitly
+  > closed, or timeout occurs. You can use `django.db.close_old_connections()`
+  > to close all old or unusable connections.
+
+  and, for this exact deployment shape: "**When using ASGI, persistent
+  connections should be disabled.** Instead, use your database backend's
+  built-in connection pooling if available"
+  (<https://docs.djangoproject.com/en/5.2/ref/databases/#persistent-connections>).
+  `grep -rn "close_old_connections\|CONN_MAX_AGE" src/ docs/` returns nothing —
+  neither the code nor the deployment docs mention either. *(Inference: I traced
+  the code path; whether a connection is actually held for the life of the
+  generator depends on the server and on `CONN_MAX_AGE`, and I did not measure
+  it.)*
+- **Transactions in async code.** Django's async topic guide says plainly:
+  "**Transactions do not yet work in async mode.** If you have a piece of code
+  that needs transactions behavior, we recommend you write that piece as a
+  single synchronous function and call it using `sync_to_async()`"
+  (<https://docs.djangoproject.com/en/5.2/topics/async/>). `django_store.py` does
+  exactly that — `_append_with_producer_sync`, `_close_with_producer_sync`, and
+  `run_sync` with `thread_sensitive=True` (`:959-967`) — so the design is
+  right. What is missing is a test that *pins* it: nothing fails if a future
+  change opens an `atomic()` on the async side of that boundary.
+- **Channel layer semantics.** The test settings use
+  `channels.layers.InMemoryChannelLayer` (`settings.py:27-31`). Channels' own
+  docs: "In-memory channel layers operate with each process as a separate layer.
+  This means that **no cross-process messaging is possible**"
+  (<https://channels.readthedocs.io/en/latest/topics/channel_layers.html>).
+  Cross-process delivery is the reason `DjangoStreamStore` exists at all
+  (`django_store.py:190-195` polls rather than waiting on an in-process event
+  "because a durable stream can be appended to by another process entirely"), so
+  the broadcast half of that story is tested only in the mode that cannot
+  exhibit it. Channels' `ChannelsLiveServerTestCase` is the documented way up a
+  level, with its own constraint: "You can't use an in-memory database for your
+  live tests" (<https://channels.readthedocs.io/en/latest/topics/testing.html>)
+  — which the current `:memory:` settings would have to change to satisfy.
+- **Sync middleware under ASGI.** `middleware.py:32` defines neither
+  `async_capable` nor `sync_capable`, and stamps a `ContextVar`
+  (`rakaia/context.py:29`). Whether the `ContextVar` set inside Django's
+  sync-middleware adaptation is visible to an append made later in the same
+  request under ASGI is *not* asserted anywhere — `test_middleware.py` has three
+  cases, all calling the middleware directly as a plain callable. **This is the
+  gap I am least certain about and the one most worth an experiment.**
+
+### Gap 8 — the singleton store leaks between tests, per-module
+
+`store.py:19` caches store instances in a module-level dict for the process
+lifetime. The in-memory store holds *all* stream state there. Exactly one test
+module clears it (`test_store_selection.py:31,33`) and exactly one adds an
+autouse reset fixture (`test_replay_command.py:26-31`, "Reset the singleton
+store between tests so streams don't leak"). There is **no
+`tests/conftest.py` and no `tests/test_django_rakaia/conftest.py`** at all, so
+the fix is copy-pasted per module rather than applied once.
+
+Note also that `RAKAIA_STORE` is *unset* in the test settings, so the suite's
+default store is the **in-memory** one. `test_replay_command.py`'s fixture calls
+`get_store().clear()` — a method the durable store does not need and the
+selection is not parameterized over, so flipping the suite to `durable` would
+not just change a setting.
+
+### Gap 9 — no query-count or performance assertions
+
+`grep -rn "assert_num_queries" tests/` — zero hits. Several docstrings make
+explicit query-count claims that nothing checks:
+
+- `django_store.py:744-748`: `append_many` is "a handful of INSERTs regardless
+  of N (not the 2N a loop of `append` issues)".
+- `effect_executor.py:19-23`: `skip_unchanged=True` "trades one UPDATE per row
+  for one SELECT per row".
+
+These are exactly the claims `django_assert_num_queries` exists to pin, and they
+are exactly the claims that regress silently. (Caveat worth knowing before
+adopting it: pytest-django documents that the fixture "wraps
+`django.test.utils.CaptureQueriesContext` and yields the wrapped
+`CaptureQueriesContext` instance"
+(<https://pytest-django.readthedocs.io/en/latest/helpers.html>) — and
+`CaptureQueriesContext` appears nowhere in Django's own documentation; it is an
+internal in `django/test/utils.py`. Django's documented public equivalent is
+`assertNumQueries`. Either is fine; the dependency is just worth naming.)
+
+### Gap 10 — the hermeticity guard is thread-local, and the store crosses threads
+
+`deny_database_access` (`hermeticity.py:79-123`, ADR 0003) is built on
+`connection.execute_wrapper`. Django's instrumentation docs say what that
+installs:
+
+> Returns a context manager which, when entered, installs a wrapper around
+> database query executions, and when exited, removes the wrapper. **The wrapper
+> is installed on the thread-local connection object.**
+
+(<https://docs.djangoproject.com/en/5.2/topics/db/instrumentation/>)
+
+Meanwhile `DjangoStreamStore.run_sync` (`django_store.py:959-967`) deliberately
+moves every ORM call into a worker thread via
+`sync_to_async(fn, thread_sensitive=True)`, with the docstring "`thread_sensitive=True`
+keeps them all on the same one, which is what makes them share a transaction and
+a connection."
+
+The two facts sit next to each other and nothing in the suite tests their
+interaction. If a rebuild is ever driven from an async context — which is the
+whole reason `run_sync` exists — the deny wrapper installed on the calling
+thread's connection object is not obviously the one the store's thread uses.
+`test_hermeticity.py` and `test_rebuild_isolation.py` are entirely synchronous,
+so the question has never been asked.
+
+*(Inference, flagged as such: I have not run this. `thread_sensitive=True` runs
+work in asgiref's shared executor thread, and `connections` is thread-local, so
+a wrapper installed on the main thread would not be present there — but asgiref
+does propagate `contextvars`, and Django's `connections` handler behaviour under
+`sync_to_async` is subtle enough that this needs an experiment rather than an
+argument. It is a ten-line test either way, and the answer matters: a
+silently-inert hermeticity guard reports green for exactly the leak ADR 0003
+exists to catch.)*
+
+### Gap 11 — coverage is reported but not gated
+
+`ci.yml:48` runs `pytest --cov=... --cov-report=term-missing`. There is no
+`fail_under`, no `[tool.coverage]` section in `pyproject.toml`, and `just check`
+(`justfile:401`) is `lint fmt-check test docs` — it omits `typecheck`, which CI
+does gate (`ci.yml:40`).
+
+---
+
+## Improvement options
+
+Deliberately given as options with costs, not a single recommendation.
+
+### For the harness
+
+| Option | What it buys | What it costs |
+|---|---|---|
+| **A. Postgres CI leg** — a `services: postgres` matrix axis, env-var-driven `DATABASES`, run the same suite | Arms `select_for_update` (Gap 1) and the `TransactionManagementError` guard; makes `tests/server_store_contract.py:205` mean what it says; validates `bulk_create` PK population on the backend that is actually targeted | ~2–4 min CI; a settings split; the `:memory:` `overlay` alias has no Postgres equivalent. **Must be paired with `transaction=True` on the locking tests** — Django's docs say a `TestCase` "will (perhaps unexpectedly) pass without raising a `TransactionManagementError`" even on Postgres, so a Postgres leg alone still does not test the lock |
+| **B. Django/Python version matrix** — `4.2` (on py3.10/3.11), `5.2`, `6.0` | Backs the `django>=4.2` claim, or refutes it | `uv.lock` is single-resolution; needs `--resolution lowest-direct` or per-version constraint files, which cuts against the lockfile discipline `pyproject.toml:78-86` was written to protect (#118). Realistic middle path: one extra "oldest declared" job, not a full cross-product |
+| **C. Concurrency tests** — two real connections contending on `get_next_offset_block` under `transaction=True` | The only way to test the offset/fencing invariants at all; would have to be Postgres-gated | Threaded DB tests are the flakiest thing in a suite; needs `transaction=True`, careful connection teardown, and a skip marker for SQLite |
+| **D. `manage.py makemigrations --check django_rakaia` in CI** (`--check` implies `--dry-run`) | Catches model/migration drift before it reaches consumers | Near-zero. Cheapest item on this list |
+| **E. A `tests/conftest.py`** with an autouse store-reset fixture, a `databases` default, and (optionally) a store-parameterized fixture | Removes the per-module copy-paste (Gap 8); makes "run the whole suite against the durable store" a flag rather than a rewrite | Small; the store-parameterization is the non-trivial half, because `clear()` is memory-only |
+| **F. `django_assert_num_queries` on the two documented query-count claims** | Pins `append_many`'s batching and `skip_unchanged`'s trade (Gap 9) | Low; query counts are backend-sensitive, so assert `<=` bounds rather than exact numbers |
+| **G. Test the documented ASGI mount** — build the composed app from `docs/django-integration.md` in `tests/.../asgi.py` and drive it | Takes `integration.py` off 0%; proves the prefix-stripping instruction users are given | Low |
+| **H. `serialized_rollback=True` case** for the `raw=True` guard | Tests the guard against the mechanism its docstring names | Low, but `serialized_rollback` is slow and needs `TransactionTestCase` semantics |
+| **I. `fail_under` on coverage; add `typecheck` to `just check`** | Stops silent erosion; makes the local gate match CI | Trivial |
+| **J. One async hermeticity test** — arm `deny_database_access`, drive a store call through `run_sync`, assert it still trips | Settles Gap 10, the one place where a *safety guard* may be silently inert | Ten lines. The result is the finding either way |
+| **K. A Channels-layer test that is not in-memory** (`ChannelsLiveServerTestCase`, or a `channels-redis` service) | Gap 7 — cross-process delivery, the reason the durable store exists, is currently only tested in the layer Channels documents as unable to do it | Needs a file-backed test DB ("You can't use an in-memory database for your live tests") and a Redis service; the `prod` extra already declares `channels-redis`, and `justfile:121` already has `redis-up` |
+
+### For the integration code
+
+| Option | Problem it addresses | Trade-off |
+|---|---|---|
+| **1. Move broadcast to `transaction.on_commit`** (`channels_signals.py:95`, `django_store.py:849`) | Gap 4 — a rolled-back append currently notifies subscribers. Django: "If the transaction is instead rolled back … the callback will be discarded, and never called", and "If you call `on_commit()` while there isn't an open transaction, the callback will be executed immediately" (<https://docs.djangoproject.com/en/5.2/topics/db/transactions/#performing-actions-after-commit>) — so the no-transaction case keeps today's behaviour for free | Changes observable timing; under the default `django_db` test mode "no transaction is ever actually committed, thus your `on_commit()` callbacks will never be run", so ~every existing broadcast test would need `captureOnCommitCallbacks` / `django_capture_on_commit_callbacks` or `transaction=True`. Non-trivial, and arguably the highest-value change on this list |
+| **2. Forward `using` through `@stream_model`** — take `kwargs["using"]` in `handle_post_save`/`handle_post_delete`, thread it into `create_stream_event`, `transaction.atomic(using=…)`, and `write_enveloped_event` | Gap 5 — a non-default-alias save currently splits its write across two databases | Widens `create_stream_event`'s signature (public API, `__init__.py`); needs a router-configured test to be meaningful |
+| **3. `--database` on `manage.py replay`** | Gap 5 — the operator-facing entry point cannot reach the seam the library's ADR 0003 story is built on | Small and additive |
+| **4. Explicit backend capability check** — a startup check (`rakaia.W002`?) when `RAKAIA_STORE = "durable"` and `connection.features.has_select_for_update` is `False` | Makes Gap 1 visible to *deployments*, not just to CI. A SQLite production deployment of the durable store has no offset serialization and nothing says so | Another check to silence in dev; needs care not to fire during tests |
+| **5. Close/return the DB connection in the SSE generator** after catch-up, before the indefinite `receive()` loop | Gap 7 — held connection per open EventSource | Needs verification that this is actually the behaviour under ASGI before changing anything; see open questions |
+| **6. Mark `ProvenanceMiddleware` explicitly sync/async-capable** | Gap 7 — removes the ambiguity about `ContextVar` propagation under ASGI | Only worth doing once the behaviour is measured |
+| **7. Give `deny_database_access` an alias-scoped escape** for the log's own reads | `hermeticity.py:81-92` and ADR 0003 both note the guard cannot be armed where the log lives on the guarded alias — which is the common single-database case | Design work; the row-count guard exists precisely because this is hard |
+
+### The cheapest coherent bundle
+
+If only four things are done: **D** (migration check), **G** (test the
+documented mount), **E** (a real `conftest.py`) and **J** (the async hermeticity
+test) are all small and all remove a class of silent failure — and **J** is the
+only one that might turn up a live defect rather than a missing assertion.
+
+If only one *large* thing is done, it is **A + C together** — the Postgres leg
+*and* moving the locking tests to `transaction=True`. Five separate comments in
+the source already say the suite cannot see what it needs to see, options **4**
+and the meaning of `tests/server_store_contract.py:205` both depend on it, and
+Django's own documentation says each half alone is insufficient.
+
+---
+
+## Open questions / what would change the answer
+
+- **Does the sync `ProvenanceMiddleware` `ContextVar` survive Django's ASGI
+  middleware adaptation?** Everything in Gap 7's third bullet is inference from
+  reading `middleware.py` and `rakaia/context.py`. One test — append inside a
+  view, under `AsyncClient`, assert the envelope `metadata` — settles it, and
+  it may well already work.
+- **Is `deny_database_access` inert across the `sync_to_async` boundary?** Gap
+  10. Django documents the wrapper as installed "on the thread-local connection
+  object"; the store deliberately runs its ORM work on another thread. This is
+  the single question on this list whose answer could be a *live defect in a
+  safety guard* rather than a missing test, and it is also the cheapest to
+  settle.
+- **Would the existing suite pass on Postgres unmodified?** Unknown. The
+  contract suites are backend-agnostic by construction, but
+  `test_django_store.py` and the `overlay` alias tests are not obviously so, and
+  `:memory:` aliases have no Postgres equivalent. Running it once is the
+  experiment; the failures are the finding.
+- **Is Django 4.2 actually supported, and should it be?** The floor in
+  `pyproject.toml:36` has never been installed, and 4.2 is no longer on Django's
+  supported list at all. Three coherent answers: test it (a `4.2` matrix leg),
+  raise the floor to `>=5.2` (the current LTS), or state the floor is
+  best-effort. Raising it is a breaking change for consumers; leaving it as-is
+  is a claim the project cannot back and Django no longer stands behind.
+- **Is pre-commit broadcast a bug or a decision?** `django_store.py:847` frames
+  it as consistency ("matching the receiver's existing timing"), not as a
+  choice about at-most-once vs at-least-once delivery. `subscription.py:53-55`
+  shows the project has thought carefully about at-least-once elsewhere. If the
+  SSE channel is explicitly best-effort — a live tail that a client resumes via
+  `Last-Event-ID` against the durable log (`channels_views.py:27-31`) — then
+  pre-commit broadcast is defensible and should be *written down*, not fixed.
+  That is the question to answer before touching option 1.
+- **Does a second adopter deploy on anything but Postgres?** If the answer is
+  "durable store is Postgres-only, forever", option 4 becomes a hard error
+  rather than a warning, and Gap 1 gets simpler.
+
+---
+
+## Docs build
+
+This file is **not** added to `zensical.toml`'s `nav`, for the reason
+[`handler-types.md`](handler-types.md) records: research notes are not part of
+the published manual, and zensical uses an explicit `nav`, so an un-navigated
+page under `docs/` is simply not published rather than being an error.

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -1,0 +1,243 @@
+---
+icon: lucide/graduation-cap
+---
+
+# Tutorial: your first rebuilt table
+
+By the end of this you will have a Django table that is built from a record of
+changes rather than written to directly — and you will have fixed a bug in that
+table by correcting the code and re-running, without touching the data.
+
+It takes about ten minutes. Everything here was run start to finish against
+`rakaia-streams` 0.2.0 and Django 6.1; the output shown is the real output.
+
+You need Python 3.10 or newer. You don't need to know any event-sourcing
+vocabulary — see the [glossary](glossary.md) if a word here is unfamiliar.
+
+## 1. Install
+
+```bash
+mkdir billing-tutorial && cd billing-tutorial
+python -m venv .venv && source .venv/bin/activate
+pip install "rakaia-streams[django]"
+```
+
+## 2. Make a Django project
+
+```bash
+django-admin startproject billing .
+python manage.py startapp invoices
+```
+
+Add both apps to `INSTALLED_APPS` in `billing/settings.py`:
+
+```python
+INSTALLED_APPS = [
+    "django_rakaia",
+    "invoices",
+    # ...the rest, unchanged
+]
+```
+
+## 3. Describe the table you want
+
+This is an ordinary Django model. The only thing unusual is the rule you're
+adopting: **nothing writes to this table by hand.** It gets built for you.
+
+```python title="invoices/models.py"
+from django.db import models
+
+
+class InvoiceSummary(models.Model):
+    """One row per invoice. Never edited by hand — rebuilt from the log."""
+
+    invoice_id = models.CharField(max_length=64, unique=True)
+    customer = models.CharField(max_length=100, default="")
+    total = models.DecimalField(max_digits=12, decimal_places=2, default=0)
+
+    class Meta:
+        ordering = ["invoice_id"]
+```
+
+## 4. Write the rule that fills it in
+
+A **handler** is a plain function. It takes one recorded change and returns a
+description of the row that change implies. It does not touch the database
+itself — it just says what should be true.
+
+`Upsert` means "make sure a row with this `lookup` exists, and give it these
+`defaults`".
+
+```python title="invoices/handlers.py"
+from decimal import Decimal
+
+from rakaia import Effect, Upsert, register_handler
+
+
+@register_handler(name="invoice_total", event_match="invoices", effective_from=0)
+def invoice_total(event: dict) -> Effect | None:
+    total = Decimal("0")
+    for item in event["items"]:
+        total += Decimal(str(item["price"]))
+    return Upsert(
+        model_label="invoices.InvoiceSummary",
+        lookup={"invoice_id": event["invoice_id"]},
+        defaults={"customer": event["customer"], "total": total},
+    )
+```
+
+That code has a deliberate bug. Leave it in — fixing it is the point of step 7.
+
+Handlers have to be loaded at startup, so import the module when the app is
+ready:
+
+```python title="invoices/apps.py"
+from django.apps import AppConfig
+
+
+class InvoicesConfig(AppConfig):
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "invoices"
+
+    def ready(self):
+        from . import handlers  # noqa: F401
+```
+
+## 5. Add some changes, and build the table
+
+Create `invoices/management/commands/rebuild.py` (with empty `__init__.py` files
+in `invoices/management/` and `invoices/management/commands/`):
+
+```python title="invoices/management/commands/rebuild.py"
+from django.core.management.base import BaseCommand
+
+from django_rakaia import DjangoExecutor, get_store
+from invoices.models import InvoiceSummary
+from rakaia import CollectingExecutor, replay, seed_stream
+
+STREAM = "invoices"
+
+EVENTS = [
+    {"invoice_id": "INV-1", "customer": "Ana",
+     "items": [{"price": "10.00", "quantity": 3}]},
+    {"invoice_id": "INV-2", "customer": "Bo",
+     "items": [{"price": "5.00", "quantity": 2}, {"price": "1.50", "quantity": 4}]},
+]
+
+
+class Command(BaseCommand):
+    def handle(self, *args, **opts):
+        store = get_store()
+        store.delete(STREAM)
+        seed_stream(STREAM, EVENTS, store=store)
+
+        # Rehearsal: work out every change, write none of them.
+        preview = CollectingExecutor()
+        replay(store=store, stream_path=STREAM, executor=preview)
+        self.stdout.write(f"Dry run: would apply {len(preview.effects)} changes, wrote nothing.")
+
+        # For real this time.
+        replay(store=store, stream_path=STREAM, executor=DjangoExecutor())
+        for row in InvoiceSummary.objects.all():
+            self.stdout.write(f"  {row.invoice_id}  {row.customer:6}  {row.total}")
+```
+
+Create the table and run it:
+
+```bash
+python manage.py makemigrations invoices
+python manage.py migrate
+python manage.py rebuild
+```
+
+```text
+Dry run: would apply 2 changes, wrote nothing.
+  INV-1  Ana     10.00
+  INV-2  Bo      6.50
+```
+
+## 6. Notice the numbers are wrong
+
+INV-1 is three items at $10.00. It should be $30.00, not $10.00. The handler
+adds up prices and ignores quantities.
+
+In an ordinary Django app this is now a data problem: the wrong totals are in
+your table, and getting them right means a migration or a repair script that has
+to work out what each row *should* have been.
+
+Here it isn't a data problem, because the table isn't the original. The record of
+what happened still has the quantities in it.
+
+## 7. Fix the code, rebuild the table
+
+Change one line in `invoices/handlers.py`:
+
+```python
+        total += Decimal(str(item["price"])) * item["quantity"]
+```
+
+Run the same command again:
+
+```bash
+python manage.py rebuild
+```
+
+```text
+Dry run: would apply 2 changes, wrote nothing.
+  INV-1  Ana     30.00
+  INV-2  Bo      16.00
+```
+
+The table is correct. You wrote no migration and no repair script — you fixed the
+rule and the rows were rebuilt from the record.
+
+Run it a third time and you get the same two rows, not four. Rebuilding is safe
+to repeat.
+
+## What you just relied on
+
+- **The record is the original; the table is derived.** That is what made the fix
+  a code change rather than a data change.
+- **The rehearsal is real.** The `CollectingExecutor` run worked out all the
+  changes and wrote none of them. On a real database you would combine it with
+  the guards in [preview a replay with no writes](dry-run-and-executors.md),
+  which make writing during a rehearsal an error rather than a matter of trust.
+- **Rebuilding is repeatable.** Each row is matched by its `lookup`, so replaying
+  the same record converges instead of duplicating.
+
+## Where next
+
+- [Add streams to a Django model](django-integration.md) — emit these changes
+  automatically on `save()` instead of writing them out by hand.
+- [Why Rakaia exists](why-rakaia.md) — what this buys you beyond the toy case.
+- [Versioned handlers](versioned-handlers.md) — for when the rule *should*
+  change over time rather than being fixed.
+
+---
+
+## Appendix — details deliberately skipped above
+
+**Fixing a bug vs. changing a rule.** In step 7 you replaced the handler
+outright, so the correction applied to all of history. That is right for a bug:
+the old totals were never correct. It is wrong for a *rule change* — if tax rises
+next year, rebuilding must not retroactively tax last year's invoices. That case
+uses `effective_from` / `effective_to` to bracket each version of the rule to the
+stretch of the record it governed. See [versioned handlers](versioned-handlers.md).
+
+**Why `effective_from=0`.** It marks this handler as applying from the very start
+of the record. With no `effective_to`, it applies to everything after, too — one
+rule, all of history, which is what a bug fix wants.
+
+**Where the record is stored.** `get_store()` returned the in-memory store, which
+is process-local and disappears when the command exits. That is why `rebuild`
+seeds and replays in the same run. For a real project the record lives in your
+database — see [Django integration](django-integration.md) for switching to the
+durable store.
+
+**`Upsert` vs `Update`.** `Upsert` creates the row if it is missing. `Update`
+only touches rows that already exist, which is what you want for a handler that
+decorates someone else's row and must never bring a half-built one into being.
+
+**`store.delete()` at the top.** Only so the tutorial command is re-runnable
+against the in-memory store. Do not do this to a real record — it is the one
+thing in this file that destroys data rather than deriving it.

--- a/docs/why-rakaia.md
+++ b/docs/why-rakaia.md
@@ -1,0 +1,108 @@
+---
+icon: lucide/help-circle
+---
+
+# Why Rakaia exists
+
+Most Django projects that need to answer *"who changed this, and when?"* reach for
+an audit-log tool. That works, right up until the day you need to do something
+with the history other than read it.
+
+Rakaia takes the other route. Instead of your tables being the truth and the
+history being a copy of them, **the history is the truth and your tables are
+built from it**. Every change is recorded once, in order, and your tables are
+produced by reading that record back.
+
+That one inversion buys three things an audit log can't give you.
+
+## 1. You can rebuild a table
+
+If your tables are derived from the log, a bug in how you derived them is not a
+data-loss event. Fix the code, replay the log, and the tables come back correct —
+including for rows that were written wrong months ago.
+
+With an audit log, the table is the original and the log is the copy. You can
+read what a row used to be, but you can't regenerate the table from it.
+
+## 2. You can rehearse the rebuild before you run it
+
+This is the part nothing else does.
+
+Before touching real data, Rakaia can run the entire rebuild and tell you exactly
+what it *would* write — every row it would create, update, or delete — while
+physically blocking any write from reaching the database. If the code tries to
+write anyway, the run fails loudly instead of quietly succeeding.
+
+It also fails when a rebuild would do *nothing at all*. A dry run that produces
+no changes is usually a broken rebuild rather than a clean bill of health, so
+Rakaia reports that case as a distinct result rather than a pass.
+
+So the question "is this migration safe?" stops being a judgement call.
+
+## 3. Old data keeps working when the code changes
+
+Your rules will change. Rakaia lets you say *"this rule applied between these two
+points in the log"*, so a replay applies the rule that was correct at the time
+rather than today's rule to all of history. Events written in an old shape are
+translated forward on the way in, so old records stay readable without being
+rewritten.
+
+## Does it actually reproduce an audit log?
+
+Yes, and this is checked on every commit rather than asserted.
+
+The `partisipa_history` example takes a stream of changes, rebuilds an audit
+trail from it, and compares that against a reference `pgh_event` table — the
+table layout `django-pghistory` produces. It checks the order, the change type,
+the person responsible, the timestamp, and the field values, and requires them to
+match exactly. It also checks the recovery case: restoring a truncated record
+from its most complete earlier version, which is the job people actually keep an
+audit log for.
+
+Run it yourself:
+
+```bash
+just partisipa-history-demo
+```
+
+It exits non-zero if any of that stops being true, and CI runs it.
+
+!!! warning "The honest limits"
+
+    - The comparison is against a faithful **model** of a `pgh_event` table, not
+      a live `django-pghistory` installation. It proves the shape and contents
+      match; it is not an integration test against that package.
+    - Rakaia records changes when your model is saved. Operations that skip
+      `save()` — notably `QuerySet.update()`, which Django documents as not
+      emitting `pre_save` or `post_save` signals — are invisible to it.
+      `django-pghistory` installs database triggers instead, so it catches those,
+      and raw SQL besides. If your project writes in bulk, this difference
+      matters and you should know about it before you choose.
+    - Rakaia is pre-1.0. See [the public API](public-api.md) for what is and
+      isn't promised.
+
+## Is this for you?
+
+**Probably yes, if:** you have a Django project with a load-bearing audit trail,
+you have written one-off backfill scripts to repair derived data, and you would
+sleep better previewing those before running them.
+
+**Probably not, if:** you want change tracking and nothing more. An audit-log
+package is less machinery and will catch bulk writes that Rakaia won't.
+
+## Where next
+
+- [Tutorial: your first rebuilt table](tutorial.md) — the shortest path from
+  nothing to a table you can rebuild.
+- [Glossary](glossary.md) — the vocabulary, in plain language.
+- [Preview a replay with no writes](dry-run-and-executors.md) — how the rehearsal
+  in point 2 works.
+
+---
+
+## Appendix — the parity design in detail
+
+The reasoning behind the audit-trail replacement, the envelope fields it depends
+on, and the migration path off `django-pghistory` are recorded in
+[the pghistory parity notes](pghistory-retirement.md). That page assumes the
+vocabulary; this one doesn't.

--- a/justfile
+++ b/justfile
@@ -384,6 +384,22 @@ fmt:
 typecheck:
     uv run pyright src/
 
+# Regenerate docs/api-reference.md from what the packages actually export.
+# Commit the result; `api-reference-check` fails if it drifts.
+api-reference:
+    uv run python scripts/gen_api_reference.py
+
+# Fail if the committed API reference is out of date with the code.
+api-reference-check:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    uv run python scripts/gen_api_reference.py
+    if ! git diff --quiet -- docs/api-reference.md; then
+        echo "docs/api-reference.md is out of date. Run 'just api-reference' and commit." >&2
+        git --no-pager diff -- docs/api-reference.md >&2
+        exit 1
+    fi
+
 # Build the documentation site
 docs:
     uv run zensical build
@@ -392,13 +408,11 @@ docs:
 docs-serve:
     uv run zensical serve
 
-# Run the full quality gate (lint + format + tests + docs build).
-# Note: `typecheck` is a separate recipe — pyright currently surfaces a
-# bunch of pre-existing Django ORM dynamism warnings on this codebase
-# (queryset annotations, related managers, implicit `id` fields). Run
-# `just typecheck` if you want to see them; fixing them is tracked
-# separately and would benefit from migrating to `django-stubs`.
-check: lint fmt-check test docs
+# Run the full quality gate, mirroring CI.
+# `typecheck` was excluded here while pyright still surfaced pre-existing
+# Django ORM dynamism warnings. That stopped being true in #143 — pyright is a
+# hard gate at zero errors in CI — so it belongs in the local gate too.
+check: lint fmt-check typecheck test api-reference-check docs
 
 # ---------------------------------------------------------------------------
 # Release / publishing (dist name: rakaia-streams)

--- a/scripts/gen_api_reference.py
+++ b/scripts/gen_api_reference.py
@@ -1,0 +1,300 @@
+"""Generate `docs/api-reference.md` from what the packages actually export.
+
+A hand-written list of 130-odd names goes stale the first time someone adds one.
+This reads `rakaia.__all__` and `django_rakaia.__all__` at runtime, so the
+reference cannot drift from the code — the worst it can do is be regenerated.
+
+Run it with `just api-reference` (or `uv run python scripts/gen_api_reference.py`)
+and commit the result. CI checks the committed file is up to date.
+
+Grouping is the one editorial choice here: `GROUPS` below assigns names to
+sections by hand, because the module a name happens to live in is an
+implementation detail the public API deliberately does not promise. Anything
+unassigned lands in "Everything else", which is the signal to come and group it.
+"""
+
+from __future__ import annotations
+
+import inspect
+import os
+import pathlib
+import re
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent / "src"))
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "tests.test_django_rakaia.settings")
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent))
+
+import django  # noqa: E402
+
+django.setup()
+
+import django_rakaia  # noqa: E402
+import rakaia  # noqa: E402
+
+GROUPS: dict[str, tuple[str, ...]] = {
+    "Running a server": (
+        "app",
+        "create_app",
+        "get_asgi_app",
+        "ServerOptions",
+        "get_store",
+    ),
+    "Reading and writing streams": (
+        "Stream",
+        "StreamStore",
+        "DjangoStreamStore",
+        "ReadableStore",
+        "WritableStore",
+        "StreamServerStore",
+        "append_event",
+        "append_if_changed",
+        "seed_stream",
+        "create_stream_event",
+        "AppendOptions",
+        "AppendResult",
+        "CloseResult",
+        "ClosedBy",
+        "StreamMessage",
+        "Poll",
+        "PollStatus",
+        "poll",
+        "poll_consumer",
+    ),
+    "Rebuilding tables (replay)": (
+        "replay",
+        "replay_stream",
+        "merge_replay",
+        "ReplayResult",
+        "fold_events",
+        "project_latest",
+    ),
+    "Describing changes (effects)": (
+        "Effect",
+        "AnyEffect",
+        "Upsert",
+        "Update",
+        "Delete",
+        "Retire",
+        "Exclude",
+        "RowEffect",
+        "ExternalEffect",
+        "Ref",
+        "RefResolver",
+        "UnresolvedRefError",
+        "Transition",
+        "TouchedSubject",
+    ),
+    "Registering rules (handlers, reducers, upcasters)": (
+        "register_handler",
+        "register_reducer",
+        "register_simple",
+        "register_upcaster",
+        "upcast",
+        "HandlerRegistry",
+        "UpcasterRegistry",
+        "HandlerVersion",
+        "ReducerVersion",
+        "UpcasterVersion",
+        "get_default_registry",
+        "get_default_upcaster_registry",
+        "reset_default_registries",
+        "check_disjoint_defaults",
+    ),
+    "Applying changes (executors and readers)": (
+        "Executor",
+        "CollectingExecutor",
+        "DjangoExecutor",
+        "InMemoryProjections",
+        "ProjectionReader",
+        "DjangoProjectionReader",
+        "PreloadedProjectionReader",
+        "ModelStreamReader",
+    ),
+    "Rehearsing a rebuild safely": (
+        "deny_database_access",
+        "assert_no_live_writes",
+        "AmbientDatabaseAccess",
+        "LiveWriteLeaked",
+        "diff_effects_against_rows",
+        "DiffReport",
+        "RowDiff",
+        "FieldDiff",
+        "snapshots_equal",
+        "GREEN",
+        "RED",
+        "VACUOUS",
+        "VacuousVerification",
+        "VerificationError",
+    ),
+    "Audit trails and provenance": (
+        "provenance",
+        "get_provenance",
+        "ProvenanceMiddleware",
+        "envelope_actor",
+        "label_marker",
+        "materialize_history",
+        "history_effects",
+        "ENVELOPE_TS",
+    ),
+    "Keeping child rows in step": (
+        "reconcile_children",
+        "reconcile_tree",
+        "reconcile_aggregate",
+        "reconcile_by_key",
+    ),
+    "Consumer cursors": (
+        "CursorStore",
+        "CursorOptions",
+        "calculate_cursor",
+        "generate_response_cursor",
+        "commit_cursor",
+        "load_cursor",
+    ),
+    "Producer fencing": (
+        "ProducerState",
+        "ProducerAccepted",
+        "ProducerDuplicate",
+        "ProducerStaleEpoch",
+        "ProducerSequenceGap",
+        "ProducerInvalidEpochSeq",
+        "ProducerStreamClosed",
+        "ProducerValidationResult",
+    ),
+    "Django model integration": (
+        "stream_model",
+        "register_stream_event_admin",
+        "canonical_value",
+        "DEFAULT_NORMALIZERS",
+    ),
+    "Constants": (
+        "__version__",
+        "HANDLERS_META_STREAM",
+        "REDUCERS_META_STREAM",
+        "UPCASTERS_META_STREAM",
+        "SCRATCH_PATH",
+    ),
+    "Errors": (
+        "StreamError",
+        "StreamNotFound",
+        "SequenceConflict",
+        "ContentTypeMismatch",
+        "InvalidJson",
+        "InvalidOffset",
+        "EmptyJsonArray",
+        "SpareKeys",
+        "StreamConfigConflict",
+        "HandlerDriftError",
+        "HandlerGapError",
+        "HandlerOverlapError",
+        "EffectCollisionError",
+        "DuplicateProducesError",
+        "UpcasterChainError",
+        "UpcasterConflictError",
+    ),
+}
+
+INTRO = """---
+icon: lucide/list
+---
+
+# Python API reference
+
+Every name the two packages export, with its signature. This page is generated
+from `rakaia.__all__` and `django_rakaia.__all__`, so it lists exactly what is
+importable and nothing else.
+
+For *what these names promise* — which are stable, which may change, and how to
+pin a version — see [the public API](public-api.md). This page is the index; that
+page is the contract.
+
+!!! note "Generated file"
+
+    Do not edit by hand. Run `just api-reference` and commit the result.
+
+"""
+
+
+def signature_of(obj: object) -> str:
+    if not (inspect.isfunction(obj) or inspect.isclass(obj) or inspect.ismethod(obj)):
+        return ""  # constants have no signature; str/tuple instances would report their type's
+    try:
+        sig = str(inspect.signature(obj))  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return ""
+    # Default values that repr as `<function f at 0x7f…>` embed a memory address,
+    # which changes every run and would churn the committed diff for no reason.
+    return re.sub(r" at 0x[0-9a-f]+", "", sig)
+
+
+def summary_of(obj: object) -> str:
+    doc = inspect.getdoc(obj)
+    if not doc:
+        return ""
+    # `inspect.getdoc` falls back to the *type's* docstring for instances, so a
+    # module-level `FOO: str = "…"` would otherwise be documented as `str(...)`.
+    is_callable = (
+        inspect.isfunction(obj) or inspect.isclass(obj) or inspect.ismethod(obj)
+    )
+    if not is_callable and doc == inspect.getdoc(type(obj)):
+        return ""
+    first = doc.strip().split("\n\n")[0].replace("\n", " ").strip()
+    return first if len(first) < 200 else first[:197].rsplit(" ", 1)[0] + "…"
+
+
+def main() -> int:
+    home: dict[str, list[str]] = {}
+    for pkg_name, pkg in (("rakaia", rakaia), ("django_rakaia", django_rakaia)):
+        for name in pkg.__all__:
+            home.setdefault(name, []).append(pkg_name)
+
+    grouped = {n for names in GROUPS.values() for n in names}
+    ungrouped = sorted(n for n in home if n not in grouped)
+
+    out = [INTRO]
+    sections = list(GROUPS.items())
+    if ungrouped:
+        sections.append(("Everything else", tuple(ungrouped)))
+
+    for title, names in sections:
+        present = [n for n in names if n in home]
+        if not present:
+            continue
+        out.append(f"## {title}\n")
+        out.append("| Name | Import from | Signature | What it does |")
+        out.append("|---|---|---|---|")
+        for name in present:
+            pkgs = home[name]
+            obj = getattr(rakaia if "rakaia" in pkgs else django_rakaia, name)
+            imports = " / ".join(f"`{p}`" for p in pkgs)
+            sig = signature_of(obj).replace("|", "\\|")
+            sig = f"`{sig}`" if sig else "—"
+            summary = summary_of(obj).replace("|", "\\|") or "—"
+            out.append(f"| `{name}` | {imports} | {sig} | {summary} |")
+        out.append("")
+
+    missing = sorted(
+        n
+        for n in home
+        if not summary_of(getattr(rakaia if "rakaia" in home[n] else django_rakaia, n))
+    )
+    out.append("---\n")
+    out.append("## Appendix — coverage\n")
+    out.append(
+        f"{len(home)} exported names across {len(sections)} sections. "
+        f"{len(home) - len(missing)} carry a docstring; {len(missing)} do not "
+        "and show `—` above.\n"
+    )
+    if missing:
+        out.append("Undocumented: " + ", ".join(f"`{n}`" for n in missing) + ".\n")
+
+    target = (
+        pathlib.Path(__file__).resolve().parent.parent / "docs" / "api-reference.md"
+    )
+    target.write_text("\n".join(out))
+    print(f"wrote {target} — {len(home)} names, {len(ungrouped)} ungrouped")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/zensical.toml
+++ b/zensical.toml
@@ -9,46 +9,69 @@
 site_name = "Rakaia"
 site_description = "Python implementation of the Durable Streams protocol — zero-dependency ASGI server plus a Django integration."
 site_author = "Josh Brooks"
-site_url = "https://github.com/joshbrooks/durable-streams"
+# The canonical home for the built site. Nothing is served here yet — publishing
+# to GitHub Pages is a separate step — but `site_url` feeds canonical links and
+# the sitemap, so it must name the intended destination rather than a repo URL.
+site_url = "https://joshbrooks.github.io/rakaia/"
 
 copyright = """
 Copyright &copy; 2026 Josh Brooks
 """
 
 # Explicit navigation. Order matters; nested tables become sections.
+# Grouped by what the reader is trying to do, not by subsystem. The four
+# Diátaxis modes (tutorial / how-to / explanation / reference) were used to
+# diagnose what each page is *for*; the section names are the plain-English
+# version of the same split, because "How do I…" tells a stranger more than
+# "How-to guides" does.
+#
+# "Experiments" holds pages that were design spikes. They are real, tested work
+# and stay published, but they are not the manual and should not be the third
+# thing a newcomer scrolls past.
 nav = [
-    { "Overview" = "index.md" },
-    { "What's new" = "whats-new.md" },
-    { "Examples & concept coverage" = "examples.md" },
-    { "Glossary" = "glossary.md" },
-    { "The public API" = "public-api.md" },
-    { "Framework vs. protocol server" = "framework-vs-protocol-server.md" },
-    { "Django integration" = "django-integration.md" },
-    { "Versioned handlers" = "versioned-handlers.md" },
-    { "Projections & fan-out" = "projections-and-fan-out.md" },
-    { "Event envelope & provenance" = "event-envelope.md" },
-    { "History read-model" = "history-read-model.md" },
-    { "Alerts projection" = "alerts-projection.md" },
-    { "Subscriber cursors" = "subscriber-cursors.md" },
-    { "Dry-run & executors" = "dry-run-and-executors.md" },
-    { "Projection cookbook" = "projection-cookbook.md" },
-    { "pghistory retirement (spike)" = "pghistory-retirement.md" },
-    { "Staged replay (spike)" = "staged-replay.md" },
-    { "Close preconditions (spike)" = "close-preconditions.md" },
-    { "Multi-stream merge (spike)" = "multi-stream-merge.md" },
-    { "Tree-reconcile (spike)" = "tree-reconcile.md" },
-    { "Translations (example)" = "translations.md" },
-    { "Deployment" = "deployment.md" },
-    { Reference = [
+    { "Start here" = [
+        { "Overview" = "index.md" },
+        { "Why Rakaia exists" = "why-rakaia.md" },
+        { "Tutorial: your first rebuilt table" = "tutorial.md" },
+        { "Glossary" = "glossary.md" },
+        { "What's new" = "whats-new.md" },
+    ] },
+    { "How do I…" = [
+        { "Add streams to a Django model" = "django-integration.md" },
+        { "Preview a replay with no writes" = "dry-run-and-executors.md" },
+        { "Build a projection" = "projection-cookbook.md" },
+        { "Read a stream incrementally" = "subscriber-cursors.md" },
+        { "Combine human and machine decisions" = "alerts-projection.md" },
+        { "Deploy it" = "deployment.md" },
+    ] },
+    { "How it works" = [
+        { "Framework vs. protocol server" = "framework-vs-protocol-server.md" },
+        { "Versioned handlers" = "versioned-handlers.md" },
+        { "Projections & fan-out" = "projections-and-fan-out.md" },
+        { "Event envelope & provenance" = "event-envelope.md" },
+        { "History read-model" = "history-read-model.md" },
+        { "pghistory parity (design notes)" = "pghistory-retirement.md" },
+        { "Decision records" = [
+            { "ADR 0001 — Ordering child collections" = "adr/0001-ordering-child-collections-in-projections.md" },
+            { "ADR 0002 — Framework vs protocol-server boundary" = "adr/0002-framework-vs-protocol-server-boundary.md" },
+            { "ADR 0003 — Handler hermeticity" = "adr/0003-handler-hermeticity.md" },
+            { "ADR 0004 — Handler types & fold order" = "adr/0004-handler-types-and-fold-order.md" },
+        ] },
+    ] },
+    { "Look it up" = [
+        { "The public API" = "public-api.md" },
+        { "Python API reference" = "api-reference.md" },
         { "Protocol specification" = "protocol.md" },
         { "Producer fencing & validation" = "producer-fencing.md" },
         { "Backend storage" = "streams-backend-storage.md" },
+        { "Example index" = "examples.md" },
     ] },
-    { "Decision records" = [
-        { "ADR 0001 — Ordering child collections" = "adr/0001-ordering-child-collections-in-projections.md" },
-        { "ADR 0002 — Framework vs protocol-server boundary" = "adr/0002-framework-vs-protocol-server-boundary.md" },
-        { "ADR 0003 — Handler hermeticity" = "adr/0003-handler-hermeticity.md" },
-        { "ADR 0004 — Handler types & fold order" = "adr/0004-handler-types-and-fold-order.md" },
+    { Experiments = [
+        { "Staged replay" = "staged-replay.md" },
+        { "Close preconditions" = "close-preconditions.md" },
+        { "Multi-stream merge" = "multi-stream-merge.md" },
+        { "Tree-reconcile" = "tree-reconcile.md" },
+        { "Translations" = "translations.md" },
     ] },
 ]
 
@@ -85,4 +108,4 @@ toggle.name = "Switch to light mode"
 
 [[project.extra.social]]
 icon = "fontawesome/brands/github"
-link = "https://github.com/joshbrooks/durable-streams"
+link = "https://github.com/joshbrooks/rakaia"


### PR DESCRIPTION
The front page was the most jargon-heavy page in the docs — denser than the glossary, whose job is jargon — and there was no tutorial at all. This regroups the navigation by what the reader is trying to do, adds the missing tutorial and a plain-language page on why the project exists, and generates the API reference so it cannot go stale.

It also fixes what the audit turned up along the way: docs naming a model that was deleted in migration 0008, a page still claiming a feature had not landed when it had, two links pointing at a repository that 404s, the strongest feature missing from the page that should describe it, and a stale exclusion in the local quality gate.

Technical detail is in a comment below.