### PR TITLE
Spike: events that say what changed, instead of re-sending the whole form

### DIFF
--- a/docs/research/delta-events.md
+++ b/docs/research/delta-events.md
@@ -1,0 +1,203 @@
+---
+icon: lucide/microscope
+---
+
+# Delta events: partial updates and array operations (spike)
+
+- **Date:** 2026-08-20
+- **Status:** research note — not a decision. Decisions go in `docs/adr/`.
+- **Spike branch:** `spike/delta-events` — `src/rakaia/deltas.py`,
+  `tests/test_rakaia/test_deltas.py`, `tests/test_rakaia/test_deltas_integration.py`
+  (81 tests, full gate green)
+- **Related:** [ADR 0001](../adr/0001-ordering-child-collections-in-projections.md)
+  (row keying and order representation),
+  [ADR 0004](../adr/0004-handler-types-and-fold-order.md) (the extension point;
+  its rejection of a "thin event" concept), `event-envelope.md`
+  (`append_if_changed`), `projections.py` (`project_latest`)
+
+## The question
+
+Two event shapes were proposed, both to stop re-carrying a whole form when one
+part of it changed:
+
+1. **Partial update** — an event carrying only the changed fields. Motivated by
+   Partisipa's *repeaters*: repeated child collections inside a form's `fields`
+   blob, where editing one cell today re-appends every row.
+2. **Array operations** — `AddPart` (key + index), `RemovePart`, `MovePart`, so a
+   collection's structural changes are recorded as intent rather than inferred
+   from two snapshots.
+
+This note answers three things: whether the mechanism can be built cleanly (yes),
+what it costs the rest of rakaia (six named hazards, all payable), and whether the
+production data supports the stated motivation (**no — and the numbers are not
+close**).
+
+## What was built
+
+`rakaia.deltas` — five frozen operation types, a pure `apply_delta`, a JSON wire
+form, and `fold_snapshot` over a message window. One type per shape of change,
+following `effects.py`: a `part_id` on a `SetField` is a type error, not a runtime
+check.
+
+```python
+from rakaia.deltas import AddPart, MovePart, SetField, encode_patch, fold_snapshot
+
+store.append(path, json.dumps(encode_patch([
+    SetField(("fields", "total_amount"), 6000),
+    AddPart("repeaterBalance", 2, "b7f3", {"balance_cash": 400}),
+])).encode(), AppendOptions(label="patch"))
+
+state = fold_snapshot(store.read(path).messages)   # snapshots + patches -> state
+```
+
+Two design points carried the weight, and both are pinned by tests:
+
+**Parts have identity; positions do not.** ADR 0001 requires a stable child id
+and notes that when the source has none, one must be *assigned at ingestion*.
+`AddPart` **is** that assignment — it carries the id the producer mints and stamps
+it into the folded row under `_part`, so `reconcile_tree(id_fn=…)` works directly
+on folded output. `index` on an add or a move is a command parameter (a position
+at the moment of the edit), never an identity.
+
+**A delta with no base is refused, never guessed.** `fold_snapshot` raises
+`NoBaseSnapshotError` when a patch has no preceding snapshot and
+`DeltaConflictError` when an op does not fit the state (clearing an absent key,
+moving an unknown part). Both mean "the fold is not standing where the producer
+stood", and applying anyway would produce a state nobody ever saved. This is the
+price the size saving is bought with, and it is charged loudly.
+
+The mechanism works. That was never the hard part.
+
+## What it costs the rest of rakaia
+
+Six places assume every event is a full snapshot. Each is a *test* in
+`test_deltas_integration.py` rather than a paragraph here, so the cost is
+measured, and so a change that removes a hazard fails a test instead of going
+unnoticed. All six are payable; two are sharp.
+
+| # | Hazard | Remedy | Sharpness |
+|---|---|---|---|
+| 1 | **Content routing misses a patch.** `match_field` tests a glob against `str(event[match_field])`. A snapshot carries `form_type`; a patch does not, so the handler silently does not fire — an unmatched content-routed event is *normal*, so nothing raises | carry the routing fields on the patch alongside `ops` | **sharp** — silent |
+| 2 | **Upcasters do not see inside a path.** A rename upcaster moves a *key*. In a patch the old name is a segment of a path string, so the upcaster passes it through and the fold resurrects the pre-rename key | a second, path-aware upcaster body per rename — which nothing makes you write | **sharp** — long fuse; only bites when a schema version lands, by which time the un-upcast patches are durable |
+| 3 | `project_latest` folds a patch as a whole state, so the row becomes the diff. No exception on the way | fold before projecting | contained |
+| 4 | **History rows stop being self-contained.** "What did this look like at version N" needs a re-fold from the last snapshot row. `peak_snapshot` (most fields wins) can never select a patch — accidentally right, for the wrong reason | re-fold, or keep a snapshot column | contained |
+| 5 | **Random access is gone.** A tail read must reach the last snapshot or be handed a base. The choice between *periodic snapshots* and *an explicit base from the projection row* **is** the adoption decision | either, exercised in the spike | design work |
+| 6 | **A delta is not an Effect.** Every Effect converges on re-application; adding a part twice does not. Idempotency lives at the fold, not the op | rebuild by re-folding then upserting, never by re-applying a delta to a row | inherent |
+
+Hazards 1 and 2 are the ones to weigh. Both are *silent* under the current
+registries — the machinery has no way to notice that a delta was routed nowhere or
+upcast incompletely — and both would need registry-side support to be safe, which
+is new surface in the place ADR 0004 just finished narrowing.
+
+## Whether the data supports the motivation
+
+Measured against the live Partisipa dataset (`partisipa-agent-bigbang`):
+16,588 submissions with a `fields` blob, 70,910 history events over 16,791
+subjects, 54,119 consecutive save pairs.
+
+### The payloads are small
+
+| | p50 | p90 | p99 | max |
+|---|---|---|---|---|
+| submission `fields` bytes | **366** | 1,096 | 1,867 | 9,356 |
+| repeater rows per submission | 2 | 4 | — | 32 |
+
+8,463 of 16,588 submissions have at least one repeater row; a repeater is a median
+41% of the payload it sits in. The largest form blob in production is 9 KB.
+
+### Two thirds of the log is already avoidable without any new event type
+
+| | pairs | share |
+|---|---|---|
+| consecutive save pairs | 54,119 | |
+| **`fields` byte-identical** (the row changed — status, timestamps — the payload did not) | **35,981** | **66%** |
+| payload actually changed | 18,138 | 34% |
+
+That 66% confirms ADR 0004's 62% figure on a larger sample. It is removed by
+`append_if_changed`, which rakaia already ships, which the glossary already names,
+and which the consumer has never imported. **Two thirds of the volume needs no new
+event type at all.**
+
+### On the third that did change, deltas save 8 MB
+
+| | value |
+|---|---|
+| full-snapshot bytes over all changed pairs | 11.6 MB |
+| delta-patch bytes for the same changes | 3.6 MB |
+| saving | **69% — 8 MB** |
+| patch/snapshot ratio | p50 **0.17**, p90 0.92 |
+| pairs where the patch is **no smaller** | 1,691 (**9%**) |
+
+For scale: `formkit_ninja_submissionevent` is 62 MB and `rakaia_streamevent`
+42 MB. Eight megabytes across the entire production history is not a storage
+problem, and 9% of the time the delta is the *larger* representation.
+
+### The reorder case, which the array ops exist for, does not occur
+
+7,161 repeater-array changes, classified by comparing the before/after arrays:
+
+| shape | n | share | is index-keying already correct? |
+|---|---|---|---|
+| `content_only` — same length and order, cells edited | 5,158 | 72% | yes |
+| `append_only` — rows added at the end | 1,106 | 15% | yes |
+| `truncate_only` — rows dropped from the end | 693 | 10% | yes |
+| `insert_shift` — a row inserted mid-list, survivors' order kept | 121 | 2% | no |
+| `other` | 75 | 1% | no |
+| **`pure_reorder` — a permutation, nothing else** | **8** | **0.1%** | no |
+
+Rows a positional diff marks changed: 8,466. Rows an identity-aware diff needs:
+8,281. **Over-reporting factor 1.02×.**
+
+ADR 0001's caveat — that `[A,B,C] -> [C,A,B]` is indistinguishable from "every
+slot's content changed" — is real, and it fires **eight times in the entire
+production history**. 97% of repeater changes are exactly the fixed-order /
+append-only shape the ADR says index-keyed `reconcile_children` already handles
+correctly.
+
+### The prerequisite nobody has
+
+The array events can only carry intent the **producer actually has**. Under
+whole-form saves the producer has to *infer* "row 3 moved to position 1" by
+diffing two snapshots — and a diff over rows with no stable id cannot distinguish
+a move from two edits any better than the projection can. So the fidelity
+argument is conditional on the frontend becoming command-sourced (emitting "row
+moved" as the user drags it), which is ADR 0001's own framing: *"if the client is
+command-sourced … Not available under full-snapshot submissions."*
+
+That is a producer-side change in a different repository, and it is the real
+blocker. rakaia can accept a `MovePart` today; nothing upstream is in a position
+to emit one.
+
+## Recommendation
+
+**Do not adopt either shape yet.** Stated as triggers rather than judgement, so
+the answer is checkable when it changes:
+
+1. **Land `append_if_changed` at the consumer first.** It removes 66% of the log
+   with no new event type, no fold, and none of the six hazards. Doing anything
+   else before this is optimising the 34% while ignoring the 66%.
+2. **Keep the spike on its branch, unmerged.** It is 81 green tests and a
+   working design; its value right now is as the answer to "what would this
+   cost", not as shipped surface. `rakaia.deltas` is deliberately absent from
+   `__all__` — the public API promises nothing here.
+
+### What would reopen it
+
+- **A command-sourced producer.** A frontend that emits row-level intent, not a
+  whole-form save. Until one exists the array ops have no source of truth to
+  carry, and the reorder count stays at 8.
+- **Payloads an order of magnitude larger.** A form family whose blob runs to
+  hundreds of kilobytes, or a repeater in the hundreds of rows — 9 KB and 32 rows
+  are the current maxima and neither is close.
+- **A latency problem, not a storage one.** The measured case is bytes-at-rest,
+  where 8 MB is nothing. If a write path becomes slow *because* of payload size
+  (mobile upload over a thin link, say), that is a different measurement and this
+  note does not answer it.
+- **Registry support for hazards 1 and 2.** If content routing and upcasting grow
+  a way to fail loudly on a payload shape they cannot handle, the sharp half of
+  the cost goes away and the balance changes.
+
+The honest summary: the mechanism is sound and cheap to build, the stated reason
+(efficiency) is not supported by the data by roughly an order of magnitude, and
+the better reason (recovering reorder intent) is blocked on a producer that does
+not exist.

--- a/src/rakaia/deltas.py
+++ b/src/rakaia/deltas.py
@@ -1,0 +1,541 @@
+"""
+Deltas: partial-update and part (array) events — an event that says *what
+changed* instead of re-carrying the whole subject.
+
+Every event rakaia has projected so far is a **full snapshot**: `project_latest`
+says as much ("Because every event is a full snapshot, 'latest' needs no
+reducer"). That holds up until one field of a large form changes. The first
+production consumer's forms carry repeated child collections (FormKit
+"repeaters") of dozens of rows; editing one cell re-appends every row, and 62% of
+its re-saves re-carried the blob with no content change at all.
+
+A **delta** event carries only the change. Five operations, one per shape of
+change, mirroring the one-type-per-operation split in `effects.py`:
+
+* :class:`SetField` / :class:`ClearField` — the partial update. Set or remove one
+  location in the payload.
+* :class:`AddPart` / :class:`RemovePart` / :class:`MovePart` — the array ops.
+  Insert, delete or reorder one row of a repeated collection.
+
+They travel together in one **patch event**: envelope ``label="patch"``, payload
+``{"ops": [...]}``. One save is one event however many things it touched, so
+atomicity is preserved and the audit log still reads one row per save.
+
+Two design points are load-bearing and are pinned by tests rather than left to
+convention:
+
+**Parts have identity, positions do not.** ADR 0001 rejects positional index as
+identity and requires a stable child id — noting that when the source has none,
+one must be *assigned at ingestion*. :class:`AddPart` is that assignment: it
+carries the ``part_id`` the producer mints and stamps it into the folded row
+under `PART_ID_KEY`. That is what makes :class:`MovePart` expressible at all,
+and it closes the caveat the ADR left open: under full snapshots
+``[A,B,C] -> [C,A,B]`` is indistinguishable from "every slot's content changed",
+so no projection can recover "C moved". With a move event it is one reorder of
+three stable rows. ``index`` on an add or a move is a *command parameter* — a
+position in the collection at the moment of the edit — never an identity.
+
+**A delta is meaningless without a base, and this module refuses to guess one.**
+`fold_snapshot` raises :class:`NoBaseSnapshotError` when a patch arrives with no
+preceding snapshot, and :class:`DeltaConflictError` when an op does not fit the
+state it is applied to (clearing an absent key, moving an unknown part). Both
+mean the same thing: the fold is not standing where the producer stood. Applying
+the patch anyway would produce a state nobody ever saved — the one failure a
+system whose selling point is "replay gives the answer that was correct at the
+time" cannot afford to make quietly. This is the cost deltas buy their size
+saving with, and it is why `fold_snapshot` takes an explicit ``base=``: an
+incremental tail read must supply the state it is resuming from.
+
+Nothing here is a new registration kind. A delta is a *payload shape* a handler
+decodes, consistent with ADR 0004 — the extension point stays the content-routed
+staged handler.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+from .types import StreamMessage
+
+# =============================================================================
+# Constants
+# =============================================================================
+
+#: The envelope label a patch event carries. Chosen rather than reusing
+#: ``update`` so that a consumer reading a stream can tell a snapshot from a
+#: delta without decoding the payload, and so `label_marker` keeps mapping
+#: ``update`` to ``~`` unchanged.
+PATCH_LABEL = "patch"
+
+#: The key under which a part's stable id is stamped into its folded row.
+#:
+#: Underscore-prefixed so it cannot collide with a form field, and *reserved*:
+#: :class:`AddPart` rejects a value that already carries it, because a payload
+#: setting its own part id would let two rows claim one identity.
+PART_ID_KEY = "_part"
+
+#: The payload key holding a patch's operation list.
+OPS_KEY = "ops"
+
+
+# =============================================================================
+# Errors
+# =============================================================================
+
+
+class DeltaError(Exception):
+    """Base for the two ways a delta fails."""
+
+
+class DeltaConflictError(DeltaError):
+    """An operation does not fit the state it was applied to.
+
+    Clearing a key that is absent, adding a part id that already exists, moving
+    or removing one that does not, indexing past the end of a collection. Every
+    case means the same thing — the state being folded is not the state the
+    producer patched against — and every case is raised rather than skipped: a
+    delta silently dropped converges on a state that was never saved, which is
+    indistinguishable from a correct fold at the point where anyone looks.
+    """
+
+
+class NoBaseSnapshotError(DeltaError):
+    """A patch was folded with nothing to apply it to.
+
+    Either the message window opened mid-stream (a tail read starting after the
+    last snapshot) or the subject's latest event was a tombstone. Pass
+    ``fold_snapshot(..., base=…)`` with the state being resumed from.
+    """
+
+
+# =============================================================================
+# The operations
+# =============================================================================
+#
+# One frozen dataclass per operation, each carrying only the fields its own
+# operation uses — the same reasoning as `effects.py`: a `part_id` on a
+# `SetField` or a `value` on a `MovePart` is then a type error rather than a
+# runtime check.
+
+
+@dataclass(frozen=True)
+class SetField:
+    """Set one location in the payload to ``value``.
+
+    ``path`` is a tuple of segments walked from the root. A segment addressing a
+    member of a repeated collection is that member's **part id**, not its index
+    — ``("rows", "p2", "n")`` means "field ``n`` of the part ``p2``", and stays
+    correct across every reorder.
+
+    The parent of the target must already exist: a set through a missing branch
+    raises rather than autovivifying it, so a patch written against one schema
+    cannot silently invent a branch in another.
+    """
+
+    path: tuple[str, ...]
+    value: Any
+
+    def __post_init__(self) -> None:
+        if not self.path:
+            raise ValueError("SetField has an empty path; it must name a location.")
+
+
+@dataclass(frozen=True)
+class ClearField:
+    """Remove one location from the payload. ``path`` reads as in :class:`SetField`.
+
+    Distinct from ``SetField(path, None)`` on purpose: a form field explicitly
+    answered "none" and a field that is not present are different facts, and a
+    projection that cannot tell them apart cannot round-trip its own state.
+    """
+
+    path: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        if not self.path:
+            raise ValueError("ClearField has an empty path; it must name a location.")
+
+
+@dataclass(frozen=True)
+class AddPart:
+    """Insert a row into the repeated collection at ``key``.
+
+    ``index`` is where it lands in the collection *as it stands now* — a command
+    parameter, not an identity. ``part_id`` is the identity: minted by the
+    producer, stamped into the stored row under `PART_ID_KEY`, and the thing
+    every later op names. The collection is created when ``key`` is absent, so
+    the first add needs no prior array.
+    """
+
+    key: str
+    index: int
+    part_id: str
+    value: dict[str, Any]
+
+    def __post_init__(self) -> None:
+        if self.index < 0:
+            raise ValueError(f"AddPart index must be >= 0, got {self.index}.")
+        if not self.part_id:
+            raise ValueError("AddPart needs a non-empty part_id.")
+        if PART_ID_KEY in self.value:
+            raise ValueError(
+                f"AddPart value carries the reserved key {PART_ID_KEY!r}; the "
+                f"part id comes from part_id=, so a payload setting its own "
+                f"would let two rows claim one identity."
+            )
+
+
+@dataclass(frozen=True)
+class RemovePart:
+    """Remove the part ``part_id`` from the collection at ``key``.
+
+    By id, never by position — which is what keeps a remove correct when it is
+    folded after a reorder it did not know about.
+    """
+
+    key: str
+    part_id: str
+
+
+@dataclass(frozen=True)
+class MovePart:
+    """Move the part ``part_id`` to position ``index`` within ``key``.
+
+    ``index`` is the destination in the collection **with the moved part taken
+    out** — the position a drag-and-drop UI reports, and the reading that makes
+    moving a part to the position it already occupies a no-op rather than an
+    off-by-one.
+    """
+
+    key: str
+    part_id: str
+    index: int
+
+    def __post_init__(self) -> None:
+        if self.index < 0:
+            raise ValueError(f"MovePart index must be >= 0, got {self.index}.")
+
+
+#: Anything a patch event may carry.
+Delta = SetField | ClearField | AddPart | RemovePart | MovePart
+
+
+# =============================================================================
+# Applying one delta
+# =============================================================================
+
+
+def _find_part(rows: list[Any], part_id: str) -> int:
+    for i, row in enumerate(rows):
+        if isinstance(row, dict) and row.get(PART_ID_KEY) == part_id:
+            return i
+    return -1
+
+
+def _collection(state: dict[str, Any], key: str, op: str) -> list[Any]:
+    rows = state.get(key)
+    if not isinstance(rows, list):
+        raise DeltaConflictError(
+            f"{op}: {key!r} is not a collection in the state being folded "
+            f"({'absent' if rows is None else type(rows).__name__})."
+        )
+    return rows
+
+
+def _descend(state: dict[str, Any], path: tuple[str, ...]) -> tuple[Any, str]:
+    """Walk `path[:-1]`, copying each container on the way, and return the
+    mutable parent plus the final segment.
+
+    Copy-on-descend rather than a deep copy: the fold is a chain of applications
+    over states a caller may still hold (the ``base=``), so no input is ever
+    mutated, but untouched subtrees stay shared instead of being cloned per op.
+    """
+    parent: Any = state
+    for depth, segment in enumerate(path[:-1]):
+        walked = "/".join(path[: depth + 1])
+        if isinstance(parent, list):
+            i = _find_part(parent, segment)
+            if i < 0:
+                raise DeltaConflictError(
+                    f"no part {segment!r} in the collection at /{walked}."
+                )
+            child = dict(parent[i])
+            parent[i] = child
+            parent = child
+            continue
+        if not isinstance(parent, dict) or segment not in parent:
+            raise DeltaConflictError(
+                f"path /{walked} does not exist in the state being folded; a "
+                f"set through a missing branch is refused rather than creating it."
+            )
+        value = parent[segment]
+        if isinstance(value, dict):
+            child = dict(value)
+        elif isinstance(value, list):
+            child = list(value)
+        else:
+            child = value
+        if not isinstance(child, (dict, list)):
+            raise DeltaConflictError(
+                f"path /{walked} is a {type(child).__name__}, not a container."
+            )
+        parent[segment] = child
+        parent = child
+    return parent, path[-1]
+
+
+def apply_delta(state: dict[str, Any], delta: Delta) -> dict[str, Any]:
+    """Return ``state`` with ``delta`` applied. Pure: the input is not mutated.
+
+    Raises :class:`DeltaConflictError` when the op does not fit the state.
+    """
+    new = dict(state)
+
+    if isinstance(delta, (SetField, ClearField)):
+        parent, last = _descend(new, delta.path)
+        if isinstance(parent, list):
+            # The path's last segment is a part id, so it addresses a whole row
+            # rather than a field of one. Replacing or dropping a row is what
+            # AddPart/RemovePart are for — and routing it here would lose the
+            # part's identity checks, so it is refused rather than approximated.
+            raise DeltaConflictError(
+                f"path /{'/'.join(delta.path)} addresses a whole part of "
+                f"/{'/'.join(delta.path[:-1])}; name a field inside it, or use "
+                f"AddPart/RemovePart to add or drop the row itself."
+            )
+        if isinstance(delta, SetField):
+            parent[last] = delta.value
+        else:
+            if last not in parent:
+                raise DeltaConflictError(
+                    f"cannot clear /{'/'.join(delta.path)}: it is not present in "
+                    f"the state being folded."
+                )
+            del parent[last]
+        return new
+
+    if isinstance(delta, AddPart):
+        rows = list(new.get(delta.key) or [])
+        if delta.key in new and not isinstance(new[delta.key], list):
+            raise DeltaConflictError(
+                f"AddPart: {delta.key!r} is a "
+                f"{type(new[delta.key]).__name__}, not a collection."
+            )
+        if _find_part(rows, delta.part_id) >= 0:
+            raise DeltaConflictError(
+                f"AddPart: part {delta.part_id!r} already exists in {delta.key!r}; "
+                f"a re-used id would give two rows one identity."
+            )
+        if delta.index > len(rows):
+            raise DeltaConflictError(
+                f"AddPart: index {delta.index} is past the end of {delta.key!r} "
+                f"(length {len(rows)})."
+            )
+        rows.insert(delta.index, {PART_ID_KEY: delta.part_id, **delta.value})
+        new[delta.key] = rows
+        return new
+
+    if isinstance(delta, RemovePart):
+        rows = list(_collection(new, delta.key, "RemovePart"))
+        i = _find_part(rows, delta.part_id)
+        if i < 0:
+            raise DeltaConflictError(
+                f"RemovePart: no part {delta.part_id!r} in {delta.key!r}."
+            )
+        del rows[i]
+        new[delta.key] = rows
+        return new
+
+    if isinstance(delta, MovePart):
+        rows = list(_collection(new, delta.key, "MovePart"))
+        i = _find_part(rows, delta.part_id)
+        if i < 0:
+            raise DeltaConflictError(
+                f"MovePart: no part {delta.part_id!r} in {delta.key!r}."
+            )
+        row = rows.pop(i)
+        if delta.index > len(rows):
+            raise DeltaConflictError(
+                f"MovePart: index {delta.index} is past the end of {delta.key!r} "
+                f"(length {len(rows)} once the moved part is taken out)."
+            )
+        rows.insert(delta.index, row)
+        new[delta.key] = rows
+        return new
+
+    raise TypeError(f"not a delta: {delta!r}")
+
+
+# =============================================================================
+# The wire form
+# =============================================================================
+#
+# Paths are encoded as JSON Pointers (RFC 6901) so the escaping rule for a
+# segment containing "/" or "~" is a citation rather than a house invention.
+
+
+def _encode_pointer(path: tuple[str, ...]) -> str:
+    return "".join("/" + s.replace("~", "~0").replace("/", "~1") for s in path)
+
+
+def _decode_pointer(pointer: str) -> tuple[str, ...]:
+    if not pointer.startswith("/"):
+        raise ValueError(f"not a JSON Pointer: {pointer!r} (must start with '/')")
+    return tuple(
+        s.replace("~1", "/").replace("~0", "~") for s in pointer[1:].split("/")
+    )
+
+
+def encode_patch(deltas: Iterable[Delta]) -> dict[str, Any]:
+    """The JSON payload of a patch event carrying ``deltas``, in order."""
+    ops: list[dict[str, Any]] = []
+    for d in deltas:
+        if isinstance(d, SetField):
+            ops.append({"op": "set", "path": _encode_pointer(d.path), "value": d.value})
+        elif isinstance(d, ClearField):
+            ops.append({"op": "clear", "path": _encode_pointer(d.path)})
+        elif isinstance(d, AddPart):
+            ops.append(
+                {
+                    "op": "add_part",
+                    "key": d.key,
+                    "index": d.index,
+                    "part": d.part_id,
+                    "value": d.value,
+                }
+            )
+        elif isinstance(d, RemovePart):
+            ops.append({"op": "remove_part", "key": d.key, "part": d.part_id})
+        elif isinstance(d, MovePart):
+            ops.append(
+                {"op": "move_part", "key": d.key, "part": d.part_id, "index": d.index}
+            )
+        else:
+            raise TypeError(f"not a delta: {d!r}")
+    return {OPS_KEY: ops}
+
+
+def decode_patch(payload: dict[str, Any]) -> list[Delta]:
+    """The deltas a patch payload carries. Raises ``ValueError`` on an unknown op.
+
+    Unknown ops are refused rather than skipped: a reader that quietly ignores an
+    operation it does not understand folds to a state the producer never wrote,
+    and reports success while doing it.
+    """
+    raw = payload.get(OPS_KEY)
+    if not isinstance(raw, list):
+        raise ValueError(f"patch payload has no {OPS_KEY!r} list")
+    out: list[Delta] = []
+    for op in raw:
+        kind = op.get("op")
+        if kind == "set":
+            out.append(SetField(_decode_pointer(op["path"]), op.get("value")))
+        elif kind == "clear":
+            out.append(ClearField(_decode_pointer(op["path"])))
+        elif kind == "add_part":
+            out.append(
+                AddPart(op["key"], op["index"], op["part"], op.get("value") or {})
+            )
+        elif kind == "remove_part":
+            out.append(RemovePart(op["key"], op["part"]))
+        elif kind == "move_part":
+            out.append(MovePart(op["key"], op["part"], op["index"]))
+        else:
+            raise ValueError(
+                f"unknown delta op {kind!r}; a reader that skipped it would fold "
+                f"to a state the producer never wrote."
+            )
+    return out
+
+
+def is_patch(payload: Any) -> bool:
+    """Whether ``payload`` is a patch payload (an ``ops`` *list*).
+
+    Shape-based rather than label-based so a caller holding only the decoded
+    payload can still tell. Prefer the envelope ``label == PATCH_LABEL`` when you
+    have the message, which is what `fold_snapshot` uses.
+    """
+    return isinstance(payload, dict) and isinstance(payload.get(OPS_KEY), list)
+
+
+# =============================================================================
+# Folding a message window
+# =============================================================================
+
+
+def fold_snapshot(
+    messages: Sequence[StreamMessage],
+    *,
+    base: dict[str, Any] | None = None,
+    tombstone_labels: Sequence[str] = ("delete",),
+) -> dict[str, Any] | None:
+    """Fold snapshots and patches into the current state, or ``None`` if deleted.
+
+    A message whose label is `PATCH_LABEL` is applied to the state so far; any
+    other message *replaces* it (an ordinary full snapshot), and a tombstone
+    label clears it. So a stream may mix the two freely, and a periodic full
+    snapshot is all a compaction strategy needs: it bounds how far back a reader
+    must go.
+
+    Args:
+        messages: the window, oldest first — typically ``store.read(path)`` for a
+            single subject, or one subject's slice of a family stream.
+        base: the state a patch at position 0 applies to. Required when the
+            window opens mid-stream; ``None`` (the default) means the window must
+            start with a snapshot.
+        tombstone_labels: labels meaning "no live state for this subject".
+
+    Raises:
+        NoBaseSnapshotError: a patch arrived with nothing to apply it to.
+        DeltaConflictError: an op did not fit the state; the message's offset is
+            named in the error so the divergence can be located in the log.
+    """
+    state: dict[str, Any] | None = dict(base) if base is not None else None
+    tombstones = set(tombstone_labels)
+
+    for msg in messages:
+        if msg.label in tombstones:
+            state = None
+            continue
+        payload = json.loads(msg.data)
+        if msg.label != PATCH_LABEL:
+            state = payload
+            continue
+        if state is None:
+            raise NoBaseSnapshotError(
+                f"patch at offset {msg.offset} has no base snapshot: the window "
+                f"opens after the subject's last full snapshot, or its last "
+                f"event was a tombstone. Pass base= with the state being "
+                f"resumed from."
+            )
+        for delta in decode_patch(payload):
+            try:
+                state = apply_delta(state, delta)
+            except DeltaConflictError as exc:
+                raise DeltaConflictError(f"at offset {msg.offset}: {exc}") from exc
+    return state
+
+
+def parts_of(state: dict[str, Any], key: str) -> list[tuple[str, int, dict[str, Any]]]:
+    """The collection at ``key`` as ``(part_id, position, row)`` triples.
+
+    The bridge to the projection helpers: pass the rows to `reconcile_tree` with
+    ``id_fn`` reading `PART_ID_KEY`, and write the position into the row's
+    ``defaults`` as its order field. Identity comes from the log, position from
+    the fold — the split ADR 0001 asks for.
+    """
+    rows = state.get(key) or []
+    if not isinstance(rows, list):
+        raise DeltaConflictError(f"{key!r} is not a collection.")
+    out: list[tuple[str, int, dict[str, Any]]] = []
+    for position, row in enumerate(rows):
+        if not isinstance(row, dict) or PART_ID_KEY not in row:
+            raise DeltaConflictError(
+                f"row {position} of {key!r} has no {PART_ID_KEY!r}; it was not "
+                f"materialised by an AddPart, so it has no stable identity."
+            )
+        out.append((row[PART_ID_KEY], position, row))
+    return out

--- a/tests/test_rakaia/test_deltas.py
+++ b/tests/test_rakaia/test_deltas.py
@@ -1,0 +1,445 @@
+"""Spike tests for rakaia.deltas — partial-update and part (array) events.
+
+Written test-first. Each class pins one question the design has to answer, and
+the failure modes are as load-bearing as the happy paths: a delta is only worth
+having if a fold that lost its place *says so* instead of quietly producing a
+state nobody ever saved.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from rakaia.deltas import (
+    PART_ID_KEY,
+    PATCH_LABEL,
+    AddPart,
+    ClearField,
+    DeltaConflictError,
+    MovePart,
+    NoBaseSnapshotError,
+    RemovePart,
+    SetField,
+    apply_delta,
+    decode_patch,
+    encode_patch,
+    fold_snapshot,
+    is_patch,
+    parts_of,
+)
+from rakaia.types import StreamMessage
+
+
+def _msg(payload: dict, *, label: str = "update", offset: str = "1") -> StreamMessage:
+    return StreamMessage(
+        data=json.dumps(payload).encode("utf-8"),
+        offset=offset,
+        timestamp=1.0,
+        label=label,
+    )
+
+
+def _patch_msg(*ops, offset: str = "1") -> StreamMessage:
+    return _msg(encode_patch(ops), label=PATCH_LABEL, offset=offset)
+
+
+# =============================================================================
+# 1. Partial update — set and clear a location, without re-carrying the blob
+# =============================================================================
+
+
+class TestSetField:
+    def test_sets_a_top_level_key(self):
+        state = {"suku": "Aileu", "output": 3}
+        assert apply_delta(state, SetField(("output",), 4)) == {
+            "suku": "Aileu",
+            "output": 4,
+        }
+
+    def test_does_not_mutate_the_input(self):
+        state = {"output": 3}
+        apply_delta(state, SetField(("output",), 4))
+        assert state == {"output": 3}
+
+    def test_sets_a_nested_key(self):
+        state = {"fields": {"a": 1, "b": 2}}
+        assert apply_delta(state, SetField(("fields", "b"), 9)) == {
+            "fields": {"a": 1, "b": 9}
+        }
+
+    def test_sets_a_key_that_did_not_exist(self):
+        assert apply_delta({"a": 1}, SetField(("b",), 2)) == {"a": 1, "b": 2}
+
+    def test_sets_a_field_inside_a_part(self):
+        state = {"rows": [{PART_ID_KEY: "p1", "n": 1}, {PART_ID_KEY: "p2", "n": 2}]}
+        out = apply_delta(state, SetField(("rows", "p2", "n"), 5))
+        assert out["rows"][1]["n"] == 5
+        assert out["rows"][0]["n"] == 1
+
+    def test_a_missing_parent_is_a_conflict_not_an_autovivify(self):
+        # Autovivifying {"fields": {"x": 1}} here would let a patch written
+        # against one schema silently invent a branch in another.
+        with pytest.raises(DeltaConflictError):
+            apply_delta({"a": 1}, SetField(("fields", "x"), 1))
+
+    def test_an_unknown_part_id_is_a_conflict(self):
+        state = {"rows": [{PART_ID_KEY: "p1", "n": 1}]}
+        with pytest.raises(DeltaConflictError):
+            apply_delta(state, SetField(("rows", "nope", "n"), 5))
+
+    def test_empty_path_is_rejected_at_construction(self):
+        with pytest.raises(ValueError):
+            SetField((), 1)
+
+
+class TestClearField:
+    def test_removes_a_key(self):
+        assert apply_delta({"a": 1, "b": 2}, ClearField(("b",))) == {"a": 1}
+
+    def test_removes_a_nested_key(self):
+        state = {"fields": {"a": 1, "b": 2}}
+        assert apply_delta(state, ClearField(("fields", "b"))) == {"fields": {"a": 1}}
+
+    def test_clearing_an_absent_key_is_a_conflict(self):
+        # A clear of something that is not there means the fold's base is not
+        # the base the producer patched against.
+        with pytest.raises(DeltaConflictError):
+            apply_delta({"a": 1}, ClearField(("b",)))
+
+    def test_clearing_a_field_of_a_part(self):
+        state = {"rows": [{PART_ID_KEY: "p1", "n": 1, "note": "x"}]}
+        out = apply_delta(state, ClearField(("rows", "p1", "note")))
+        assert out["rows"][0] == {PART_ID_KEY: "p1", "n": 1}
+
+
+class TestAWholePartIsNotAField:
+    # A path whose last segment is a part id addresses the row, not a field of
+    # it. Both ops refuse it rather than approximating RemovePart — which would
+    # skip the identity checks and, for ClearField, used to silently no-op.
+    def test_set_on_a_whole_part_is_refused(self):
+        state = {"rows": [{PART_ID_KEY: "p1", "n": 1}]}
+        with pytest.raises(DeltaConflictError, match="whole part"):
+            apply_delta(state, SetField(("rows", "p1"), {"n": 2}))
+
+    def test_clear_on_a_whole_part_is_refused(self):
+        state = {"rows": [{PART_ID_KEY: "p1", "n": 1}]}
+        with pytest.raises(DeltaConflictError, match="whole part"):
+            apply_delta(state, ClearField(("rows", "p1")))
+
+    def test_the_row_survives_the_refusal(self):
+        state = {"rows": [{PART_ID_KEY: "p1", "n": 1}]}
+        with pytest.raises(DeltaConflictError):
+            apply_delta(state, ClearField(("rows", "p1")))
+        assert state == {"rows": [{PART_ID_KEY: "p1", "n": 1}]}
+
+
+# =============================================================================
+# 2. Part ops — add / remove / move a row of an array
+# =============================================================================
+
+
+class TestAddPart:
+    def test_appends_at_the_index(self):
+        state = {"rows": [{PART_ID_KEY: "p1"}]}
+        out = apply_delta(state, AddPart("rows", 1, "p2", {"n": 7}))
+        assert out["rows"] == [{PART_ID_KEY: "p1"}, {PART_ID_KEY: "p2", "n": 7}]
+
+    def test_inserts_at_a_middle_index(self):
+        state = {"rows": [{PART_ID_KEY: "a"}, {PART_ID_KEY: "b"}]}
+        out = apply_delta(state, AddPart("rows", 1, "c", {}))
+        assert [r[PART_ID_KEY] for r in out["rows"]] == ["a", "c", "b"]
+
+    def test_stamps_the_part_id_into_the_row(self):
+        # The whole point: the source data has no stable child id, so the add
+        # event mints one and the folded row carries it (ADR 0001).
+        out = apply_delta({"rows": []}, AddPart("rows", 0, "p1", {"n": 1}))
+        assert out["rows"][0][PART_ID_KEY] == "p1"
+
+    def test_creates_the_array_when_the_key_is_absent(self):
+        out = apply_delta({}, AddPart("rows", 0, "p1", {"n": 1}))
+        assert out["rows"] == [{PART_ID_KEY: "p1", "n": 1}]
+
+    def test_a_duplicate_part_id_is_a_conflict(self):
+        state = {"rows": [{PART_ID_KEY: "p1"}]}
+        with pytest.raises(DeltaConflictError):
+            apply_delta(state, AddPart("rows", 1, "p1", {}))
+
+    def test_an_index_past_the_end_is_a_conflict(self):
+        with pytest.raises(DeltaConflictError):
+            apply_delta({"rows": []}, AddPart("rows", 3, "p1", {}))
+
+    def test_a_negative_index_is_rejected_at_construction(self):
+        with pytest.raises(ValueError):
+            AddPart("rows", -1, "p1", {})
+
+    def test_a_value_carrying_the_part_id_key_is_rejected(self):
+        with pytest.raises(ValueError):
+            AddPart("rows", 0, "p1", {PART_ID_KEY: "other"})
+
+
+class TestRemovePart:
+    def test_removes_by_id_not_by_position(self):
+        state = {"rows": [{PART_ID_KEY: "a"}, {PART_ID_KEY: "b"}, {PART_ID_KEY: "c"}]}
+        out = apply_delta(state, RemovePart("rows", "b"))
+        assert [r[PART_ID_KEY] for r in out["rows"]] == ["a", "c"]
+
+    def test_an_unknown_part_id_is_a_conflict(self):
+        with pytest.raises(DeltaConflictError):
+            apply_delta({"rows": [{PART_ID_KEY: "a"}]}, RemovePart("rows", "zz"))
+
+    def test_an_unknown_array_is_a_conflict(self):
+        with pytest.raises(DeltaConflictError):
+            apply_delta({}, RemovePart("rows", "a"))
+
+
+class TestMovePart:
+    def test_moves_to_a_later_index(self):
+        state = {"rows": [{PART_ID_KEY: c} for c in "abc"]}
+        out = apply_delta(state, MovePart("rows", "a", 2))
+        assert [r[PART_ID_KEY] for r in out["rows"]] == ["b", "c", "a"]
+
+    def test_moves_to_an_earlier_index(self):
+        state = {"rows": [{PART_ID_KEY: c} for c in "abc"]}
+        out = apply_delta(state, MovePart("rows", "c", 0))
+        assert [r[PART_ID_KEY] for r in out["rows"]] == ["c", "a", "b"]
+
+    def test_the_index_is_the_destination_after_removal(self):
+        # Pinned because "index" is ambiguous for a move: it is the position in
+        # the list *without* the moved element, which is what a drag-and-drop
+        # UI reports and what makes move(x, i) idempotent for i == current.
+        state = {"rows": [{PART_ID_KEY: c} for c in "abcd"]}
+        out = apply_delta(state, MovePart("rows", "b", 2))
+        assert [r[PART_ID_KEY] for r in out["rows"]] == ["a", "c", "b", "d"]
+
+    def test_moving_to_its_current_position_is_a_no_op(self):
+        state = {"rows": [{PART_ID_KEY: c} for c in "abc"]}
+        out = apply_delta(state, MovePart("rows", "b", 1))
+        assert [r[PART_ID_KEY] for r in out["rows"]] == ["a", "b", "c"]
+
+    def test_carries_the_row_content_with_it(self):
+        state = {"rows": [{PART_ID_KEY: "a", "n": 1}, {PART_ID_KEY: "b", "n": 2}]}
+        out = apply_delta(state, MovePart("rows", "a", 1))
+        assert out["rows"][1] == {PART_ID_KEY: "a", "n": 1}
+
+    def test_an_index_past_the_end_is_a_conflict(self):
+        with pytest.raises(DeltaConflictError):
+            apply_delta({"rows": [{PART_ID_KEY: "a"}]}, MovePart("rows", "a", 4))
+
+    def test_an_unknown_part_id_is_a_conflict(self):
+        with pytest.raises(DeltaConflictError):
+            apply_delta({"rows": [{PART_ID_KEY: "a"}]}, MovePart("rows", "z", 0))
+
+
+# =============================================================================
+# 3. The wire form — a patch event's payload
+# =============================================================================
+
+
+class TestEncoding:
+    @pytest.mark.parametrize(
+        "delta",
+        [
+            SetField(("fields", "output"), 4),
+            SetField(("rows", "p1", "n"), None),
+            ClearField(("fields", "note")),
+            AddPart("rows", 2, "p9", {"n": 1, "s": "x"}),
+            RemovePart("rows", "p9"),
+            MovePart("rows", "p9", 0),
+        ],
+    )
+    def test_round_trips_through_json(self, delta):
+        payload = json.loads(json.dumps(encode_patch([delta])))
+        assert decode_patch(payload) == [delta]
+
+    def test_a_patch_carries_several_ops_in_order(self):
+        ops = [
+            SetField(("a",), 1),
+            AddPart("rows", 0, "p", {}),
+            MovePart("rows", "p", 0),
+        ]
+        assert decode_patch(encode_patch(ops)) == ops
+
+    def test_paths_are_json_pointers(self):
+        assert encode_patch([SetField(("fields", "output"), 4)])["ops"][0]["path"] == (
+            "/fields/output"
+        )
+
+    def test_a_path_segment_with_a_slash_survives_the_round_trip(self):
+        delta = SetField(("fields", "a/b~c"), 1)
+        assert decode_patch(encode_patch([delta])) == [delta]
+
+    def test_is_patch_recognises_the_payload(self):
+        assert is_patch(encode_patch([SetField(("a",), 1)]))
+
+    def test_is_patch_rejects_an_ordinary_snapshot(self):
+        assert not is_patch({"suku": "Aileu", "ops": "not a patch"})
+
+    def test_an_unknown_op_is_rejected_loudly(self):
+        with pytest.raises(ValueError):
+            decode_patch({"ops": [{"op": "frobnicate", "path": "/a"}]})
+
+
+# =============================================================================
+# 4. Folding a stream — snapshots and patches together
+# =============================================================================
+
+
+class TestFoldSnapshot:
+    def test_a_lone_snapshot_folds_to_itself(self):
+        assert fold_snapshot([_msg({"a": 1})]) == {"a": 1}
+
+    def test_a_patch_applies_to_the_preceding_snapshot(self):
+        msgs = [_msg({"a": 1, "b": 2}), _patch_msg(SetField(("b",), 9))]
+        assert fold_snapshot(msgs) == {"a": 1, "b": 9}
+
+    def test_a_later_snapshot_replaces_the_state_entirely(self):
+        msgs = [
+            _msg({"a": 1}),
+            _patch_msg(SetField(("a",), 2)),
+            _msg({"z": 26}),
+        ]
+        assert fold_snapshot(msgs) == {"z": 26}
+
+    def test_patches_compose_in_order(self):
+        msgs = [
+            _msg({"rows": []}),
+            _patch_msg(AddPart("rows", 0, "a", {"n": 1})),
+            _patch_msg(AddPart("rows", 1, "b", {"n": 2})),
+            _patch_msg(MovePart("rows", "b", 0)),
+            _patch_msg(SetField(("rows", "a", "n"), 10)),
+        ]
+        state = fold_snapshot(msgs)
+        assert [(r[PART_ID_KEY], r["n"]) for r in state["rows"]] == [
+            ("b", 2),
+            ("a", 10),
+        ]
+
+    def test_a_patch_with_no_base_is_refused(self):
+        # The single most important failure: reading from a mid-stream offset
+        # lands on a patch, and folding it against {} would produce a state that
+        # was never saved. Deltas cost random access; this is where you pay.
+        with pytest.raises(NoBaseSnapshotError):
+            fold_snapshot([_patch_msg(SetField(("b",), 9))])
+
+    def test_an_explicit_base_lets_an_incremental_tail_fold(self):
+        base = {"a": 1, "b": 2}
+        msgs = [_patch_msg(SetField(("b",), 9))]
+        assert fold_snapshot(msgs, base=base) == {"a": 1, "b": 9}
+
+    def test_the_base_is_not_mutated(self):
+        base = {"a": 1}
+        fold_snapshot([_patch_msg(SetField(("a",), 2))], base=base)
+        assert base == {"a": 1}
+
+    def test_a_tombstone_folds_to_none(self):
+        msgs = [_msg({"a": 1}), _msg({}, label="delete")]
+        assert fold_snapshot(msgs) is None
+
+    def test_a_patch_after_a_tombstone_is_refused(self):
+        msgs = [
+            _msg({"a": 1}),
+            _msg({}, label="delete"),
+            _patch_msg(SetField(("a",), 2)),
+        ]
+        with pytest.raises(NoBaseSnapshotError):
+            fold_snapshot(msgs)
+
+    def test_a_conflicting_patch_names_the_offset_it_failed_at(self):
+        msgs = [
+            _msg({"a": 1}, offset="7"),
+            _patch_msg(ClearField(("nope",)), offset="8"),
+        ]
+        with pytest.raises(DeltaConflictError) as exc:
+            fold_snapshot(msgs)
+        assert "8" in str(exc.value)
+
+    def test_an_empty_message_list_with_no_base_folds_to_none(self):
+        assert fold_snapshot([]) is None
+
+    def test_folding_is_deterministic_across_repeats(self):
+        msgs = [
+            _msg({"rows": []}),
+            _patch_msg(AddPart("rows", 0, "a", {"n": 1})),
+            _patch_msg(AddPart("rows", 1, "b", {"n": 2})),
+        ]
+        assert fold_snapshot(msgs) == fold_snapshot(msgs)
+
+
+# =============================================================================
+# 5. The payoff — a folded array is reconcile_tree-ready
+# =============================================================================
+
+
+class TestPartsAreProjectable:
+    def test_parts_of_yields_id_and_position(self):
+        state = {"rows": [{PART_ID_KEY: "a", "n": 1}, {PART_ID_KEY: "b", "n": 2}]}
+        assert parts_of(state, "rows") == [
+            ("a", 0, {PART_ID_KEY: "a", "n": 1}),
+            ("b", 1, {PART_ID_KEY: "b", "n": 2}),
+        ]
+
+    def test_a_reorder_changes_position_but_not_identity(self):
+        # ADR 0001's caveat, closed: under full snapshots [a,b,c] -> [c,a,b] is
+        # indistinguishable from "every slot's content changed". With a move
+        # event the identities are unchanged and only the positions move, so a
+        # reconcile_tree keyed on the part id rewrites order, not rows.
+        msgs = [
+            _msg({"rows": []}),
+            _patch_msg(AddPart("rows", 0, "a", {"n": 1})),
+            _patch_msg(AddPart("rows", 1, "b", {"n": 2})),
+            _patch_msg(AddPart("rows", 2, "c", {"n": 3})),
+        ]
+        before = parts_of(fold_snapshot(msgs), "rows")
+        after = parts_of(
+            fold_snapshot([*msgs, _patch_msg(MovePart("rows", "c", 0))]), "rows"
+        )
+        assert {i for i, _, _ in before} == {i for i, _, _ in after}
+        assert [i for i, _, _ in after] == ["c", "a", "b"]
+        assert {i: r for i, _, r in before} == {i: r for i, _, r in after}
+
+    def test_reconcile_tree_over_folded_parts_keys_by_part_id(self):
+        from rakaia.projections import reconcile_tree
+
+        state = fold_snapshot(
+            [
+                _msg({"rows": []}),
+                _patch_msg(AddPart("rows", 0, "a", {"n": 1})),
+                _patch_msg(AddPart("rows", 1, "b", {"n": 2})),
+            ]
+        )
+        effects = reconcile_tree(
+            "app.Row",
+            {"submission_id": 5},
+            "part_id",
+            [row for _, _, row in parts_of(state, "rows")],
+            id_fn=lambda r: r[PART_ID_KEY],
+            defaults_fn=lambda r: {"n": r["n"]},
+        )
+        assert effects[0].lookup == {"submission_id": 5, "part_id": "a"}
+        assert effects[1].lookup == {"submission_id": 5, "part_id": "b"}
+
+
+# =============================================================================
+# 6. Size — the reason this exists at all
+# =============================================================================
+
+
+class TestPayloadSize:
+    def test_a_one_field_edit_of_a_large_repeater_is_orders_of_magnitude_smaller(self):
+        rows = [
+            {
+                PART_ID_KEY: f"p{i}",
+                "project": f"proj-{i}",
+                "output": i,
+                "note": "x" * 40,
+            }
+            for i in range(60)
+        ]
+        snapshot = {"suku": "Aileu", "rows": rows}
+        full = len(json.dumps(snapshot).encode())
+        patch = len(
+            json.dumps(encode_patch([SetField(("rows", "p30", "output"), 99)])).encode()
+        )
+        assert patch * 20 < full

--- a/tests/test_rakaia/test_deltas_integration.py
+++ b/tests/test_rakaia/test_deltas_integration.py
@@ -1,0 +1,335 @@
+"""What a delta event costs the rest of rakaia.
+
+The `test_deltas.py` cases pin what deltas *do*. These pin what they *break* —
+four places that quietly assume every event is a full snapshot. Each is written
+as an executable statement of the hazard rather than a paragraph in a design doc,
+so the cost of adopting deltas is measured rather than asserted, and so a future
+change that removes a hazard fails a test here instead of going unnoticed.
+
+None of these are bugs in the code under test. They are the price of the payload
+shape, and the point of writing them down is that the price is payable — each has
+a named remedy, exercised alongside the hazard.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from rakaia.deltas import (
+    PATCH_LABEL,
+    AddPart,
+    SetField,
+    apply_delta,
+    encode_patch,
+    fold_snapshot,
+    is_patch,
+)
+from rakaia.history import history_effects, label_marker
+from rakaia.projections import project_latest
+from rakaia.registry import HandlerRegistry, UpcasterRegistry
+from rakaia.types import StreamMessage
+
+
+def _msg(payload: dict, *, label: str = "update", offset: str = "1") -> StreamMessage:
+    return StreamMessage(
+        data=json.dumps(payload).encode("utf-8"),
+        offset=offset,
+        timestamp=1.0,
+        label=label,
+    )
+
+
+def _patch_msg(*ops, offset: str = "1", subject: str | None = None) -> StreamMessage:
+    payload = encode_patch(ops)
+    if subject is not None:
+        payload = {"subject": subject, **payload}
+    return _msg(payload, label=PATCH_LABEL, offset=offset)
+
+
+# =============================================================================
+# Hazard 1 — content routing reads a field the patch does not carry
+# =============================================================================
+
+
+class TestContentRoutingMissesAPatch:
+    """`match_field` routing tests a glob against ``str(event[match_field])``.
+
+    A snapshot carries ``form_type`` because it carries everything. A patch
+    carries only what changed, so the routing field is in the *base*, not the
+    event — and the handler that would have projected it simply does not fire.
+    Silently: an unmatched content-routed event is normal (a different form_type
+    on the same stream), so nothing raises.
+    """
+
+    def _registry(self) -> HandlerRegistry:
+        reg = HandlerRegistry()
+        reg.register(
+            name="tf611",
+            event_match="TF_6_1_1",
+            fn=lambda event: [],  # noqa: ARG005
+            effective_from=0,
+            match_field="form_type",
+        )
+        return reg
+
+    def test_a_snapshot_routes(self):
+        reg = self._registry()
+        assert reg.resolve("ignored", 0, {"form_type": "TF_6_1_1", "fields": {}})
+
+    def test_a_bare_patch_does_not_route(self):
+        reg = self._registry()
+        patch = encode_patch([SetField(("fields", "output"), 4)])
+        assert not reg.resolve("ignored", 0, patch)
+
+    def test_the_remedy_is_to_carry_the_routing_fields_on_the_patch(self):
+        # A patch is "only what changed" plus whatever the *transport* needs to
+        # deliver it. Routing fields are the latter, so they ride along — the
+        # payload stays small because the repeater does not, not because the
+        # discriminator was dropped.
+        reg = self._registry()
+        patch = {
+            "form_type": "TF_6_1_1",
+            **encode_patch([SetField(("fields", "output"), 4)]),
+        }
+        assert reg.resolve("ignored", 0, patch)
+        assert is_patch(patch)
+
+
+# =============================================================================
+# Hazard 2 — an upcaster rewrites a snapshot's fields, not a patch's paths
+# =============================================================================
+
+
+class TestUpcastersDoNotSeeInsideAPath:
+    """A rename upcaster is ``event -> event``. Against a snapshot it moves a
+    key. Against a patch the key it is looking for is not a key at all — it is a
+    *segment of a path string* — so the upcaster passes the patch through
+    untouched and the fold writes the pre-rename name.
+
+    This is the hazard with the longest fuse: it only bites on the day a schema
+    version lands, by which time the un-upcast patches are already durable.
+    """
+
+    def _registry(self) -> UpcasterRegistry:
+        reg = UpcasterRegistry()
+
+        def rename(event: dict) -> dict:
+            out = dict(event)
+            if "beneficiaries" in out:
+                out["beneficiary_count"] = out.pop("beneficiaries")
+            return out
+
+        reg.register(event_match="subs/*", from_version=1, fn=rename)
+        return reg
+
+    def test_a_snapshot_is_renamed(self):
+        upcast = self._registry().upcast_to_current({"beneficiaries": 120}, "subs/x")
+        assert upcast == {"beneficiary_count": 120, "schema_version": 2}
+
+    def test_a_patch_path_is_left_at_the_old_name(self):
+        patch = encode_patch([SetField(("beneficiaries",), 120)])
+        upcast = self._registry().upcast_to_current(patch, "subs/x")
+        assert upcast["ops"][0]["path"] == "/beneficiaries"
+
+    def test_so_the_fold_writes_the_pre_rename_key(self):
+        upcast = self._registry().upcast_to_current(
+            encode_patch([SetField(("beneficiaries",), 120)]), "subs/x"
+        )
+        folded = fold_snapshot(
+            [_msg({"beneficiary_count": 1}), _msg(upcast, label=PATCH_LABEL)]
+        )
+        assert folded is not None
+        assert "beneficiaries" in folded  # the old name, resurrected
+        assert folded["beneficiary_count"] == 1  # the rename did not reach it
+
+    def test_the_remedy_is_a_path_aware_upcaster(self):
+        # Writable, but it is a *second* upcaster body per rename, and nothing in
+        # the registry makes forgetting it visible. That asymmetry is the finding.
+        def rename_paths(event: dict) -> dict:
+            if not is_patch(event):
+                return event
+            ops = [
+                {
+                    **op,
+                    "path": op["path"].replace("/beneficiaries", "/beneficiary_count"),
+                }
+                if "path" in op
+                else op
+                for op in event["ops"]
+            ]
+            return {**event, "ops": ops}
+
+        patched = rename_paths(encode_patch([SetField(("beneficiaries",), 120)]))
+        assert patched["ops"][0]["path"] == "/beneficiary_count"
+
+
+# =============================================================================
+# Hazard 3 — the latest-state projection folds a patch as if it were a snapshot
+# =============================================================================
+
+
+class TestProjectLatestTreatsAPatchAsAWholeState:
+    """`project_latest`'s contract is "every event is a full snapshot, so latest
+    needs no reducer". Handed a patch it does exactly what it says: the newest
+    event wins and becomes the row. The row is then the *diff*, not the state,
+    and no exception is raised on the way there.
+    """
+
+    def _messages(self):
+        return [
+            _msg({"subject": "s1", "suku": "Aileu", "output": 3}, offset="1"),
+            _patch_msg(SetField(("output",), 4), offset="2", subject="s1"),
+        ]
+
+    def test_the_row_becomes_the_diff(self):
+        effects = project_latest(
+            self._messages(),
+            "app.Sub",
+            subject_of=lambda e: e["subject"],
+            defaults_of=lambda _m, e: {k: v for k, v in e.items() if k != "subject"},
+        )
+        assert len(effects) == 1
+        assert "ops" in (effects[0].defaults or {})
+        assert "suku" not in (effects[0].defaults or {})
+
+    def test_the_remedy_is_to_fold_before_projecting(self):
+        state = fold_snapshot(self._messages())
+        assert state == {"subject": "s1", "suku": "Aileu", "output": 4}
+
+
+# =============================================================================
+# Hazard 4 — the audit row stops being a self-contained snapshot
+# =============================================================================
+
+
+class TestHistoryRowsAreNoLongerSelfContained:
+    """`history_effects` writes one row per event carrying the payload snapshot.
+    For a patch that payload is the ops list, so "what did this look like at
+    version N" stops being answerable by reading row N — you have to re-fold from
+    the last snapshot row. The peak-snapshot recovery (most fields wins) is worse
+    off still: a patch always has fewer fields than a snapshot, so it can never
+    be the peak, which is accidentally the right answer for the wrong reason.
+    """
+
+    def _effects(self):
+        msgs = [
+            _msg({"subject": "s1", "a": 1, "b": 2}, offset="1"),
+            _patch_msg(SetField(("b",), 9), offset="2", subject="s1"),
+        ]
+        return msgs, history_effects(
+            msgs,
+            "app.Audit",
+            subject_of=lambda e: e["subject"],
+            defaults_of=lambda m, e: {"label": m.label, "snapshot": e},
+            version_of=lambda m: m.offset,
+        )
+
+    def test_one_row_per_event_still(self):
+        _msgs, effects = self._effects()
+        assert [e.lookup["version"] for e in effects] == ["1", "2"]
+
+    def test_the_second_row_holds_ops_not_a_state(self):
+        _msgs, effects = self._effects()
+        assert "ops" in (effects[1].defaults or {})["snapshot"]
+
+    def test_so_reading_row_n_alone_no_longer_answers_what_it_looked_like(self):
+        msgs, effects = self._effects()
+        row = (effects[1].defaults or {})["snapshot"]
+        assert row.get("a") is None  # the value at version 2 is not in the row
+        assert fold_snapshot(msgs) == {
+            "subject": "s1",
+            "a": 1,
+            "b": 9,
+        }  # only a re-fold has it
+
+    def test_the_patch_label_needs_a_marker_decision(self):
+        # `label_marker` maps anything unrecognised to `~`, which happens to be
+        # right for a partial update and wrong for a patch whose only op adds or
+        # removes a part. Not broken — undecided, and the decision belongs with
+        # whoever owns the /history rendering.
+        assert label_marker(PATCH_LABEL) == "~"
+
+
+# =============================================================================
+# Hazard 5 — random access: a tail read has to find its base
+# =============================================================================
+
+
+class TestRandomAccessCosts:
+    """Under full snapshots any single message is a complete state, so a reader
+    can resume from any offset. Under deltas it cannot: the window must reach
+    back to the last snapshot, or be handed the state it is resuming from.
+
+    Both routes are exercised here because the choice between them *is* the
+    adoption decision — periodic snapshots bound the read, an explicit base
+    couples the reader to a projection row.
+    """
+
+    def _stream(self):
+        return [
+            _msg({"a": 1, "rows": []}, offset="1"),
+            _patch_msg(AddPart("rows", 0, "p1", {"n": 1}), offset="2"),
+            _patch_msg(AddPart("rows", 1, "p2", {"n": 2}), offset="3"),
+            _patch_msg(SetField(("a",), 5), offset="4"),
+        ]
+
+    def test_a_full_window_folds(self):
+        state = fold_snapshot(self._stream())
+        assert state is not None
+        assert state["a"] == 5
+        assert len(state["rows"]) == 2
+
+    def test_a_tail_window_refuses_rather_than_guessing(self):
+        from rakaia.deltas import NoBaseSnapshotError
+
+        with pytest.raises(NoBaseSnapshotError):
+            fold_snapshot(self._stream()[2:])
+
+    def test_route_a_periodic_snapshot_bounds_the_read(self):
+        stream = self._stream()
+        compacted = [_msg(fold_snapshot(stream) or {}, offset="5")]
+        assert fold_snapshot(compacted) == fold_snapshot(stream)
+
+    def test_route_b_an_explicit_base_from_the_projection_row(self):
+        stream = self._stream()
+        base = fold_snapshot(stream[:2])
+        assert fold_snapshot(stream[2:], base=base) == fold_snapshot(stream)
+
+
+# =============================================================================
+# Hazard 6 — a delta is not idempotent, so it cannot be an Effect
+# =============================================================================
+
+
+class TestDeltasAreNotEffects:
+    """Every rakaia Effect converges on re-application: that is what makes replay
+    safe. A delta does not — adding a part twice is two parts — which is why this
+    module produces *state*, and the state produces Effects, rather than deltas
+    being a sixth Effect applied straight to a row.
+    """
+
+    def test_re_applying_a_snapshot_upsert_converges(self):
+        state = {"rows": []}
+        once = apply_delta(state, AddPart("rows", 0, "p1", {"n": 1}))
+        assert fold_snapshot([_msg(once), _msg(once)]) == once
+
+    def test_re_applying_an_add_does_not(self):
+        from rakaia.deltas import DeltaConflictError
+
+        state = apply_delta({"rows": []}, AddPart("rows", 0, "p1", {"n": 1}))
+        # It raises rather than duplicating — the loud version of non-idempotent,
+        # which is the whole reason the conflict errors exist.
+        with pytest.raises(DeltaConflictError):
+            apply_delta(state, AddPart("rows", 0, "p1", {"n": 1}))
+
+    def test_but_re_folding_the_same_window_converges(self):
+        # Idempotency lives at the *fold*, not the op: replaying the window is
+        # safe, replaying one op is not. So a projection is rebuilt by re-folding
+        # and re-upserting, never by re-applying a delta to a row.
+        stream = [
+            _msg({"rows": []}, offset="1"),
+            _patch_msg(AddPart("rows", 0, "p1", {"n": 1}), offset="2"),
+        ]
+        assert fold_snapshot(stream) == fold_snapshot(stream)


### PR DESCRIPTION
Spikes #171 and #172. **Not for merge** — this is the measurement, not a proposal
to ship.

Adds a partial-update event and three array operations (add, remove, move a row),
with a pure fold that rebuilds current state from a snapshot plus the patches
after it. Rows get a stable id minted when they are added, which is what makes a
reorder recordable and closes a gap ADR 0001 documented and left open.

The design works and the gate is green, but the numbers it was built to justify do
not hold: two thirds of saves in production are already identical and need only a
feature rakaia ships today, the smaller events would save 8 MB across the whole
history, and the reordering case happens eight times in 7,161 collection changes.
The recommendation is to hold, and both issues carry the trigger that would change
the answer.