### PR TITLE
Run the test suite against Postgres, so the row locking is actually exercised

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,65 @@ jobs:
       - name: Build docs
         run: uv run zensical build
 
+  test-postgres:
+    # A second run of the same suite against a real Postgres. It exists because
+    # SQLite makes `select_for_update()` a no-op: Django's SQL compiler emits
+    # `FOR UPDATE` only when `connection.features.has_select_for_update` is
+    # true, and the SQLite backend leaves it false. So on the `test` job above,
+    # every row lock in django_rakaia is silently skipped, and the
+    # `TransactionManagementError` that enforces "select_for_update must be
+    # inside a transaction" can never fire either.
+    #
+    # Deliberately a separate job, not extra steps on `test`: it needs a
+    # service container and takes longer, and the SQLite run is the one that has
+    # to stay fast and green.
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    services:
+      postgres:
+        # Pinned to a major on purpose. `postgres:latest` would move the suite
+        # onto a new major the day one is released, turning an unrelated PR red
+        # for reasons no one changed. 16 is the major this leg was developed
+        # and verified against, and it is in community support until late 2028,
+        # so the pin will not need touching soon. Bump it deliberately.
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        ports:
+          - 5432:5432
+        # Without a health check the job can start psql-ing before the server
+        # accepts connections; the runner holds the job until this passes.
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      RAKAIA_TEST_DB: postgres
+      PGHOST: 127.0.0.1
+      PGPORT: 5432
+      PGUSER: postgres
+      PGPASSWORD: postgres
+      PGDATABASE: postgres
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: astral-sh/setup-uv@v9.0.0
+        with:
+          enable-cache: true
+          version: "0.9.22"
+
+      - name: Set up Python 3.12
+        run: uv python install 3.12
+
+      - name: Install dependencies
+        run: uv sync --extra dev --extra django --extra postgres
+
+      - name: Run tests against Postgres
+        run: uv run pytest
+
   demos:
     # The examples are a tested surface, not a directory of prose. Every demo
     # asserts its own claims and exits non-zero when one does not hold, so this

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,17 @@
   with `No module named pytest` until the extras are synced.
 - CI (`.github/workflows/ci.yml`) runs `ruff check`, `ruff format --check`,
   `pyright src/`, `pytest`, and `zensical build`; run those before pushing.
+- **Postgres leg.** The default `pytest` run is SQLite, where every
+  `select_for_update()` in `django_rakaia` is a no-op — Django emits
+  `FOR UPDATE` only when the backend reports `has_select_for_update`, and the
+  SQLite backend does not. A second CI job (`test-postgres`) runs the same
+  suite against Postgres 16. Locally: `just test-pg` (starts a podman
+  container and sets `RAKAIA_TEST_DB=postgres`), or set `RAKAIA_TEST_DB` and
+  the `PG*` variables yourself. Needs `uv sync --extra postgres`.
+  Anything that asserts locking or concurrency must also be marked
+  `django_db(transaction=True)`; a plain `django_db` test runs inside a
+  transaction pytest-django rolls back, so a lock taken outside the code's own
+  `atomic()` still looks fine and a second connection can never see the rows.
 - **pyright is a hard gate** and `src/` is expected at zero errors. Run it as
   `PYRIGHT_PYTHON_FORCE_VERSION=latest uv run pyright src/` locally — plain
   `uv run pyright` can object to its own pinned version. Django's synthesised

--- a/justfile
+++ b/justfile
@@ -21,6 +21,12 @@ REDIS_IMAGE     := env_var_or_default("REDIS_IMAGE", "docker.io/redis:7-alpine")
 REDIS_PORT      := env_var_or_default("REDIS_PORT", "6379")
 REDIS_URL       := env_var_or_default("REDIS_URL", "redis://localhost:" + REDIS_PORT + "/0")
 
+# Throwaway Postgres for `just test-pg`. Pinned to the same major as the
+# `test-postgres` CI job so a local pass means the same thing as a CI pass.
+PG_CONTAINER    := env_var_or_default("PG_CONTAINER", "rakaia-test-pg")
+PG_IMAGE        := env_var_or_default("PG_IMAGE", "docker.io/library/postgres:16-alpine")
+PG_PORT         := env_var_or_default("PG_PORT", "55432")
+
 # Where the chat sample lives. The justfile recipes change into this dir
 # so manage.py / hypercorn / chat_project.* imports all resolve.
 CHAT_DIR        := "examples/chat"
@@ -363,6 +369,33 @@ conformance-baseline port="4437":
 # Run the test suite
 test:
     uv run pytest
+
+# Start a throwaway Postgres for `just test-pg` (idempotent)
+pg-up:
+    @podman start {{PG_CONTAINER}} 2>/dev/null \
+        || podman run -d --name {{PG_CONTAINER}} \
+                      -e POSTGRES_USER=postgres \
+                      -e POSTGRES_PASSWORD=postgres \
+                      -e POSTGRES_DB=postgres \
+                      -p {{PG_PORT}}:5432 \
+                      {{PG_IMAGE}}
+    @podman ps --filter name={{PG_CONTAINER}}
+
+# Stop and remove the test Postgres
+pg-down:
+    -podman stop {{PG_CONTAINER}}
+    -podman rm {{PG_CONTAINER}}
+
+# Run the test suite against Postgres instead of SQLite.
+#
+# This is the run that makes select_for_update() do anything: Django emits
+# FOR UPDATE only when the backend reports has_select_for_update, and SQLite
+# does not, so on the default `just test` every row lock in django_rakaia is
+# silently skipped. Mirrors the `test-postgres` CI job.
+test-pg *ARGS: pg-up
+    RAKAIA_TEST_DB=postgres PGHOST=127.0.0.1 PGPORT={{PG_PORT}} \
+    PGUSER=postgres PGPASSWORD=postgres PGDATABASE=postgres \
+    uv run pytest {{ARGS}}
 
 # Run the test suite with coverage
 test-cov:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,13 @@ dev = [
     "django-types>=0.23.0",
     "pytest-django>=4.9.0",
 ]
