### PR TITLE
Keep a save and the event it emits on the same database

### DIFF
--- a/src/django_rakaia/decorators.py
+++ b/src/django_rakaia/decorators.py
@@ -29,9 +29,9 @@ DataclassTransformer = Callable[[models.Model], Any]
 DeleteEventType = Literal["delete", "update"] | None
 
 
-def _get_or_create_stream(stream_id: str) -> Stream:
-    """Get or create a Stream record."""
-    stream, _ = Stream.objects.get_or_create(stream_id=stream_id)
+def _get_or_create_stream(stream_id: str, using: str | None = None) -> Stream:
+    """Get or create a Stream record on `using` (the default database if None)."""
+    stream, _ = Stream.objects.using(using).get_or_create(stream_id=stream_id)
     return stream
 
 
@@ -40,6 +40,7 @@ def create_stream_event(
     to_dataclass: DataclassTransformer,
     instance: models.Model,
     action: str,
+    using: str | None = None,
 ) -> StreamEvent:
     """
     Create a stream event for the given model instance.
@@ -53,6 +54,10 @@ def create_stream_event(
         to_dataclass: Callable converting model instance to dataclass.
         instance: The model instance that changed.
         action: Event type ("create", "update", or "delete").
+        using: Database alias to write to. Defaults to the instance's own
+            (`instance._state.db`), so an event lands on the same database as
+            the save that produced it — the two are one write and must not be
+            split (#159). Pass explicitly to override.
 
     Returns:
         The created StreamEvent instance.
@@ -130,11 +135,21 @@ def create_stream_event(
     # Atomic because `get_next_offset` locks the per-path high-water for the
     # duration of the transaction. A savepoint when the caller already has one
     # open, so the event stays inside the save that produced it.
-    with transaction.atomic():
+    # The save being audited decides the database, unless a caller says
+    # otherwise. `write_enveloped_event` then takes the alias from the streams
+    # themselves, and offset allocation from the stream row it locks.
+    # `getattr` rather than `instance._state.db`: this door accepts anything
+    # with the attributes `to_dataclass` reads, and the envelope-writer tests
+    # pass a plain stand-in with no ORM state. No state means no routing, which
+    # is the default database.
+    state = getattr(instance, "_state", None)
+    alias = using if using is not None else getattr(state, "db", None)
+
+    with transaction.atomic(using=alias):
         # One envelope shared by every entry: a fan-out is one event appearing
         # in several streams, not several events that look alike.
         event, _entries = write_enveloped_event(
-            [_get_or_create_stream(stream_id) for stream_id in stream_ids],
+            [_get_or_create_stream(stream_id, using=alias) for stream_id in stream_ids],
             payload,
             label=action,
             event_ts=event_ts,
@@ -247,7 +262,16 @@ def stream_model(
             if kwargs.get("raw"):
                 return
             action = "create" if created else "update"
-            create_stream_event(stream_paths, to_dataclass, instance, action)
+            # Django tells the receiver which database the save went to. That
+            # was dropped here, so a save routed elsewhere recorded its event on
+            # the default database instead (#159).
+            create_stream_event(
+                stream_paths,
+                to_dataclass,
+                instance,
+                action,
+                using=kwargs.get("using"),
+            )
 
         if on_delete is not None:
             delete_transformer = delete_to_dataclass or to_dataclass
@@ -261,10 +285,16 @@ def stream_model(
                 sender: type[models.Model],  # noqa: ARG001
                 instance: models.Model,
                 signal: Any,  # noqa: ARG001
-                **kwargs: Any,  # noqa: ARG001
+                **kwargs: Any,
             ) -> None:
+                # Same alias forwarding as the save path: a delete routed to
+                # another database records its event there too (#159).
                 create_stream_event(
-                    stream_paths, delete_transformer, instance, delete_event_type
+                    stream_paths,
+                    delete_transformer,
+                    instance,
+                    delete_event_type,
+                    using=kwargs.get("using"),
                 )
 
         return model_cls

--- a/src/django_rakaia/django_store.py
+++ b/src/django_rakaia/django_store.py
@@ -137,7 +137,14 @@ def write_enveloped_event(
     `django_rakaia.envelope`'s module docstring warns about, in the module it
     warns about it in (#131).
     """
