### PR TITLE
Tell a published-0.1.0 consumer what they are crossing, and report what a batch wrote

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,22 @@ protocol is covered by both stores.
 
 ### Added
 
+- **`ApplyReport` says how much a batch actually wrote.** `skip_unchanged`
+  computes exactly which columns differ and then threw the answer away, so a
+  replay that rewrote every row and one that wrote nothing reported the same
+  thing — converged state, and silence. The question the option exists to answer,
+  *how much write churn did this cause*, could only be reached by counting
+  queries around the call. `ApplyReport` now carries `upserts_created`,
+  `upserts_written` and `upserts_skipped`, with
+  `written + skipped == <number of upsert effects>` and `written - created` the
+  number of updates. Scoped to `update_or_create` on purpose: that is where
+  `skip_unchanged` is wired, because `update` already issues one UPDATE that does
+  not advance `auto_now`, and deletes and retires are counted by their own
+  effects. `InMemoryProjections` reports them too — it writes unconditionally, so
+  its `skipped` is always 0, which is also what `DjangoExecutor` reports with the
+  option off — and `tests/executor_contract.py` pins them for every executor.
+  Additive fields with defaults; nothing breaks.
+
 - **`rakaia.InMemoryProjections`, and shared contracts for the executor and reader
   seams.** Rakaia had four ways to apply effects and four ways to read
   projections back, and — unlike the store seam, which has two adapters and two

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -21,6 +21,63 @@ Everything in this file so far. `0.1.0` was the initial groundwork and `0.2.0`
 is the first release describing the library, so a consumer moving off a pinned
 revision is crossing all of the below at once.
 
