### PR TITLE
Make the rebuild safety check work across the store's worker thread

### DIFF
--- a/docs/dry-run-and-executors.md
+++ b/docs/dry-run-and-executors.md
@@ -149,10 +149,12 @@ with assert_no_live_writes(OrderSummary):
     `transaction.atomic()` if you need the write undone as well as reported, and
     prefer `deny_database_access` when you want prevention.
 
-    Both install themselves on the calling thread's connection. A write issued on
-    another thread — including ORM work handed off by the durable store's
-    `run_sync` — is **not** caught. See
-    [ADR 0003](adr/0003-handler-hermeticity.md).
+    Both install themselves on the calling thread's connection, and Django keeps
+    one connection per thread. `assert_no_live_writes` is unaffected — it
+    compares row counts, so it sees a write from any thread. `deny_database_access`
+    would miss one, so the durable store carries the guard across the one thread
+    hop it makes (`run_sync`); a write issued on a thread rakaia does not control
+    is still not caught. See [ADR 0003](adr/0003-handler-hermeticity.md).
 
 ### A rebuild that changes nothing is not a pass
 

--- a/src/django_rakaia/django_store.py
+++ b/src/django_rakaia/django_store.py
@@ -66,6 +66,7 @@ from rakaia.types import (
 )
 from rakaia.types import Stream as ProtocolStream
 
