### PR TITLE
Pin the architecture review's findings as failing tests

### DIFF
--- a/tests/test_django_rakaia/test_architecture_spikes.py
+++ b/tests/test_django_rakaia/test_architecture_spikes.py
@@ -1,0 +1,274 @@
+"""Executable proof for the django_rakaia findings of the 2026-08-17 architecture review.
+
+Same contract as `tests/test_rakaia/test_architecture_spikes.py`: every test here
+**fails today**, is marked `xfail(strict=True)`, and asserts a property the code
+already claims somewhere — in a docstring, in `docs/glossary.md`, or in a sibling
+implementation. When a finding is fixed its test reports XPASS(strict), which is
+a failure telling you to delete the marker.
+
+Epic: #152.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from django.db import transaction
+
+from django_rakaia.django_store import DjangoStreamStore
+from django_rakaia.models import StreamEntry, StreamEvent
+from rakaia.types import AppendOptions
+
+pytestmark = pytest.mark.django_db
+
+
+class _RecordingChannelLayer:
+    """A channel layer that records what was published, and when.
+
+    `broadcast_entries` is documented as a no-op when the channel layer is
+    absent, so `get_channel_layer` is already a seam — this is its second
+    adapter.
+    """
+
+    def __init__(self) -> None:
+        self.sent: list[tuple[str, dict[str, Any]]] = []
+
+    async def group_send(self, group: str, message: dict[str, Any]) -> None:
+        self.sent.append((group, message))
+
+
+@pytest.fixture
+def recording_layer(monkeypatch: pytest.MonkeyPatch) -> _RecordingChannelLayer:
+    layer = _RecordingChannelLayer()
+    import django_rakaia.channels_signals as cs
+
+    monkeypatch.setattr(cs, "get_channel_layer", lambda: layer)
+    return layer
+
+
+# ---------------------------------------------------------------------------
+# Finding 1 — "a stored row as an event" has six implementations
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "FINDING 1 (#153): channels_signals._frame publishes "
+        "entry.event.event_type raw, so a subscriber sees the internal "
+        "'append' sentinel where store.read() reports '' for the same event. "
+        "One row-to-event translation would make both agree."
+    ),
+)
+def test_a_subscriber_and_a_reader_see_the_same_event_label(
+    recording_layer: _RecordingChannelLayer,
+) -> None:
+    """The envelope label means the same thing to every reader of the log.
+
+    `store.read()` inverts the `"append"` sentinel to `""` -- an append carries
+    no envelope label -- and documents that it does so to match the in-memory
+    store. The SSE frame skips that inversion, so the same event is described
+    two different ways depending on which door you came through.
+    """
+    store = DjangoStreamStore()
+    store.create("labels")
+    store.append("labels", b'{"x": 1}')
+
+    message = store.read("labels")[0][0]
+    assert recording_layer.sent, "nothing was published"
+    _group, frame = recording_layer.sent[-1]
+
+    assert frame["event"]["event_type"] == message.label
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "FINDING 1 (#153): _frame passes entry.event.data straight through, "
+        "with no decode_payload, so a base64-stored payload reaches subscribers "
+        "as its base64 text rather than as the bytes that were appended. "
+        "(A text/plain payload happens to round-trip, which is why this needs "
+        "bytes that are not valid UTF-8.)"
+    ),
+)
+def test_a_subscriber_and_a_reader_see_the_same_payload(
+    recording_layer: _RecordingChannelLayer,
+) -> None:
+    """What was appended is what is published. `read()` decodes; the frame does not.
+
+    `encode_payload` stores a non-UTF-8 body base64-encoded and marks it, and
+    `read()` inverts that. The SSE frame reads the column directly, so a
+    subscriber receives the base64 text and has no way to know it should decode.
+    """
+    payload = b"\xff\xfe binary, not utf-8"
+    store = DjangoStreamStore()
+    store.create("payloads", content_type="application/octet-stream")
+    store.append("payloads", payload)
+
+    message = store.read("payloads")[0][0]
+    assert message.data == payload, "precondition: read() returns the original bytes"
+
+    _group, frame = recording_layer.sent[-1]
+    published = frame["event"]["data"]
+    published_bytes = published.encode() if isinstance(published, str) else published
+    assert published_bytes == payload
+
+
+# ---------------------------------------------------------------------------
+# Finding 2 — the batch door skips admission
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "FINDING 2 (#154): append_many never calls decide_append -- it checks "
+        "content type and Stream-Seq only. A batch from a fenced (stale-epoch) "
+        "producer is admitted, where the same items through append() are "
+        "refused. One append pipeline would make the four doors agree."
+    ),
+)
+def test_a_batch_from_a_fenced_producer_is_refused() -> None:
+    """Producer fencing is a property of the stream, not of which door you used.
+
+    A newer epoch has taken over the stream; the displaced producer must not be
+    able to write. `append` enforces this through `decide_append`; `append_many`
+    does not consult it at all.
+    """
+    store = DjangoStreamStore()
+    store.create("fenced")
+
+    # Epoch 2 takes the stream.
+    store.append(
+        "fenced",
+        b'{"n": 1}',
+        AppendOptions(producer_id="p", producer_epoch=2, producer_seq=1),
+    )
+
+    # The displaced epoch-1 producer now tries a batch.
+    results = store.append_many(
+        "fenced",
+        [
+            (
+                b'{"n": 99}',
+                AppendOptions(producer_id="p", producer_epoch=1, producer_seq=2),
+            )
+        ],
+    )
+
+    assert results[0].message is None, (
+        "a stale-epoch batch was written; producer fencing does not cover append_many"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Finding 5 — publication happens before commit
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "FINDING 5 (#157): both publish paths run inside transaction.atomic() "
+        "and there is no on_commit anywhere in src/, so a rolled-back append "
+        "has already told every subscriber about an event that does not exist."
+    ),
+)
+@pytest.mark.django_db(transaction=True)
+def test_a_rolled_back_append_is_never_published(
+    recording_layer: _RecordingChannelLayer,
+) -> None:
+    """Subscribers are told about events, and a rolled-back append is not one.
+
+    The log is the source of truth. If the row is not in it, nothing downstream
+    should believe it ever was.
+    """
+    store = DjangoStreamStore()
+    store.create("rollback")
+    recording_layer.sent.clear()
+
+    class Rollback(Exception):
+        pass
+
+    with pytest.raises(Rollback), transaction.atomic():
+        store.append("rollback", b'{"doomed": true}')
+        raise Rollback
+
+    assert StreamEntry.objects.filter(stream__stream_id="rollback").count() == 0
+    assert recording_layer.sent == [], (
+        f"{len(recording_layer.sent)} frame(s) published for an append that "
+        "was rolled back"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Finding 7 — the alias seam stops half-way
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "FINDING 7 (#159): decorators.py drops kwargs['using'] from the "
+        "post_save receiver and opens transaction.atomic() with no alias, so a "
+        "save routed to another database writes its model row there and its "
+        "stream event to the default one -- one save, split across two "
+        "databases."
+    ),
+)
+@pytest.mark.django_db(databases=["default", "overlay"])
+def test_a_save_to_another_database_records_its_event_there() -> None:
+    """A save and the event it emits are one write, so they share a database.
+
+    `assert_no_live_writes` names "a receiver that saves without a `using=`" as
+    the exact leak it exists to detect -- and the receiver in question is this
+    package's own `@stream_model`.
+    """
+    from .models import Area
+
+    before_default = StreamEvent.objects.using("default").count()
+
+    area = Area(name="overlay-area")
+    area.save(using="overlay")
+
+    after_default = StreamEvent.objects.using("default").count()
+    overlay_events = StreamEvent.objects.using("overlay").count()
+
+    assert after_default == before_default, (
+        "a save routed to 'overlay' wrote its stream event to 'default'"
+    )
+    assert overlay_events == 1
+
+
+# ---------------------------------------------------------------------------
+# Finding 8 — the skip rule and the diff rule can disagree
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "FINDING 8 (#160): canonical_value lives in verification.py and takes "
+        "its normalizers as an argument, but DjangoExecutor(skip_unchanged=True) "
+        "can only use DEFAULT_NORMALIZERS -- there is no way to construct an "
+        "executor that agrees with a diff run under custom normalizers. Both "
+        "docstrings flag the divergence; neither can close it from where it sits."
+    ),
+)
+def test_the_skip_rule_can_be_given_the_normalizers_a_diff_uses() -> None:
+    """ "Unchanged" must mean one thing on the write path and the verify path.
+
+    `diff_effects_against_rows` accepts `normalizers=`; the executor's
+    `skip_unchanged` comparison does not. So a projection verified as identical
+    under one equality rule is rewritten under another.
+    """
+    import inspect
+
+    from django_rakaia.effect_executor import DjangoExecutor
+
+    parameters = inspect.signature(DjangoExecutor.__init__).parameters
+    assert "normalizers" in parameters, (
+        "DjangoExecutor cannot be given the normalizer set a diff uses, so the "
+        "two equality rules cannot be made to agree"
+    )

--- a/tests/test_rakaia/test_architecture_spikes.py
+++ b/tests/test_rakaia/test_architecture_spikes.py
@@ -1,0 +1,169 @@
+"""Executable proof for the core-package findings of the 2026-08-17 architecture review.
+
+Each test here **fails today** and is marked `xfail(strict=True)`, so:
+
+* the suite stays green while the finding is open;
+* the day someone fixes the underlying defect, the test reports XPASS(strict) —
+  a failure that says "your fix worked, now delete this marker";
+* nobody has to take the review's word for anything. The claim is the test.
+
+These are not tests of desired new interfaces. Each asserts a property the code
+**already claims** — in a docstring, in the glossary, or in a sibling
+implementation — and does not currently hold.
+
+Epic: #152.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from rakaia.effects import Upsert
+from rakaia.executors import CollectingExecutor
+from rakaia.registry import HandlerRegistry
+from rakaia.replay import replay
+from rakaia.store import StreamStore
+
+
+def _handler(event: dict) -> Upsert:
+    """A trivial handler defined in a real file, so its source can be hashed."""
+    return Upsert(model_label="m", lookup={"k": event.get("a", 0)}, defaults={})
+
+
+def _registry() -> HandlerRegistry:
+    reg = HandlerRegistry()
+    reg.register("h", "s", _handler, 0, None)
+    return reg
+
+
+# ---------------------------------------------------------------------------
+# Finding 3 — wire framing is stored in the event
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "FINDING 3 (#155): json_mode.process_json_append appends a trailing "
+        "comma and the store keeps that framed blob as StreamMessage.data, so "
+        "the replay path cannot decode what the append path wrote. Fixing it "
+        "means storing payloads unframed and framing in format_response."
+    ),
+)
+def test_a_json_mode_stream_can_be_replayed() -> None:
+    """A stream is a stream. Its content type is a transport fact, not an event fact.
+
+    `replay()` reads through `ReadableStore`, which says nothing about content
+    types -- so a JSON-mode stream must replay exactly like any other. Today the
+    first event fails to decode, because the bytes carry a trailing comma that
+    only `format_response` knows how to strip.
+    """
+    store = StreamStore()
+    store.create("s", content_type="application/json")
+    store.append("s", b'{"a": 1}')
+
+    result = replay(
+        store=store,
+        stream_path="s",
+        executor=CollectingExecutor(),
+        handler_registry=_registry(),
+    )
+
+    assert result.events_processed == 1
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "FINDING 3 (#155): a JSON array append is documented as flattening "
+        "into separate messages, but produces one message holding the "
+        "concatenated, comma-framed blob."
+    ),
+)
+def test_a_json_array_append_stores_one_message_per_element() -> None:
+    """`server_store_contract.py` names this behaviour in a test title.
+
+    That contract test asserts through `format_response`, which re-wraps the
+    blob -- so it passes while the property it names does not hold. Asserting on
+    the stored messages instead is what makes the claim observable.
+    """
+    store = StreamStore()
+    store.create("s", content_type="application/json")
+    store.append("s", b'[{"id": 1}, {"id": 2}]')
+
+    messages = store.read("s")[0]
+
+    assert len(messages) == 2
+    assert messages[0].data == b'{"id": 1}'
+
+
+# ---------------------------------------------------------------------------
+# Finding 4 — drift is hashed per event, not per registration
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "FINDING 4 (#156): _check_handler_drift calls hash_function_source from "
+        "_dispatch_event, so a handler's source is re-read and re-hashed once "
+        "per event. Drift is a property of a registration; hashing belongs at "
+        "the start of the replay, not in the dispatch hot path."
+    ),
+)
+def test_a_handler_source_is_hashed_once_per_replay(monkeypatch) -> None:
+    """Drift is a property of a registration, so the cost must not scale with events.
+
+    Measured on this checkout: 2000 events spend ~86% of total replay time
+    re-hashing one unchanged function. This pins the shape rather than the
+    timing -- one resolved handler means one hash, whatever the stream length.
+    """
+    import sys
+
+    replay_module = sys.modules["rakaia.replay"]
+    calls: list[object] = []
+    original = replay_module.hash_function_source
+
+    def counting(fn: object) -> str:
+        calls.append(fn)
+        return original(fn)
+
+    monkeypatch.setattr(replay_module, "hash_function_source", counting)
+
+    store = StreamStore()
+    store.create("s")
+    for i in range(50):
+        store.append("s", b'{"a": %d}' % i)
+
+    replay(
+        store=store,
+        stream_path="s",
+        executor=CollectingExecutor(),
+        handler_registry=_registry(),
+    )
+
+    assert len(calls) == 1, (
+        f"one registered handler, one replay, but the source was hashed "
+        f"{len(calls)} times -- once per event"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Finding "also surfaced" — the function shadows the module
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "FINDING 9 (#161): `from .replay import replay` in rakaia/__init__.py "
+        "rebinds the `replay` attribute on the package from the submodule to "
+        "the function, so `import rakaia.replay as rp; rp.anything` fails. "
+        "Low value, but it silently misdirects monkeypatches."
+    ),
+)
+def test_importing_the_replay_submodule_yields_the_module() -> None:
+    """`import x.y as z` should bind the submodule, as it does for every other one."""
+    import rakaia.replay as replay_module
+
+    assert hasattr(replay_module, "build_pipeline")


### PR DESCRIPTION
An architecture review found eight places where a single rule has more than one implementation and the copies have drifted apart. Rather than leave that as a written claim that ages badly, this adds one test per finding that fails today for exactly the reason stated.

Each is marked as a strictly-expected failure, so the suite stays green while the work is outstanding, and the marker flips into a real failure the moment someone fixes the underlying problem. No behaviour changes here and no source file is touched — this is the evidence, not the fix.

Refs #152. Detail in a comment.