+## Start here if you installed `rakaia-streams==0.1.0` from PyPI
+
+The sections below are keyed to the revisions their changes landed in, which is
+what a SHA-pinned consumer needs — but the **published** `0.1.0` is not the
+oldest of those revisions, so part of the work below is already behind you.
+
+`v0.1.0` is `f676302`, which is `5e4a6e3` plus exactly two commits: `5d576b6`
+(the issue #80 Django fixes) and the packaging commit itself. So from published
+`0.1.0`:
+
+| Change | From published `0.1.0` |
+|---|---|
+| The distribution rename to `rakaia-streams` | **Already done** — `f676302` *is* that commit, so you installed under the new name. |
+| Migration `0006` | **Already applied** — it shipped in `0.1.0`. |
+| `DjangoStreamStore.get()` returns metadata, not the ORM row | **Still to cross.** This is your one code change. |
+| Migrations `0007` and `0008` | **New.** Apply both; `0008` drops a table. |
+
+### The one break that matters, and why testing may not show it
+
+`store.get()` no longer returns the `django_rakaia.models.Stream` ORM row, so
+anything that hands the result to the ORM breaks:
+
+```python
+stream = store.get(path)
+entries = StreamEntry.objects.filter(stream=stream)   # <-- TypeError
+```
+
+```
+TypeError: Field 'id' expected a number but got Stream(path='history/tf',
+  content_type=None, messages=[], current_offset='00000000000000014678', ...)
+```
+
+The fix is one line, and it is one query instead of two:
+
+```diff
+-entries = StreamEntry.objects.filter(stream=store.get(path))
++entries = StreamEntry.objects.filter(stream__stream_id=path)
+```
+
+**Test this against a database that already has streams in it.** In the first
+production consumer every one of these calls sat behind an `if store.has(path):`
+guard, so on an empty database the branch is never taken, the upgrade looks
+clean, and the failure only appears on the *second* run once the stream exists.
+A consumer who validates the upgrade on a fresh database will conclude it is
+clean and ship the break. Grep for `store.get(` and check what each result is
+passed to.
+
+### `0007` walks every `Stream` row
+
+`0007` carries a data migration seeding `last_activity_at` from `created_at`,
+one row at a time. On a fresh install that costs nothing — a consumer whose
+production database had never installed `django_rakaia` measured the entire
+`migrate`, `0001` through `0008`, at **8 seconds** against empty tables. On a
+database that already holds streams the cost is proportional to how many: that
+same deployment reached **95,635 events across 31 streams** once seeded. If your
+log is already large, plan a window.
+
 ## Upgrading past `5e4a6e3` (`append_many`, 2026-08-08)
 
 Three changes need action. Nothing else in this range requires a code change.

--- a/docs/public-api.md
+++ b/docs/public-api.md
@@ -112,6 +112,43 @@ this is written.
 Note the distribution is `rakaia-streams`; the import names are `rakaia` and
 `django_rakaia` (plain `rakaia` was already taken on PyPI).
 
+#### If you depend on Tier 2, pin harder
+
+`>=0.2,<0.3` is the right bound for code living inside Tier 1. It is *not* enough
+if you also query the ORM models or import a submodule path directly, because the
+table shape and the module layout are both allowed to move within a minor:
+
+```toml
+dependencies = ["rakaia-streams==0.2.*"]
+```
+
+Assume this applies to you rather than assuming it does not. The first production
+consumer reached 127 import statements and roughly twenty direct ORM queries
+against `StreamEntry`/`Stream` before anyone asked which tier it was on — and the
+answer was Tier 2, plus one private symbol. Two questions settle it:
+
+- Does anything you import begin with `_`, or come from a `django_rakaia`
+  submodule that is not listed in `_EXPORTS`?
+- Do you query `django_rakaia.models` directly, or rely on `StreamEntry.offset`
+  being an orderable integer column?
+
+A "yes" to either puts you outside the Tier 1 promise, and `==0.2.*` is the
+honest bound until what you need is promoted. Tell us what you are reaching for
+when that happens: a Tier 2 dependency is a gap in Tier 1, and the store protocol
+offering only `read(path, offset)` is the usual reason.
+
+**Whichever bound you pick, do not verify an upgrade by reading
+`rakaia.__version__` alone.** It reports the installed distribution version,
+which is correct — but a consumer pinned to a git revision gets whatever version
+the *source* declares, and two revisions a whole release apart can report the
+same number. Check the artifact instead:
+
+```python
+importlib.metadata.distribution("rakaia-streams").read_text("direct_url.json")
+```
+
+which names the revision you actually installed.
+
 ## Contracts inside Tier 1
 
 Being in `__all__` is not the whole promise. Four behavioural contracts are

--- a/src/django_rakaia/effect_executor.py
+++ b/src/django_rakaia/effect_executor.py
@@ -87,6 +87,7 @@ class DjangoExecutor:
         # and a sibling's Ref values are substituted before that sibling applies.
         resolver = RefResolver()
         retire_flips: list[tuple[Retire, list[dict[str, Any]]]] = []
+        created = written = skipped = 0
         with transaction.atomic(using=self._using):
             # Writes first, then deletes, then retires: reconcile batches
             # (upsert current rows, prune/soft-delete the rest) converge
@@ -95,7 +96,14 @@ class DjangoExecutor:
             # refs it.
             for eff in effects_list:
                 if isinstance(eff, Upsert):
-                    obj = self._upsert(resolver.resolve_effect(eff))
+                    obj, outcome = self._upsert(resolver.resolve_effect(eff))
+                    if outcome == "created":
+                        created += 1
+                        written += 1
+                    elif outcome == "written":
+                        written += 1
+                    else:
+                        skipped += 1
                     if eff.produces is not None:
                         resolver.record(eff.produces, _row_accessor(obj))
                 elif isinstance(eff, Update):
@@ -109,16 +117,27 @@ class DjangoExecutor:
                     flipped = self._retire(reff)
                     if reff.transition is not None:
                         retire_flips.append((reff, flipped))
-        return ApplyReport(retire_flips=retire_flips)
+        return ApplyReport(
+            retire_flips=retire_flips,
+            upserts_created=created,
+            upserts_written=written,
+            upserts_skipped=skipped,
+        )
 
-    def _upsert(self, eff: Upsert) -> Any:
+    def _upsert(self, eff: Upsert) -> tuple[Any, str]:
+        """Apply one upsert; return the row and how it resolved.
+
+        The outcome is `"created"`, `"written"` or `"skipped"` — see
+        :class:`ApplyReport` for what the three mean. Only the `skip_unchanged`
+        path can report `"skipped"`; `update_or_create` always writes.
+        """
         model = apps.get_model(eff.model_label)
         defaults = eff.defaults or {}
         if not self._skip_unchanged:
-            obj, _ = self._manager(model).update_or_create(
+            obj, was_created = self._manager(model).update_or_create(
                 **eff.lookup, defaults=defaults
             )
-            return obj
+            return obj, ("created" if was_created else "written")
         return self._upsert_skip_unchanged(model, eff.lookup, defaults)
 
     def _update(self, eff: Update) -> None:
@@ -134,7 +153,9 @@ class DjangoExecutor:
         model = apps.get_model(eff.model_label)
         self._manager(model).filter(**eff.lookup).update(**defaults)
 
-    def _upsert_skip_unchanged(self, model: type, lookup: dict, defaults: dict) -> Any:
+    def _upsert_skip_unchanged(
+        self, model: type, lookup: dict, defaults: dict
+    ) -> tuple[Any, str]:
         try:
             row = self._manager(model).get(**lookup)
         except model.DoesNotExist:
@@ -142,7 +163,7 @@ class DjangoExecutor:
             # dropping any lookup that isn't a concrete field assignment.
             params = {k: v for k, v in lookup.items() if "__" not in k}
             params.update(defaults)
-            return self._manager(model).create(**params)
+            return self._manager(model).create(**params), "created"
         # Compare through the field's canonical form, not raw ``!=`` (P4): the log
         # can carry a representation the column would round or re-type — a JSON
         # float for a DecimalField, a UUID string for a UUIDField — which is not a
@@ -159,11 +180,11 @@ class DjangoExecutor:
             != canonical_value(model, k, v)
         }
         if not changed:
-            return row  # nothing to write — skip the UPDATE entirely
+            return row, "skipped"  # nothing to write — skip the UPDATE entirely
         for field, value in changed.items():
             setattr(row, field, value)
         row.save(using=self._using, update_fields=list(changed))
-        return row
+        return row, "written"
 
     @staticmethod
     def _spare(qs: Any, spare_keys: list[dict[str, Any]] | None) -> Any:

--- a/src/django_rakaia/hermeticity.py
+++ b/src/django_rakaia/hermeticity.py
@@ -46,6 +46,35 @@ another alias. A ``DjangoStreamStore`` on ``default`` would itself trip the
 guard, which is correct: a truly hermetic rebuild reads its log from somewhere
 other than the database it is proving it can reconstruct.
 
+That is the whole obstacle in practice, and it is six lines to clear. Drain the
+durable log into memory *first*, with the guard down, then arm it around the
+replay alone::
+
+    durable = get_store()                       # DjangoStreamStore on "default"
+    mem = StreamStore()
+    mem.create(path)
+    messages, _has_more = durable.read(path)
+    for m in messages:
+        # m.data is already the encoded bytes — re-encoding double-wraps it.
+        mem.append(path, m.data,
+                   AppendOptions(label=m.label, metadata=m.metadata,
+                                 event_ts=m.event_ts))
+
+    with deny_database_access("default"):
+        replay(mem, path, DjangoExecutor(using="rebuild"),
+               reader=DjangoProjectionReader(using="rebuild"), ...)
+
+Worth stating because the first production consumer left this guard unwired for
+months, having recorded "a blanket deny on ``default`` trips on the store's own
+reads" as the blocker. It is not a blocker; it is the drain above.
+
+**A pass only means something if you have watched the guard fail.** Nothing here
+distinguishes "no handler read the database" from "the guard was never armed",
+so pair the run with a deliberate ambient read and check that it raises::
+
+    with deny_database_access("default"):
+        SomeModel.objects.filter(pk=1).exists()   # must raise AmbientDatabaseAccess
+
 See ADR 0003 (``docs/adr/0003-handler-hermeticity.md``).
 """
 

--- a/src/rakaia/effects.py
+++ b/src/rakaia/effects.py
@@ -381,16 +381,40 @@ class RefResolver:
 class ApplyReport:
     """What ``Executor.apply`` observed while applying a batch.
 
-    Currently carries ``retire_flips``: one ``(retire_effect, flipped_rows)``
-    entry per retire that opted into notifications (a :class:`Transition`),
-    where ``flipped_rows`` is the list of identity dicts for the rows whose
-    liveness sentinel actually went NULL->set. The orchestrator turns these into
-    one :class:`ExternalEffect` each. Executors that don't observe flips (or
-    predate this) may return ``None``; the orchestrator treats that as empty."""
+    ``retire_flips``: one ``(retire_effect, flipped_rows)`` entry per retire that
+    opted into notifications (a :class:`Transition`), where ``flipped_rows`` is the
+    list of identity dicts for the rows whose liveness sentinel actually went
+    NULL->set. The orchestrator turns these into one :class:`ExternalEffect` each.
+    Executors that don't observe flips (or predate this) may return ``None``; the
+    orchestrator treats that as empty.
+
+    ``upserts_created`` / ``upserts_written`` / ``upserts_skipped``: how the batch's
+    :class:`Upsert` effects resolved. ``created`` inserted a row, ``written`` issued
+    a write of either kind (so ``created`` is a subset of it), and ``skipped``
+    matched an existing row whose stored values already equalled the effect's — no
+    write issued. The three satisfy
+    ``written + skipped == <number of Upsert effects>``, and ``written - created``
+    is the number of updates.
+
+    **Scoped to :class:`Upsert` on purpose.** The question these answer is how much
+    write churn a replay actually caused, which is a property of the upsert path:
+    ``skip_unchanged`` is wired there and nowhere else, because :class:`Update`
+    already issues a single UPDATE that does not advance ``auto_now`` columns.
+    Deletes and retires are counted by their own effects.
+
+    Without ``skip_unchanged`` an executor writes unconditionally, so ``skipped`` is
+    0 and ``written`` equals the upsert count. A non-zero ``skipped`` is the
+    measurement that was previously unobservable: the executor computed which
+    columns changed and then discarded the answer, so a consumer could not tell a
+    replay that rewrote every row from one that wrote nothing — both reported the
+    same converged state."""
 
     retire_flips: list[tuple[Retire, list[dict[str, Any]]]] = dc_field(
         default_factory=list
     )