+postgres = [
+    # Only needed to run the test suite with RAKAIA_TEST_DB=postgres, which is
+    # what makes the select_for_update() calls in django_rakaia actually emit
+    # FOR UPDATE. Kept out of `dev` so the default SQLite run stays free of a
+    # compiled driver.
+    "psycopg[binary]>=3.1",
+]
 docs = [
     "zensical>=0.0.51",
     "markdown>=3.10.2",

--- a/tests/test_django_rakaia/settings.py
+++ b/tests/test_django_rakaia/settings.py
@@ -1,10 +1,60 @@
-DATABASES = {
-    "default": {"ENGINE": "django.db.backends.sqlite3", "NAME": ":memory:"},
-    # A second in-memory alias used by the `using=` seam tests — a disposable
-    # database a from-scratch rebuild can be replayed into without touching
-    # `default` (see test_using_seam.py; #68 item 2).
-    "overlay": {"ENGINE": "django.db.backends.sqlite3", "NAME": ":memory:"},
-}
+import os
+
+# Which database the suite runs against. Unset (or anything other than
+# "postgres") keeps the historical in-memory SQLite behaviour, so a plain
+# `pytest` is unchanged. `RAKAIA_TEST_DB=postgres` points the same suite at a
+# real Postgres, which is the only way the `select_for_update()` calls in
+# `models.py`, `django_store.py` and `effect_executor.py` do anything at all:
+# Django's SQL compiler emits `FOR UPDATE` only when
+# `connection.features.has_select_for_update` is true, and the SQLite backend
+# leaves it false, so on SQLite every one of those calls is a silent no-op and
+# the "must be inside a transaction" TransactionManagementError never fires.
+#
+# Django settings reference for DATABASES / TEST:
+#   https://docs.djangoproject.com/en/6.0/ref/settings/#databases
+#   https://docs.djangoproject.com/en/6.0/ref/settings/#test
+# pytest-django creates and (with --reuse-db) reuses the test databases named
+# by DATABASES[alias]["TEST"]["NAME"]:
+#   https://pytest-django.readthedocs.io/en/latest/database.html
+RAKAIA_TEST_DB = os.environ.get("RAKAIA_TEST_DB", "sqlite")
+
+
+def _postgres(test_name: str) -> dict[str, object]:
+    """One Postgres alias, configured entirely from the environment.
+
+    The connection parameters use the standard libpq environment variable
+    names so the same settings module works against a GitHub Actions
+    `services:` container, a local podman container, or a developer's own
+    server without editing anything.
+    """
+    return {
+        "ENGINE": "django.db.backends.postgresql",
+        "NAME": os.environ.get("PGDATABASE", "postgres"),
+        "USER": os.environ.get("PGUSER", "postgres"),
+        "PASSWORD": os.environ.get("PGPASSWORD", "postgres"),
+        "HOST": os.environ.get("PGHOST", "127.0.0.1"),
+        "PORT": os.environ.get("PGPORT", "5432"),
+        # Each alias needs its own test database. Without an explicit TEST
+        # NAME both aliases would derive `test_postgres` from the same NAME
+        # and the second would clobber the first.
+        "TEST": {"NAME": test_name},
+    }
+
+
+if RAKAIA_TEST_DB == "postgres":
+    DATABASES = {
+        "default": _postgres("test_rakaia"),
+        # See the SQLite branch below for what `overlay` is for.
+        "overlay": _postgres("test_rakaia_overlay"),
+    }
+else:
+    DATABASES = {
+        "default": {"ENGINE": "django.db.backends.sqlite3", "NAME": ":memory:"},
+        # A second in-memory alias used by the `using=` seam tests — a disposable
+        # database a from-scratch rebuild can be replayed into without touching
+        # `default` (see test_using_seam.py; #68 item 2).
+        "overlay": {"ENGINE": "django.db.backends.sqlite3", "NAME": ":memory:"},
+    }
 INSTALLED_APPS = [
     "daphne",
     "channels",

--- a/tests/test_django_rakaia/test_alerts.py
+++ b/tests/test_django_rakaia/test_alerts.py
@@ -318,7 +318,11 @@ class TestMachineReconciledAlerts:
         assert row.resolved_at == "t4"
 
 
-@pytest.mark.django_db
+# transaction=True: the retire-with-transition path takes a real row lock
+# (`select_for_update()` in DjangoExecutor._retire) to keep the reported flip
+# set in step with the rows the UPDATE flips. Only a committing test can hold
+# that lock to its actual contract.
+@pytest.mark.django_db(transaction=True)
 class TestRetireFlipReport:
     """Issue #32 R3: the executor reports which rows a retire actually flipped
     (NULL->set) so the orchestrator can emit one transition per real resolution.
@@ -372,7 +376,11 @@ class TestRetireFlipReport:
         assert report.retire_flips == []
 
 
-@pytest.mark.django_db
+# transaction=True: the retire-with-transition path takes a real row lock
+# (`select_for_update()` in DjangoExecutor._retire) to keep the reported flip
+# set in step with the rows the UPDATE flips. Only a committing test can hold
+# that lock to its actual contract.
+@pytest.mark.django_db(transaction=True)
 class TestMachineResolutionTransitions:
     """Issue #32 R4 (headline): replaying machine reconciles produces exactly one
     ``alert_transition`` per *real* resolution, returned to the caller in

--- a/tests/test_django_rakaia/test_concurrent_appends.py
+++ b/tests/test_django_rakaia/test_concurrent_appends.py
@@ -1,0 +1,160 @@
+"""Two connections racing to append to one stream.
+
+Everything else in this suite tests the durable store from a single
+connection, which cannot observe the property offset allocation actually
+promises: that two writers hitting the same stream at the same moment get
+*different* offsets. That promise rests on the ``select_for_update()`` in
+``Stream.get_next_offset_block`` — and on SQLite that call compiles to nothing
+at all, because Django emits ``FOR UPDATE`` only when
+``connection.features.has_select_for_update`` is true and the SQLite backend
+leaves it false.
+
+So these tests are skipped on SQLite. Not because they are slow or awkward
+there, but because SQLite genuinely cannot answer the question: it has no row
+locks, and it serialises writers with a whole-database write lock that hides
+the defect behind a lock-timeout error instead of surfacing it as a duplicate
+offset. Run them with ``RAKAIA_TEST_DB=postgres`` (the ``test-postgres`` CI
+job) to get a real answer.
+
+They also require ``django_db(transaction=True)``. Under a plain ``django_db``
+test pytest-django wraps the whole test in one transaction on one connection
+and rolls it back, so a second connection could never see the rows the first
+one wrote, and the race would not exist to begin with.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from typing import Any
+
+import pytest
+from django.db import connection, connections, transaction
+
+from django_rakaia.django_store import DjangoStreamStore
+from django_rakaia.models import Stream, StreamEntry
+
+requires_row_locks = pytest.mark.skipif(
+    not connection.features.has_select_for_update,
+    reason=(
+        "backend has no row locks (has_select_for_update is False), so "
+        "select_for_update() compiles to a plain SELECT and the race cannot "
+        "be observed -- run with RAKAIA_TEST_DB=postgres"
+    ),
+)
+
+PATH = "race"
+
+
+def _run(*targets: Any) -> None:
+    """Run each callable on its own thread and re-raise the first failure.
+
+    Each thread gets its own database connection, which is the whole point;
+    each also has to close it, or the test database cannot be torn down.
+    """
+    errors: list[BaseException] = []
+
+    def wrap(fn: Any) -> Any:
+        def inner() -> None:
+            try:
+                fn()
+            except BaseException as exc:  # noqa: BLE001 - re-raised below
+                errors.append(exc)
+            finally:
+                connections.close_all()
+
+        return inner
+
+    threads = [threading.Thread(target=wrap(t)) for t in targets]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=30)
+    for t in threads:
+        assert not t.is_alive(), "a racing thread deadlocked"
+    if errors:
+        raise errors[0]
+
+
+@requires_row_locks
+@pytest.mark.django_db(transaction=True)
+def test_a_second_writer_blocks_on_the_offset_watermark() -> None:
+    """The forced-interleave case: B must not read A's watermark mid-flight.
+
+    Thread A allocates an offset and then *holds its transaction open* while
+    thread B tries to allocate one. If the watermark row is genuinely locked,
+    B blocks until A commits and then reads the advanced high-water mark. If
+    it is not, B reads the pre-A value and hands out the offset A already
+    took -- two events at the same offset in the same stream, which the
+    unique constraint would reject at insert time in production.
+    """
+    DjangoStreamStore().create(PATH)
+
+    got: dict[str, int] = {}
+    a_allocated = threading.Event()
+    b_started = threading.Event()
+
+    def writer_a() -> None:
+        with transaction.atomic():
+            stream = Stream.objects.get(stream_id=PATH)
+            got["a"] = stream.get_next_offset_block(1)
+            a_allocated.set()
+            # Stay inside the transaction until B has had a fair chance to
+            # reach the lock. The sleep is what makes the interleave real
+            # rather than accidental.
+            assert b_started.wait(timeout=10)
+            time.sleep(0.5)
+
+    def writer_b() -> None:
+        assert a_allocated.wait(timeout=10)
+        b_started.set()
+        with transaction.atomic():
+            stream = Stream.objects.get(stream_id=PATH)
+            got["b"] = stream.get_next_offset_block(1)
+
+    _run(writer_a, writer_b)
+
+    assert sorted(got.values()) == [1, 2], (
+        f"two connections were handed overlapping offsets: {got}. "
+        "The watermark row lock did not hold."
+    )
+
+
+@requires_row_locks
+@pytest.mark.django_db(transaction=True)
+def test_many_concurrent_appends_produce_no_duplicate_offsets() -> None:
+    """The realistic case: four writers appending to one stream at once.
+
+    No barriers, no orchestration -- just contention. Every append must land
+    at its own offset, and the set of offsets must be exactly 1..N with no
+    gaps, because allocation is a contiguous reservation and not a
+    best-effort guess.
+    """
+    store = DjangoStreamStore()
+    store.create(PATH)
+
+    writers = 4
+    per_writer = 15
+    ready = threading.Barrier(writers)
+
+    def writer(n: int) -> Any:
+        def inner() -> None:
+            # Start together, so the appends actually overlap.
+            ready.wait(timeout=10)
+            for i in range(per_writer):
+                store.append(PATH, f'{{"w": {n}, "i": {i}}}'.encode())
+
+        return inner
+
+    _run(*[writer(n) for n in range(writers)])
+
+    offsets = sorted(
+        StreamEntry.objects.filter(stream__stream_id=PATH).values_list(
+            "offset", flat=True
+        )
+    )
+    total = writers * per_writer
+    assert offsets == list(range(1, total + 1)), (
+        f"expected offsets 1..{total} with no duplicates or gaps, got "
+        f"{len(offsets)} offsets ending {offsets[-5:] if offsets else []}"
+    )

--- a/tests/test_django_rakaia/test_django_store.py
+++ b/tests/test_django_rakaia/test_django_store.py
@@ -23,7 +23,14 @@ from rakaia.seed import seed_stream
 from rakaia.types import AppendOptions, SequenceConflict, StreamConfigConflict
 
 
-@pytest.mark.django_db
+# transaction=True so this module's `select_for_update()` calls are held to
+# their real contract on Postgres. A plain `django_db` test runs inside an
+# outer transaction that pytest-django rolls back, which means a lock taken
+# outside the code's own `transaction.atomic()` would still look fine --
+# Django only raises TransactionManagementError when there is genuinely no
+# transaction open. It is also the only mode in which another connection can
+# see this test's committed rows, which is what a concurrency test needs.
+@pytest.mark.django_db(transaction=True)
 class TestDjangoStreamStore:
     # The shared read/append/create/has surface (create-idempotence, append-
     # requires-stream, ordered round-trip, partial read, envelope round-trip,
@@ -378,7 +385,14 @@ class TestDjangoStreamStore:
             stream.get_next_offset_block(0)
 
 
-@pytest.mark.django_db
+# transaction=True so this module's `select_for_update()` calls are held to
+# their real contract on Postgres. A plain `django_db` test runs inside an
+# outer transaction that pytest-django rolls back, which means a lock taken
+# outside the code's own `transaction.atomic()` would still look fine --
+# Django only raises TransactionManagementError when there is genuinely no
+# transaction open. It is also the only mode in which another connection can
+# see this test's committed rows, which is what a concurrency test needs.
+@pytest.mark.django_db(transaction=True)
 class TestDjangoStreamStoreReplay:
     def _register(self) -> HandlerRegistry:
         reg = HandlerRegistry()
@@ -410,7 +424,14 @@ class TestDjangoStreamStoreReplay:
         ]
 
 
-@pytest.mark.django_db
+# transaction=True so this module's `select_for_update()` calls are held to
+# their real contract on Postgres. A plain `django_db` test runs inside an
+# outer transaction that pytest-django rolls back, which means a lock taken
+# outside the code's own `transaction.atomic()` would still look fine --
+# Django only raises TransactionManagementError when there is genuinely no
+# transaction open. It is also the only mode in which another connection can
+# see this test's committed rows, which is what a concurrency test needs.
+@pytest.mark.django_db(transaction=True)
 def test_get_store_returns_durable_when_setting_set(settings):
     from django_rakaia.store import get_store
 
@@ -418,7 +439,14 @@ def test_get_store_returns_durable_when_setting_set(settings):
     assert isinstance(get_store(), DjangoStreamStore)
 
 
-@pytest.mark.django_db
+# transaction=True so this module's `select_for_update()` calls are held to
+# their real contract on Postgres. A plain `django_db` test runs inside an
+# outer transaction that pytest-django rolls back, which means a lock taken
+# outside the code's own `transaction.atomic()` would still look fine --
+# Django only raises TransactionManagementError when there is genuinely no
+# transaction open. It is also the only mode in which another connection can
+# see this test's committed rows, which is what a concurrency test needs.
+@pytest.mark.django_db(transaction=True)
 class TestExpiryReaping:
     def test_a_refused_append_still_reaps_the_expired_row(self):
         """The reap must run outside the write transaction.

--- a/tests/test_django_rakaia/test_hermeticity.py
+++ b/tests/test_django_rakaia/test_hermeticity.py
@@ -118,3 +118,73 @@ class TestDenyDatabaseAccess:
             .filter(submission_id="Epsilon")
             .exists()
         )
+
+
+# ---------------------------------------------------------------------------
+# Does the guard survive the thread hop in DjangoStreamStore.run_sync?
+# ---------------------------------------------------------------------------
+#
+# `deny_database_access` works by installing an `execute_wrapper` on a
+# connection. Django stores connections in a thread-local
+# (`ConnectionHandler` uses `asgiref.local.Local(thread_critical=True)`), so a
+# different thread gets a *different* connection object with its own, empty,
+# `execute_wrappers` list.
+#
+# `DjangoStreamStore.run_sync` deliberately moves ORM work onto another thread
+# (`sync_to_async(..., thread_sensitive=True)`), because Django refuses ORM
+# access from an async context. Those two facts are in tension, and the tests
+# below record which one wins rather than assuming.
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "KNOWN GAP: deny_database_access is thread-local, so a write issued "
+        "through DjangoStreamStore.run_sync steps straight past it and the "
+        "gate stays green. Left failing on purpose -- fixing it means changing "
+        "the guard, not the test. See the note above."
+    ),
+)
+@pytest.mark.django_db(transaction=True)
+async def test_deny_database_access_should_block_a_write_through_run_sync():
+    """What the guard would have to do to be safe around async store work.
+
+    It does not do it today. `deny_database_access` installs an
+    `execute_wrapper` on `connections["default"]`, and that connection object
+    is thread-local; `run_sync` hands the ORM call to another thread, which
+    resolves `connections["default"]` to a *different* connection with an
+    empty wrapper list. The append is executed, committed, and never seen.
+
+    Scope: the guard is documented for a *synchronous* replay -- `with
+    deny_database_access("default"): replay(...)` -- which is how every
+    example and every other test uses it, and where it does hold (see the
+    control test below). Nothing in the codebase arms it around `await`-ed
+    store work today, so this is a sharp edge in the guard's contract rather
+    than a live hole in the rebuild gate. It becomes a real hole the moment
+    someone wraps an async rebuild in it, and it fails silently when they do,
+    which is the dangerous shape.
+    """
+    from django_rakaia.django_store import DjangoStreamStore
+    from django_rakaia.models import StreamEntry
+
+    store = DjangoStreamStore()
+    await store.run_sync(store.create, "guarded")
+
+    with deny_database_access("default"), pytest.raises(AmbientDatabaseAccess):
+        await store.run_sync(store.append, "guarded", b'{"x": 1}')
+
+    # Reached only if the guard did not raise: the write really landed, so the
+    # leak is a completed write and not merely a query that dodged the wrapper.
+    assert await StreamEntry.objects.filter(stream__stream_id="guarded").acount() == 0
+
+
+@pytest.mark.django_db(transaction=True)
+def test_deny_database_access_does_hold_on_the_calling_thread():
+    """The control for the test above: same guard, no thread hop, blocks."""
+    from django_rakaia.django_store import DjangoStreamStore
+
+    store = DjangoStreamStore()
+    store.create("guarded-sync")
+
+    with deny_database_access("default"), pytest.raises(AmbientDatabaseAccess):
+        store.append("guarded-sync", b'{"x": 1}')

