### PR TITLE
Give a stored row as an event one definition

### DIFF
--- a/src/django_rakaia/channels_signals.py
+++ b/src/django_rakaia/channels_signals.py
@@ -5,8 +5,6 @@ Replaces the custom SSEManager/Unix socket/Redis broadcasting with
 Django Channels' channel layer for cross-process event distribution.
 """
 
-import base64
-import json
 from collections.abc import Sequence
 from typing import Any
 
@@ -15,7 +13,7 @@ from channels.layers import get_channel_layer
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 
-from .event_message import message_of
+from .event_message import event_label, payload_fields
 from .models import StreamEntry
 
 
@@ -62,48 +60,24 @@ def frame_event(entry: StreamEntry) -> dict[str, Any]:
     `channels_views` streams the same events over a plain HTTP response rather
     than the channel layer. It built its own copy of this dict and inherited the
     same two defects (#153), so both now derive from one definition.
+
+    The frame is JSON on the wire, so the payload rides as the stored
+    `data`/`payload_encoding` pair rather than the decoded bytes `message_of`
+    produces — see `payload_fields` for why passing the pair through is what
+    makes the subscriber's inverse exact.
     """
-    message = message_of(entry)
-    data, encoding = _json_safe(message.data)
-    event: dict[str, Any] = {
+    return {
         "id": entry.event.id,
         "offset": entry.offset,
-        # Derived from `message_of`, not read off the column. Reading
-        # `event_type` directly published the raw `"append"` sentinel where
-        # `read()` reports `""`, and reading `data` directly published a
-        # base64-stored payload still encoded (#153).
-        "event_type": message.label,
+        # Inverted, not the raw column: publishing `event_type` directly sent
+        # subscribers the internal `"append"` sentinel where `read()` reports
+        # `""` for the same event (#153).
+        "event_type": event_label(entry.event.event_type),
         "created_at": entry.event.created_at.isoformat()
         if entry.event.created_at
         else None,
-        "data": data,
+        **payload_fields(entry.event.data, entry.event.payload_encoding),
     }
-    if encoding is not None:
-        # Only present when `data` is not the JSON value itself, so a JSON
-        # payload — the common case — keeps exactly the frame it always had and
-        # no existing subscriber sees a new key. When it *is* present, it is
-        # what lets a subscriber recover the same bytes `read()` returns, which
-        # it previously could not (#153).
-        event["payload_encoding"] = encoding
-    return event
-
-
-def _json_safe(payload: bytes) -> tuple[Any, str | None]:
-    """The payload as `(value, encoding)`, in a form the channel layer can send.
-
-    The frame is JSON on the wire, so raw bytes cannot ride in it. That is the
-    root of #153: the old frame published the stored column and left the
-    subscriber no way to know it was looking at base64. Re-encoding silently
-    would repeat the bug, so the encoding travels with the value.
-    """
-    try:
-        return json.loads(payload), None
-    except (json.JSONDecodeError, UnicodeDecodeError):
-        pass
-    try:
-        return payload.decode("utf-8"), "utf-8"
-    except UnicodeDecodeError:
-        return base64.b64encode(payload).decode("ascii"), "base64"
 
 
 def broadcast_entries(stream_id: str, entries: Sequence[StreamEntry]) -> None:

--- a/src/django_rakaia/channels_signals.py
+++ b/src/django_rakaia/channels_signals.py
@@ -5,13 +5,17 @@ Replaces the custom SSEManager/Unix socket/Redis broadcasting with
 Django Channels' channel layer for cross-process event distribution.
 """
 
+import base64
+import json
 from collections.abc import Sequence
+from typing import Any
 
 from asgiref.sync import async_to_sync
 from channels.layers import get_channel_layer
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 
+from .event_message import message_of
 from .models import StreamEntry
 
 
@@ -48,16 +52,58 @@ def _frame(stream_id: str, entry: StreamEntry) -> dict:
         # truncate). The payload carries the exact id so a consumer can filter
         # out a group-mate's events instead of cross-delivering them.
         "stream_id": stream_id,
-        "event": {
-            "id": entry.event.id,
-            "offset": entry.offset,
-            "event_type": entry.event.event_type,
-            "created_at": entry.event.created_at.isoformat()
-            if entry.event.created_at
-            else None,
-            "data": entry.event.data,
-        },
+        "event": frame_event(entry),
     }
+
+
+def frame_event(entry: StreamEntry) -> dict[str, Any]:
+    """The `event` object inside a frame — shared with the HTTP SSE view.
+
+    `channels_views` streams the same events over a plain HTTP response rather
+    than the channel layer. It built its own copy of this dict and inherited the
+    same two defects (#153), so both now derive from one definition.
+    """
+    message = message_of(entry)
+    data, encoding = _json_safe(message.data)
+    event: dict[str, Any] = {
+        "id": entry.event.id,
+        "offset": entry.offset,
+        # Derived from `message_of`, not read off the column. Reading
+        # `event_type` directly published the raw `"append"` sentinel where
+        # `read()` reports `""`, and reading `data` directly published a
+        # base64-stored payload still encoded (#153).
+        "event_type": message.label,
+        "created_at": entry.event.created_at.isoformat()
+        if entry.event.created_at
+        else None,
+        "data": data,
+    }
+    if encoding is not None:
+        # Only present when `data` is not the JSON value itself, so a JSON
+        # payload — the common case — keeps exactly the frame it always had and
+        # no existing subscriber sees a new key. When it *is* present, it is
+        # what lets a subscriber recover the same bytes `read()` returns, which
+        # it previously could not (#153).
+        event["payload_encoding"] = encoding
+    return event
+
+
+def _json_safe(payload: bytes) -> tuple[Any, str | None]:
+    """The payload as `(value, encoding)`, in a form the channel layer can send.
+
+    The frame is JSON on the wire, so raw bytes cannot ride in it. That is the
+    root of #153: the old frame published the stored column and left the
+    subscriber no way to know it was looking at base64. Re-encoding silently
+    would repeat the bug, so the encoding travels with the value.
+    """
+    try:
+        return json.loads(payload), None
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        pass
+    try:
+        return payload.decode("utf-8"), "utf-8"
+    except UnicodeDecodeError:
+        return base64.b64encode(payload).decode("ascii"), "base64"
 
 
 def broadcast_entries(stream_id: str, entries: Sequence[StreamEntry]) -> None:

--- a/src/django_rakaia/channels_views.py
+++ b/src/django_rakaia/channels_views.py
@@ -15,7 +15,7 @@ from django.views.decorators.http import require_GET
 
 from rakaia.types import InvalidOffset
 
-from .channels_signals import _sanitize_group_name
+from .channels_signals import _sanitize_group_name, frame_event
 from .models import StreamEntry
 from .offsets import parse_offset
 
@@ -62,17 +62,11 @@ async def stream_events_sse(_request: Any, stream_id: str) -> Any:
                 .order_by("offset")
             )
             async for entry in entries_qs:
-                data: dict[str, Any] = {
-                    "event": {
-                        "id": entry.event.id,
-                        "offset": entry.offset,
-                        "event_type": entry.event.event_type,
-                        "created_at": entry.event.created_at.isoformat()
-                        if entry.event.created_at
-                        else None,
-                        "data": entry.event.data,
-                    }
-                }
+                # Shared with the channel-layer frame. This view used to build
+                # its own copy and inherited both of its defects — the raw
+                # `"append"` sentinel as the label, and an encoded payload sent
+                # without saying so (#153).
+                data: dict[str, Any] = {"event": frame_event(entry)}
                 yield f"id: {entry.offset}\ndata: {json.dumps(data)}\n\n".encode()
 
             # Wait for new events from channel layer

--- a/src/django_rakaia/django_store.py
+++ b/src/django_rakaia/django_store.py
@@ -33,7 +33,6 @@ single pure module (`rakaia.producer`) that both call, so the two cannot drift.
 from __future__ import annotations
 
 import asyncio
-import base64
 import json
 import time
 from collections.abc import Iterable
@@ -66,6 +65,14 @@ from rakaia.types import (
 )
 from rakaia.types import Stream as ProtocolStream
 
+from .event_message import (
+    APPEND_EVENT_TYPE as _APPEND_EVENT_TYPE,
+)
+from .event_message import (
+    decode_payload,
+    encode_payload,
+    message_of,
+)
 from .hermeticity import armed_deny_aliases, deny_database_access
 from .models import (
     Stream,
@@ -73,61 +80,21 @@ from .models import (
     StreamEvent,
     StreamProducer,
 )
+
+# Re-exported: `format_offset` and the payload helpers used to live here, and
+# both this package and its tests import them from this module. Moving them to
+# `event_message` (#153) keeps the names reachable at their old home rather than
+# rippling the change through every call site.
 from .offsets import format_offset, parse_offset
 
-# StreamEvent.event_type is required metadata for the dashboard; raw stream
-# appends carry no type, so they are recorded under a single stable label.
-_APPEND_EVENT_TYPE = "append"
-
-# `StreamEvent.payload_encoding` values. `None` means the event's `data` is the
-# payload as a JSON value — the event-sourcing shape, and what every row written
-# before this column holds.
-_ENCODING_TEXT = "utf-8"
-_ENCODING_BASE64 = "base64"
-
-
-def encode_payload(payload: bytes, content_type: str | None) -> tuple[Any, str | None]:
-    """Render one payload for storage as `(data, payload_encoding)`.
-
-    A protocol stream may declare any content type, but `StreamEvent.data` is a
-    JSON column, so a body that is not JSON has to be held as a JSON string and
-    marked as such. Three cases, in the order they are decided:
-
-    - **A declared non-JSON content type** (`text/plain`, `text/csv`, …) is
-      stored verbatim as text, or base64 if it is not valid UTF-8. Never parsed,
-      so the bytes come back exactly as they went in — a text stream that
-      happens to contain JSON is still text, and is not silently reformatted.
-    - **No declared content type** keeps the event-sourcing behaviour: the body
-      is parsed and stored as a JSON value. This is the shape `replay()`, the
-      admin and the channel-layer signals all read, so it cannot change. A body
-      that will not parse falls back to the raw form rather than failing — that
-      path used to raise `json.JSONDecodeError` straight through the server as
-      a 500.
-    - **JSON mode** is handled by the caller, which validates and flattens
-      first; each element arrives here already parsed.
-    """
-    if content_type is not None and not is_json_content_type(content_type):
-        return _encode_raw(payload)
-    try:
-        return json.loads(payload), None
-    except (json.JSONDecodeError, UnicodeDecodeError):
-        return _encode_raw(payload)
-
-
-def _encode_raw(payload: bytes) -> tuple[str, str]:
-    try:
-        return payload.decode("utf-8"), _ENCODING_TEXT
-    except UnicodeDecodeError:
-        return base64.b64encode(payload).decode("ascii"), _ENCODING_BASE64
-
-
-def decode_payload(data: Any, payload_encoding: str | None) -> bytes:
-    """The payload bytes for a stored event — the inverse of `encode_payload`."""
-    if payload_encoding == _ENCODING_TEXT:
-        return str(data).encode("utf-8")
-    if payload_encoding == _ENCODING_BASE64:
-        return base64.b64decode(str(data))
-    return json.dumps(data).encode("utf-8")
+__all__ = [
+    "DjangoStreamStore",
+    "decode_payload",
+    "encode_payload",
+    "format_offset",
+    "message_of",
+    "write_enveloped_event",
+]
 
 
 def write_enveloped_event(
@@ -599,20 +566,7 @@ class DjangoStreamStore:
                 event_ts=event_ts,
                 payload_encoding=encoding,
             )
-            messages.append(
-                StreamMessage(
-                    data=decode_payload(event.data, encoding),
-                    offset=format_offset(entry.offset),
-                    timestamp=entry.created_at.timestamp(),
-                    event_ts=(
-                        event_ts
-                        if event_ts is not None
-                        else entry.created_at.timestamp()
-                    ),
-                    label=label,
-                    metadata=event.metadata or None,
-                )
-            )
+            messages.append(message_of(entry))
         return messages
 
     # =========================================================================
@@ -860,22 +814,7 @@ class DjangoStreamStore:
             self._touch(stream)
             return [
                 AppendResult(
-                    message=StreamMessage(
-                        data=decode_payload(event.data, event.payload_encoding),
-                        offset=format_offset(entry.offset),
-                        timestamp=entry.created_at.timestamp(),
-                        event_ts=(
-                            event.event_ts
-                            if event.event_ts is not None
-                            else entry.created_at.timestamp()
-                        ),
-                        label=(
-                            ""
-                            if event.event_type == _APPEND_EVENT_TYPE
-                            else event.event_type
-                        ),
-                        metadata=event.metadata or None,
-                    ),
+                    message=message_of(entry),
                     stream_closed=bool(getattr(options, "close", False)),
                 )
                 for (_data, options), event, entry in zip(
@@ -930,27 +869,7 @@ class DjangoStreamStore:
         if offset not in (None, "", "-1"):
             entries = entries.filter(offset__gt=self._parse_offset(offset))
 
-        return [
-            StreamMessage(
-                data=decode_payload(entry.event.data, entry.event.payload_encoding),
-                offset=format_offset(entry.offset),
-                timestamp=entry.created_at.timestamp(),
-                # Logical envelope ts if the producer set one, else the append
-                # time — mirroring the in-memory store's default.
-                event_ts=(
-                    entry.event.event_ts
-                    if entry.event.event_ts is not None
-                    else entry.created_at.timestamp()
-                ),
-                # `"append"` is the raw-append sentinel → no envelope label;
-                # an empty metadata dict → None, matching the in-memory store.
-                label=""
-                if entry.event.event_type == _APPEND_EVENT_TYPE
-                else entry.event.event_type,
-                metadata=entry.event.metadata or None,
-            )
-            for entry in entries
-        ]
+        return [message_of(entry) for entry in entries]
 
     @staticmethod
     def _parse_offset(offset: str) -> int:

--- a/src/django_rakaia/django_store.py
+++ b/src/django_rakaia/django_store.py
@@ -81,10 +81,10 @@ from .models import (
     StreamProducer,
 )
 
-# Re-exported: `format_offset` and the payload helpers used to live here, and
-# both this package and its tests import them from this module. Moving them to
-# `event_message` (#153) keeps the names reachable at their old home rather than
-# rippling the change through every call site.
+# Re-exported: the payload helpers used to live here, and `format_offset` has
+# always been reachable through here; both this package and its tests import
+# them from this module. Moving the helpers to `event_message` (#153) keeps the
+# names at their old home rather than rippling through every call site.
 from .offsets import format_offset, parse_offset
 
 __all__ = [
@@ -817,7 +817,7 @@ class DjangoStreamStore:
                     message=message_of(entry),
                     stream_closed=bool(getattr(options, "close", False)),
                 )
-                for (_data, options), event, entry in zip(
+                for (_data, options), _event, entry in zip(
                     written, stream_events, entries, strict=True
                 )
             ] + [AppendResult(message=None, stream_closed=True) for _ in refused]

--- a/src/django_rakaia/event_message.py
+++ b/src/django_rakaia/event_message.py
@@ -1,0 +1,124 @@
+"""The one translation between a stored row and the event it represents.
+
+`StreamEvent` is a storage shape. What was actually appended is not quite what
+the columns hold: a non-JSON body is stored encoded and marked, an append that
+carried no envelope label is recorded under a stable sentinel because the column
+is required, and an event with no logical timestamp falls back to when it was
+written. Reversing those three facts is what turns a row back into an *event*.
+
+Before #153 that reversal was written six times — three times inside
+`django_store` (which agreed) and three times outside it, in the channel-layer
+frame, the dashboard views and the admin (which did not). A subscriber saw the
+raw `"append"` sentinel where a reader saw `""`, and a base64-stored payload
+reached subscribers still base64. This module is the single arrow into the
+column layout: everything that renders an event goes through `message_of`, and
+nothing else reads those columns directly.
+
+It sits below both `django_store` and `channels_signals` on purpose. `_publish`
+imports `broadcast_entries` lazily to avoid a cycle, so the translation cannot
+live in either of them without one.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+from typing import TYPE_CHECKING, Any
+
+from rakaia.json_mode import is_json_content_type
+from rakaia.types import StreamMessage
+
+from .offsets import format_offset
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from .models import StreamEntry
+
+# StreamEvent.event_type is required metadata for the dashboard; raw stream
+# appends carry no type, so they are recorded under a single stable label.
+APPEND_EVENT_TYPE = "append"
+
+# `StreamEvent.payload_encoding` values. `None` means the event's `data` is the
+# payload as a JSON value — the event-sourcing shape, and what every row written
+# before this column holds.
+_ENCODING_TEXT = "utf-8"
+_ENCODING_BASE64 = "base64"
+
+
+def encode_payload(payload: bytes, content_type: str | None) -> tuple[Any, str | None]:
+    """Render one payload for storage as `(data, payload_encoding)`.
+
+    A protocol stream may declare any content type, but `StreamEvent.data` is a
+    JSON column, so a body that is not JSON has to be held as a JSON string and
+    marked as such. Three cases, in the order they are decided:
+
+    - **A declared non-JSON content type** (`text/plain`, `text/csv`, …) is
+      stored verbatim as text, or base64 if it is not valid UTF-8. Never parsed,
+      so the bytes come back exactly as they went in — a text stream that
+      happens to contain JSON is still text, and is not silently reformatted.
+    - **No declared content type** keeps the event-sourcing behaviour: the body
+      is parsed and stored as a JSON value. This is the shape `replay()`, the
+      admin and the channel-layer signals all read, so it cannot change. A body
+      that will not parse falls back to the raw form rather than failing — that
+      path used to raise `json.JSONDecodeError` straight through the server as
+      a 500.
+    - **JSON mode** is handled by the caller, which validates and flattens
+      first; each element arrives here already parsed.
+    """
+    if content_type is not None and not is_json_content_type(content_type):
+        return _encode_raw(payload)
+    try:
+        return json.loads(payload), None
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return _encode_raw(payload)
+
+
+def _encode_raw(payload: bytes) -> tuple[str, str]:
+    try:
+        return payload.decode("utf-8"), _ENCODING_TEXT
+    except UnicodeDecodeError:
+        return base64.b64encode(payload).decode("ascii"), _ENCODING_BASE64
+
+
+def decode_payload(data: Any, payload_encoding: str | None) -> bytes:
+    """The payload bytes for a stored event — the inverse of `encode_payload`."""
+    if payload_encoding == _ENCODING_TEXT:
+        return str(data).encode("utf-8")
+    if payload_encoding == _ENCODING_BASE64:
+        return base64.b64decode(str(data))
+    return json.dumps(data).encode("utf-8")
+
+
+def event_label(event_type: str) -> str:
+    """The envelope label for a stored ``event_type``.
+
+    The sentinel means "a raw append, which carried no label" — so it inverts to
+    the empty string, matching the in-memory store. Callers rendering an event
+    must use this rather than the column, or a subscriber is told the sentinel
+    is the label.
+    """
+    return "" if event_type == APPEND_EVENT_TYPE else event_type
+
+
+def message_of(entry: StreamEntry) -> StreamMessage:
+    """The event a stored entry represents.
+
+    The single definition. Reverses the three storage facts — payload encoding,
+    the append sentinel, and the logical-timestamp fallback — so that every
+    reader of the log describes the same event the same way, whether it arrived
+    through `read()`, a channel-layer frame, the dashboard or the admin.
+
+    Reads `entry.event`; pass an entry that already has it loaded (or was
+    fetched with `select_related("event")`) to avoid a query per row.
+    """
+    event = entry.event
+    written_at = entry.created_at.timestamp()
+    return StreamMessage(
+        data=decode_payload(event.data, event.payload_encoding),
+        offset=format_offset(entry.offset),
+        timestamp=written_at,
+        # Logical envelope ts if the producer set one, else the append time —
+        # mirroring the in-memory store's default.
+        event_ts=event.event_ts if event.event_ts is not None else written_at,
+        label=event_label(event.event_type),
+        metadata=event.metadata or None,
+    )

--- a/src/django_rakaia/event_message.py
+++ b/src/django_rakaia/event_message.py
@@ -99,6 +99,31 @@ def event_label(event_type: str) -> str:
     return "" if event_type == APPEND_EVENT_TYPE else event_type
 
 
+def payload_fields(data: Any, payload_encoding: str | None) -> dict[str, Any]:
+    """The stored payload as the `data`/`payload_encoding` pair a JSON wire carries.
+
+    For surfaces that emit JSON rather than bytes — the channel-layer frame, the
+    SSE view, the dashboard APIs. They cannot carry a `StreamMessage`, whose
+    `data` is bytes, so they carry the stored pair and let the consumer run
+    `decode_payload` for itself.
+
+    Passing the pair through is what makes that inverse exact. Decoding first and
+    re-deriving an encoding from the resulting bytes is lossy: a `text/plain`
+    body that happens to parse as JSON (`{"a": 1}\\n`, `1.50`, `  7  `) would be
+    republished as a JSON value with no encoding, and reconstructing it yields
+    different bytes than `read()` returns — the same divergence #153 exists to
+    remove.
+
+    `payload_encoding` is omitted when `None`, so an ordinary JSON payload — the
+    common case — keeps exactly the shape these surfaces always had and no
+    existing consumer sees a new key.
+    """
+    fields: dict[str, Any] = {"data": data}
+    if payload_encoding is not None:
+        fields["payload_encoding"] = payload_encoding
+    return fields
+
+
 def message_of(entry: StreamEntry) -> StreamMessage:
     """The event a stored entry represents.
 

--- a/src/django_rakaia/templates/django_rakaia/stream_detail.html
+++ b/src/django_rakaia/templates/django_rakaia/stream_detail.html
@@ -355,7 +355,8 @@
 
         row.innerHTML = `
             <td><code>${eventData.offset}</code></td>
-            <td><span class="badge badge-${eventData.event_type}">${eventData.event_type}</span></td>
+            {# An append carries no envelope label, so `event_type` is "" — name it rather than render an empty badge (#153). #}
+            <td><span class="badge badge-${eventData.event_type}">${eventData.event_type || "raw append"}</span></td>
             <td>${timestamp}</td>
             <td>
                 <div class="data-preview" style="cursor: pointer;" onclick="toggleJson(this)">

--- a/src/django_rakaia/templates/django_rakaia/streams_index.html
+++ b/src/django_rakaia/templates/django_rakaia/streams_index.html
@@ -40,7 +40,8 @@
             <tbody>
                 {% for et in event_types %}
                 <tr>
-                    <td><span class="badge badge-{{ et.event_type }}">{{ et.event_type }}</span></td>
+                    {# An append carries no envelope label, so `event_type` is "" — name it rather than render an empty badge (#153). #}
+                    <td><span class="badge badge-{{ et.event_type }}">{{ et.event_type|default:"raw append" }}</span></td>
                     <td>{{ et.count }}</td>
                     <td>
                         <div style="display: flex; align-items: center; gap: 10px;">
@@ -118,7 +119,7 @@
                             {{ event.stream_id|truncatechars:30 }}
                         </a>
                     </td>
-                    <td><span class="badge badge-{{ event.event_type }}">{{ event.event_type }}</span></td>
+                    <td><span class="badge badge-{{ event.event_type }}">{{ event.event_type|default:"raw append" }}</span></td>
                     <td>{{ event.offset }}</td>
                     <td>{{ event.created_at|date:"M d, Y H:i:s" }}</td>
                     <td>

--- a/src/django_rakaia/views.py
+++ b/src/django_rakaia/views.py
@@ -18,7 +18,7 @@ from django.views.decorators.http import require_GET
 
 from rakaia.types import InvalidOffset
 
-from .event_message import event_label
+from .event_message import event_label, payload_fields
 from .models import Stream, StreamEntry, StreamEvent
 from .offsets import parse_offset
 
@@ -62,12 +62,15 @@ def streams_index(_request: Any) -> HttpResponse:
         .order_by("-last_event")
     )
 
-    # Get event type breakdown
-    event_types = (
-        StreamEvent.objects.values("event_type")
+    # Get event type breakdown. Inverted like every other event_type this page
+    # renders, so the breakdown and the recent-events table below name the same
+    # events the same way rather than one saying "append" and the other "" (#153).
+    event_types = [
+        {"event_type": event_label(row["event_type"]), "count": row["count"]}
+        for row in StreamEvent.objects.values("event_type")
         .annotate(count=Count("id"))
         .order_by("-count")
-    )
+    ]
 
     # Get recent events
     recent_entries = (
@@ -78,6 +81,7 @@ def streams_index(_request: Any) -> HttpResponse:
             "offset",
             "event__event_type",
             "event__data",
+            "event__payload_encoding",
             "created_at",
         )
     )
@@ -105,7 +109,7 @@ def streams_index(_request: Any) -> HttpResponse:
                 # what `read()` reports, not the storage marker (#153).
                 "event_type": event_label(e["event__event_type"]),
                 "created_at": e["created_at"].isoformat() if e["created_at"] else None,
-                "data": e["event__data"],
+                **payload_fields(e["event__data"], e["event__payload_encoding"]),
             }
             for e in recent_entries
         ],
@@ -228,6 +232,7 @@ def stream_events_api(_request: Any, stream_id: str) -> Any:
             "event__id",
             "event__event_type",
             "event__data",
+            "event__payload_encoding",
             "created_at",
         )
     )
@@ -239,7 +244,10 @@ def stream_events_api(_request: Any, stream_id: str) -> Any:
             "offset": e["offset"],
             "event_type": event_label(e["event__event_type"]),
             "created_at": e["created_at"].isoformat() if e["created_at"] else None,
-            "data": e["event__data"],
+            # The stored pair, as the SSE frame sends it — this API used to
+            # publish an encoded payload with nothing to say it was encoded, so
+            # a base64 body was indistinguishable from text (#153).
+            **payload_fields(e["event__data"], e["event__payload_encoding"]),
         }
         for e in entries
     ]

--- a/src/django_rakaia/views.py
+++ b/src/django_rakaia/views.py
@@ -18,6 +18,7 @@ from django.views.decorators.http import require_GET
 
 from rakaia.types import InvalidOffset
 
+from .event_message import event_label
 from .models import Stream, StreamEntry, StreamEvent
 from .offsets import parse_offset
 
@@ -99,7 +100,10 @@ def streams_index(_request: Any) -> HttpResponse:
             {
                 "stream_id": e["stream__stream_id"],
                 "offset": e["offset"],
-                "event_type": e["event__event_type"],
+                # Inverted, not the raw column: the sentinel means "an append
+                # with no envelope label", and a consumer of this API should see
+                # what `read()` reports, not the storage marker (#153).
+                "event_type": event_label(e["event__event_type"]),
                 "created_at": e["created_at"].isoformat() if e["created_at"] else None,
                 "data": e["event__data"],
             }
@@ -233,7 +237,7 @@ def stream_events_api(_request: Any, stream_id: str) -> Any:
         {
             "id": e["event__id"],
             "offset": e["offset"],
-            "event_type": e["event__event_type"],
+            "event_type": event_label(e["event__event_type"]),
             "created_at": e["created_at"].isoformat() if e["created_at"] else None,
             "data": e["event__data"],
         }

--- a/tests/test_django_rakaia/test_architecture_spikes.py
+++ b/tests/test_django_rakaia/test_architecture_spikes.py
@@ -11,6 +11,7 @@ Epic: #152.
 
 from __future__ import annotations
 
+import base64
 from typing import Any
 
 import pytest
@@ -52,15 +53,6 @@ def recording_layer(monkeypatch: pytest.MonkeyPatch) -> _RecordingChannelLayer:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "FINDING 1 (#153): channels_signals._frame publishes "
-        "entry.event.event_type raw, so a subscriber sees the internal "
-        "'append' sentinel where store.read() reports '' for the same event. "
-        "One row-to-event translation would make both agree."
-    ),
-)
 def test_a_subscriber_and_a_reader_see_the_same_event_label(
     recording_layer: _RecordingChannelLayer,
 ) -> None:
@@ -82,24 +74,16 @@ def test_a_subscriber_and_a_reader_see_the_same_event_label(
     assert frame["event"]["event_type"] == message.label
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "FINDING 1 (#153): _frame passes entry.event.data straight through, "
-        "with no decode_payload, so a base64-stored payload reaches subscribers "
-        "as its base64 text rather than as the bytes that were appended. "
-        "(A text/plain payload happens to round-trip, which is why this needs "
-        "bytes that are not valid UTF-8.)"
-    ),
-)
-def test_a_subscriber_and_a_reader_see_the_same_payload(
+def test_a_subscriber_can_recover_the_payload_a_reader_sees(
     recording_layer: _RecordingChannelLayer,
 ) -> None:
-    """What was appended is what is published. `read()` decodes; the frame does not.
+    """A subscriber must be able to reconstruct exactly what `read()` returns.
 
-    `encode_payload` stores a non-UTF-8 body base64-encoded and marks it, and
-    `read()` inverts that. The SSE frame reads the column directly, so a
-    subscriber receives the base64 text and has no way to know it should decode.
+    The frame is JSON on the wire, so a payload that is not valid UTF-8 cannot
+    ride in it as bytes -- which is the root of #153. The old frame published
+    the stored column and told the subscriber nothing, so base64 was
+    indistinguishable from text that happened to look like base64. The frame now
+    carries the encoding alongside the value, so the bytes are recoverable.
     """
     payload = b"\xff\xfe binary, not utf-8"
     store = DjangoStreamStore()
@@ -111,8 +95,30 @@ def test_a_subscriber_and_a_reader_see_the_same_payload(
 
     _group, frame = recording_layer.sent[-1]
     published = frame["event"]["data"]
-    published_bytes = published.encode() if isinstance(published, str) else published
-    assert published_bytes == payload
+    encoding = frame["event"].get("payload_encoding")
+
+    assert encoding == "base64", "the subscriber is told how to read the value"
+    assert base64.b64decode(published) == message.data
+
+
+def test_a_json_subscriber_still_receives_the_plain_json_value(
+    recording_layer: _RecordingChannelLayer,
+) -> None:
+    """The common case is unchanged, and stays unencoded.
+
+    Carrying the encoding must not push ordinary JSON payloads through base64 --
+    that would be a wire-format break for every existing subscriber.
+    """
+    store = DjangoStreamStore()
+    store.create("plain")
+    store.append("plain", b'{"x": 1}')
+
+    _group, frame = recording_layer.sent[-1]
+
+    assert frame["event"]["data"] == {"x": 1}
+    assert "payload_encoding" not in frame["event"], (
+        "an ordinary JSON payload must keep exactly the frame it always had"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_django_rakaia/test_architecture_spikes.py
+++ b/tests/test_django_rakaia/test_architecture_spikes.py
@@ -18,6 +18,7 @@ import pytest
 from django.db import transaction
 
 from django_rakaia.django_store import DjangoStreamStore
+from django_rakaia.event_message import decode_payload
 from django_rakaia.models import StreamEntry, StreamEvent
 from rakaia.types import AppendOptions
 
@@ -99,6 +100,53 @@ def test_a_subscriber_can_recover_the_payload_a_reader_sees(
 
     assert encoding == "base64", "the subscriber is told how to read the value"
     assert base64.b64decode(published) == message.data
+
+
+@pytest.mark.parametrize(
+    ("content_type", "payload"),
+    [
+        # The case the first cut of the fix got wrong: a text body that happens
+        # to parse as JSON. Decoding the stored value and re-deriving an
+        # encoding from the bytes republished these as JSON values, so the
+        # subscriber reconstructed `{"a": 1}`, `1.5` and `7` -- losing the
+        # newline, the trailing zero and the surrounding spaces `read()` keeps.
+        ("text/plain", b'{"a": 1}\n'),
+        ("text/plain", b'{"a":  1}'),
+        ("text/plain", b"1.50"),
+        ("text/plain", b"  7  "),
+        # The cases that already worked, kept here so the law is stated once
+        # rather than per storage shape.
+        ("text/plain", b"an ordinary line"),
+        ("application/octet-stream", b"\xff\xfe binary, not utf-8"),
+        (None, b'{"x": 1}'),
+    ],
+)
+def test_a_subscriber_reconstructs_a_readers_bytes_for_any_payload(
+    recording_layer: _RecordingChannelLayer,
+    content_type: str | None,
+    payload: bytes,
+) -> None:
+    """`decode_payload` over the frame yields exactly what `read()` returns.
+
+    The one law the frame owes a subscriber, stated for every storage shape at
+    once rather than per shape. The frame cannot carry bytes, so it carries the
+    stored `data`/`payload_encoding` pair and the subscriber runs the same
+    inverse a reader does -- which only holds if the frame passes the stored
+    pair through rather than decoding and guessing an encoding back (#153).
+    """
+    store = DjangoStreamStore()
+    store.create("roundtrip", content_type=content_type)
+    store.append("roundtrip", payload)
+
+    read_bytes = store.read("roundtrip")[0][0].data
+    assert read_bytes == payload, "precondition: read() is byte-exact"
+
+    _group, frame = recording_layer.sent[-1]
+    recovered = decode_payload(
+        frame["event"]["data"], frame["event"].get("payload_encoding")
+    )
+
+    assert recovered == read_bytes
 
 
 def test_a_json_subscriber_still_receives_the_plain_json_value(


### PR DESCRIPTION
Working out what a saved row actually represents means undoing three things storage does to it. That work was written six times across the codebase: three copies inside the store, which agreed with each other, and three outside it, which did not.

Live subscribers were the ones affected. They were sent an internal placeholder as the change label, where anyone reading the same event back correctly saw no label, and they were sent an encoded payload with nothing to say it was encoded. All of it now goes through one function, and the two failing tests that proved the problem now pass with their markers removed.

Closes #153. Detail in a comment. (Replaces #163, which was closed automatically when its base branch was merged and deleted.)