+    upserts_created: int = 0
+    upserts_written: int = 0
+    upserts_skipped: int = 0
 
 
 @runtime_checkable

--- a/src/rakaia/executors.py
+++ b/src/rakaia/executors.py
@@ -134,12 +134,18 @@ class InMemoryProjections:
         # and a sibling's Ref values are substituted before that sibling applies.
         resolver = RefResolver()
         retire_flips: list[tuple[Retire, list[dict[str, Any]]]] = []
+        created = written = 0
         # Writes first, then deletes, then retires — so a reconcile batch
         # converges regardless of the order its handlers emitted, and a produces=
         # row is recorded before any later effect Refs it.
         for eff in effects_list:
             if isinstance(eff, Upsert):
-                self._upsert(resolver, resolver.resolve_effect(eff))
+                # No skip_unchanged here, so every upsert writes: `skipped` stays
+                # 0 and `written` counts them all, which is what the Django
+                # executor also reports when the option is off.
+                if self._upsert(resolver, resolver.resolve_effect(eff)) == "created":
+                    created += 1
+                written += 1
             elif isinstance(eff, Update):
                 self._update(resolver.resolve_effect(eff))
         for eff in effects_list:
@@ -151,15 +157,26 @@ class InMemoryProjections:
                 flipped = self._retire(reff)
                 if reff.transition is not None:
                     retire_flips.append((reff, flipped))
