### PR TITLE
Read a rule's source once per rebuild, not once per event

### DIFF
--- a/src/rakaia/registry.py
+++ b/src/rakaia/registry.py
@@ -921,6 +921,7 @@ class UpcasterRegistry(_LogBackedRegistry):
         target_version: int,
         *,
         drift_callback: Callable[[UpcasterVersion, str], None] | None = None,
+        hasher: Callable[[Any], str] | None = None,
     ) -> dict[str, Any]:
         """
         Upcast `event` from its current schema_version up to `target_version`.
@@ -940,6 +941,12 @@ class UpcasterRegistry(_LogBackedRegistry):
         If `drift_callback` is provided, it is called once per step with
         `(version, current_hash)` if the upcaster's source hash has changed
         since registration. The callback decides whether to raise or warn.
+
+        `hasher` overrides how a step's live source hash is computed. A replay
+        passes one memoised for its own duration: an upcaster's source cannot
+        change mid-replay, and re-reading it per event per step was a measurable
+        share of replay time (#156). Defaults to hashing afresh, so a caller
+        that keeps no such ledger is unaffected.
         """
         current = int(event.get("schema_version", 1))
         if current > target_version:
@@ -969,7 +976,7 @@ class UpcasterRegistry(_LogBackedRegistry):
                 )
             step = matching[0]
             if drift_callback is not None:
-                live_hash = hash_function_source(step.fn)
+                live_hash = (hasher or hash_function_source)(step.fn)
                 if live_hash != step.source_hash:
                     drift_callback(step, live_hash)
             event = step.fn(event)
@@ -983,6 +990,7 @@ class UpcasterRegistry(_LogBackedRegistry):
         event_match_str: str,
         *,
         drift_callback: Callable[[UpcasterVersion, str], None] | None = None,
+        hasher: Callable[[Any], str] | None = None,
     ) -> dict[str, Any]:
         """Upcast `event` all the way to the current schema for its match.
 
@@ -992,7 +1000,11 @@ class UpcasterRegistry(_LogBackedRegistry):
         """
         target = self.current_version(event_match_str, event)
         return self.apply_chain(
-            event, event_match_str, target, drift_callback=drift_callback
+            event,
+            event_match_str,
+            target,
+            drift_callback=drift_callback,
+            hasher=hasher,
         )
 
     def all_upcasters(self) -> list[UpcasterVersion]:

--- a/src/rakaia/replay.py
+++ b/src/rakaia/replay.py
@@ -34,6 +34,7 @@ import json
 import logging
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass, field
+from functools import partial
 from typing import Any, Literal
 
 from .effects import (
@@ -135,6 +136,21 @@ class _ReplayCtx:
     # registry or rebuilding the drift callback.
     upcasters: Any = None
     drift_callback: Any = None
+    # Source hashes computed during this replay, keyed by the callable.
+    #
+    # Drift is a property of a *registration*, not of an event: a handler's
+    # source cannot change while its own replay is running. Checking it per
+    # event meant `inspect.getsource` + SHA-256 for every (event x version) —
+    # measured at ~86% of total replay time on a 2000-event stream (#156).
+    #
+    # Scoped to the replay rather than cached globally on purpose. A long-lived
+    # process that reloads code between replays must still be able to detect the
+    # drift that reload introduced.
+    source_hashes: dict[Any, str] = field(default_factory=dict)
+    # Registrations already reported as drifted, so the warning is emitted once
+    # rather than once per event. `result.drift_detected` already dedupes by
+    # name; `result.warnings` and the log did not.
+    drift_reported: set = field(default_factory=set)
 
 
 #: One event ready for dispatch: its sequence, the routing subject to match
@@ -340,7 +356,7 @@ def _dispatch_event(
     versions = ctx.handlers.resolve(match_str, seq, event=upcasted, stage=stage)
     all_effects: list[AnyEffect] = []
     for version in versions:
-        _check_handler_drift(version, ctx.on_drift, ctx.result)
+        _check_handler_drift(version, ctx)
         all_effects.extend(_call_handler(version, upcasted, ctx.reader))
     if ctx.track_touched:
         _record_touched(
@@ -357,7 +373,7 @@ def _run_stage_reducers(ctx: _ReplayCtx, stage: int | None) -> None:
     # far (cumulative across stages already run this pass); reducer *outputs* are
     # not themselves recorded as touched.
     for reducer in ctx.handlers.reducers_for_stage(stage):
-        _check_reducer_drift(reducer, ctx.on_drift, ctx.result)
+        _check_reducer_drift(reducer, ctx)
         if _reducer_wants_touched(reducer.fn):
             out = reducer.fn(ctx.reader, tuple(ctx.touched))
         else:
@@ -433,6 +449,7 @@ def replay(
             _decode_event(data, stream_path, seq),
             match_str,
             drift_callback=ctx.drift_callback,
+            hasher=partial(live_source_hash, ctx),
         )
 
     def _in_range(seq: int) -> bool:
@@ -545,6 +562,7 @@ def merge_replay(
                 _decode_event(msg.data, path, offset),
                 match_str,
                 drift_callback=ctx.drift_callback,
+                hasher=partial(live_source_hash, ctx),
             )
             if order_key is ENVELOPE_TS:
                 if msg.event_ts is None:
@@ -580,39 +598,52 @@ def merge_replay(
     return run_passes(ctx, merged, what="merge_replay")
 
 
-def _check_handler_drift(
-    version: HandlerVersion,
-    on_drift: OnDriftPolicy,
-    result: ReplayResult,
-) -> None:
-    live_hash = hash_function_source(version.fn)
+def live_source_hash(ctx: _ReplayCtx, fn: Any) -> str:
+    """The source hash of `fn`, computed at most once per replay.
+
+    The expensive part of a drift check — `inspect.getsource` and a SHA-256 —
+    depends only on the callable, so it is memoised here. The *comparison* stays
+    per registration, because two registrations may legitimately share a
+    function while storing different hashes.
+    """
+    cached = ctx.source_hashes.get(fn)
+    if cached is None:
+        cached = hash_function_source(fn)
+        ctx.source_hashes[fn] = cached
+    return cached
+
+
+def _check_handler_drift(version: HandlerVersion, ctx: _ReplayCtx) -> None:
+    live_hash = live_source_hash(ctx, version.fn)
     if live_hash == version.source_hash:
         return
+    if ("handler", version.name) in ctx.drift_reported:
+        return
+    ctx.drift_reported.add(("handler", version.name))
     _record_drift(
         kind="handler",
         name=version.name,
         stored_hash=version.source_hash,
         live_hash=live_hash,
-        on_drift=on_drift,
-        result=result,
+        on_drift=ctx.on_drift,
+        result=ctx.result,
     )
 
 
-def _check_reducer_drift(
-    reducer: ReducerVersion,
-    on_drift: OnDriftPolicy,
-    result: ReplayResult,
-) -> None:
-    live_hash = hash_function_source(reducer.fn)
+def _check_reducer_drift(reducer: ReducerVersion, ctx: _ReplayCtx) -> None:
+    live_hash = live_source_hash(ctx, reducer.fn)
     if live_hash == reducer.source_hash:
         return
+    if ("reducer", reducer.name) in ctx.drift_reported:
+        return
+    ctx.drift_reported.add(("reducer", reducer.name))
     _record_drift(
         kind="reducer",
         name=reducer.name,
         stored_hash=reducer.source_hash,
         live_hash=live_hash,
-        on_drift=on_drift,
-        result=result,
+        on_drift=ctx.on_drift,
+        result=ctx.result,
     )
 
 

--- a/tests/test_rakaia/test_architecture_spikes.py
+++ b/tests/test_rakaia/test_architecture_spikes.py
@@ -102,15 +102,6 @@ def test_a_json_array_append_stores_one_message_per_element() -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "FINDING 4 (#156): _check_handler_drift calls hash_function_source from "
-        "_dispatch_event, so a handler's source is re-read and re-hashed once "
-        "per event. Drift is a property of a registration; hashing belongs at "
-        "the start of the replay, not in the dispatch hot path."
-    ),
-)
 def test_a_handler_source_is_hashed_once_per_replay(monkeypatch) -> None:
     """Drift is a property of a registration, so the cost must not scale with events.
 

--- a/tests/test_rakaia/test_replay.py
+++ b/tests/test_rakaia/test_replay.py
@@ -409,6 +409,35 @@ class TestDrift:
         assert result.drift_detected.count("h") == 1
         assert any("RAKAIA_DRIFT" in w for w in result.warnings)
 
+    def test_handler_drift_is_reported_once_not_once_per_event(
+        self, store: StreamStore
+    ):
+        """Drift is a property of a registration, so it is reported per registration.
+
+        `drift_detected` always deduplicated by name, but `warnings` and the log
+        did not — a drifted handler over a long stream produced one warning per
+        event. Since #156 the source is hashed once per replay and the report is
+        made once, so both agree.
+        """
+        reg = HandlerRegistry()
+
+        def h(event):  # noqa: ARG001
+            return None
+
+        version = reg.register("h", "s", h, 0, None)
+        object.__setattr__(version, "source_hash", "deadbeef" * 8)
+
+        seed_stream("s", [{"id": i} for i in range(10)], store=store)
+
+        result = replay(store, "s", CaptureExecutor(), handler_registry=reg)
+
+        assert result.events_processed == 10
+        drift_warnings = [w for w in result.warnings if "RAKAIA_DRIFT" in w]
+        assert len(drift_warnings) == 1, (
+            f"10 events produced {len(drift_warnings)} drift warnings for one "
+            "drifted registration"
+        )
+
     def test_handler_drift_raises_when_strict(self, store: StreamStore):
         reg = HandlerRegistry()
 


### PR DESCRIPTION
Before applying each rule, the code checked whether that rule's source had changed since it was registered, by reading it off disk and hashing it. Worth doing once; it was happening once per event, on functions that cannot change while their own rebuild is running.

Rebuilding 2000 events now takes 18ms instead of 146ms, and reads the source once rather than 2000 times. Nothing a caller can observe changes, except that a rule which has drifted is reported once rather than once per event. The memo lasts for one rebuild only, so a long-running process that reloads code between rebuilds can still detect the change that reload introduced.

Closes #156. Stacked on #162. Detail in a comment.