### PR TITLE
Store a JSON message as itself, not with punctuation attached

### DIFF
--- a/src/django_rakaia/django_store.py
+++ b/src/django_rakaia/django_store.py
@@ -523,13 +523,14 @@ class DjangoStreamStore:
         if not is_json_content_type(stream.content_type):
             return [encode_payload(data, stream.content_type)]
 
-        processed = process_json_append(data, is_initial_create=is_initial_create)
-        if not processed:
+        # `process_json_append` validates and flattens, and now returns one
+        # payload per message rather than a framed blob — so its result is the
+        # split, and this no longer re-parses the body to redo the same work.
+        payloads = process_json_append(data, is_initial_create=is_initial_create)
+        if not payloads:
             # An empty array on create: a stream with no messages yet.
             return []
-        parsed = json.loads(data)
-        elements = parsed if isinstance(parsed, list) else [parsed]
-        return [(element, None) for element in elements]
+        return [(json.loads(payload), None) for payload in payloads]
 
     def _write(
         self,
@@ -957,13 +958,13 @@ class DjangoStreamStore:
         drop the JSON-array framing on the expiry race instead of failing.
         """
         stream = self._require(path)
-        concatenated = b"".join(m.data for m in messages)
         if is_json_content_type(stream.content_type):
-            # Stored payloads are standalone JSON documents; the shared
-            # formatter expects the store's comma-separated concatenation.
-            joined = b",".join(m.data for m in messages)
-            return format_json_response(joined + b"," if joined else b"")
-        return concatenated
+            # Stored payloads are standalone JSON documents, which is now what
+            # the shared formatter takes. It used to want the in-memory store's
+            # comma-separated concatenation, so this path had to re-frame the
+            # payloads just to have them unframed again (#155).
+            return format_json_response([m.data for m in messages])
+        return b"".join(m.data for m in messages)
 
     async def wait_for_messages(
         self, path: str, offset: str, timeout_seconds: float

--- a/src/rakaia/json_mode.py
+++ b/src/rakaia/json_mode.py
@@ -8,6 +8,7 @@ for streams with Content-Type: application/json.
 from __future__ import annotations
 
 import json
+from collections.abc import Sequence
 from typing import Any
 
 from .types import EmptyJsonArray, InvalidJson
@@ -29,23 +30,27 @@ def is_json_content_type(content_type: str | None) -> bool:
     return normalize_content_type(content_type) == "application/json"
 
 
-def process_json_append(data: bytes, is_initial_create: bool = False) -> bytes:
-    """
-    Process JSON data for append in JSON mode.
+def process_json_append(data: bytes, is_initial_create: bool = False) -> list[bytes]:
+    """The messages a JSON-mode append stores, one payload per message.
 
-    - Validates JSON
-    - Extracts array elements if data is an array (one-level flatten)
-    - Appends trailing comma for easy concatenation
+    The protocol is explicit that message boundaries are preserved and that a
+    posted array is flattened one level, "storing two messages" for a two-element
+    body (spec 7.1). So this returns a *list* — the boundaries are the list, and
+    the caller stores one message per element.
 
-    Args:
-        data: Raw bytes of the JSON body
-        is_initial_create: If True, empty arrays are allowed (creates empty stream)
+    It used to return the elements concatenated with trailing commas, as a
+    single blob, which the response formatter knew how to unwrap. That destroyed
+    the boundaries the spec requires and, because the comma rode along in
+    `StreamMessage.data`, made a JSON-mode stream undecodable to anything that
+    read the payload directly — `replay()` failed on the first event (#155).
+    Framing now happens where it belongs, at the response.
 
-    Returns:
-        Processed bytes ready for storage (with trailing comma)
+    Returns an empty list when there is nothing to store: an empty array on
+    create, which the spec allows as "an empty stream".
 
     Raises:
-        ValueError: If JSON is invalid or array is empty (on non-create append)
+        InvalidJson: the body is not valid JSON.
+        EmptyJsonArray: an empty array on append (a no-op the spec rejects).
     """
     text = data.decode("utf-8")
 
@@ -57,40 +62,24 @@ def process_json_append(data: bytes, is_initial_create: bool = False) -> bytes:
     if isinstance(parsed, list):
         if len(parsed) == 0:
             if is_initial_create:
-                # Empty array on create = empty stream, no data to store
-                return b""
+                return []
             raise EmptyJsonArray("Empty arrays are not allowed in append operations")
-
-        # Flatten one level: each element becomes a separate message
-        # Store as individual JSON values with trailing commas
-        parts: list[bytes] = []
-        for item in parsed:
-            parts.append(json.dumps(item, separators=(",", ":")).encode("utf-8") + b",")
-        return b"".join(parts)
-    else:
-        # Single value - store with trailing comma
-        return json.dumps(parsed, separators=(",", ":")).encode("utf-8") + b","
+        return [_canonical(item) for item in parsed]
+    return [_canonical(parsed)]
 
 
-def format_json_response(data: bytes) -> bytes:
+def _canonical(value: Any) -> bytes:
+    """One stored payload, in the compact form the response concatenates."""
+    return json.dumps(value, separators=(",", ":")).encode("utf-8")
+
+
+def format_json_response(payloads: Sequence[bytes]) -> bytes:
+    """The GET body for a JSON-mode range: a JSON array of the stored messages.
+
+    Takes the payloads rather than a pre-concatenated blob. Each is already a
+    complete JSON value, so framing is a join and a pair of brackets — the
+    separators live here and never in what was stored.
     """
-    Format JSON mode response by wrapping stored data in array brackets.
-
-    Strips trailing comma before wrapping. Stored data has trailing commas
-    between elements for easy concatenation.
-
-    Args:
-        data: Concatenated stored message data
-
-    Returns:
-        JSON array bytes: [element1,element2,...]
-    """
-    if len(data) == 0:
+    if not payloads:
         return b"[]"
-
-    # Strip trailing comma before wrapping in array brackets
-    trimmed = data
-    if trimmed.endswith(b","):
-        trimmed = trimmed[:-1]
-
-    return b"[" + trimmed + b"]"
+    return b"[" + b",".join(payloads) + b"]"

--- a/src/rakaia/store.py
+++ b/src/rakaia/store.py
@@ -527,13 +527,11 @@ class StreamStore:
         if stream is None:
             raise StreamNotFound(f"Stream not found: {path}")
 
-        # Concatenate all message data
-        concatenated = b"".join(m.data for m in messages)
-
         if is_json_content_type(stream.content_type):
-            return format_json_response(concatenated)
+            # Framing lives here, not in what was stored.
+            return format_json_response([m.data for m in messages])
 
-        return concatenated
+        return b"".join(m.data for m in messages)
 
     async def wait_for_messages(
         self,
@@ -640,44 +638,59 @@ class StreamStore:
         event_ts: float | None = None,
     ) -> StreamMessage | None:
         """Append data to a stream, handling JSON mode processing."""
-        processed_data = data
-        if is_json_content_type(stream.content_type):
-            processed_data = process_json_append(data, is_initial_create)
-            if len(processed_data) == 0:
+        # One payload per stored message. Outside JSON mode the body is the
+        # single message; in JSON mode the protocol flattens a posted array one
+        # level and each element becomes its own message (spec 7.1).
+        json_mode = is_json_content_type(stream.content_type)
+        if json_mode:
+            payloads = process_json_append(data, is_initial_create)
+            if not payloads:
                 return None
+        else:
+            payloads = [data]
 
         # Parse current offset and calculate new one
         parts = stream.current_offset.split("_")
         read_seq = int(parts[0])
         byte_offset = int(parts[1])
 
-        new_byte_offset = byte_offset + len(processed_data)
-        # Offsets are `{read_seq}_{byte_offset}`, each zero-padded to 16 digits
-        # so they sort byte-wise lexicographically (the protocol's requirement,
-        # and what keeps offsets monotonic across recreate). `:016d` is a minimum
-        # width, not a cap: the ordering guarantee holds only while both fields
-        # stay < 10**16. That bound is unreachable here — the byte offset is
-        # capped by the process's memory (this store holds every message in RAM,
-        # so 10**16 bytes = ~10 PB is impossible) and 10**16 recreations of one
-        # path equally so. A durable backend that could exceed it must widen the
-        # fields (and INITIAL_OFFSET) in lockstep.
-        new_offset = f"{read_seq:016d}_{new_byte_offset:016d}"
-
         # Envelope timestamp defaults to append time when the producer didn't set
         # a logical one, so `event_ts` is always populated after a store append.
         append_time = time.time()
-        message = StreamMessage(
-            data=processed_data,
-            offset=new_offset,
-            timestamp=append_time,
-            event_ts=event_ts if event_ts is not None else append_time,
-            label=label,
-            metadata=metadata,
-        )
+        message: StreamMessage | None = None
 
-        self._messages.setdefault(stream.path, []).append(message)
-        stream.current_offset = new_offset
+        for payload in payloads:
+            # A JSON-mode offset is a position in the *response* body, where the
+            # payloads are joined by commas — so each message advances the byte
+            # offset by its own length plus the separator that will sit after it.
+            # Storing the payload unframed (#155) therefore leaves every offset
+            # exactly where it was; only `StreamMessage.data` changes.
+            byte_offset += len(payload) + (1 if json_mode else 0)
+            # Offsets are `{read_seq}_{byte_offset}`, each zero-padded to 16
+            # digits so they sort byte-wise lexicographically (the protocol's
+            # requirement, and what keeps offsets monotonic across recreate).
+            # `:016d` is a minimum width, not a cap: the ordering guarantee holds
+            # only while both fields stay < 10**16. That bound is unreachable
+            # here — the byte offset is capped by the process's memory (this
+            # store holds every message in RAM, so 10**16 bytes = ~10 PB is
+            # impossible) and 10**16 recreations of one path equally so. A
+            # durable backend that could exceed it must widen the fields (and
+            # INITIAL_OFFSET) in lockstep.
+            new_offset = f"{read_seq:016d}_{byte_offset:016d}"
 
+            message = StreamMessage(
+                data=payload,
+                offset=new_offset,
+                timestamp=append_time,
+                event_ts=event_ts if event_ts is not None else append_time,
+                label=label,
+                metadata=metadata,
+            )
+            self._messages.setdefault(stream.path, []).append(message)
+            stream.current_offset = new_offset
+
+        # The last message, whose offset is the stream's new head — what a
+        # caller resumes from. A flattened array writes several.
         return message
 
     @staticmethod

--- a/tests/test_rakaia/test_architecture_spikes.py
+++ b/tests/test_rakaia/test_architecture_spikes.py
@@ -41,15 +41,6 @@ def _registry() -> HandlerRegistry:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "FINDING 3 (#155): json_mode.process_json_append appends a trailing "
-        "comma and the store keeps that framed blob as StreamMessage.data, so "
-        "the replay path cannot decode what the append path wrote. Fixing it "
-        "means storing payloads unframed and framing in format_response."
-    ),
-)
 def test_a_json_mode_stream_can_be_replayed() -> None:
     """A stream is a stream. Its content type is a transport fact, not an event fact.
 
@@ -72,14 +63,6 @@ def test_a_json_mode_stream_can_be_replayed() -> None:
     assert result.events_processed == 1
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "FINDING 3 (#155): a JSON array append is documented as flattening "
-        "into separate messages, but produces one message holding the "
-        "concatenated, comma-framed blob."
-    ),
-)
 def test_a_json_array_append_stores_one_message_per_element() -> None:
     """`server_store_contract.py` names this behaviour in a test title.
 
@@ -94,7 +77,11 @@ def test_a_json_array_append_stores_one_message_per_element() -> None:
     messages = store.read("s")[0]
 
     assert len(messages) == 2
-    assert messages[0].data == b'{"id": 1}'
+    # Stored in the canonical compact form the response concatenates, which is
+    # what the append path has always produced -- the change is that the payload
+    # is now a complete JSON value rather than one with a comma stuck to it.
+    assert messages[0].data == b'{"id":1}'
+    assert messages[1].data == b'{"id":2}'
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_rakaia/test_json_mode.py
+++ b/tests/test_rakaia/test_json_mode.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+
 import pytest
 
 from rakaia.json_mode import (
@@ -50,22 +52,21 @@ class TestIsJsonContentType:
 
 
 class TestProcessJsonAppend:
-    def test_single_object_appends_trailing_comma(self):
-        result = process_json_append(b'{"foo": "bar"}')
-        assert result.endswith(b",")
-        assert b'"foo"' in result
-        assert b'"bar"' in result
+    def test_single_object_is_one_unframed_message(self):
+        # The payload is stored exactly as it will be read back. It carried a
+        # trailing comma until #155, which made it undecodable to anything
+        # reading the message directly.
+        assert process_json_append(b'{"foo": "bar"}') == [b'{"foo":"bar"}']
 
-    def test_array_flattens_elements(self):
-        result = process_json_append(b'[{"a": 1}, {"b": 2}]')
-        # Each element gets its own trailing comma
-        assert result.count(b",") >= 2
-        assert b'"a"' in result
-        assert b'"b"' in result
+    def test_array_flattens_into_one_message_per_element(self):
+        # The spec: a two-element body "stores two messages" (7.1).
+        assert process_json_append(b'[{"a": 1}, {"b": 2}]') == [
+            b'{"a":1}',
+            b'{"b":2}',
+        ]
 
-    def test_empty_array_on_create_returns_empty(self):
-        result = process_json_append(b"[]", is_initial_create=True)
-        assert result == b""
+    def test_empty_array_on_create_stores_nothing(self):
+        assert process_json_append(b"[]", is_initial_create=True) == []
 
     def test_empty_array_on_append_raises(self):
         with pytest.raises(ValueError, match="Empty arrays"):
@@ -82,23 +83,25 @@ class TestProcessJsonAppend:
             process_json_append(b"\xff\xfe")
 
     def test_scalar_value_works(self):
-        result = process_json_append(b"42")
-        assert result == b"42,"
+        assert process_json_append(b"42") == [b"42"]
 
     def test_string_value_works(self):
-        result = process_json_append(b'"hello"')
-        assert result == b'"hello",'
+        assert process_json_append(b'"hello"') == [b'"hello"']
 
 
 class TestFormatJsonResponse:
     def test_empty_returns_empty_array(self):
-        assert format_json_response(b"") == b"[]"
+        assert format_json_response([]) == b"[]"
 
-    def test_single_element_strips_trailing_comma(self):
-        assert format_json_response(b'{"a":1},') == b'[{"a":1}]'
+    def test_single_element_wrapped(self):
+        assert format_json_response([b'{"a":1}']) == b'[{"a":1}]'
 
-    def test_multiple_elements_wrapped(self):
-        assert format_json_response(b'{"a":1},{"b":2},') == b'[{"a":1},{"b":2}]'
+    def test_multiple_elements_joined_and_wrapped(self):
+        # The separators are added here and exist nowhere else.
+        assert format_json_response([b'{"a":1}', b'{"b":2}']) == b'[{"a":1},{"b":2}]'
 
-    def test_no_trailing_comma_still_wraps(self):
-        assert format_json_response(b'{"a":1}') == b'[{"a":1}]'
+    def test_a_stored_payload_round_trips_through_the_response(self):
+        """What is stored is a complete JSON value, and framing is reversible."""
+        payloads = process_json_append(b'[{"a": 1}, {"b": 2}]')
+        assert [json.loads(p) for p in payloads] == [{"a": 1}, {"b": 2}]
+        assert json.loads(format_json_response(payloads)) == [{"a": 1}, {"b": 2}]


### PR DESCRIPTION
When a stream declares that it holds JSON, its messages are joined into one array when read back. The code was adding the punctuation for that join at write time and storing it alongside the message, so what came out of storage was not valid on its own — anything reading a message directly, rebuilding tables most of all, failed on the very first one.

The punctuation now belongs to the response, which is the only place that needs it. Nothing changes on the wire: positions within a JSON stream are positions in the response body, so accounting for the separator that will follow each message leaves every position exactly where it was, and the conformance suite reports no change at all.

Closes #155. Detail in a comment.