### PR TITLE
Decide a batch write with the same rule as every other write

### DIFF
--- a/src/django_rakaia/django_store.py
+++ b/src/django_rakaia/django_store.py
@@ -42,7 +42,7 @@ from typing import Any
 from asgiref.sync import sync_to_async
 from django.db import transaction
 
-from rakaia.append_decision import StreamFacts, decide_append
+from rakaia.append_decision import AppendVerdict, StreamFacts, decide_append
 from rakaia.context import merge_provenance
 from rakaia.json_mode import (
     format_json_response,
@@ -54,11 +54,9 @@ from rakaia.types import (
     AppendOptions,
     AppendResult,
     CloseResult,
-    ContentTypeMismatch,
     ProducerAccepted,
     ProducerState,
     ProducerValidationResult,
-    SequenceConflict,
     StreamConfigConflict,
     StreamMessage,
     StreamNotFound,
@@ -719,12 +717,20 @@ class DjangoStreamStore:
         the stream does not exist, like :meth:`append`, and returns one
         ``AppendResult`` per item in input order.
 
-        The rest of :meth:`append`'s semantics hold per item too: a closed
-        stream refuses every item with ``stream_closed=True``; per-item
-        ``content_type`` and ``seq`` are validated (the whole batch, before any
-        row is written — a conflict raises and writes nothing); and an item
-        with ``close=True`` closes the stream, refusing the items after it,
-        exactly as a loop of ``append`` would.
+        The rest of :meth:`append`'s semantics hold per item too, because the
+        same ``decide_append`` rule decides every item: a closed stream refuses
+        every item with ``stream_closed=True``; per-item ``content_type`` and
+        ``seq`` are validated (the whole batch, before any row is written — a
+        conflict raises and writes nothing); **producer fencing applies per
+        item**, with an item's outcome returned in its own slot rather than
+        aborting its siblings; and an item with ``close=True`` closes the
+        stream, refusing the items after it, exactly as a loop of ``append``
+        would.
+
+        Fencing used to be the exception: this method hand-rolled a shorter
+        admission check that read content type and ``Stream-Seq`` and nothing
+        else, so a batch was never fenced and never recorded the producer state
+        it established (#154). Both now go through the shared rule.
         """
         items = list(events)
         if not items:
@@ -737,35 +743,82 @@ class DjangoStreamStore:
             if stream.closed:
                 return [AppendResult(message=None, stream_closed=True) for _ in items]
 
-            # Validate before writing, exactly as a loop of `append` would:
-            # per-item content type, and a sequentially advancing Stream-Seq.
-            # The batch is cut at the first item that closes the stream; items
-            # after it observe the closed stream and are refused, not written.
+            # Admission, decided by the same rule the other three write doors
+            # use. This loop used to hand-roll a shorter version — content type
+            # and Stream-Seq only — which meant a batch was never fenced: a
+            # producer displaced by a newer epoch was refused item-by-item
+            # through `append` and silently accepted in bulk (#154).
+            #
+            # The facts advance across the batch exactly as they would across a
+            # loop of `append`: `last_seq` moves with each accepted item, and a
+            # producer's state moves with each accepted fenced write. Conflicts
+            # still raise (they are caller errors and the whole batch is
+            # abandoned); fencing outcomes are returned per item, so an item the
+            # fence refuses becomes a refusal in its own slot rather than
+            # aborting its siblings.
+            now = time.time()
             last_seq = stream.last_seq
+            producer_states = {
+                pid: self._producer_state(stream, pid)
+                for pid in {getattr(o, "producer_id", None) for _d, o in items} - {None}
+            }
+            verdicts: list[AppendVerdict] = []
             cut = len(items)
             for i, (_data, options) in enumerate(items):
-                provided_ct = getattr(options, "content_type", None)
-                if (
-                    provided_ct
-                    and stream.content_type
-                    and normalize_content_type(provided_ct)
-                    != normalize_content_type(stream.content_type)
-                ):
-                    raise ContentTypeMismatch(
-                        f"Content-type mismatch: expected "
-                        f"{stream.content_type}, got {provided_ct}"
-                    )
+                producer_id = getattr(options, "producer_id", None)
+                verdict = decide_append(
+                    StreamFacts(
+                        closed=False,
+                        closed_by=stream.closed_by,
+                        content_type=stream.content_type,
+                        last_seq=last_seq,
+                    ),
+                    options,
+                    producer_state=producer_states.get(producer_id),
+                    now=now,
+                )
+                verdicts.append(verdict)
+                if not verdict.write:
+                    continue
                 seq = getattr(options, "seq", None)
                 if seq is not None:
-                    if last_seq is not None and seq <= last_seq:
-                        raise SequenceConflict(
-                            f"Sequence conflict: {seq} <= {last_seq}"
-                        )
                     last_seq = seq
+                if verdict.producer_result is not None and producer_id is not None:
+                    # Advance the in-batch view of this producer, so a second
+                    # item from the same producer is fenced against the first
+                    # rather than against the pre-batch row.
+                    producer_states[producer_id] = ProducerState(
+                        epoch=getattr(options, "producer_epoch", 0) or 0,
+                        last_seq=getattr(options, "producer_seq", 0) or 0,
+                        last_updated=now,
+                    )
                 if getattr(options, "close", False):
                     cut = i + 1
                     break
-            written, refused = items[:cut], items[cut:]
+
+            # An item the fence refused is not written, but it keeps its slot in
+            # the results so callers still get one answer per input item.
+            admitted = [
+                (item, v)
+                for item, v in zip(items[:cut], verdicts[:cut], strict=False)
+                if v.write
+            ]
+            written = [item for item, _v in admitted]
+            refused = items[cut:]
+
+            if not written:
+                # Every item was refused — by the fence, or by a close earlier in
+                # the batch. There is nothing to allocate an offset block for,
+                # and asking for a block of zero is an error. Each item still
+                # gets its own answer.
+                return [
+                    AppendResult(
+                        message=None,
+                        stream_closed=v.stream_closed,
+                        producer_result=v.producer_result,
+                    )
+                    for v in verdicts
+                ] + [AppendResult(message=None, stream_closed=True) for _ in refused]
 
             # Mirror `append`'s per-event envelope mapping and payload encoding.
             # `merge_provenance` is evaluated per item so ambient provenance is
@@ -803,6 +856,14 @@ class DjangoStreamStore:
             # receiver's existing timing on the `append` path.
             self._publish(stream.stream_id, entries)
 
+            # Persist the fencing state each accepted item established, so a
+            # later batch or append is fenced against this one. `append` does
+            # this via `_commit_producer`; the bulk path did not do it at all,
+            # because it never asked the fence in the first place (#154).
+            for _item, verdict in admitted:
+                if verdict.producer_result is not None:
+                    self._commit_producer(stream, verdict.producer_result)
+
             if last_seq != stream.last_seq:
                 stream.last_seq = last_seq
                 stream.save(update_fields=["last_seq"])
@@ -812,15 +873,35 @@ class DjangoStreamStore:
             if closing:
                 self._close_from_append(stream, written[-1][1])
             self._touch(stream)
-            return [
-                AppendResult(
-                    message=message_of(entry),
-                    stream_closed=bool(getattr(options, "close", False)),
+
+            # One result per input item, in input order. An item the fence
+            # refused keeps its slot with the outcome to report, rather than
+            # vanishing from the results and shifting every later item's answer
+            # onto the wrong input.
+            persisted = iter(entries)
+            results: list[AppendResult] = []
+            for i, (_data, options) in enumerate(items):
+                if i >= cut:
+                    results.append(AppendResult(message=None, stream_closed=True))
+                    continue
+                verdict = verdicts[i]
+                if not verdict.write:
+                    results.append(
+                        AppendResult(
+                            message=None,
+                            stream_closed=verdict.stream_closed,
+                            producer_result=verdict.producer_result,
+                        )
+                    )
+                    continue
+                results.append(
+                    AppendResult(
+                        message=message_of(next(persisted)),
+                        stream_closed=bool(getattr(options, "close", False)),
+                        producer_result=verdict.producer_result,
+                    )
                 )
-                for (_data, options), _event, entry in zip(
-                    written, stream_events, entries, strict=True
-                )
-            ] + [AppendResult(message=None, stream_closed=True) for _ in refused]
+            return results
 
     @staticmethod
     def _publish(stream_id: str, entries: list[StreamEntry]) -> None:

--- a/tests/test_django_rakaia/test_architecture_spikes.py
+++ b/tests/test_django_rakaia/test_architecture_spikes.py
@@ -174,15 +174,6 @@ def test_a_json_subscriber_still_receives_the_plain_json_value(
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "FINDING 2 (#154): append_many never calls decide_append -- it checks "
-        "content type and Stream-Seq only. A batch from a fenced (stale-epoch) "
-        "producer is admitted, where the same items through append() are "
-        "refused. One append pipeline would make the four doors agree."
-    ),
-)
 def test_a_batch_from_a_fenced_producer_is_refused() -> None:
     """Producer fencing is a property of the stream, not of which door you used.
 
@@ -193,12 +184,16 @@ def test_a_batch_from_a_fenced_producer_is_refused() -> None:
     store = DjangoStreamStore()
     store.create("fenced")
 
-    # Epoch 2 takes the stream.
-    store.append(
+    # Epoch 2 takes the stream. A producer's first sequence is 0, so this
+    # append is genuinely accepted and the epoch is genuinely established --
+    # an earlier version of this test started at 1, which was itself refused
+    # for a sequence gap and so proved less than it claimed.
+    taken = store.append(
         "fenced",
         b'{"n": 1}',
-        AppendOptions(producer_id="p", producer_epoch=2, producer_seq=1),
+        AppendOptions(producer_id="p", producer_epoch=2, producer_seq=0),
     )
+    assert taken.message is not None, "precondition: epoch 2 holds the stream"
 
     # The displaced epoch-1 producer now tries a batch.
     results = store.append_many(
@@ -206,7 +201,7 @@ def test_a_batch_from_a_fenced_producer_is_refused() -> None:
         [
             (
                 b'{"n": 99}',
-                AppendOptions(producer_id="p", producer_epoch=1, producer_seq=2),
+                AppendOptions(producer_id="p", producer_epoch=1, producer_seq=1),
             )
         ],
     )
@@ -325,4 +320,104 @@ def test_the_skip_rule_can_be_given_the_normalizers_a_diff_uses() -> None:
     assert "normalizers" in parameters, (
         "DjangoExecutor cannot be given the normalizer set a diff uses, so the "
         "two equality rules cannot be made to agree"
+    )
+
+
+def test_a_partly_fenced_batch_keeps_one_result_per_item() -> None:
+    """Refusing an item must not shift every later item's answer onto the wrong input.
+
+    `append_many` promises one result per input item, in input order. Now that
+    the fence can refuse an individual item mid-batch, the refusal has to keep
+    its slot -- dropping it would silently re-pair each subsequent result with
+    the wrong item (#154).
+    """
+    store = DjangoStreamStore()
+    store.create("mixed")
+    store.append(
+        "mixed",
+        b'{"n": 0}',
+        AppendOptions(producer_id="p", producer_epoch=2, producer_seq=0),
+    )
+
+    results = store.append_many(
+        "mixed",
+        [
+            # accepted: unfenced
+            (b'{"n": 1}', None),
+            # refused: epoch 1 is stale, epoch 2 holds the stream
+            (
+                b'{"n": 2}',
+                AppendOptions(producer_id="p", producer_epoch=1, producer_seq=9),
+            ),
+            # accepted: the current epoch, advancing its sequence
+            (
+                b'{"n": 3}',
+                AppendOptions(producer_id="p", producer_epoch=2, producer_seq=1),
+            ),
+        ],
+    )
+
+    assert len(results) == 3
+    assert results[0].message is not None
+    assert results[1].message is None, "the stale-epoch item must be refused"
+    assert results[2].message is not None
+    assert results[0].message.data == b'{"n": 1}'
+    assert results[2].message.data == b'{"n": 3}', (
+        "the accepted item after a refusal was paired with the wrong input"
+    )
+
+
+def test_a_batch_advances_producer_state_for_the_next_writer() -> None:
+    """Fencing state established by a batch must fence what comes after it.
+
+    Asking the fence but never recording the answer leaves the next write judged
+    against the pre-batch state. The visible consequence is not just a
+    mis-refused replay -- it is that a producer which legitimately continues
+    after its own batch is rejected for a sequence gap it did not create.
+    """
+    from django_rakaia.models import StreamProducer
+
+    store = DjangoStreamStore()
+    store.create("advance")
+
+    store.append_many(
+        "advance",
+        [
+            (
+                b'{"n": 1}',
+                AppendOptions(producer_id="p", producer_epoch=1, producer_seq=0),
+            ),
+            (
+                b'{"n": 2}',
+                AppendOptions(producer_id="p", producer_epoch=1, producer_seq=1),
+            ),
+        ],
+    )
+
+    row = StreamProducer.objects.get(producer_id="p")
+    assert (row.epoch, row.last_seq) == (1, 1), (
+        "the batch did not record the fencing state it established"
+    )
+
+    # Re-sending the batch's last item is a duplicate, not a gap.
+    replayed = store.append(
+        "advance",
+        b'{"n": 2 again}',
+        AppendOptions(producer_id="p", producer_epoch=1, producer_seq=1),
+    )
+    assert replayed.message is None
+    assert replayed.producer_result is not None
+    assert replayed.producer_result.status == "duplicate", (
+        f"expected a duplicate, got {replayed.producer_result.status} -- the "
+        "next writer is being judged against the pre-batch state"
+    )
+
+    # And the producer can carry on from where its batch left off.
+    carried_on = store.append(
+        "advance",
+        b'{"n": 3}',
+        AppendOptions(producer_id="p", producer_epoch=1, producer_seq=2),
+    )
+    assert carried_on.message is not None, (
+        "a producer continuing after its own batch was refused"
     )


### PR DESCRIPTION
There are four ways to write to a stream. Three of them ask the shared rule whether the write is allowed. The fourth, the one that writes many events at once, checked two of the conditions itself and skipped the rest — so a writer that had been superseded by a newer one was correctly refused when writing one at a time, and silently accepted when writing a batch.

It also never recorded the result, which had a second consequence: a producer that legitimately carried on after its own batch was rejected for a gap it had not created. Both are now fixed by asking the same rule per item, with an item the rule refuses keeping its slot in the results rather than disappearing.

Closes #154. Builds on #165, which is not yet merged. Detail in a comment.