### PR TITLE
Pin the producer-fencing table where it is decided

### DIFF
--- a/src/rakaia/replay.py
+++ b/src/rakaia/replay.py
@@ -2,6 +2,24 @@
 Replay orchestrator: re-derive materialized state from a stream by running
 versioned handlers and an effect executor.
 
+.. warning::
+
+   **`rakaia.replay` the attribute is the function, not this module.** The
+   package root does ``from .replay import … replay``, which rebinds
+   ``rakaia.replay`` to the function — so ``import rakaia.replay as rp`` then
+   ``rp.build_pipeline`` raises ``AttributeError: 'function' object has no
+   attribute 'build_pipeline'``.
+
+   ``from rakaia.replay import X`` and ``sys.modules["rakaia.replay"]`` both work
+   normally; only attribute access through the package root is shadowed. The
+   trap is that a ``monkeypatch.setattr("rakaia.replay.<name>", …)`` lands on the
+   function object and silently patches nothing, so a test measuring call counts
+   reports zero and reads as a pass. That cost a wrong measurement once (#161).
+
+   Renaming either one would be a breaking change to `rakaia.__all__`, so this
+   is a documented sharp edge rather than a bug to fix. Import the names you
+   need directly.
+
 Per event the pipeline is:
     1. Load the raw event bytes from the stream
     2. Decode as JSON, upcast to current schema via UpcasterRegistry

--- a/src/rakaia/replay.py
+++ b/src/rakaia/replay.py
@@ -14,7 +14,8 @@ versioned handlers and an effect executor.
    normally; only attribute access through the package root is shadowed. The
    trap is that a ``monkeypatch.setattr("rakaia.replay.<name>", …)`` lands on the
    function object and silently patches nothing, so a test measuring call counts
-   reports zero and reads as a pass. That cost a wrong measurement once (#161).
+   reports zero and reads as a pass. That cost a wrong measurement while
+   verifying #156, and is recorded as item 1 of #161.
 
    Renaming either one would be a breaking change to `rakaia.__all__`, so this
    is a documented sharp edge rather than a bug to fix. Import the names you

--- a/tests/test_rakaia/test_producer.py
+++ b/tests/test_rakaia/test_producer.py
@@ -6,21 +6,35 @@ outcomes follows. Both stores call it — the in-memory one keeps producer state
 a dict, the durable one in a table — so that they cannot decide differently.
 
 Until now nothing named `validate_producer` or `is_producer_state_expired`. The
-module was covered only *through* callers: `test_append_decision.py` reaches it
-via `decide_append`, and `tests/server_store_contract.py` via a live append. That
-is real coverage but it is the wrong shape for this module. The rule is a pure
-function over five arguments with a small closed set of outcomes — the cheapest
-thing in the package to pin exhaustively — and the defect in #154 was a write
-door that skipped this table entirely. A table nothing tests directly is a table
-whose branches can be reordered, merged or dropped while every caller-level test
-stays green, because each caller exercises one row of it.
+callers do cover it, and more thoroughly than "untested" would suggest — stubbing
+out the stale-epoch branch alone fails seven tests across five files
+(`test_append_decision.py`, both `test_server_store_contract.py`, `test_store.py`,
+`test_protocol_server.py`). What they cover is the *outcomes*, each reached
+through a live append or a `decide_append` call.
+
+What that shape does not reach is the **edges and the payloads**. A caller
+appending for real picks inputs comfortably inside a branch and looks at which
+outcome came back, not at what it carried. Measured: of nine mutations to
+`producer.py`, seven leave the entire suite outside this file green —
+
+- expiry `>` → `>=`, and `abs()` around the age (clock skew reads as expired);
+- an unknown producer's gap reporting `expected_seq=seq` instead of `0`;
+- a new epoch carrying the old `last_seq` forward instead of restarting at 0;
+- the proposal stamping the old `last_updated` rather than the `now` it was given;
+- `validate_producer` mutating the state it was handed;
+- `is_new` set on a same-epoch continuation.
+
+Only two of the nine — the duplicate boundary and the gap's `expected_seq` — are
+caught elsewhere. #154's defect was a write door that skipped this table
+altogether, so the branches being individually load-bearing is not hypothetical.
 
 So this file is the table itself: one class per outcome, every branch reached,
-and the boundaries (epoch equal, seq exactly one ahead, expiry exactly at the
-TTL) asserted rather than assumed.
+and the boundaries asserted rather than assumed.
 """
 
 from __future__ import annotations
+
+import inspect
 
 import pytest
 
@@ -33,7 +47,6 @@ from rakaia.types import (
     ProducerSequenceGap,
     ProducerStaleEpoch,
     ProducerState,
-    ProducerStreamClosed,
 )
 
 NOW = 1_000_000.0
@@ -55,6 +68,17 @@ def _stale_state(epoch: int = 1, last_seq: int = 5) -> ProducerState:
 
 
 class TestExpiry:
+    def test_the_ttl_is_seven_days(self):
+        # Every other expiry test is expressed *relative* to the constant, so
+        # they all stay green if its value changes — which means the value itself
+        # was asserted nowhere in the repo and a TTL change would land silently.
+        # Restating a constant normally tests nothing, but this one is how long
+        # producer fencing survives an idle writer (see TestExpiryOutranksFencing),
+        # so it is a decision rather than an implementation detail. Same reasoning
+        # as `test_public_api.py` writing out `__all__` by hand: when this fails,
+        # that is the test working — change the number here deliberately.
+        assert PRODUCER_STATE_TTL_SECONDS == 7 * 24 * 60 * 60
+
     def test_fresh_state_is_not_expired(self):
         assert not is_producer_state_expired(_state(1, 0), NOW)
 
@@ -350,25 +374,30 @@ class TestTheClosedOutcomeIsNotThisModulesToGive:
 
     Whether a stream is closed is not a fencing question — it is decided by
     `rakaia.append_decision.decide_append`, which checks closure *before*
-    consulting this table. Stated as a test because the union invites the
-    assumption that this function covers every member of it, and a future
-    branch added here would silently duplicate a decision that lives elsewhere.
+    consulting this table. Stated because the union invites the assumption that
+    this function covers every member of it, and a branch added here would
+    silently duplicate a decision that lives elsewhere.
+
+    **This is a boundary statement, not coverage.** No mutation of
+    `validate_producer` can fail it uniquely — nothing in the function constructs
+    the type, and every outcome it does return is already asserted positively
+    above. It is here so the boundary is written down where someone editing the
+    table will read it. The assertion below is on the source, which at least
+    fails if a branch for it appears.
     """
 
-    @pytest.mark.parametrize(
-        ("state", "epoch", "seq"),
-        [
-            (None, 0, 0),
-            (None, 0, 5),
-            (_stale_state(), 1, 0),
-            (_state(5, 3), 4, 4),
-            (_state(1, 4), 2, 9),
-            (_state(1, 4), 2, 0),
-            (_state(2, 5), 2, 5),
-            (_state(2, 5), 2, 6),
-            (_state(2, 5), 2, 8),
-        ],
-    )
-    def test_no_input_yields_the_closed_outcome(self, state, epoch, seq):
-        result = validate_producer(state, PID, epoch=epoch, seq=seq, now=NOW)
-        assert not isinstance(result, ProducerStreamClosed)
+    def test_the_module_never_constructs_the_closed_outcome(self):
+        from rakaia import producer
+
+        assert "ProducerStreamClosed" not in inspect.getsource(producer), (
+            "closure is decided in append_decision.decide_append, before this "
+            "table is consulted; a branch for it here would be a second, "
+            "weaker copy of that decision"
+        )
+
+    def test_closure_is_decided_in_append_decision_instead(self):
+        # Naming the other side, so the boundary is checkable from here rather
+        # than asserted about an absence.
+        from rakaia import append_decision
+
+        assert "ProducerStreamClosed" in inspect.getsource(append_decision)

--- a/tests/test_rakaia/test_producer.py
+++ b/tests/test_rakaia/test_producer.py
@@ -1,0 +1,374 @@
+"""The producer-fencing outcome table, pinned directly.
+
+`rakaia.producer` is the whole of the fencing rule: from a producer's last
+committed state and the `(id, epoch, seq)` tuple it presents, exactly one of six
+outcomes follows. Both stores call it — the in-memory one keeps producer state in
+a dict, the durable one in a table — so that they cannot decide differently.
+
+Until now nothing named `validate_producer` or `is_producer_state_expired`. The
+module was covered only *through* callers: `test_append_decision.py` reaches it
+via `decide_append`, and `tests/server_store_contract.py` via a live append. That
+is real coverage but it is the wrong shape for this module. The rule is a pure
+function over five arguments with a small closed set of outcomes — the cheapest
+thing in the package to pin exhaustively — and the defect in #154 was a write
+door that skipped this table entirely. A table nothing tests directly is a table
+whose branches can be reordered, merged or dropped while every caller-level test
+stays green, because each caller exercises one row of it.
+
+So this file is the table itself: one class per outcome, every branch reached,
+and the boundaries (epoch equal, seq exactly one ahead, expiry exactly at the
+TTL) asserted rather than assumed.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from rakaia.producer import is_producer_state_expired, validate_producer
+from rakaia.types import (
+    PRODUCER_STATE_TTL_SECONDS,
+    ProducerAccepted,
+    ProducerDuplicate,
+    ProducerInvalidEpochSeq,
+    ProducerSequenceGap,
+    ProducerStaleEpoch,
+    ProducerState,
+    ProducerStreamClosed,
+)
+
+NOW = 1_000_000.0
+PID = "writer-1"
+
+
+def _state(epoch: int, last_seq: int, *, last_updated: float = NOW) -> ProducerState:
+    return ProducerState(epoch=epoch, last_seq=last_seq, last_updated=last_updated)
+
+
+def _stale_state(epoch: int = 1, last_seq: int = 5) -> ProducerState:
+    """A state old enough that `is_producer_state_expired` treats it as absent."""
+    return _state(epoch, last_seq, last_updated=NOW - PRODUCER_STATE_TTL_SECONDS - 1)
+
+
+# =============================================================================
+# Expiry — the predicate the rest of the table depends on
+# =============================================================================
+
+
+class TestExpiry:
+    def test_fresh_state_is_not_expired(self):
+        assert not is_producer_state_expired(_state(1, 0), NOW)
+
+    def test_state_older_than_the_ttl_is_expired(self):
+        old = _state(1, 0, last_updated=NOW - PRODUCER_STATE_TTL_SECONDS - 1)
+        assert is_producer_state_expired(old, NOW)
+
+    def test_exactly_at_the_ttl_is_not_yet_expired(self):
+        # The boundary is `>`, not `>=`: a state whose age equals the TTL to the
+        # second is still live. Pinned because flipping the comparison is a
+        # one-character change that no caller-level test would notice.
+        edge = _state(1, 0, last_updated=NOW - PRODUCER_STATE_TTL_SECONDS)
+        assert not is_producer_state_expired(edge, NOW)
+
+    def test_one_second_past_the_ttl_is_expired(self):
+        past = _state(1, 0, last_updated=NOW - PRODUCER_STATE_TTL_SECONDS - 1)
+        assert is_producer_state_expired(past, NOW)
+
+    def test_state_stamped_in_the_future_is_not_expired(self):
+        # Clock skew between writers gives a negative age. It must not read as
+        # expired, which is what an `abs()` or a flipped subtraction would do.
+        future = _state(1, 0, last_updated=NOW + 3600)
+        assert not is_producer_state_expired(future, NOW)
+
+
+# =============================================================================
+# Unknown producer — no state, or state that has aged out
+# =============================================================================
+
+
+class TestUnknownProducer:
+    def test_opening_at_seq_zero_is_accepted_as_new(self):
+        result = validate_producer(None, PID, epoch=0, seq=0, now=NOW)
+        assert result == ProducerAccepted(
+            is_new=True,
+            producer_id=PID,
+            proposed_state=_state(0, 0),
+        )
+
+    def test_opening_above_seq_zero_is_a_gap_against_zero(self):
+        result = validate_producer(None, PID, epoch=0, seq=3, now=NOW)
+        assert result == ProducerSequenceGap(expected_seq=0, received_seq=3)
+
+    def test_the_gap_reports_the_seq_that_was_offered(self):
+        # Both numbers matter to the caller: the protocol echoes them back in
+        # Producer-Expected-Seq / Producer-Received-Seq.
+        result = validate_producer(None, PID, epoch=4, seq=9, now=NOW)
+        assert isinstance(result, ProducerSequenceGap)
+        assert (result.expected_seq, result.received_seq) == (0, 9)
+
+    def test_an_expired_state_is_treated_as_unknown(self):
+        result = validate_producer(_stale_state(), PID, epoch=1, seq=0, now=NOW)
+        assert isinstance(result, ProducerAccepted)
+        assert result.is_new is True
+
+    def test_an_expired_state_still_requires_seq_zero(self):
+        result = validate_producer(_stale_state(), PID, epoch=1, seq=6, now=NOW)
+        assert result == ProducerSequenceGap(expected_seq=0, received_seq=6)
+
+    def test_the_accepted_epoch_is_the_one_offered_not_zero(self):
+        result = validate_producer(None, PID, epoch=7, seq=0, now=NOW)
+        assert isinstance(result, ProducerAccepted)
+        assert result.proposed_state is not None
+        assert result.proposed_state.epoch == 7
+
+
+class TestExpiryOutranksFencing:
+    """An expired state is treated as absent **before** the epoch is looked at.
+
+    So a producer that was fenced out by a higher epoch is admitted again once
+    the old state ages past the TTL — even presenting the lower epoch it was
+    fenced on. That is the documented intent (expiry exists so an abandoned id
+    starts fresh rather than pinning its sequence forever), but it means fencing
+    is not permanent: it lasts as long as the winner keeps its state warm.
+
+    Pinned as its own class because it is the one row of the table where two
+    rules could each plausibly win, and nothing else says which does.
+    """
+
+    def test_a_lower_epoch_wins_once_the_state_has_expired(self):
+        fenced_out = _stale_state(epoch=9, last_seq=100)
+        result = validate_producer(fenced_out, PID, epoch=2, seq=0, now=NOW)
+        assert isinstance(result, ProducerAccepted)
+        assert result.proposed_state is not None
+        assert result.proposed_state.epoch == 2
+
+    def test_the_same_tuple_is_fenced_while_the_state_is_fresh(self):
+        # The contrast that gives the previous case its meaning: identical
+        # inputs, a fresh state, opposite outcome.
+        fresh = _state(9, 100)
+        result = validate_producer(fresh, PID, epoch=2, seq=0, now=NOW)
+        assert result == ProducerStaleEpoch(current_epoch=9)
+
+
+# =============================================================================
+# Epoch below the known one — fenced out
+# =============================================================================
+
+
+class TestStaleEpoch:
+    def test_a_lower_epoch_is_stale(self):
+        result = validate_producer(_state(5, 3), PID, epoch=4, seq=4, now=NOW)
+        assert result == ProducerStaleEpoch(current_epoch=5)
+
+    def test_staleness_is_decided_before_the_sequence(self):
+        # A stale epoch is stale whatever seq it brings — including a seq that
+        # would have been a clean accept at the current epoch.
+        result = validate_producer(_state(5, 3), PID, epoch=1, seq=0, now=NOW)
+        assert isinstance(result, ProducerStaleEpoch)
+
+    def test_it_reports_the_epoch_that_won(self):
+        result = validate_producer(_state(12, 0), PID, epoch=11, seq=0, now=NOW)
+        assert isinstance(result, ProducerStaleEpoch)
+        assert result.current_epoch == 12
+
+
+# =============================================================================
+# Epoch above the known one — a new epoch must restart the sequence
+# =============================================================================
+
+
+class TestNewEpoch:
+    def test_a_higher_epoch_opening_at_zero_is_accepted(self):
+        result = validate_producer(_state(1, 40), PID, epoch=2, seq=0, now=NOW)
+        assert result == ProducerAccepted(
+            is_new=True,
+            producer_id=PID,
+            proposed_state=_state(2, 0),
+        )
+
+    def test_a_higher_epoch_not_opening_at_zero_is_rejected(self):
+        result = validate_producer(_state(1, 40), PID, epoch=2, seq=41, now=NOW)
+        assert result == ProducerInvalidEpochSeq()
+
+    def test_continuing_the_old_sequence_under_a_new_epoch_is_rejected(self):
+        # The realistic mistake: a restarted writer bumps its epoch but carries
+        # on counting. Distinguished from a gap on purpose — the remedy differs
+        # (restart at 0, rather than resend the missing seq).
+        result = validate_producer(_state(3, 7), PID, epoch=4, seq=8, now=NOW)
+        assert isinstance(result, ProducerInvalidEpochSeq)
+        assert not isinstance(result, ProducerSequenceGap)
+
+    def test_a_new_epoch_discards_the_old_sequence_high_mark(self):
+        result = validate_producer(_state(1, 999), PID, epoch=2, seq=0, now=NOW)
+        assert isinstance(result, ProducerAccepted)
+        assert result.proposed_state is not None
+        assert result.proposed_state.last_seq == 0
+
+    def test_an_epoch_may_jump_by_more_than_one(self):
+        # Epochs are a fencing token, not a sequence: a writer that restarts
+        # several times while offline presents whatever it reached.
+        result = validate_producer(_state(1, 0), PID, epoch=50, seq=0, now=NOW)
+        assert isinstance(result, ProducerAccepted)
+        assert result.proposed_state is not None
+        assert result.proposed_state.epoch == 50
+
+
+# =============================================================================
+# Same epoch — duplicate, accept, or gap
+# =============================================================================
+
+
+class TestSameEpoch:
+    def test_exactly_one_above_the_last_is_accepted(self):
+        result = validate_producer(_state(2, 5), PID, epoch=2, seq=6, now=NOW)
+        assert result == ProducerAccepted(
+            is_new=False,
+            producer_id=PID,
+            proposed_state=_state(2, 6),
+        )
+
+    def test_an_accepted_continuation_is_not_marked_new(self):
+        result = validate_producer(_state(2, 5), PID, epoch=2, seq=6, now=NOW)
+        assert isinstance(result, ProducerAccepted)
+        assert result.is_new is False
+
+    def test_repeating_the_last_seq_is_a_duplicate(self):
+        result = validate_producer(_state(2, 5), PID, epoch=2, seq=5, now=NOW)
+        assert result == ProducerDuplicate(last_seq=5)
+
+    def test_a_seq_below_the_last_is_also_a_duplicate(self):
+        # A retry of an older request, not an error: the append already landed,
+        # so the caller is told the same thing either way.
+        result = validate_producer(_state(2, 5), PID, epoch=2, seq=1, now=NOW)
+        assert result == ProducerDuplicate(last_seq=5)
+
+    def test_two_above_the_last_is_a_gap(self):
+        result = validate_producer(_state(2, 5), PID, epoch=2, seq=7, now=NOW)
+        assert result == ProducerSequenceGap(expected_seq=6, received_seq=7)
+
+    def test_the_gap_names_the_seq_that_was_expected(self):
+        result = validate_producer(_state(2, 5), PID, epoch=2, seq=99, now=NOW)
+        assert isinstance(result, ProducerSequenceGap)
+        assert (result.expected_seq, result.received_seq) == (6, 99)
+
+    def test_seq_zero_against_a_known_sequence_is_a_duplicate_not_a_restart(self):
+        # Same epoch, so seq 0 is a replay of the opening write — a new epoch is
+        # the only way to legitimately restart a sequence.
+        result = validate_producer(_state(2, 5), PID, epoch=2, seq=0, now=NOW)
+        assert result == ProducerDuplicate(last_seq=5)
+
+    def test_a_first_write_after_opening_at_zero_is_accepted(self):
+        # The full opening handshake: seq 0 opens (is_new), seq 1 continues.
+        opened = validate_producer(None, PID, epoch=0, seq=0, now=NOW)
+        assert isinstance(opened, ProducerAccepted)
+        assert opened.proposed_state is not None
+
+        second = validate_producer(opened.proposed_state, PID, epoch=0, seq=1, now=NOW)
+        assert second == ProducerAccepted(
+            is_new=False,
+            producer_id=PID,
+            proposed_state=_state(0, 1),
+        )
+
+
+# =============================================================================
+# What the function promises about itself
+# =============================================================================
+
+
+class TestTheFunctionIsPure:
+    """The module docstring makes three promises. Each is asserted here.
+
+    They matter because the caller commits `proposed_state` only *after* the
+    append succeeds — so a function that mutated the state it was handed, or that
+    advanced a sequence itself, would let a failed write move a producer's
+    sequence forward. That is the failure this design exists to prevent, and
+    nothing was checking the design held.
+    """
+
+    def test_the_state_passed_in_is_not_mutated(self):
+        # `now` is deliberately *not* NOW. The state's `last_updated` is NOW, so
+        # calling with `now=NOW` makes a `state.last_updated = now` mutation a
+        # no-op and this assertion cannot see it — which is exactly what happened
+        # the first time this test was written.
+        state = _state(2, 5, last_updated=NOW)
+        before = ProducerState(
+            epoch=state.epoch, last_seq=state.last_seq, last_updated=state.last_updated
+        )
+        validate_producer(state, PID, epoch=2, seq=6, now=NOW + 500.0)
+        assert state == before
+
+    @pytest.mark.parametrize("seq", [0, 5, 6, 8])
+    def test_no_outcome_mutates_the_state(self, seq):
+        # Every row of the table, not just the accept: a rejection that advanced
+        # `last_updated` would keep a dead producer's state alive forever.
+        state = _state(2, 5, last_updated=NOW)
+        before = ProducerState(
+            epoch=state.epoch, last_seq=state.last_seq, last_updated=state.last_updated
+        )
+        validate_producer(state, PID, epoch=2, seq=seq, now=NOW + 500.0)
+        assert state == before
+
+    def test_the_proposed_state_is_a_different_object(self):
+        # Returning the same object would let a caller's later mutation of the
+        # proposal reach back into the committed state.
+        state = _state(2, 5)
+        result = validate_producer(state, PID, epoch=2, seq=6, now=NOW)
+        assert isinstance(result, ProducerAccepted)
+        assert result.proposed_state is not state
+
+    def test_calling_twice_gives_the_same_answer(self):
+        state = _state(2, 5)
+        args = (state, PID)
+        first = validate_producer(*args, epoch=2, seq=6, now=NOW)
+        second = validate_producer(*args, epoch=2, seq=6, now=NOW)
+        assert first == second
+
+    def test_the_proposal_stamps_the_now_it_was_given(self):
+        # Not `time.time()`: the caller supplies the clock so a replay or a test
+        # is deterministic.
+        result = validate_producer(_state(2, 5), PID, epoch=2, seq=6, now=12345.0)
+        assert isinstance(result, ProducerAccepted)
+        assert result.proposed_state is not None
+        assert result.proposed_state.last_updated == 12345.0
+
+    def test_a_rejection_proposes_no_state(self):
+        # Only an accept carries a proposal; the other outcomes have nothing to
+        # commit, and a caller that committed one anyway would advance a
+        # sequence on a rejected write.
+        for result in (
+            validate_producer(_state(5, 3), PID, epoch=4, seq=4, now=NOW),
+            validate_producer(_state(1, 4), PID, epoch=2, seq=9, now=NOW),
+            validate_producer(_state(2, 5), PID, epoch=2, seq=5, now=NOW),
+            validate_producer(_state(2, 5), PID, epoch=2, seq=8, now=NOW),
+        ):
+            assert not isinstance(result, ProducerAccepted)
+            assert not hasattr(result, "proposed_state")
+
+
+class TestTheClosedOutcomeIsNotThisModulesToGive:
+    """`ProducerStreamClosed` is in the result union but never returned here.
+
+    Whether a stream is closed is not a fencing question — it is decided by
+    `rakaia.append_decision.decide_append`, which checks closure *before*
+    consulting this table. Stated as a test because the union invites the
+    assumption that this function covers every member of it, and a future
+    branch added here would silently duplicate a decision that lives elsewhere.
+    """
+
+    @pytest.mark.parametrize(
+        ("state", "epoch", "seq"),
+        [
+            (None, 0, 0),
+            (None, 0, 5),
+            (_stale_state(), 1, 0),
+            (_state(5, 3), 4, 4),
+            (_state(1, 4), 2, 9),
+            (_state(1, 4), 2, 0),
+            (_state(2, 5), 2, 5),
+            (_state(2, 5), 2, 6),
+            (_state(2, 5), 2, 8),
+        ],
+    )
+    def test_no_input_yields_the_closed_outcome(self, state, epoch, seq):
+        result = validate_producer(state, PID, epoch=epoch, seq=seq, now=NOW)
+        assert not isinstance(result, ProducerStreamClosed)

--- a/tests/test_rakaia/test_producer.py
+++ b/tests/test_rakaia/test_producer.py
@@ -30,11 +30,20 @@ altogether, so the branches being individually load-bearing is not hypothetical.
 
 So this file is the table itself: one class per outcome, every branch reached,
 and the boundaries asserted rather than assumed.
+
+**One member of the result union is deliberately absent.**
+`ProducerStreamClosed` is never returned here: whether a stream is closed is not
+a fencing question, and `rakaia.append_decision.decide_append` checks closure
+*before* consulting this table (asserted behaviourally in
+`test_append_decision.py`). Said here rather than as a test, because no mutation
+of `validate_producer` can fail such a test uniquely — nothing in the function
+constructs the type, so the only version that reds is one asserting on the
+module's source text, which a passing mention in a comment would satisfy. A
+branch for it appearing here would be a second, weaker copy of a decision that
+lives upstream; this paragraph is where someone editing the table will read that.
 """
 
 from __future__ import annotations
-
-import inspect
 
 import pytest
 
@@ -82,9 +91,9 @@ class TestExpiry:
     def test_fresh_state_is_not_expired(self):
         assert not is_producer_state_expired(_state(1, 0), NOW)
 
-    def test_state_older_than_the_ttl_is_expired(self):
-        old = _state(1, 0, last_updated=NOW - PRODUCER_STATE_TTL_SECONDS - 1)
-        assert is_producer_state_expired(old, NOW)
+    def test_state_much_older_than_the_ttl_is_expired(self):
+        ancient = _state(1, 0, last_updated=NOW - PRODUCER_STATE_TTL_SECONDS * 10)
+        assert is_producer_state_expired(ancient, NOW)
 
     def test_exactly_at_the_ttl_is_not_yet_expired(self):
         # The boundary is `>`, not `>=`: a state whose age equals the TTL to the
@@ -97,10 +106,13 @@ class TestExpiry:
         past = _state(1, 0, last_updated=NOW - PRODUCER_STATE_TTL_SECONDS - 1)
         assert is_producer_state_expired(past, NOW)
 
-    def test_state_stamped_in_the_future_is_not_expired(self):
-        # Clock skew between writers gives a negative age. It must not read as
-        # expired, which is what an `abs()` or a flipped subtraction would do.
-        future = _state(1, 0, last_updated=NOW + 3600)
+    def test_a_clock_skewed_far_into_the_future_is_not_expired(self):
+        # Clock skew between writers gives a *negative* age, and the rule must
+        # read that as fresh. The skew has to exceed the TTL to test anything: a
+        # stamp an hour ahead is still well inside 7 days, so `abs()` around the
+        # age would return not-expired anyway and the case would pass vacuously.
+        # At TTL + 1 ahead, `abs()` reads it as expired and this goes red.
+        future = _state(1, 0, last_updated=NOW + PRODUCER_STATE_TTL_SECONDS + 1)
         assert not is_producer_state_expired(future, NOW)
 
 
@@ -321,15 +333,35 @@ class TestTheFunctionIsPure:
         validate_producer(state, PID, epoch=2, seq=6, now=NOW + 500.0)
         assert state == before
 
-    @pytest.mark.parametrize("seq", [0, 5, 6, 8])
-    def test_no_outcome_mutates_the_state(self, seq):
-        # Every row of the table, not just the accept: a rejection that advanced
-        # `last_updated` would keep a dead producer's state alive forever.
+    @pytest.mark.parametrize(
+        ("epoch", "seq"),
+        [
+            # same epoch: duplicate, accept, gap
+            (2, 0),
+            (2, 5),
+            (2, 6),
+            (2, 8),
+            # lower epoch: stale. Reached only by varying `epoch` — an earlier
+            # version of this test held it at 2 and so never entered this branch
+            # or the next, leaving a `state.last_updated = now` inserted before
+            # either `return` alive against the whole suite.
+            (1, 0),
+            (1, 6),
+            # higher epoch: accepted restart, and invalid non-zero start
+            (3, 0),
+            (3, 6),
+        ],
+    )
+    def test_no_outcome_mutates_the_state(self, epoch, seq):
+        # Every branch, not just the accept: `ProducerState` is a plain dataclass,
+        # so a rejection that advanced `last_updated` would keep a dead producer's
+        # state alive forever, and one that advanced `last_seq` would move a
+        # sequence on a write that never happened.
         state = _state(2, 5, last_updated=NOW)
         before = ProducerState(
             epoch=state.epoch, last_seq=state.last_seq, last_updated=state.last_updated
         )
-        validate_producer(state, PID, epoch=2, seq=seq, now=NOW + 500.0)
+        validate_producer(state, PID, epoch=epoch, seq=seq, now=NOW + 500.0)
         assert state == before
 
     def test_the_proposed_state_is_a_different_object(self):
@@ -367,37 +399,3 @@ class TestTheFunctionIsPure:
         ):
             assert not isinstance(result, ProducerAccepted)
             assert not hasattr(result, "proposed_state")
-
-
-class TestTheClosedOutcomeIsNotThisModulesToGive:
-    """`ProducerStreamClosed` is in the result union but never returned here.
-
-    Whether a stream is closed is not a fencing question — it is decided by
-    `rakaia.append_decision.decide_append`, which checks closure *before*
-    consulting this table. Stated because the union invites the assumption that
-    this function covers every member of it, and a branch added here would
-    silently duplicate a decision that lives elsewhere.
-
-    **This is a boundary statement, not coverage.** No mutation of
-    `validate_producer` can fail it uniquely — nothing in the function constructs
-    the type, and every outcome it does return is already asserted positively
-    above. It is here so the boundary is written down where someone editing the
-    table will read it. The assertion below is on the source, which at least
-    fails if a branch for it appears.
-    """
-
-    def test_the_module_never_constructs_the_closed_outcome(self):
-        from rakaia import producer
-
-        assert "ProducerStreamClosed" not in inspect.getsource(producer), (
-            "closure is decided in append_decision.decide_append, before this "
-            "table is consulted; a branch for it here would be a second, "
-            "weaker copy of that decision"
-        )
-
-    def test_closure_is_decided_in_append_decision_instead(self):
-        # Naming the other side, so the boundary is checkable from here rather
-        # than asserted about an absence.
-        from rakaia import append_decision
-
-        assert "ProducerStreamClosed" in inspect.getsource(append_decision)

--- a/tests/test_rakaia/test_producer.py
+++ b/tests/test_rakaia/test_producer.py
@@ -321,43 +321,43 @@ class TestTheFunctionIsPure:
     nothing was checking the design held.
     """
 
-    def test_the_state_passed_in_is_not_mutated(self):
-        # `now` is deliberately *not* NOW. The state's `last_updated` is NOW, so
-        # calling with `now=NOW` makes a `state.last_updated = now` mutation a
-        # no-op and this assertion cannot see it — which is exactly what happened
-        # the first time this test was written.
-        state = _state(2, 5, last_updated=NOW)
-        before = ProducerState(
-            epoch=state.epoch, last_seq=state.last_seq, last_updated=state.last_updated
-        )
-        validate_producer(state, PID, epoch=2, seq=6, now=NOW + 500.0)
-        assert state == before
-
+    # `now` is deliberately offset from the state's `last_updated`. With the two
+    # equal, a `state.last_updated = now` mutation is a no-op and the assertion
+    # cannot see it — which is how the first version of this test passed against
+    # code that mutated its input.
+    #
+    # `stale` selects which arm of the first branch the call lands in, because
+    # holding it fresh was how the *second* version still missed one: the
+    # unknown/expired arm was never entered, so a mutation at the top of it
+    # survived the whole suite.
     @pytest.mark.parametrize(
-        ("epoch", "seq"),
+        ("stale", "epoch", "seq"),
         [
-            # same epoch: duplicate, accept, gap
-            (2, 0),
-            (2, 5),
-            (2, 6),
-            (2, 8),
-            # lower epoch: stale. Reached only by varying `epoch` — an earlier
-            # version of this test held it at 2 and so never entered this branch
-            # or the next, leaving a `state.last_updated = now` inserted before
-            # either `return` alive against the whole suite.
-            (1, 0),
-            (1, 6),
-            # higher epoch: accepted restart, and invalid non-zero start
-            (3, 0),
-            (3, 6),
+            # known, fresh state — same epoch: duplicate, accept, gap
+            (False, 2, 0),
+            (False, 2, 5),
+            (False, 2, 6),
+            (False, 2, 8),
+            # known, fresh — lower epoch: stale-epoch rejection
+            (False, 1, 0),
+            (False, 1, 6),
+            # known, fresh — higher epoch: accepted restart, invalid non-zero start
+            (False, 3, 0),
+            (False, 3, 6),
+            # expired state: treated as unknown, so the epoch is not consulted.
+            # Both arms — the seq-0 accept and the seq-non-zero gap.
+            (True, 2, 0),
+            (True, 2, 6),
+            (True, 1, 6),
         ],
     )
-    def test_no_outcome_mutates_the_state(self, epoch, seq):
+    def test_no_outcome_mutates_the_state(self, stale, epoch, seq):
         # Every branch, not just the accept: `ProducerState` is a plain dataclass,
-        # so a rejection that advanced `last_updated` would keep a dead producer's
-        # state alive forever, and one that advanced `last_seq` would move a
-        # sequence on a write that never happened.
-        state = _state(2, 5, last_updated=NOW)
+        # and the in-memory store keeps these objects in a dict, so a rejection
+        # that advanced `last_updated` would keep a dead producer's state alive
+        # forever and one that advanced `last_seq` would move a sequence on a
+        # write that never happened.
+        state = _stale_state(2, 5) if stale else _state(2, 5, last_updated=NOW)
         before = ProducerState(
             epoch=state.epoch, last_seq=state.last_seq, last_updated=state.last_updated
         )

--- a/tests/test_rakaia/test_public_api.py
+++ b/tests/test_rakaia/test_public_api.py
@@ -275,8 +275,15 @@ class TestTheReplayModuleIsShadowed:
     measurement while verifying #156.
 
     Renaming either would break `rakaia.__all__`, so the sharp edge is documented
-    in `replay.py` rather than removed. This pins the shape so the docstring
-    cannot quietly become wrong.
+    in `replay.py` rather than removed. These two cases pin the *shape* — that the
+    attribute is the function and the module is still importable — so a future
+    change that quietly fixed or worsened the shadowing shows up here.
+
+    There was a third case asserting the word "monkeypatch" appeared in
+    `replay.py`'s docstring. It is gone: a substring check on module source is
+    satisfied by a passing mention in a comment, which is the exact reason the
+    closed-outcome assertions were deleted from `test_producer.py` in the same
+    change. Keeping one while deleting the other was the inconsistency.
     """
 
     def test_the_package_attribute_is_the_function(self):
@@ -294,12 +301,3 @@ class TestTheReplayModuleIsShadowed:
         assert replay_module_attr is replay_fn
         assert sys.modules["rakaia.replay"].__name__ == "rakaia.replay"
         assert hasattr(sys.modules["rakaia.replay"], "build_pipeline")
-
-    def test_the_shadowing_is_documented_where_it_bites(self):
-        import sys
-
-        doc = sys.modules["rakaia.replay"].__doc__ or ""
-        assert "monkeypatch" in doc, (
-            "replay.py's docstring must keep warning that a monkeypatch through "
-            "the package root silently patches nothing"
-        )

--- a/tests/test_rakaia/test_public_api.py
+++ b/tests/test_rakaia/test_public_api.py
@@ -263,3 +263,43 @@ class TestTierTwoIsDeliberatelyNotExported:
         from django_rakaia.models import Stream, StreamEntry, StreamEvent
 
         assert Stream and StreamEntry and StreamEvent
+
+
+class TestTheReplayModuleIsShadowed:
+    """`rakaia.replay` the attribute is the function, not the module (#161 item 1).
+
+    The package root does `from .replay import … replay`, rebinding the package
+    attribute. Harmless for imports, but a `monkeypatch.setattr` aimed at
+    `"rakaia.replay.<name>"` lands on the function object and patches nothing —
+    a call-count assertion then reads zero and passes. That cost a wrong
+    measurement while verifying #156.
+
+    Renaming either would break `rakaia.__all__`, so the sharp edge is documented
+    in `replay.py` rather than removed. This pins the shape so the docstring
+    cannot quietly become wrong.
+    """
+
+    def test_the_package_attribute_is_the_function(self):
+        import rakaia
+
+        assert callable(rakaia.replay)
+        assert not hasattr(rakaia.replay, "build_pipeline")
+
+    def test_the_module_is_still_reachable_by_import(self):
+        import sys
+
+        from rakaia import replay as replay_module_attr  # the function
+        from rakaia.replay import replay as replay_fn
+
+        assert replay_module_attr is replay_fn
+        assert sys.modules["rakaia.replay"].__name__ == "rakaia.replay"
+        assert hasattr(sys.modules["rakaia.replay"], "build_pipeline")
+
+    def test_the_shadowing_is_documented_where_it_bites(self):
+        import sys
+
+        doc = sys.modules["rakaia.replay"].__doc__ or ""
+        assert "monkeypatch" in doc, (
+            "replay.py's docstring must keep warning that a monkeypatch through "
+            "the package root silently patches nothing"
+        )


### PR DESCRIPTION
Closes item 5 of #161, and item 1 alongside it.

`rakaia.producer` holds the whole producer-fencing rule, and both stores call it
so they cannot decide differently — but nothing tested it directly. The callers
do cover it, better than "untested" suggests: stubbing the stale-epoch branch
alone fails seven tests across five files. What they cover is the *outcomes*,
each reached through a live append. What they do not reach is the edges and the
payloads — measured, seven of nine mutations to the module leave the entire suite
outside this file green, and the test docstring lists which.

43 cases now cover every branch and state the boundaries rather than assuming
them. Two rows earned their own treatment: expiry is consulted before the epoch,
so fencing lasts only as long as the winner keeps its state warm; and the closed
outcome in the result union is never returned here because closure is decided
upstream. Also documents the `rakaia.replay` module/function shadowing (item 1),
which silently defeats a monkeypatch and cost a wrong measurement during #156,
and pins `PRODUCER_STATE_TTL_SECONDS`, which was asserted nowhere.

No behaviour change — tests and two docstrings.