### PR TITLE
Stop re-deriving an offset high mark the watermark already holds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,29 @@ runnable demo for each.
 
 ## [Unreleased]
 
-Nothing yet.
+### Changed
+
+- **A durable append no longer scans the entry table to find its place.** Every
+  append recomputed the stream's high offset with an aggregate over all of its
+  entries, and read the offset high-water row twice — once to create it, once to
+  lock it. Allocation is now two queries: one locked read, one write. Reading the
+  stream head (`Stream.current_offset`, `DjangoStreamStore.current_offset`) drops
+  the same scan and is one query.
+
+  The high-water row is authoritative once it has been advanced, so the scan
+  survives for the single case that needs it: a watermark still at zero, which
+  means either a brand-new stream or an install upgraded across migration `0005`
+  (it creates the table without backfilling it). That runs once per stream and
+  seeds the row for every allocation after it. No migration is required and no
+  offset changes.
+
+  **Worth knowing if you write `StreamEntry` rows directly.** An entry inserted
+  without going through `Stream.get_next_offset_block` is now invisible to both
+  allocation and head-reporting once the watermark is above zero, where the old
+  aggregate would have absorbed it. Nothing in rakaia writes entries that way,
+  and `StreamEntry` is a Tier 2 read surface (see `docs/public-api.md`), but a
+  consumer that has been inserting its own rows should allocate through the
+  stream instead.
 
 ## [0.2.0] - 2026-08-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,9 @@ runnable demo for each.
   append recomputed the stream's high offset with an aggregate over all of its
   entries, and read the offset high-water row twice — once to create it, once to
   lock it. Allocation is now two queries: one locked read, one write. Reading the
-  stream head (`Stream.current_offset`, `DjangoStreamStore.current_offset`) drops
-  the same scan and is one query.
+  stream head drops the same scan — `Stream.current_offset` is one query, and
+  `DjangoStreamStore.get_current_offset` two, the second being its own
+  expiry check.
 
   The high-water row is authoritative once it has been advanced, so the scan
   survives for the single case that needs it: a watermark still at zero, which
@@ -26,12 +27,17 @@ runnable demo for each.
   offset changes.
 
   **Worth knowing if you write `StreamEntry` rows directly.** An entry inserted
-  without going through `Stream.get_next_offset_block` is now invisible to both
-  allocation and head-reporting once the watermark is above zero, where the old
-  aggregate would have absorbed it. Nothing in rakaia writes entries that way,
-  and `StreamEntry` is a Tier 2 read surface (see `docs/public-api.md`), but a
-  consumer that has been inserting its own rows should allocate through the
-  stream instead.
+  without going through `Stream.get_next_offset_block` no longer advances the
+  head, where the old aggregate would have absorbed it. The row is still stored
+  and still returned by a read — but it sits *out of order*: with a watermark at
+  1 and a hand-written entry at offset 99, the head stays at 1, the next
+  allocations are 2, 3, 4 …, and a subscriber resuming past 99 never sees them.
+  Allocation eventually reaches 99 and collides with the unique constraint.
+
+  Nothing in rakaia writes entries that way, and `StreamEntry` is a Tier 2 read
+  surface (see `docs/public-api.md`), so this is a narrowing of what the log
+  tolerates rather than a break. A consumer inserting its own rows should
+  allocate through the stream.
 
 ## [0.2.0] - 2026-08-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ runnable demo for each.
   entries, and read the offset high-water row twice — once to create it, once to
   lock it. Allocation is now two queries: one locked read, one write. Reading the
   stream head drops the same scan — `Stream.current_offset` is one query, and
-  `DjangoStreamStore.get_current_offset` two, the second being its own
+  `DjangoStreamStore.get_current_offset` two, the extra one being its own
   expiry check.
 
   The high-water row is authoritative once it has been advanced, so the scan

--- a/src/django_rakaia/django_store.py
+++ b/src/django_rakaia/django_store.py
@@ -1103,8 +1103,10 @@ class DjangoStreamStore:
         the live entries: a stream recreated at the same path reports a head at
         or above its retired high mark even before the first re-append, so a
         stale subscriber cursor reads as ``caught_up`` rather than a spurious