-    event = StreamEvent.objects.create(
+    streams = list(streams)
+    # The event is written to whatever database its streams came from, rather
+    # than always to the default one. A save routed elsewhere used to put its
+    # row on one database and its event on another — one save, split across two
+    # (#159). Deriving the alias from the streams means it follows the data and
+    # no caller has to remember to pass it.
+    using = streams[0]._state.db if streams else None
+    event = StreamEvent.objects.using(using).create(
         data=data,
         event_type=label or _APPEND_EVENT_TYPE,
         metadata=merge_provenance(metadata) or {},
@@ -145,7 +152,7 @@ def write_enveloped_event(
         payload_encoding=payload_encoding,
     )
     entries = [
-        StreamEntry.objects.create(
+        StreamEntry.objects.using(using).create(
             stream=stream,
             event=event,
             offset=stream.get_next_offset(),

--- a/src/django_rakaia/models.py
+++ b/src/django_rakaia/models.py
@@ -157,10 +157,14 @@ class Stream(models.Model):
         # transaction. get_or_create tolerates the first-writer race (it retries
         # on the unique-key IntegrityError); the subsequent locked read then
         # serializes the read-modify-write.
-        StreamOffsetWatermark.objects.get_or_create(stream_path=self.stream_id)
-        watermark = StreamOffsetWatermark.objects.select_for_update().get(
-            stream_path=self.stream_id
-        )
+        # Allocate on whatever database this stream row came from. `self.entries`
+        # already follows the instance's alias, and the watermark has to agree
+        # with it or a rebuild against a scratch database would read its
+        # high-water from the live one (#159).
+        using = self._state.db
+        watermarks = StreamOffsetWatermark.objects.using(using)
+        watermarks.get_or_create(stream_path=self.stream_id)
+        watermark = watermarks.select_for_update().get(stream_path=self.stream_id)
         # `max(entries, watermark)` is belt-and-suspenders: the watermark alone
         # is authoritative for live streams, but taking the max also seeds it
         # correctly from any pre-existing entries (e.g. rows written before this

--- a/tests/test_django_rakaia/test_architecture_spikes.py
+++ b/tests/test_django_rakaia/test_architecture_spikes.py
@@ -261,16 +261,6 @@ def test_a_rolled_back_append_is_never_published(
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "FINDING 7 (#159): decorators.py drops kwargs['using'] from the "
-        "post_save receiver and opens transaction.atomic() with no alias, so a "
-        "save routed to another database writes its model row there and its "
-        "stream event to the default one -- one save, split across two "
-        "databases."
-    ),
-)
 @pytest.mark.django_db(databases=["default", "overlay"])
 def test_a_save_to_another_database_records_its_event_there() -> None:
     """A save and the event it emits are one write, so they share a database.
@@ -293,6 +283,21 @@ def test_a_save_to_another_database_records_its_event_there() -> None:
         "a save routed to 'overlay' wrote its stream event to 'default'"
     )
     assert overlay_events == 1
+
+    # The whole write has to land together, not just the event row. The entry
+    # and the offset high-water are part of the same save.
+    from django_rakaia.models import StreamEntry as _Entry
+    from django_rakaia.models import StreamOffsetWatermark as _Watermark
+
+    path = f"area:{area.id}:projects"
+    assert _Entry.objects.using("overlay").filter(stream__stream_id=path).count() == 1
+    assert _Watermark.objects.using("overlay").filter(stream_path=path).exists(), (
+        "the offset high-water was not allocated on 'overlay'"
+    )
+    assert not _Watermark.objects.using("default").filter(stream_path=path).exists(), (
+        "offsets for an 'overlay' stream were allocated from the 'default' "
+        "high-water -- a rebuild would read its offsets from the live database"
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
A project can tell Django which database a save should go to. When it did, the row went where it was told and the event recorded alongside it went to the default one, because the instruction was discarded on the way through — one save, split across two databases.

Rather than pass the instruction hand to hand through every call, it now travels with the data: the event is written to whichever database its streams came from, and the offset high-water is read from whichever database the stream row came from. Nothing in the chain has to remember to forward anything, and the delete path is fixed by the same change as the save path.

Closes #159. Detail in a comment.