--- a/uv.lock
+++ b/uv.lock
@@ -928,6 +928,86 @@ wheels = [
 ]
 
 [[package]]
+name = "psycopg"
+version = "3.3.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/db/2f/cb91e5502ec9de1de6f1b76cfbf69531932725361168bb06963620c77e2e/psycopg-3.3.4.tar.gz", hash = "sha256:e21207764952cff81b6b8bdacad9a3939f2793367fdac2987b3aac36a651b5bc", size = 165799, upload-time = "2026-05-01T23:31:55.179Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/e0/7b3dee031daae7743609ce3c746565d4a3ed7c2c186479eb48e34e838c64/psycopg-3.3.4-py3-none-any.whl", hash = "sha256:b6bbc25ccf05c8fad3b061d9db2ef0909a555171b84b07f29458a447253d679a", size = 213001, upload-time = "2026-05-01T23:20:50.816Z" },
+]
+
+[package.optional-dependencies]
+binary = [
+    { name = "psycopg-binary", marker = "implementation_name != 'pypy'" },
+]
+
+[[package]]
+name = "psycopg-binary"
+version = "3.3.4"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/bf/70d8a60488f9955cbbcd538beae44d56bb2f1d19e673b72788f2d343ff55/psycopg_binary-3.3.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:b7bfff1ca23732b488cbca3076fc11bc98d520ee122514fdb17a8e20d3338f5a", size = 4609750, upload-time = "2026-05-01T23:24:20.06Z" },
+    { url = "https://files.pythonhosted.org/packages/db/b0/29e98ba210c9dbc75a6dc91e3f99b9e06ea901a62ca95804e02a1ae13e6b/psycopg_binary-3.3.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:32a6fbf8481e3a370d0d72b860d35948a693cb01281da217f7b2f307636e591a", size = 4676700, upload-time = "2026-05-01T23:25:21.727Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/ab/3df087b3c12bf74e47c08204172b2fabb5a144679110d5c7ad12d9201323/psycopg_binary-3.3.4-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:bdef84570ebbce1d42b4e7ea952d21c414c5f118ad02fee00c5625f35e134429", size = 5496319, upload-time = "2026-05-01T23:25:28.271Z" },
+    { url = "https://files.pythonhosted.org/packages/87/9a/f088207b4cd6772f9e0d8a91807e79fa2458d4eb9eb1ae406c68415f2bec/psycopg_binary-3.3.4-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fa1cbc10768a796c96d3243656016bf4e337c81c71097270bb7b0ad6210d9765", size = 5171906, upload-time = "2026-05-01T23:25:34.004Z" },
+    { url = "https://files.pythonhosted.org/packages/48/45/4523a857f253871d75c22e1c2e79fd47e599e736bcba1bad58d83e24be02/psycopg_binary-3.3.4-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cf7f73a4a792bc5db58a4b385d8a1467e8d468f7548702fb0ed1e9b7501b1c13", size = 6762621, upload-time = "2026-05-01T23:25:41.392Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/d1/925bf776503345bef428e6c45fb017d0139ddbe0e211814b585c4253dca8/psycopg_binary-3.3.4-cp310-cp310-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d7b4d40c153fa352ab3cca530f3a0baedf7621b2ebcbd7f084009522c21788fc", size = 5006319, upload-time = "2026-05-01T23:25:51.419Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/aa/99727337206fbba357ca084bf4ea8b29dc986f61842a2685859af61416db/psycopg_binary-3.3.4-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:f9b1c2533af01cd7648378599f82b0b8ae32f293296e6eec5753a625bc97ef28", size = 4535388, upload-time = "2026-05-01T23:25:57.957Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/a4/567ba2c37d19d8c2f63d836385dfd2495aa5897bbee6cfab104d9ee58624/psycopg_binary-3.3.4-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:ad3bc94054876155549fdaedf4a46d1ec69d39a5bcee377148afe498e84c4b8e", size = 4224544, upload-time = "2026-05-01T23:26:03.832Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/23/86457f5a82731685d7701de7bfaa5eb783dd1fecbf875321897d9d9ce33a/psycopg_binary-3.3.4-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:eb4eed2079c01a4850bf467deacfab56d356d4225040170af03dc9958321242d", size = 3956282, upload-time = "2026-05-01T23:26:09.983Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/d8/249456df16d47de082abd9b73bce8ccdeb0293eb12e590f9150c7cbdb788/psycopg_binary-3.3.4-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:f80e3f2b5331dbbf0901bcb658056c03eeb2c1ef31d774afb0d61598b242e744", size = 4261736, upload-time = "2026-05-01T23:26:16.798Z" },
+    { url = "https://files.pythonhosted.org/packages/15/6b/c4abe228acafd8a385c1fb615d4f1e3c9b8ad7a4e4f0e84118ba3ffeed9c/psycopg_binary-3.3.4-cp310-cp310-win_amd64.whl", hash = "sha256:574ea21a9651958f1535c5a1c649c7409e9168bcbffa29a3f2f961f58b322949", size = 3570620, upload-time = "2026-05-01T23:26:22.655Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/82/df3312c0ca083d5b43b352f27d4dd8b1e614bd334473074715d9e0000da4/psycopg_binary-3.3.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:612a627d733f695b1de1f9b4bd511c15f999a5d8b915d444bbd7dd71cf3370da", size = 4609813, upload-time = "2026-05-01T23:26:30.612Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/b5/d74d542458d3e8ac0571d8a88f57ca369999b9a82f4fa528052d0d7d3e4c/psycopg_binary-3.3.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:13a7f380824c35896dcac7fe0f61440f7ca49d6dc73f3c13a9a4471e6a3b302e", size = 4676799, upload-time = "2026-05-01T23:26:38.475Z" },
+    { url = "https://files.pythonhosted.org/packages/09/67/06bab9c60671999f4c6ceff1b334f3ac1f9fc5789eb467c714623ea21de9/psycopg_binary-3.3.4-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:276904e3452d6a23d474ef9a21eee19f20eed3d53ddd2576af033827e0ba0992", size = 5497050, upload-time = "2026-05-01T23:26:47.061Z" },
+    { url = "https://files.pythonhosted.org/packages/72/9b/023433e2b20f970de1e22d29132a95281277646da0b2e2879dd4ee94b8c1/psycopg_binary-3.3.4-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ab8cca8ef8fb1ccf5b048ae5bd78ba55b9e4b5d472e3ce5ca39ff4d2a9c249e4", size = 5172428, upload-time = "2026-05-01T23:26:56.708Z" },
+    { url = "https://files.pythonhosted.org/packages/08/cd/ae16da8fde228a38b2fe9269bbc13cf89e0186173f2265600f02d6a71e64/psycopg_binary-3.3.4-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7465bfe6087d2d5b42d4c53b9b11ca9f218e477317a4a162a10e3c19e984ba8e", size = 6762746, upload-time = "2026-05-01T23:27:07.023Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/81/0ba09fa5f5f88779093a2541a8e02489825721f258ab88058b11d68b3eb5/psycopg_binary-3.3.4-cp311-cp311-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:22cdbf5f91ef7bb91fe0c5757e1962d3127a8010256eefd9c61fcaf441802097", size = 5006033, upload-time = "2026-05-01T23:27:12.221Z" },
+    { url = "https://files.pythonhosted.org/packages/73/6a/629136040cc3497adb442a305710b5913f2a754d4630fc3d3717c4c0df65/psycopg_binary-3.3.4-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:e2631da29253a98bd496e6c4813b24e09a4fe3fb2a9e88513305d6f8747cce95", size = 4534175, upload-time = "2026-05-01T23:27:18.248Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/32/1027f843c6dc2d5d51960ee62cc0c2cf755a4c39455aff1371173edbef7d/psycopg_binary-3.3.4-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:7f7668f30b9dd5163197e5cbf4e0efd54e00f0a859cc566ce56cfc31f4054839", size = 4224203, upload-time = "2026-05-01T23:27:24.3Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/e1/380a724d9093c74adb14d4fce920ea8327838abb61f760b1448586b14a8e/psycopg_binary-3.3.4-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:cffc3408d77a27973f33e5d909b624cce683db5fc25964b02fe0aae7886c1007", size = 3954509, upload-time = "2026-05-01T23:27:30.815Z" },
+    { url = "https://files.pythonhosted.org/packages/db/cd/895893ae575a09c97ccfd5def070d88993d955ef34df45a881fd5ff506d6/psycopg_binary-3.3.4-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:0579252a1202cd73e4da137a1426e2dae993ae44e757605344282af3a082848c", size = 4259551, upload-time = "2026-05-01T23:27:38.828Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/c6/2330a20794e37a3ec609ef2fd8522919ec7a4395a1abf979a8e2d1775cd5/psycopg_binary-3.3.4-cp311-cp311-win_amd64.whl", hash = "sha256:41f2ec0fea529832982bcb6c9415de3c86264ebe562b77a467c0fbcd7efbba8d", size = 3572054, upload-time = "2026-05-01T23:27:45.455Z" },
+    { url = "https://files.pythonhosted.org/packages/95/7d/03818e13ba7f36de93573c93ee3482006d3dfa8b0f8d28df511bad0a1a92/psycopg_binary-3.3.4-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:5ab28a2a7649df3b72e6b674b4c190e448e8e77cf496a65bd846472048de2089", size = 4591122, upload-time = "2026-05-01T23:27:56.162Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/b9/11b341edf8d54e2694726b273fe9652b254d989f4f63e3ac6816ad6b55f4/psycopg_binary-3.3.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6402a9d8146cf4b3974ded3fd28a971e83dc6a0333eb7822524a3aa20b546578", size = 4669943, upload-time = "2026-05-01T23:28:04.522Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/18/4665bacd65e7865b4372fcd8abb8b9186ada4b0025f8c2ca691b364a556c/psycopg_binary-3.3.4-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:580ae30a5f95ccd90008ec697d3ed6a4a2047a516407ad904283fa42086936e9", size = 5469697, upload-time = "2026-05-01T23:28:11.337Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/b1/b83136c6e510593d9b0c759ba5384337bc4ad82d19fda675adc4b2703c84/psycopg_binary-3.3.4-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e7510c37550f91a187e3660a8cc50d4b760f8c3b8b2f89ebc5698cd2c7f2c85d", size = 5152995, upload-time = "2026-05-01T23:28:20.529Z" },
+    { url = "https://files.pythonhosted.org/packages/67/8d/a9821e2a648afe6091989929982a3b0f00b2631a859cb81379728f08fb75/psycopg_binary-3.3.4-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:77df19583501ea288eaf15ac0fe7ad01e6d8091a91d5c41df5c718f307d8e31b", size = 6738180, upload-time = "2026-05-01T23:28:30.654Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/58/2e349e8d23905dc2317b80ac65f48fb6f821a4777a4e994a60da91c4850f/psycopg_binary-3.3.4-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:018fbed325936da502feb546642c982dcc4b9ffdea32dfef78dbf3b7f7ad4070", size = 4978828, upload-time = "2026-05-01T23:28:37.277Z" },
+    { url = "https://files.pythonhosted.org/packages/45/48/57b00d03b4721878326122a1f1e6b0a90b85bcaec56b5b2f8ea6cfa45235/psycopg_binary-3.3.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:17a21953a9e5ff3a16dab692625a3676e2f101db5e40072f39dbee2250194d68", size = 4509757, upload-time = "2026-05-01T23:28:43.078Z" },
+    { url = "https://files.pythonhosted.org/packages/25/37/33b47d8c007df69aec500df5889767c4d313748e8e9e27a2fef8a6dabcee/psycopg_binary-3.3.4-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:eb05ee1c2b817d27c537333224c9e83c7afb86fe7296ba970990068baf819b16", size = 4190546, upload-time = "2026-05-01T23:28:50.016Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/c6/32b0835dbc2122617902b649d76a91c1e75406e76bf3d595b0c3bb5ffad6/psycopg_binary-3.3.4-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:773d573e11f437ce0bdb95b7c18dc58390494f96d43f8b45b9760436114f7652", size = 3926197, upload-time = "2026-05-01T23:28:55.55Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/68/d190ef0c0c5b16ded07831dabc8ddd412f4cdab07ec6e30ed38d9bda0e1f/psycopg_binary-3.3.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:71e55ccbdfae79a2ed9c6369c3008a3025817ff9d7e27b32a2d84e2a4267e66e", size = 4236627, upload-time = "2026-05-01T23:29:05.336Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8f/81dcbc2e8454b74d14881275ea45f00791052dac531a9fa8be1730d1685b/psycopg_binary-3.3.4-cp312-cp312-win_amd64.whl", hash = "sha256:494ca54901be8cf9eb7e02c25b731f2317c378efa44f43e8f9bd0e1184ae7be4", size = 3560782, upload-time = "2026-05-01T23:29:11.967Z" },
+    { url = "https://files.pythonhosted.org/packages/09/43/13e9c406fbbf354580476e248a16b64802a376873ebe6339e30bb655572d/psycopg_binary-3.3.4-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:fbd1d4ed566895ad2d3bf4ddfd8bae90026930ddf29df3b9d91d32c8c47866a7", size = 4590377, upload-time = "2026-05-01T23:29:18.782Z" },
+    { url = "https://files.pythonhosted.org/packages/22/be/2923cd7c3683e7afdecf4f10796a18de02f5c5ddc0969aa2ad0a8cdd3bbd/psycopg_binary-3.3.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:75a9067e236f9b9ae3535b66fe99bddb33d39c0de10112e49b9ab11eee53dc31", size = 4669023, upload-time = "2026-05-01T23:29:25.884Z" },
+    { url = "https://files.pythonhosted.org/packages/96/a0/2c913d6fe13d6a8bd13597d36739bf47af063ad9399e402cfecab16f3c1e/psycopg_binary-3.3.4-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:b56b603ebcea8aa10b46228b8410ba7f13e7c2ee54389d4d9be0927fd8ce2a70", size = 5467423, upload-time = "2026-05-01T23:29:33.416Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/38/205d10bc1ad0df4a21c5c51659126bd3ea0ef98fcad1e852f78c249bb9c3/psycopg_binary-3.3.4-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c677c4ad433cb7150c8cd304a0769ae3bcfbe5ea0676eb53faa7b1443b16d0d3", size = 5151137, upload-time = "2026-05-01T23:29:42.013Z" },
+    { url = "https://files.pythonhosted.org/packages/36/fc/f0381ddcd45eff3bb70dbca6823a996048d7f507b2ec3fc92c6fabc0fe87/psycopg_binary-3.3.4-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:26df2717e59c0473e4465a97dfb1b7afebaa479277870fd5784d1436470db47c", size = 6736671, upload-time = "2026-05-01T23:29:51.626Z" },
+    { url = "https://files.pythonhosted.org/packages/95/40/fa545ae152c24327651e5624e4902121e808270be36c10b12e9939be09bc/psycopg_binary-3.3.4-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:1dc1f79fd16bb1f3f4421417a514607539f17804d95c7ed617265369d1981cae", size = 4979601, upload-time = "2026-05-01T23:29:56.961Z" },
+    { url = "https://files.pythonhosted.org/packages/86/e4/2f8a47ee97f90cd2b933d0463081d35631ff419de2b8c984a5f369857de0/psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:136f199a407b5348b9b857c504aff60c77622a28482e7195839ce1b51238c4cc", size = 4510513, upload-time = "2026-05-01T23:30:07.243Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/0e/94e842ff4a7f98ed162580ca2e8b8864b28c1e0350f2443f8ee47f821167/psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:b6f5a29e9c775b9f12a1a717aa7a2c80f9e1db6f27ba44a5b59c80ac61d2ffcf", size = 4187243, upload-time = "2026-05-01T23:30:15.352Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/83/fc6c174b672e29b7de996ea77b6cbddf46c891751c3355f6974292baa6b4/psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:ee17a2cf4943cde261adfad1bbc5bf38d6b3776d7afff74c7cabcbeaeb08c260", size = 3927347, upload-time = "2026-05-01T23:30:21.186Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/65/768364d4a97a15b1a7f47ba52688c1686f22941d8332a8398cefc468e25f/psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5c4ab71be17bdca30cb34c34c4e1496e2f5d6f20c199c12bad226070b22ef9bf", size = 4236393, upload-time = "2026-05-01T23:30:26.211Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/3b/218efbc9e645becd80cdf651acda05f85cfe546b7a9c0458c7cbc8fe1f74/psycopg_binary-3.3.4-cp313-cp313-win_amd64.whl", hash = "sha256:dbfdb9b6cc79f31104a7b162a2b921b765fcc62af6c00540a167a8de47e4ed38", size = 3564592, upload-time = "2026-05-01T23:30:31.764Z" },
+    { url = "https://files.pythonhosted.org/packages/48/a6/828c9185701dab71b234c2a76c38a08b098ebfec5020716b4e93807492b5/psycopg_binary-3.3.4-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:28b7398fdd19db3232c884fb24550bdfe951221f510e195e233299e4c9b78f97", size = 4607292, upload-time = "2026-05-01T23:30:38.962Z" },
+    { url = "https://files.pythonhosted.org/packages/92/58/5b40dbc9d839045c9dae956960e4fb6d20bcabe6c59a2aa34fc3a371913f/psycopg_binary-3.3.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1fbaa292a3c8bb61b45df1ad3da1908ccee7cb889db9425e3557d9e34e2a4829", size = 4687023, upload-time = "2026-05-01T23:30:47.227Z" },
+    { url = "https://files.pythonhosted.org/packages/85/a9/793f0ac107a9003b48441d0d1f9f616d96e0f37458dd8dc12528ceff55fb/psycopg_binary-3.3.4-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:94596f9e7633ee3f6440711d43bb70aa31cc0a46a900ab8b4201a366ace5c9e7", size = 5486985, upload-time = "2026-05-01T23:30:55.517Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/26/42e8533497e2592334f68ec529cf5f840f7fa4e99575a4bb61aa184dbfbf/psycopg_binary-3.3.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8c0056529e68dbe9184cd4019a1f3d8f3a4ead2f6fc7a5afcf27d3314edd1277", size = 5168745, upload-time = "2026-05-01T23:31:01.904Z" },
+    { url = "https://files.pythonhosted.org/packages/15/af/b7151776cc08d5935d45c833ec818a9beb417cf7c08239af1aafbdae78ee/psycopg_binary-3.3.4-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2c09aad7051326e7603c14e50636db9c01f78272dc54b3accff03d46370461e6", size = 6761486, upload-time = "2026-05-01T23:31:14.511Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/ed/c92533b9124712d592cbf1cd6c76da933a2e0acea81dfe1fbe7e735f0cff/psycopg_binary-3.3.4-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:514404ed543efd620c85602b747df2a23cf1241b4067199e1a66f2d2757aaa41", size = 4997427, upload-time = "2026-05-01T23:31:20.901Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/23/ccadfd0de416aa188356daa199453af24087b042e296088706d190ae0295/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:46893c26858be12cc49ca4226ed6a60b4bfccadd946b3bebb783a60b38788228", size = 4533549, upload-time = "2026-05-01T23:31:26.204Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/a0/c8f43cee36386f7bc891ab41a9d31ea07cf9826038e732da79f26b1e5f34/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:df1d567fc430f6df15c9fcf67d87685fc49bdb325adc0db5af1adfb2f44eb5c9", size = 4210256, upload-time = "2026-05-01T23:31:33.884Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/2c/c1547871be3790676e8868b38655496422f94f0978dfb66b74bdba2f1676/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:6b9016b1714da4dd5ecaaa75b82098aa5a0b87854ce9b092e21c27c4ae23e014", size = 3946204, upload-time = "2026-05-01T23:31:39.626Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/b1/f6670f00fa7ea601584623f6c11602ab92117d83eaff885e0210f6de7418/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:47c656a8a7ba6eb0cff1801a4caaa9c8bdc12d03080e273aff1c8ac39971a77e", size = 4255811, upload-time = "2026-05-01T23:31:44.986Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/e6/5fff07a70d1f945ed90ae131c3bd76cab32beff7c58c6db15ad5820b6d1f/psycopg_binary-3.3.4-cp314-cp314-win_amd64.whl", hash = "sha256:c37e024c07308cd06cf3ec51bfd0e7f6157585a4d84d1bce4a7f5f7913719bf8", size = 3666849, upload-time = "2026-05-01T23:31:51.165Z" },
+]
+
+[[package]]
 name = "py-ubjson"
 version = "0.16.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1163,6 +1243,9 @@ docs = [
     { name = "pymdown-extensions" },
     { name = "zensical" },
 ]