+from .hermeticity import armed_deny_aliases, deny_database_access
 from .models import (
     Stream,
     StreamEntry,
@@ -963,8 +964,28 @@ class DjangoStreamStore:
         async context, so every sync call the protocol server makes has to
         cross into a thread. `thread_sensitive=True` keeps them all on the same
         one, which is what makes them share a transaction and a connection.
+
+        **The hermeticity guard is carried across the hop.** Django's connections
+        are thread-local, so a `deny_database_access` armed by the caller is
+        invisible on the worker thread — the ORM work would step straight past a
+        guard the caller believes is on, and the rebuild gate would report green
+        without having checked anything (#147). Re-arming it here is what makes
+        the guard mean the same thing on both sides of the boundary.
+
+        A store reading its log from a guarded alias will now raise rather than
+        pass. That is the intended answer, not a regression: a hermetic rebuild
+        must read its log from somewhere other than the database it is proving it
+        can reconstruct, which `deny_database_access` has always documented.
         """
-        return await sync_to_async(fn, thread_sensitive=True)(*args, **kwargs)
+        denied = armed_deny_aliases()
+        if not denied:
+            return await sync_to_async(fn, thread_sensitive=True)(*args, **kwargs)
+
+        def _guarded(*inner_args: Any, **inner_kwargs: Any) -> Any:
+            with deny_database_access(*denied):
+                return fn(*inner_args, **inner_kwargs)
+
+        return await sync_to_async(_guarded, thread_sensitive=True)(*args, **kwargs)
 
     def get(self, path: str) -> ProtocolStream | None:
         """Return a snapshot of the stream's metadata, or None if absent.

--- a/src/django_rakaia/hermeticity.py
+++ b/src/django_rakaia/hermeticity.py
@@ -152,6 +152,30 @@ def deny_database_access(*aliases: str) -> Iterator[None]:
         yield
 
 
+def armed_deny_aliases() -> tuple[str, ...]:
+    """The aliases `deny_database_access` is currently guarding **on this thread**.
+
+    Django keeps connections in a thread-local, so the wrapper
+    `deny_database_access` installs is only visible to the thread that armed it.
+    Anything that hands ORM work to another thread has to carry the guard across
+    itself, and this is how it asks what to carry — see
+    `DjangoStreamStore.run_sync`, the one such hop in this package.
+
+    Reading `execute_wrappers` does not open a connection: `connections[alias]`
+    returns the wrapper object, and the socket is opened lazily on first query.
+    """
+    from django.db import connections
+
+    return tuple(
+        alias
+        for alias in connections
+        if any(
+            getattr(w, "_rakaia_deny_guard", False)
+            for w in connections[alias].execute_wrappers
+        )
+    )
+
+
 @contextmanager
 def _without_deny_guards(alias: str) -> Iterator[None]:
     """Suspend rakaia's own `deny_database_access` wrappers on `alias`.

--- a/tests/test_django_rakaia/test_hermeticity.py
+++ b/tests/test_django_rakaia/test_hermeticity.py
@@ -132,37 +132,28 @@ class TestDenyDatabaseAccess:
 #
 # `DjangoStreamStore.run_sync` deliberately moves ORM work onto another thread
 # (`sync_to_async(..., thread_sensitive=True)`), because Django refuses ORM
-# access from an async context. Those two facts are in tension, and the tests
-# below record which one wins rather than assuming.
+# access from an async context. Those two facts were in tension, and the guard
+# lost: work crossing the hop was invisible to it, so the gate reported green
+# without having checked anything.
+#
+# Fixed in #147 by having `run_sync` re-arm the caller's guard on the worker
+# thread (`hermeticity.armed_deny_aliases`). These tests hold that fix in place
+# from both sides of the boundary.
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "KNOWN GAP: deny_database_access is thread-local, so a write issued "
-        "through DjangoStreamStore.run_sync steps straight past it and the "
-        "gate stays green. Left failing on purpose -- fixing it means changing "
-        "the guard, not the test. See the note above."
-    ),
-)
 @pytest.mark.django_db(transaction=True)
-async def test_deny_database_access_should_block_a_write_through_run_sync():
-    """What the guard would have to do to be safe around async store work.
+async def test_deny_database_access_blocks_a_write_through_run_sync():
+    """The guard survives the thread hop `run_sync` makes.
 
-    It does not do it today. `deny_database_access` installs an
-    `execute_wrapper` on `connections["default"]`, and that connection object
-    is thread-local; `run_sync` hands the ORM call to another thread, which
-    resolves `connections["default"]` to a *different* connection with an
-    empty wrapper list. The append is executed, committed, and never seen.
+    `deny_database_access` installs an `execute_wrapper` on
+    `connections["default"]`, and that connection object is thread-local, so
+    the worker thread `run_sync` dispatches to resolves `connections["default"]`
+    to a *different* connection. Before #147 that connection had an empty
+    wrapper list and the append was executed, committed, and never seen.
 
-    Scope: the guard is documented for a *synchronous* replay -- `with
-    deny_database_access("default"): replay(...)` -- which is how every
-    example and every other test uses it, and where it does hold (see the
-    control test below). Nothing in the codebase arms it around `await`-ed
-    store work today, so this is a sharp edge in the guard's contract rather
-    than a live hole in the rebuild gate. It becomes a real hole the moment
-    someone wraps an async rebuild in it, and it fails silently when they do,
-    which is the dangerous shape.
+    `run_sync` now asks `armed_deny_aliases()` what the caller is guarding and
+    re-arms it inside the worker, so the guard means the same thing on both
+    sides. This test fails if that propagation is removed.
     """
     from django_rakaia.django_store import DjangoStreamStore
     from django_rakaia.models import StreamEntry
@@ -173,9 +164,33 @@ async def test_deny_database_access_should_block_a_write_through_run_sync():
     with deny_database_access("default"), pytest.raises(AmbientDatabaseAccess):
         await store.run_sync(store.append, "guarded", b'{"x": 1}')
 
-    # Reached only if the guard did not raise: the write really landed, so the
-    # leak is a completed write and not merely a query that dodged the wrapper.
+    # The guard must *prevent*, not merely report: nothing may have landed.
     assert await StreamEntry.objects.filter(stream__stream_id="guarded").acount() == 0
+
+
+@pytest.mark.django_db(transaction=True, databases=["default", "overlay"])
+async def test_run_sync_guard_does_not_block_an_unguarded_alias():
+    """Propagation must carry the guard, not freeze the process.
+
+    The counterpart to the test above, and the one that would catch the fix
+    over-reaching. `DjangoStreamStore` has no `using=` — it always works on the
+    default alias — so the case to prove is the mirror: guarding the *overlay*
+    alias must leave the store's default-alias work running normally across the
+    same thread hop. If propagation froze the worker outright rather than
+    carrying the specific guard, this would fail and the guard would be
+    unusable rather than merely leaky.
+    """
+    from django_rakaia.django_store import DjangoStreamStore
+    from django_rakaia.models import StreamEntry
+
+    store = DjangoStreamStore()
+    await store.run_sync(store.create, "unguarded")
+
+    with deny_database_access("overlay"):
+        await store.run_sync(store.append, "unguarded", b'{"x": 1}')
+
+    landed = await StreamEntry.objects.filter(stream__stream_id="unguarded").acount()
+    assert landed == 1
 
 
 @pytest.mark.django_db(transaction=True)


### PR DESCRIPTION
Switching on the check that makes a rebuild rehearsal prove it touched nothing only ever watched one thread, because Django keeps a separate database connection per thread. The durable store deliberately hands its work to a different thread, so anything going through that route slipped past and the rehearsal still reported a clean run. It gave no warning when it happened, which is the part worth fixing — a check that quietly stops checking is worse than no check.

The store now asks what the caller is guarding and switches the same guard on inside its worker, so it means the same thing on both sides. A store reading its log from a guarded database will now raise instead of passing quietly, which is what the guard always said it would do. The companion row-counting check was never affected; the documentation claimed it was, and that is corrected here.

Closes #147. Detail in a comment below.