-        return ApplyReport(retire_flips=retire_flips)
+        return ApplyReport(
+            retire_flips=retire_flips,
+            upserts_created=created,
+            upserts_written=written,
+            upserts_skipped=0,
+        )
 
-    def _upsert(self, resolver: RefResolver, eff: Upsert) -> None:
+    def _upsert(self, resolver: RefResolver, eff: Upsert) -> str:
+        """Apply one upsert; return `"created"` or `"written"`.
+
+        Never `"skipped"` — that outcome belongs to `skip_unchanged`, which this
+        executor does not implement (it holds no columns to compare against).
+        """
         label = eff.model_label
         lookup = eff.lookup
         existing = self._find(label, lookup)
         if existing:
             row = existing[0]
             row.update(eff.defaults or {})
+            outcome = "written"
         else:
             # Mirror update_or_create's create path: the lookup's concrete field
             # assignments plus defaults, dropping any operator lookup.
@@ -168,6 +185,7 @@ class InMemoryProjections:
             row.update(eff.defaults or {})
             self._table(label)[self._next_pk] = row
             self._next_pk += 1
+            outcome = "created"
         if eff.produces is not None:
             # Let a sibling Ref bind to this row's pk (or any other column).
             resolver.record(
@@ -176,6 +194,7 @@ class InMemoryProjections:
                     row["pk"] if field in ("pk", "id") else row.get(field)
                 ),
             )