+postgres = [
+    { name = "psycopg", extra = ["binary"] },
+]
 prod = [
     { name = "channels-redis" },
     { name = "hypercorn" },
@@ -1185,6 +1268,7 @@ requires-dist = [
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.27.0" },
     { name = "hypercorn", marker = "extra == 'prod'", specifier = ">=0.17.0" },
     { name = "markdown", marker = "extra == 'docs'", specifier = ">=3.10.2" },
+    { name = "psycopg", extras = ["binary"], marker = "extra == 'postgres'", specifier = ">=3.1" },
     { name = "pymdown-extensions", marker = "extra == 'docs'", specifier = ">=11.0.1" },
     { name = "pyright", marker = "extra == 'dev'", specifier = ">=1.1.400" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
@@ -1196,7 +1280,7 @@ requires-dist = [
     { name = "whitenoise", marker = "extra == 'prod'", specifier = ">=6.0" },
     { name = "zensical", marker = "extra == 'docs'", specifier = ">=0.0.51" },
 ]
-provides-extras = ["django", "prod", "dev", "docs"]
+provides-extras = ["django", "prod", "dev", "postgres", "docs"]
 
 [package.metadata.requires-dev]
 dev = [{ name = "django-extensions", specifier = ">=4.1" }]


### PR DESCRIPTION
The suite has only ever run on SQLite, which has no row locking. Everything the code does to stop two writers colliding was therefore never exercised — five comments in the source already say a Postgres run is what would catch it. This adds one, as a separate opt-in job so the existing fast run is untouched.

The good news is that nothing was hiding: the whole suite passes on Postgres with no changes to the library. It also adds two tests that genuinely race two writers against one stream, which pass on Postgres and are skipped with a stated reason on SQLite, and it records one real finding as a known failure — a rebuild safety check does not cover work the store hands to another thread, tracked in #147.

Detail in a comment below. The follow-up test plan is #148.