-        ``rewound`` (#34, Defect #2). Mirrors ``Stream.get_next_offset``'s
-        ``max(entries, watermark)`` so allocation and tail-reporting agree.
+        ``rewound`` (#34, Defect #2). Reads the high-water the same way
+        ``Stream.get_next_offset_block`` allocates from it — the watermark row,
+        falling back to the entries only when it has never been advanced — so
+        allocation and tail-reporting cannot name different heads.
 
         An expired stream reports ``None`` exactly as an absent one does — the
         in-memory store behaves the same, and every other read on this store

--- a/src/django_rakaia/models.py
+++ b/src/django_rakaia/models.py
@@ -101,8 +101,17 @@ class Stream(models.Model):
         to keep in step. Named to match the in-memory `Stream.current_offset`,
         which is what lets one protocol server read either.
         """
+        # Read the high-water from the same database this stream row came from,
+        # as `get_next_offset_block` allocates from (#159). Before the watermark
+        # became authoritative here this read took `max(entries, watermark)`, and
+        # the entries half already followed the alias — so a scratch-database
+        # rebuild happened to report its own entries when they were higher.
+        # Reporting the watermark alone without the alias would have turned that
+        # into reading the *live* high-water every time.
+        using = self._state.db
         watermark_high = (
-            StreamOffsetWatermark.objects.filter(stream_path=self.stream_id)
+            StreamOffsetWatermark.objects.using(using)
+            .filter(stream_path=self.stream_id)
             .values_list("high", flat=True)
             .first()
         )

--- a/src/django_rakaia/models.py
+++ b/src/django_rakaia/models.py
@@ -165,12 +165,24 @@ class Stream(models.Model):
         watermarks = StreamOffsetWatermark.objects.using(using)
         watermarks.get_or_create(stream_path=self.stream_id)
         watermark = watermarks.select_for_update().get(stream_path=self.stream_id)
-        # `max(entries, watermark)` is belt-and-suspenders: the watermark alone
-        # is authoritative for live streams, but taking the max also seeds it
-        # correctly from any pre-existing entries (e.g. rows written before this
-        # high-water table existed) on the first allocation after migration.
-        entries_max = self.entries.aggregate(max_offset=Max("offset"))["max_offset"]
-        start = max(entries_max or 0, watermark.high) + 1
+        # A watermark that has been advanced even once is authoritative: every
+        # `StreamEntry` in the codebase gets its offset from this method, so
+        # nothing can write an entry above the high mark. Re-deriving that mark
+        # from the entry table on every append would scan a growing table for an
+        # answer already held in one row.
+        #
+        # `high == 0` is the one case it cannot answer, because it means either
+        # "brand new path" or "install upgraded across migration 0005", which
+        # creates this table without backfilling it. On an upgraded install the
+        # entries are already there and the watermark is not, so allocating from
+        # the watermark alone would reissue offset 1 over the top of them. So the
+        # aggregate runs then — once per path, ever — and seeds the high mark for
+        # every allocation after it.
+        if watermark.high == 0:
+            entries_max = self.entries.aggregate(max_offset=Max("offset"))["max_offset"]
+            start = (entries_max or 0) + 1
+        else:
+            start = watermark.high + 1
         watermark.high = start + count - 1
         watermark.save(update_fields=["high"])
         return start

--- a/src/django_rakaia/models.py
+++ b/src/django_rakaia/models.py
@@ -101,13 +101,20 @@ class Stream(models.Model):
         to keep in step. Named to match the in-memory `Stream.current_offset`,
         which is what lets one protocol server read either.
         """
-        entries_max = self.entries.aggregate(max_offset=Max("offset"))["max_offset"]
         watermark_high = (
             StreamOffsetWatermark.objects.filter(stream_path=self.stream_id)
             .values_list("high", flat=True)
             .first()
         )
-        return format_offset(max(entries_max or 0, watermark_high or 0))
+        if watermark_high:
+            return format_offset(watermark_high)
+        # Zero, or no row at all: either this path has never been appended to, or
+        # the install was upgraded across migration 0005, which creates the
+        # high-water table without backfilling it. The same one case
+        # `get_next_offset_block` has to look at the entry table for, and for the
+        # same reason — see the gate there. Every other read is one row lookup.
+        entries_max = self.entries.aggregate(max_offset=Max("offset"))["max_offset"]
+        return format_offset(entries_max or 0)
 
     @property
     def closed_by(self) -> ClosedBy | None:
@@ -154,17 +161,26 @@ class Stream(models.Model):
         if count < 1:
             raise ValueError(f"count must be >= 1, got {count}")
         # Lock the per-path high-water for the duration of the enclosing
-        # transaction. get_or_create tolerates the first-writer race (it retries
-        # on the unique-key IntegrityError); the subsequent locked read then
-        # serializes the read-modify-write.
+        # transaction, so concurrent writers serialize here rather than colliding
+        # on unique_together(stream, offset).
+        #
         # Allocate on whatever database this stream row came from. `self.entries`
         # already follows the instance's alias, and the watermark has to agree
         # with it or a rebuild against a scratch database would read its
         # high-water from the live one (#159).
+        #
+        # One locked `get_or_create` rather than a plain one followed by a
+        # `select_for_update().get()`: the pair read the same row twice and threw
+        # the first result away, because the first call existed only to make the
+        # row exist. `get_or_create` on a locked queryset issues its `get` with
+        # `FOR UPDATE`, so the row is both created-if-absent and locked in one
+        # round trip, and it still tolerates the first-writer race the same way
+        # (it retries on the unique-key IntegrityError).
         using = self._state.db
         watermarks = StreamOffsetWatermark.objects.using(using)
-        watermarks.get_or_create(stream_path=self.stream_id)
-        watermark = watermarks.select_for_update().get(stream_path=self.stream_id)
+        watermark, _ = watermarks.select_for_update().get_or_create(
+            stream_path=self.stream_id
+        )
         # A watermark that has been advanced even once is authoritative: every
         # `StreamEntry` in the codebase gets its offset from this method, so
         # nothing can write an entry above the high mark. Re-deriving that mark

--- a/tests/test_django_rakaia/test_locking.py
+++ b/tests/test_django_rakaia/test_locking.py
@@ -46,9 +46,11 @@ from typing import Any
 import pytest
 from django.db import connection, connections, transaction
 from django.db.models import QuerySet
+from django.test.utils import CaptureQueriesContext
 
 from django_rakaia.django_store import DjangoStreamStore
 from django_rakaia.effect_executor import DjangoExecutor
+from django_rakaia.models import Stream
 from rakaia.effects import Retire, Transition
 from rakaia.types import AppendOptions
 
@@ -425,4 +427,47 @@ class TestRetireLock:
         assert len(seen) == 6, (
             f"expected all 6 alerts announced exactly once between the two "
             f"retires, got {len(seen)}"
+        )
+
+
+@requires_row_locks
+@pytest.mark.django_db(transaction=True)
+class TestTheWatermarkReadIsALockingRead:
+    """The offset watermark is read once, and that one read still takes the lock.
+
+    `get_next_offset_block` folds what used to be a plain `get_or_create` plus a
+    `select_for_update().get()` into a single locked `get_or_create`, halving the
+    reads on the hottest path in the package. That is only safe if Django applies
+    the queryset's `FOR UPDATE` to the `get` half — it does, but nothing in the
+    default run can see it, because SQLite reports `has_select_for_update` false
+    and Django then omits the clause entirely.
+
+    `test_concurrent_appends.py` races this lock and proves it *serialises*. This
+    asserts the clause is actually emitted, which is the failure mode a fold like
+    this introduces: a lock silently dropped still serialises fine under one
+    connection, so contention tests keep passing while the guarantee is gone.
+    Spying on `QuerySet.select_for_update` would only prove the method was called.
+    """
+
+    def test_the_single_watermark_read_carries_for_update(self):
+        Stream.objects.create(stream_id="lockread")
+        with transaction.atomic():
+            stream = Stream.objects.get(stream_id="lockread")
+            # Advance off zero first, so the measured call is the steady-state
+            # path rather than the once-per-path seeding branch.
+            stream.get_next_offset_block(1)
+            with CaptureQueriesContext(connection) as ctx:
+                stream.get_next_offset_block(1)
+
+        reads = [
+            q["sql"]
+            for q in ctx.captured_queries
+            if "rakaia_streamoffsetwatermark" in q["sql"]
+            and q["sql"].lstrip().upper().startswith("SELECT")
+        ]
+        assert len(reads) == 1, (
+            f"expected one watermark read, got {len(reads)}: {reads}"
+        )
+        assert "FOR UPDATE" in reads[0].upper(), (
+            f"the watermark read is not a locking read: {reads[0]}"
         )

--- a/tests/test_django_rakaia/test_offset_allocation.py
+++ b/tests/test_django_rakaia/test_offset_allocation.py
@@ -23,6 +23,7 @@ from django.db import connection
 from django.test.utils import CaptureQueriesContext
 
 from django_rakaia.models import Stream, StreamEntry, StreamEvent, StreamOffsetWatermark
+from django_rakaia.offsets import format_offset
 
 pytestmark = pytest.mark.django_db
 
@@ -67,6 +68,134 @@ class TestAllocationQueryCount:
             stream.get_next_offset_block(1)
 
         assert len(_aggregate_queries(ctx)) == 1
+
+    def test_a_steady_state_allocation_reads_the_watermark_once(self):
+        # `get_or_create` then `select_for_update().get()` read the same row
+        # twice: the first read exists only to make the row exist, and its
+        # result was thrown away. One locked `get_or_create` does both jobs.
+        stream = Stream.objects.create(stream_id="s")
+        stream.get_next_offset_block(1)
+
+        with CaptureQueriesContext(connection) as ctx:
+            stream.get_next_offset_block(1)
+
+        reads = [
+            q["sql"]
+            for q in ctx.captured_queries
+            if q["sql"].lstrip().upper().startswith("SELECT")
+            and "rakaia_streamoffsetwatermark" in q["sql"]
+        ]
+        assert len(reads) == 1, reads
+
+    def test_a_steady_state_allocation_costs_two_queries(self):
+        # The headline number, asserted exactly rather than as a ceiling: one
+        # locked read of the watermark, one write of it. Anything else on this
+        # path is paid by every append on every write surface, so a third query
+        # should have to be argued for rather than slipped in.
+        stream = Stream.objects.create(stream_id="s")
+        stream.get_next_offset_block(1)
+
+        with CaptureQueriesContext(connection) as ctx:
+            stream.get_next_offset_block(1)
+
+        assert len(ctx.captured_queries) == 2, [q["sql"] for q in ctx.captured_queries]
+
+
+@pytest.mark.skipif(
+    not connection.features.has_select_for_update,
+    reason=(
+        "backend has no row locks, so select_for_update() compiles to a plain "
+        "SELECT and the emitted SQL cannot answer this -- run with "
+        "RAKAIA_TEST_DB=postgres"
+    ),
+)
+class TestTheLockSurvivesGetOrCreate:
+    """That the *one* remaining read is still a locking one.
+
+    Folding the plain `get_or_create` and the `select_for_update().get()` into a
+    single locked `get_or_create` is only safe if Django applies the queryset's
+    `FOR UPDATE` to the `get` half. It does — but nothing in the default test run
+    can see that, because SQLite reports `has_select_for_update` false and Django
+    then omits the clause entirely. Spying on `QuerySet.select_for_update` (as
+    `test_django_store.py` does) proves the method was *called*, not that the
+    clause reached the database.
+
+    So this reads the SQL. It is the only assertion in the file that can tell a
+    real lock from a call that was silently dropped, and it is the reason this
+    change has to be run against Postgres before it is believed.
+    """
+
+    @pytest.mark.django_db(transaction=True)
+    def test_the_watermark_read_is_a_locking_read(self):
+        from django.db import transaction as db_transaction
+
+        Stream.objects.create(stream_id="s")
+        with db_transaction.atomic():
+            stream = Stream.objects.get(stream_id="s")
+            stream.get_next_offset_block(1)  # off zero, so the next is steady state
+            with CaptureQueriesContext(connection) as ctx:
+                stream.get_next_offset_block(1)
+
+        watermark_reads = [
+            q["sql"]
+            for q in ctx.captured_queries
+            if "rakaia_streamoffsetwatermark" in q["sql"]
+            and q["sql"].lstrip().upper().startswith("SELECT")
+        ]
+        assert len(watermark_reads) == 1, watermark_reads
+        assert "FOR UPDATE" in watermark_reads[0].upper(), watermark_reads[0]
+
+
+class TestTheReadSideAgrees:
+    """`Stream.current_offset` answers the same question from the same source.
+
+    It carried its own copy of `max(entries, watermark)`, so the read side had
+    the identical scan on the identical growing table — and would have kept it
+    after the write side stopped. Reported here rather than left as a follow-up
+    because #34/#59 already went that way once: the write side of a store
+    invariant was fixed and the read side was missed, and the two then disagreed
+    about where the stream head was.
+    """
+
+    def test_reading_the_head_does_not_aggregate_over_entries(self):
+        stream = Stream.objects.create(stream_id="s")
+        stream.get_next_offset_block(1)
+
+        with CaptureQueriesContext(connection) as ctx:
+            head = stream.current_offset
+
+        assert head == format_offset(1)
+        assert _aggregate_queries(ctx) == []
+
+    def test_the_head_matches_what_allocation_handed_out(self):
+        # The symmetry that matters: the two sides must name the same position.
+        # `current_offset` is "the offset of the last event", i.e. one below the
+        # next allocation.
+        stream = Stream.objects.create(stream_id="s")
+        stream.get_next_offset_block(4)
+        assert stream.current_offset == format_offset(4)
+        assert stream.get_next_offset_block(1) == 5
+
+    def test_an_upgraded_install_reads_its_existing_entries(self):
+        # The read side's version of the seeding case: entries exist, no
+        # watermark row does, and the head must still be 7 rather than 0.
+        stream = Stream.objects.create(stream_id="s")
+        for offset in (1, 2, 7):
+            _entry_at(stream, offset)
+
+        assert stream.current_offset == format_offset(7)
+
+    def test_a_fresh_stream_reads_zero(self):
+        stream = Stream.objects.create(stream_id="s")
+        assert stream.current_offset == format_offset(0)
+
+    def test_the_head_survives_delete_and_recreate(self):
+        stream = Stream.objects.create(stream_id="s")
+        stream.get_next_offset_block(3)
+        Stream.objects.filter(stream_id="s").delete()
+
+        recreated = Stream.objects.create(stream_id="s")
+        assert recreated.current_offset == format_offset(3)
 
 
 def _entry_at(stream: Stream, offset: int) -> None:

--- a/tests/test_django_rakaia/test_offset_allocation.py
+++ b/tests/test_django_rakaia/test_offset_allocation.py
@@ -185,6 +185,34 @@ class TestTheReadSideAgrees:
 
         assert stream.current_offset == format_offset(7)
 
+    def test_a_watermark_row_sitting_at_zero_still_falls_back(self):
+        # The read side has two ways to be unseeded and they are not the same
+        # value: no row at all reads as `None`, a row that exists but has never
+        # been advanced reads as `0`. The gate is a truthiness test so it covers
+        # both — writing it as `is not None` returns a head of 0 beside entries
+        # running to 7, and every other test in the file stays green.
+        #
+        # The zero-row state is reachable: allocation outside a transaction used
+        # to autocommit the `get_or_create` and only then raise on the locked
+        # read, leaving the row behind at zero.
+        stream = Stream.objects.create(stream_id="s")
+        StreamOffsetWatermark.objects.create(stream_path="s", high=0)
+        for offset in (1, 2, 7):
+            _entry_at(stream, offset)
+
+        assert stream.current_offset == format_offset(7)
+
+    def test_allocation_also_seeds_past_a_zero_watermark_row(self):
+        # The write side's version. It has no None/0 distinction — `get_or_create`
+        # hands back `high == 0` either way — but the state is the same one, and
+        # the two sides agreeing on it is the property this PR is about.
+        stream = Stream.objects.create(stream_id="s")
+        StreamOffsetWatermark.objects.create(stream_path="s", high=0)
+        for offset in (1, 2, 7):
+            _entry_at(stream, offset)
+
+        assert stream.get_next_offset_block(1) == 8
+
     def test_a_fresh_stream_reads_zero(self):
         stream = Stream.objects.create(stream_id="s")
         assert stream.current_offset == format_offset(0)

--- a/tests/test_django_rakaia/test_offset_allocation.py
+++ b/tests/test_django_rakaia/test_offset_allocation.py
@@ -1,0 +1,140 @@
+"""What the durable offset allocation costs, and what it must keep costing.
+
+`Stream.get_next_offset_block` is the single allocation path behind every
+durable write surface — the store's single and bulk append, `@stream_model`
+signals, the protocol views — so a query it issues is a query every append pays.
+These cases pin the count *and* the properties the count must not be bought
+with: monotonicity, the one watermark lock, and correct seeding on an install
+that predates the high-water table.
+
+The seeding case is why the count was what it was. Migration 0005 creates
+`StreamOffsetWatermark` but does **not** backfill it, so on an upgraded install
+the watermark starts at 0 while `entries` already holds offsets. The
+`max(entries, watermark)` aggregate is what stopped the first post-migration
+allocation from reissuing offset 1 over the top of existing rows. It is
+load-bearing exactly once per stream, and it used to run on every append
+forever.
+"""
+
+from __future__ import annotations
+
+import pytest
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
+
+from django_rakaia.models import Stream, StreamEntry, StreamEvent, StreamOffsetWatermark
+
+pytestmark = pytest.mark.django_db
+
+
+def _aggregate_queries(ctx: CaptureQueriesContext) -> list[str]:
+    """The captured queries that aggregate over `rakaia_streamentry`.
+
+    Matched on `MAX(` plus the entry table rather than on an exact SQL string,
+    so the assertion survives a backend whose quoting differs (SQLite's
+    double quotes vs Postgres's) and still fails if the aggregate comes back
+    under any spelling.
+    """
+    return [
+        q["sql"]
+        for q in ctx.captured_queries
+        if "MAX(" in q["sql"].upper() and "rakaia_streamentry" in q["sql"]
+    ]
+
+
+class TestAllocationQueryCount:
+    def test_a_steady_state_allocation_does_not_aggregate_over_entries(self):
+        # The point of the whole change. Once the watermark has been advanced
+        # even once it is authoritative, so re-deriving the high mark from the
+        # entry table is a scan of a growing table for an answer already held
+        # in a single row.
+        stream = Stream.objects.create(stream_id="s")
+        stream.get_next_offset_block(1)  # advance the watermark off zero
+
+        with CaptureQueriesContext(connection) as ctx:
+            stream.get_next_offset_block(1)
+
+        assert _aggregate_queries(ctx) == []
+
+    def test_the_first_allocation_for_a_path_still_aggregates(self):
+        # The gate's other half, stated so that removing the aggregate outright
+        # fails here. A watermark still at zero cannot distinguish "brand new"
+        # from "upgraded install with rows already in entries", so it has to
+        # look.
+        stream = Stream.objects.create(stream_id="s")
+
+        with CaptureQueriesContext(connection) as ctx:
+            stream.get_next_offset_block(1)
+
+        assert len(_aggregate_queries(ctx)) == 1
+
+
+def _entry_at(stream: Stream, offset: int) -> None:
+    """Write an entry directly at `offset`, as a pre-0005 install's rows look.
+
+    Deliberately bypasses `get_next_offset_block` — that is the whole scenario:
+    rows that exist without ever having advanced a watermark, because the
+    watermark table did not exist when they were written.
+    """
+    StreamEntry.objects.create(
+        stream=stream,
+        event=StreamEvent.objects.create(data={"n": offset}, event_type="append"),
+        offset=offset,
+    )
+
+
+class TestAllocationIsCorrect:
+    """The numbers, not the query count.
+
+    Split from the count assertions on purpose: an allocation that issues the
+    right *queries* and the wrong *offsets* is worse than the one it replaced,
+    and a file that only counted queries could not tell the difference.
+    """
+
+    def test_a_fresh_stream_starts_at_one(self):
+        stream = Stream.objects.create(stream_id="s")
+        assert stream.get_next_offset_block(1) == 1
+
+    def test_successive_allocations_do_not_repeat_or_skip(self):
+        stream = Stream.objects.create(stream_id="s")
+        assert [stream.get_next_offset_block(1) for _ in range(5)] == [1, 2, 3, 4, 5]
+
+    def test_a_block_reserves_contiguously_and_the_next_starts_past_it(self):
+        stream = Stream.objects.create(stream_id="s")
+        assert stream.get_next_offset_block(4) == 1
+        assert stream.get_next_offset_block(1) == 5
+
+    def test_an_upgraded_install_resumes_above_its_existing_entries(self):
+        # The seeding case, with values. Migration 0005 leaves a watermark at 0
+        # beside entries that already run to 7; allocating from the watermark
+        # alone would hand out 1 and collide with the row already there.
+        stream = Stream.objects.create(stream_id="s")
+        for offset in (1, 2, 7):
+            _entry_at(stream, offset)
+        assert StreamOffsetWatermark.objects.filter(stream_path="s").count() == 0
+
+        assert stream.get_next_offset_block(1) == 8
+
+    def test_the_seeded_high_mark_persists_to_the_next_allocation(self):
+        # Seeding has to *write* what it found, not just use it — otherwise the
+        # second allocation aggregates again and the gate never closes.
+        stream = Stream.objects.create(stream_id="s")
+        _entry_at(stream, 7)
+        stream.get_next_offset_block(1)
+
+        assert StreamOffsetWatermark.objects.get(stream_path="s").high == 8
+        with CaptureQueriesContext(connection) as ctx:
+            assert stream.get_next_offset_block(1) == 9
+        assert _aggregate_queries(ctx) == []
+
+    def test_offsets_survive_delete_and_recreate(self):
+        # #34 Defect #2, restated at this seam because the gate is new code on
+        # the path that guarantees it. The watermark outlives the Stream, so a
+        # path recreated after deletion must not rewind into offsets a stale
+        # subscriber cursor still points at.
+        stream = Stream.objects.create(stream_id="s")
+        stream.get_next_offset_block(3)
+        Stream.objects.filter(stream_id="s").delete()
+
+        recreated = Stream.objects.create(stream_id="s")
+        assert recreated.get_next_offset_block(1) == 4

--- a/tests/test_django_rakaia/test_offset_allocation.py
+++ b/tests/test_django_rakaia/test_offset_allocation.py
@@ -101,51 +101,6 @@ class TestAllocationQueryCount:
         assert len(ctx.captured_queries) == 2, [q["sql"] for q in ctx.captured_queries]
 
 
-@pytest.mark.skipif(
-    not connection.features.has_select_for_update,
-    reason=(
-        "backend has no row locks, so select_for_update() compiles to a plain "
-        "SELECT and the emitted SQL cannot answer this -- run with "
-        "RAKAIA_TEST_DB=postgres"
-    ),
-)
-class TestTheLockSurvivesGetOrCreate:
-    """That the *one* remaining read is still a locking one.
-
-    Folding the plain `get_or_create` and the `select_for_update().get()` into a
-    single locked `get_or_create` is only safe if Django applies the queryset's
-    `FOR UPDATE` to the `get` half. It does — but nothing in the default test run
-    can see that, because SQLite reports `has_select_for_update` false and Django
-    then omits the clause entirely. Spying on `QuerySet.select_for_update` (as
-    `test_django_store.py` does) proves the method was *called*, not that the
-    clause reached the database.
-
-    So this reads the SQL. It is the only assertion in the file that can tell a
-    real lock from a call that was silently dropped, and it is the reason this
-    change has to be run against Postgres before it is believed.
-    """
-
-    @pytest.mark.django_db(transaction=True)
-    def test_the_watermark_read_is_a_locking_read(self):
-        from django.db import transaction as db_transaction
-
-        Stream.objects.create(stream_id="s")
-        with db_transaction.atomic():
-            stream = Stream.objects.get(stream_id="s")
-            stream.get_next_offset_block(1)  # off zero, so the next is steady state
-            with CaptureQueriesContext(connection) as ctx:
-                stream.get_next_offset_block(1)
-
-        watermark_reads = [
-            q["sql"]
-            for q in ctx.captured_queries
-            if "rakaia_streamoffsetwatermark" in q["sql"]
-            and q["sql"].lstrip().upper().startswith("SELECT")
-        ]
-        assert len(watermark_reads) == 1, watermark_reads
-        assert "FOR UPDATE" in watermark_reads[0].upper(), watermark_reads[0]
-
-
 class TestTheReadSideAgrees:
     """`Stream.current_offset` answers the same question from the same source.
 

--- a/tests/test_django_rakaia/test_using_seam.py
+++ b/tests/test_django_rakaia/test_using_seam.py
@@ -151,3 +151,50 @@ class TestFromScratchRebuildProof:
         line = FinanceLine.objects.using("overlay").get(submission_id="s1")
         assert line.delta == area.pk
         assert FinanceLine.objects.using("default").count() == 0
+
+
+class TestTheStreamHeadFollowsItsAlias:
+    """Reading a stream's head must come from the database the stream is on.
+
+    `Stream.get_next_offset_block` allocates from the alias its row came from
+    (#159), and the head has to be read the same way or a rebuild against a
+    scratch database reports the live stream's position.
+
+    This is the read half of that invariant, and it was uncovered: dropping the
+    alias from the allocation path fails a test, dropping it from `current_offset`
+    used to fail nothing. It matters more now the watermark is authoritative here
+    — the previous `max(entries, watermark)` read had the entries half following
+    the alias, so a scratch database at least reported its own entries when they
+    were higher. Reading the watermark alone without the alias would report the
+    live high-water outright.
+    """
+
+    def _stream_on(self, alias: str, path: str, blocks: int):
+        from django_rakaia.models import Stream
+
+        stream = Stream.objects.using(alias).create(stream_id=path)
+        for _ in range(blocks):
+            stream.get_next_offset_block(1)
+        return stream
+
+    def test_the_head_reports_its_own_databases_high_water(self):
+        from django_rakaia.offsets import format_offset
+
+        # Same path on both aliases, deliberately at different positions.
+        self._stream_on("default", "shared", blocks=7)
+        overlay_stream = self._stream_on("overlay", "shared", blocks=2)
+
+        assert overlay_stream.current_offset == format_offset(2), (
+            "the head was read from the wrong database — a rebuild against a "
+            "scratch alias would report the live stream's position"
+        )
+
+    def test_the_default_head_is_unaffected_by_the_overlay(self):
+        from django_rakaia.models import Stream
+        from django_rakaia.offsets import format_offset
+
+        self._stream_on("default", "shared", blocks=7)
+        self._stream_on("overlay", "shared", blocks=2)
+
+        default_stream = Stream.objects.using("default").get(stream_id="shared")
+        assert default_stream.current_offset == format_offset(7)


### PR DESCRIPTION
Closes the first item in #62, whose un-defer trigger has fired: #11 landed, and
the polyglot stress harness in #174 measures every durable save at ten queries,
four of them spent working out which offset to use next.

Two of those four were avoidable. The high mark was recomputed from a scan of the
whole entry table on every append, even though the watermark row already holds
it and nothing can write an entry above it; and the watermark row itself was read
twice, once to make sure it existed and again to read it under a lock. Allocation
is now two queries. `Stream.current_offset` had the same scan on the read side and
is fixed alongside it, because fixing one half of this invariant and leaving the
other is exactly how #34/#59 went wrong before.

The aggregate could not simply be deleted: migration 0005 creates the watermark
table without backfilling it, so an upgraded install has entries beside a
watermark still at zero. It now runs once per stream, ever, and writes what it
finds.