+        return outcome
 
     def _update(self, eff: Update) -> None:
         """Update-if-exists: never mints a row (the multi-owner primitive)."""

--- a/tests/executor_contract.py
+++ b/tests/executor_contract.py
@@ -461,6 +461,60 @@ class ExecutorContract:
         row = seam.reader.get(seam.model, field_key="a")
         assert (row.severity, row.message) == ("error", "from the other owner")
 
+    # -- upsert accounting ---------------------------------------------------
+
+    def test_upsert_counts_separate_inserts_from_updates(self, seam):
+        """`upserts_created` counts inserts, `upserts_written` counts every upsert
+        that issued a write, and both agree with what actually happened: a first
+        apply creates the rows, a second one updates them.
+
+        `upserts_skipped` is 0 for an executor that writes unconditionally, which
+        is every binding here except `DjangoExecutor(skip_unchanged=True)` — that
+        one has its own case. The invariant holding everywhere is
+        `written + skipped == <number of upsert effects>`.
+        """
+        first = seam.executor.apply([self._upsert(seam, "a"), self._upsert(seam, "b")])
+        if first is not None:
+            assert (first.upserts_created, first.upserts_written) == (2, 2)
+            assert first.upserts_written + first.upserts_skipped == 2
+
+        # Same natural keys, one changed column: updates, so nothing is created.
+        second = seam.executor.apply(
+            [
+                self._upsert(seam, "a", message="changed"),
+                self._upsert(seam, "b", message="changed"),
+            ]
+        )
+        if second is not None:
+            assert second.upserts_created == 0
+            assert second.upserts_written + second.upserts_skipped == 2
+
+    def test_upsert_counts_ignore_the_other_ops(self, seam):
+        """The counts are scoped to `update_or_create`. A batch of in-place
+        updates and deletes leaves all three at 0 — otherwise "how much write
+        churn did this replay cause" would fold in ops whose cost is a different
+        question, and `skip_unchanged` is wired to the upsert path alone."""
+        seam.executor.apply([self._upsert(seam, "a")])
+        report = seam.executor.apply(
+            [
+                Update(
+                    model_label=seam.model,
+                    lookup={"stream_key": "s", "field_key": "a"},
+                    defaults={"message": "patched"},
+                ),
+                Delete(
+                    model_label=seam.model,
+                    lookup={"stream_key": "s", "field_key": "zzz"},
+                ),
+            ]
+        )
+        if report is not None:
+            assert (
+                report.upserts_created,
+                report.upserts_written,
+                report.upserts_skipped,
+            ) == (0, 0, 0)
+
     # -- retire flips -------------------------------------------------------
 
     def test_retire_flips_reported_only_when_notifications_were_asked_for(self, seam):

--- a/tests/test_django_rakaia/test_executor_contract.py
+++ b/tests/test_django_rakaia/test_executor_contract.py
@@ -37,3 +37,35 @@ class TestDjangoExecutorSkipUnchangedContract(ExecutorContract):
             reader=DjangoProjectionReader(),
             model="test_django_rakaia.Alert",
         )
