### PR TITLE
Tell subscribers about a write only once it is permanent

### DIFF
--- a/src/django_rakaia/channels_signals.py
+++ b/src/django_rakaia/channels_signals.py
@@ -122,6 +122,14 @@ def broadcast_entries(stream_id: str, entries: Sequence[StreamEntry]) -> None:
     #
     # Outside a transaction Django runs the callback immediately, so an append in
     # autocommit still publishes synchronously.
+    #
+    # The alias is taken from the entries, the way `write_enveloped_event` takes
+    # it from the streams. An entry written to another database commits on *that*
+    # connection, so queuing against the default one would be queuing on a
+    # connection that is not in a transaction at all — Django then runs the
+    # callback immediately and publishes a write that has not happened yet, which
+    # is the very defect this defers to avoid (#157 on the path #159 opened up).
+    using = entries[0]._state.db
     frames = [_frame(stream_id, entry) for entry in entries]
 
     def _send() -> None:
@@ -129,7 +137,7 @@ def broadcast_entries(stream_id: str, entries: Sequence[StreamEntry]) -> None:
         for frame in frames:
             send(group_name, frame)
 
-    transaction.on_commit(_send)
+    transaction.on_commit(_send, using=using)
 
 
 @receiver(post_save, sender=StreamEntry)

--- a/src/django_rakaia/channels_signals.py
+++ b/src/django_rakaia/channels_signals.py
@@ -10,6 +10,7 @@ from typing import Any
 
 from asgiref.sync import async_to_sync
 from channels.layers import get_channel_layer
+from django.db import transaction
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 
@@ -107,9 +108,28 @@ def broadcast_entries(stream_id: str, entries: Sequence[StreamEntry]) -> None:
         return
 
     group_name = _sanitize_group_name(f"stream.{stream_id}")
-    send = async_to_sync(channel_layer.group_send)
-    for entry in entries:
-        send(group_name, _frame(stream_id, entry))
+    # Frame now, publish after the write is permanent.
+    #
+    # Both publish paths run inside `transaction.atomic()`, so this used to
+    # announce events that a later rollback erased — a subscriber was told about
+    # an append that never happened, and had no way to find out (#157). The log
+    # is the source of truth; if the row is not in it, nothing downstream should
+    # believe it ever was.
+    #
+    # Framing happens here rather than in the callback because `_frame` reads the
+    # entry's related rows, and deferring that would issue those queries after
+    # the transaction closed — or fail outright once the objects are stale.
+    #
+    # Outside a transaction Django runs the callback immediately, so an append in
+    # autocommit still publishes synchronously.
+    frames = [_frame(stream_id, entry) for entry in entries]
+
+    def _send() -> None:
+        send = async_to_sync(channel_layer.group_send)
+        for frame in frames:
+            send(group_name, frame)
+
+    transaction.on_commit(_send)
 
 
 @receiver(post_save, sender=StreamEntry)

--- a/tests/test_django_rakaia/test_architecture_spikes.py
+++ b/tests/test_django_rakaia/test_architecture_spikes.py
@@ -22,7 +22,11 @@ from django_rakaia.event_message import decode_payload
 from django_rakaia.models import StreamEntry, StreamEvent
 from rakaia.types import AppendOptions
 
-pytestmark = pytest.mark.django_db
+# `transaction=True` throughout: publication is deferred to commit (#157), and
+# under a plain `django_db` marker pytest-django wraps the test in a transaction
+# it never commits, so an `on_commit` callback would never run and every
+# subscriber assertion here would see nothing.
+pytestmark = pytest.mark.django_db(transaction=True)
 
 
 class _RecordingChannelLayer:
@@ -221,15 +225,6 @@ def test_a_batch_from_a_fenced_producer_is_refused() -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "FINDING 5 (#157): both publish paths run inside transaction.atomic() "
-        "and there is no on_commit anywhere in src/, so a rolled-back append "
-        "has already told every subscriber about an event that does not exist."
-    ),
-)
-@pytest.mark.django_db(transaction=True)
 def test_a_rolled_back_append_is_never_published(
     recording_layer: _RecordingChannelLayer,
 ) -> None:

--- a/tests/test_django_rakaia/test_architecture_spikes.py
+++ b/tests/test_django_rakaia/test_architecture_spikes.py
@@ -22,11 +22,18 @@ from django_rakaia.event_message import decode_payload
 from django_rakaia.models import StreamEntry, StreamEvent
 from rakaia.types import AppendOptions
 
-# `transaction=True` throughout: publication is deferred to commit (#157), and
-# under a plain `django_db` marker pytest-django wraps the test in a transaction
-# it never commits, so an `on_commit` callback would never run and every
-# subscriber assertion here would see nothing.
-pytestmark = pytest.mark.django_db(transaction=True)
+pytestmark = pytest.mark.django_db
+
+# Publication is deferred to commit (#157), so a test that asserts what a
+# subscriber *received* needs a real one: under a plain `django_db` marker
+# pytest-django opens a transaction it never commits, the `on_commit` callback
+# never runs, and the assertion sees nothing.
+#
+# Applied per test rather than to the module. CLAUDE.md records that converting
+# tests wholesale to `transaction=True` was considered and rejected in #148,
+# because it makes every run pay truncation teardown for nothing — and most of
+# this file never looks at a subscriber.
+observes_a_subscriber = pytest.mark.django_db(transaction=True)
 
 
 class _RecordingChannelLayer:
@@ -58,6 +65,7 @@ def recording_layer(monkeypatch: pytest.MonkeyPatch) -> _RecordingChannelLayer:
 # ---------------------------------------------------------------------------
 
 
+@observes_a_subscriber
 def test_a_subscriber_and_a_reader_see_the_same_event_label(
     recording_layer: _RecordingChannelLayer,
 ) -> None:
@@ -79,6 +87,7 @@ def test_a_subscriber_and_a_reader_see_the_same_event_label(
     assert frame["event"]["event_type"] == message.label
 
 
+@observes_a_subscriber
 def test_a_subscriber_can_recover_the_payload_a_reader_sees(
     recording_layer: _RecordingChannelLayer,
 ) -> None:
@@ -106,6 +115,7 @@ def test_a_subscriber_can_recover_the_payload_a_reader_sees(
     assert base64.b64decode(published) == message.data
 
 
+@observes_a_subscriber
 @pytest.mark.parametrize(
     ("content_type", "payload"),
     [
@@ -153,6 +163,7 @@ def test_a_subscriber_reconstructs_a_readers_bytes_for_any_payload(
     assert recovered == read_bytes
 
 
+@observes_a_subscriber
 def test_a_json_subscriber_still_receives_the_plain_json_value(
     recording_layer: _RecordingChannelLayer,
 ) -> None:
@@ -220,6 +231,7 @@ def test_a_batch_from_a_fenced_producer_is_refused() -> None:
 # ---------------------------------------------------------------------------
 
 
+@observes_a_subscriber
 def test_a_rolled_back_append_is_never_published(
     recording_layer: _RecordingChannelLayer,
 ) -> None:
@@ -244,6 +256,54 @@ def test_a_rolled_back_append_is_never_published(
         f"{len(recording_layer.sent)} frame(s) published for an append that "
         "was rolled back"
     )
+
+
+@pytest.mark.django_db(transaction=True, databases=["default", "overlay"])
+def test_a_rolled_back_save_to_another_database_is_never_published(
+    recording_layer: _RecordingChannelLayer,
+) -> None:
+    """The same law, on a database that is not `default`.
+
+    Once a save can be routed elsewhere (#159), deferring on the default
+    connection defers on the wrong one: it is not in a transaction, so Django
+    runs the callback at once and the rollback below never reaches the
+    subscriber that was already told.
+    """
+    from .models import Area
+
+    recording_layer.sent.clear()
+
+    class Rollback(Exception):
+        pass
+
+    with pytest.raises(Rollback), transaction.atomic(using="overlay"):
+        Area(name="overlay-area").save(using="overlay")
+        raise Rollback
+
+    assert StreamEvent.objects.using("overlay").count() == 0
+    assert recording_layer.sent == [], (
+        f"{len(recording_layer.sent)} frame(s) published for a save to "
+        "'overlay' that was rolled back"
+    )
+
+
+@pytest.mark.django_db(transaction=True, databases=["default", "overlay"])
+def test_a_save_to_another_database_publishes_only_after_its_own_commit(
+    recording_layer: _RecordingChannelLayer,
+) -> None:
+    """Nothing is published while the overlay transaction is still open."""
+    from .models import Area
+
+    recording_layer.sent.clear()
+
+    with transaction.atomic(using="overlay"):
+        Area(name="overlay-area").save(using="overlay")
+        published_early = len(recording_layer.sent)
+
+    assert published_early == 0, (
+        f"{published_early} frame(s) published before the overlay commit"
+    )
+    assert len(recording_layer.sent) == 1, "and exactly one after it"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_django_rakaia/test_decorators_consumer_contract.py
+++ b/tests/test_django_rakaia/test_decorators_consumer_contract.py
@@ -235,12 +235,19 @@ class TestJsonEncoding:
         assert event.data["ref"] == str(measure.ref)
         json.dumps(event.data)
 
-    def test_sse_broadcast_of_a_django_typed_payload_does_not_raise(self, monkeypatch):
+    def test_sse_broadcast_of_a_django_typed_payload_does_not_raise(
+        self, monkeypatch, django_capture_on_commit_callbacks
+    ):
         """The real crash path: ``handle_stream_entry_created`` broadcasts the
         in-memory payload from inside the consumer's own ``post_save``.
 
         A raw ``UUID`` there takes down the save being audited — msgpack under
         ``channels_redis``, ``json.dumps`` under the SSE view.
+
+        Publication is deferred to commit (#157), and this test runs under a
+        plain ``django_db`` marker whose transaction never commits — so the
+        callbacks are captured and run explicitly rather than paying for a
+        truncating ``transaction=True`` run just to observe a frame.
         """
         sent: list[dict] = []
 
@@ -253,16 +260,17 @@ class TestJsonEncoding:
         )
         measure = Measure.objects.create(ref=uuid.uuid4(), amount=Decimal("3.25"))
 
-        create_stream_event(
-            stream_paths="measure:sse",
-            to_dataclass=lambda obj: MeasureData(
-                ref=obj.ref,
-                amount=obj.amount,
-                recorded_at=dt.datetime(2026, 8, 9, tzinfo=dt.timezone.utc),
-            ),
-            instance=measure,
-            action="create",
-        )
+        with django_capture_on_commit_callbacks(execute=True):
+            create_stream_event(
+                stream_paths="measure:sse",
+                to_dataclass=lambda obj: MeasureData(
+                    ref=obj.ref,
+                    amount=obj.amount,
+                    recorded_at=dt.datetime(2026, 8, 9, tzinfo=dt.timezone.utc),
+                ),
+                instance=measure,
+                action="create",
+            )
 
         assert sent, "the SSE receiver did not fire"
         for message in sent:


### PR DESCRIPTION
Live updates were being sent while the database change was still in progress. If the surrounding work then failed and the change was undone, the notification had already gone out, and subscribers were left believing in an event that does not exist.

Sending now waits for the commit. The message is still built immediately, because building it reads rows that have to be read while the transaction is open, and outside a transaction the send still happens straight away — so an ordinary append is unchanged. Tests that assert what a subscriber receives are now asserting something that happens after commit, and have been adjusted to say so.

Closes #157. Detail, including why the second half of that issue is deliberately not done here, is in a comment.