+
+    def test_reapplying_an_identical_batch_is_reported_as_skipped(self, seam):
+        """The one executor that can skip, doing so — and saying so.
+
+        This is the counter's reason to exist. `skip_unchanged` already computed
+        which columns differed and then threw the answer away, so a replay that
+        rewrote every row and one that wrote nothing reported the same thing:
+        converged state, and silence. A consumer measuring write churn had no
+        signal at all. Now an identical second apply reports every upsert
+        skipped and none written.
+        """
+        effects = [self._upsert(seam, "a"), self._upsert(seam, "b")]
+
+        first = seam.executor.apply(effects)
+        assert (
+            first.upserts_created,
+            first.upserts_written,
+            first.upserts_skipped,
+        ) == (2, 2, 0)
+
+        # A byte-identical batch against the rows it just wrote: nothing to do.
+        again = seam.executor.apply(effects)
+        assert (
+            again.upserts_created,
+            again.upserts_written,
+            again.upserts_skipped,
+        ) == (0, 0, 2)
+
+        # A genuine change is still written, so `skipped` tracks the data rather
+        # than merely counting repeat applies.
+        changed = seam.executor.apply([self._upsert(seam, "a", message="different")])
+        assert (changed.upserts_written, changed.upserts_skipped) == (1, 0)


### PR DESCRIPTION
Findings from a pre-release shakedown: partisipa (the only production consumer) was repinned to `origin/main` and its full event history replayed twice against production-data clones — control on published 0.1.0, experiment on main. Four of the recommendations that came out of it, three docs and one small feature.

### Tell a published-0.1.0 consumer what they are actually crossing

`UPGRADING.md` is keyed to the revisions changes landed in, which is right for a SHA-pinned consumer and wrong for the only consumer PyPI can produce. `v0.1.0` is `f676302` — `5e4a6e3` plus the #80 fixes and the packaging commit — so someone on published 0.1.0 already has the distribution rename and migration `0006` behind them, and two of that section's three items do not apply to them.

Adds a "start here" section under the 0.2.0 heading, leading with the break that matters and the reason it is easy to miss: in the first production consumer every `store.get()` call sat behind an `if store.has(path):` guard, so on an empty database the branch is never taken and the upgrade looks clean. It fires on the *second* `--reset`. **Anyone validating this upgrade against a fresh database will conclude it is clean and ship the break** — measured, with the traceback.

Also records what `0007` costs: free on a fresh install (a consumer whose database had never installed `django_rakaia` measured the whole `0001..0008` at 8 seconds against empty tables) and proportional to log size otherwise — the same deployment held 95,635 events across 31 streams an hour later.

### State the drain-to-memory recipe, not just the rule

`hermeticity.py` already said the event source must not read the denied alias. The rule was not enough: the only production consumer left the read guard unwired for months, recording "a blanket deny on `default` trips on the store's own reads" as the blocker. It is not a blocker, it is a six-line drain — shown here, and demonstrated on a production clone (845 events replayed with the guard armed, plus a positive control confirming the guard fires).

### Bound advice for a consumer outside Tier 1

`>=0.2,<0.3` is right for Tier 1. The one real consumer is on Tier 2 — direct `StreamEntry`/`Stream` ORM queries — plus one underscore-prefixed symbol, so `==0.2.*` is the honest recommendation for that case. Adds two questions that settle which case you are in, and a warning not to verify an upgrade by reading `__version__`: two revisions a release apart can report the same number, so check `direct_url.json`. That is not hypothetical — it is what `uv lock` printed during the shakedown (`v0.1.0 -> v0.1.0 (a8a337a2)`).

### `ApplyReport` says how much a batch actually wrote

`skip_unchanged` computes exactly which columns differ and then discards the answer, so a replay that rewrote every row and one that wrote nothing report the same thing: converged state, and silence. Adds `upserts_created` / `upserts_written` / `upserts_skipped`, scoped to `Upsert` because that is where `skip_unchanged` is wired.

Pinned in `tests/executor_contract.py` the way `retire_flips` is, plus a case on the `skip_unchanged` binding for the outcome only it can produce. **Both were watched failing before being kept** — the contract case caught a real defect on its first run (`InMemoryProjections._upsert` had gained the return type and not the return), and the skip case was confirmed by flipping `"skipped"` to `"written"` in the executor and seeing it go red.

---

Rebased onto `4bfd392`, after #142 reshaped `Effect`; the counts are expressed against the `Upsert` variant. `ruff`, `ruff format`, **1379 passed**, `pyright` clean on the touched modules, `zensical build` clean.
