### PR TITLE
Let the event log be read from the database it is being rebuilt into

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -33,7 +33,7 @@ page is the contract.
 |---|---|---|---|
 | `Stream` | `rakaia` | `(path: 'str', content_type: 'str \| None' = None, current_offset: 'str' = '0000000000000000_0000000000000000', last_seq: 'str \| None' = None, ttl_seconds: 'int \| None' = None, expires_at: 'str \| None' = None, created_at: 'float' = 0.0, last_activity_at: 'float' = 0.0, producers: 'dict[str, ProducerState]' = <factory>, closed: 'bool' = False, closed_by: 'ClosedBy \| None' = None) -> None` | Stream metadata. |
 | `StreamStore` | `rakaia` | `() -> 'None'` | In-memory store for durable streams. |
-| `DjangoStreamStore` | `django_rakaia` | `()` | A durable store backed by the django_rakaia ORM models. |
+| `DjangoStreamStore` | `django_rakaia` | `(*, using: 'str \| None' = None) -> 'None'` | A durable store backed by the django_rakaia ORM models. |
 | `ReadableStore` | `rakaia` | `(*args, **kwargs)` | A store `replay()` can read events from. |
 | `WritableStore` | `rakaia` | `(*args, **kwargs)` | A store the event-sourcing framework both writes to and reads from. |
 | `StreamServerStore` | `rakaia` | `(*args, **kwargs)` | A store that can back a Durable Streams **protocol server**. |

--- a/src/django_rakaia/django_store.py
+++ b/src/django_rakaia/django_store.py
@@ -339,7 +339,7 @@ class DjangoStreamStore:
         comment. Do not unwrap it.
         """
         self._reap_if_expired(path)
-        with transaction.atomic():
+        with transaction.atomic(using=self._using):
             existing = self._get_if_not_expired(path)
             if existing is not None:
                 same = (
@@ -410,7 +410,7 @@ class DjangoStreamStore:
         self, path: str, producer_id: str, epoch: int, seq: int
     ) -> CloseResult | None:
         self._reap_if_expired(path)
-        with transaction.atomic():
+        with transaction.atomic(using=self._using):
             stream = self._get_if_not_expired(path, for_update=True)
             if stream is None:
                 return None
@@ -488,7 +488,7 @@ class DjangoStreamStore:
         """
         opts = options if options is not None else AppendOptions()
         self._reap_if_expired(path)
-        with transaction.atomic():
+        with transaction.atomic(using=self._using):
             stream = self._require(path, for_update=True)
 
             # Admission is decided in `rakaia.append_decision`, shared with the
@@ -689,7 +689,7 @@ class DjangoStreamStore:
             return self.append(path, data, opts)
 
         self._reap_if_expired(path)
-        with transaction.atomic():
+        with transaction.atomic(using=self._using):
             # The row lock is what makes fencing fence: validation reads the
             # producer's last state, and two concurrent retries of the same
             # (producer_id, epoch, seq) that both read before either commits
@@ -795,7 +795,7 @@ class DjangoStreamStore:
             return []
 
         self._reap_if_expired(path)
-        with transaction.atomic():
+        with transaction.atomic(using=self._using):
             stream = self._require(path, for_update=True)
 
             if stream.closed:

--- a/src/django_rakaia/django_store.py
+++ b/src/django_rakaia/django_store.py
@@ -173,7 +173,58 @@ class DjangoStreamStore:
 
     Satisfies `rakaia.StreamServerStore`: the event-sourcing read/emit surface
     plus the full protocol lifecycle.
+
+    Pass ``using`` to read and write the log on a named database alias instead of
+    the default — the same seam `DjangoExecutor` and `DjangoProjectionReader`
+    already sit on. That is what lets a from-scratch rebuild replay into a
+    *disposable* database and be verified against the real ORM without touching
+    production (ADR 0003): the projections went to the alias already, and now the
+    log they are derived from can come from it too.
+
+    Before this, the log was the one part of a rebuild that could not leave the
+    default database, so `hermeticity.py` documented a drain-to-memory as the
+    workaround — six lines every consumer wrote, tested nowhere, because the store
+    was untestable off ``default``.
+
+    ``using=None`` targets the default alias, exactly as before. Pair with
+    ``DjangoExecutor(using=...)`` and ``DjangoProjectionReader(using=...)``.
     """
+
+    def __init__(self, *, using: str | None = None) -> None:
+        self._using = using
+
+    # =========================================================================
+    # Alias
+    # =========================================================================
+
+    def _streams(self) -> Any:
+        """`Stream` rows on this store's alias.
+
+        Every read and write of a model goes through one of these accessors, so
+        the alias is applied in one place rather than being remembered at each of
+        the ten call sites it used to be absent from. `.using(None)` keeps
+        Django's default routing, so this is uniform whether or not an alias was
+        given — the same shape as `DjangoExecutor._manager`.
+
+        It also fixes the alias for rows *derived* from a stream: the write path
+        takes its alias from the stream row it was handed
+        (`write_enveloped_event`, #159), and `Stream.get_next_offset_block` from
+        ``self._state.db``. Loading the stream on the right alias is therefore
+        what puts its event, its entry and its offset high-water there too.
+        """
+        return Stream.objects.using(self._using)
+
+    def _events(self) -> Any:
+        """`StreamEvent` rows on this store's alias."""
+        return StreamEvent.objects.using(self._using)
+
+    def _entries(self) -> Any:
+        """`StreamEntry` rows on this store's alias."""
+        return StreamEntry.objects.using(self._using)
+
+    def _producers(self) -> Any:
+        """`StreamProducer` rows on this store's alias."""
+        return StreamProducer.objects.using(self._using)
 
     # =========================================================================
     # Expiry
@@ -220,7 +271,8 @@ class DjangoStreamStore:
         atomic step against concurrent writers. Only valid inside
         `transaction.atomic()`; a no-op on backends without row locks (SQLite).
         """
-        qs = Stream.objects.select_for_update() if for_update else Stream.objects
+        base = self._streams()
+        qs = base.select_for_update() if for_update else base
         stream = qs.filter(stream_id=path).first()
         if stream is None:
             return None
@@ -304,7 +356,7 @@ class DjangoStreamStore:
                 )
 
             now = time.time()
-            stream = Stream.objects.create(
+            stream = self._streams().create(
                 stream_id=path,
                 content_type=content_type,
                 ttl_seconds=ttl_seconds,
@@ -579,9 +631,8 @@ class DjangoStreamStore:
     # Producer fencing
     # =========================================================================
 
-    @staticmethod
     def _producer_state(
-        stream: Stream, producer_id: str | None
+        self, stream: Stream, producer_id: str | None
     ) -> ProducerState | None:
         """The last known state for `producer_id`, or None.
 
@@ -590,23 +641,22 @@ class DjangoStreamStore:
         """
         if producer_id is None:
             return None
-        row = StreamProducer.objects.filter(
-            stream=stream, producer_id=producer_id
-        ).first()
+        row = self._producers().filter(stream=stream, producer_id=producer_id).first()
         if row is None:
             return None
         return ProducerState(
             epoch=row.epoch, last_seq=row.last_seq, last_updated=row.last_updated
         )
 
-    @staticmethod
-    def _commit_producer(stream: Stream, result: ProducerValidationResult) -> None:
+    def _commit_producer(
+        self, stream: Stream, result: ProducerValidationResult
+    ) -> None:
         """Advance producer state — only ever after a successful write."""
         if not isinstance(result, ProducerAccepted):
             return
         if result.proposed_state is None:
             return
-        StreamProducer.objects.update_or_create(
+        self._producers().update_or_create(
             stream=stream,
             producer_id=result.producer_id,
             defaults={
@@ -848,14 +898,14 @@ class DjangoStreamStore:
                     written, encoded, strict=True
                 )
             ]
-            StreamEvent.objects.bulk_create(stream_events)
+            self._events().bulk_create(stream_events)
 
             start = stream.get_next_offset_block(len(stream_events))
             entries = [
                 StreamEntry(stream=stream, event=event, offset=start + i)
                 for i, event in enumerate(stream_events)
             ]
-            StreamEntry.objects.bulk_create(entries)
+            self._entries().bulk_create(entries)
             # `bulk_create` does not fire `post_save`, so the receiver that
             # publishes single appends never sees these rows — every bulk append
             # used to be invisible to subscribers (issue #82). Publish them
@@ -1034,7 +1084,7 @@ class DjangoStreamStore:
         so a stream recreated at this path resumes numbering above the retired
         mark rather than reissuing offsets a subscriber has already seen.
         """
-        deleted, _ = Stream.objects.filter(stream_id=path).delete()
+        deleted, _ = self._streams().filter(stream_id=path).delete()
         return deleted > 0
 
     def format_response(self, path: str, messages: list[StreamMessage]) -> bytes:
@@ -1120,4 +1170,4 @@ class DjangoStreamStore:
         return stream.current_offset
 
     def list_paths(self) -> list[str]:
-        return list(Stream.objects.values_list("stream_id", flat=True))
+        return list(self._streams().values_list("stream_id", flat=True))

--- a/src/django_rakaia/hermeticity.py
+++ b/src/django_rakaia/hermeticity.py
@@ -40,33 +40,30 @@ handler-dispatch region inside it::
             replay(store, path, DjangoExecutor(using="rebuild"),
                    reader=DjangoProjectionReader(using="rebuild"), ...)
 
-**The event source must not read the denied alias either.** Read the log from a
-store that does not touch it — an in-memory ``StreamStore``, or a store on
-another alias. A ``DjangoStreamStore`` on ``default`` would itself trip the
-guard, which is correct: a truly hermetic rebuild reads its log from somewhere
-other than the database it is proving it can reconstruct.
+**The event source must not read the denied alias either.** A
+``DjangoStreamStore`` on ``default`` would itself trip the guard, which is
+correct: a truly hermetic rebuild reads its log from somewhere other than the
+database it is proving it can reconstruct.
 
-That is the whole obstacle in practice, and it is six lines to clear. Drain the
-durable log into memory *first*, with the guard down, then arm it around the
-replay alone::
-
-    durable = get_store()                       # DjangoStreamStore on "default"
-    mem = StreamStore()
-    mem.create(path)
-    messages, _has_more = durable.read(path)
-    for m in messages:
-        # m.data is already the encoded bytes — re-encoding double-wraps it.
-        mem.append(path, m.data,
-                   AppendOptions(label=m.label, metadata=m.metadata,
-                                 event_ts=m.event_ts))
+Give the store the same alias as the executor and the reader, and there is
+nothing to work around::
 
     with deny_database_access("default"):
-        replay(mem, path, DjangoExecutor(using="rebuild"),
+        replay(DjangoStreamStore(using="rebuild"), path,
+               DjangoExecutor(using="rebuild"),
                reader=DjangoProjectionReader(using="rebuild"), ...)
+
+This used to be the whole obstacle in practice, because the store had no
+``using`` at all and so could only read ``default``. The answer documented here
+was a six-line drain of the durable log into an in-memory ``StreamStore`` first,
+with the guard down — code every consumer wrote and no test covered, since the
+store was untestable off ``default``. ``DjangoStreamStore(using=...)`` (#180)
+replaced it with a keyword argument. An in-memory store is still a perfectly good
+event source; it is no longer the price of admission.
 
 Worth stating because the first production consumer left this guard unwired for
 months, having recorded "a blanket deny on ``default`` trips on the store's own
-reads" as the blocker. It is not a blocker; it is the drain above.
+reads" as the blocker. That was a real blocker, and it is now gone.
 
 **A pass only means something if you have watched the guard fail.** Nothing here
 distinguishes "no handler read the database" from "the guard was never armed",

--- a/tests/test_django_rakaia/test_django_store.py
+++ b/tests/test_django_rakaia/test_django_store.py
@@ -359,10 +359,19 @@ class TestDjangoStreamStore:
         high_before = StreamOffsetWatermark.objects.get(stream_path="s").high
         events_before = StreamEvent.objects.count()
 
+        # Patched on `QuerySet` and narrowed to the entry model, rather than on
+        # `StreamEntry.objects`: the store reaches its models through one
+        # alias-scoped accessor, and `.using()` returns a fresh queryset, so a
+        # patch on the manager object is no longer on the path the store takes.
+        original_bulk_create = QuerySet.bulk_create
+
+        def fail_for_entries(qs, *args, **kwargs):
+            if qs.model is StreamEntry:
+                raise RuntimeError("boom")
+            return original_bulk_create(qs, *args, **kwargs)
+
         with (
-            patch.object(
-                StreamEntry.objects, "bulk_create", side_effect=RuntimeError("boom")
-            ),
+            patch.object(QuerySet, "bulk_create", fail_for_entries),
             pytest.raises(RuntimeError, match="boom"),
         ):
             store.append_many("s", [(b'{"id": 1}', None), (b'{"id": 2}', None)])

--- a/tests/test_django_rakaia/test_locking.py
+++ b/tests/test_django_rakaia/test_locking.py
@@ -564,12 +564,43 @@ class TestTheTransactionIsOpenedOnTheStoresAlias:
         assert [r.message is not None for r in results] == [True, True]
 
     @requires_row_locks
-    def test_closing_on_the_alias_opens_its_own_transaction(self) -> None:
+    def test_creating_with_a_body_opens_its_own_transaction(self) -> None:
+        # `create(initial_data=...)` routes through offset allocation, so it has
+        # its own atomic. Its docstring calls a missing transaction here "a
+        # guaranteed 500 in production" and points at the contract's
+        # create-with-body case as the cover — but that case never runs on an
+        # alias, so this site was unproven off `default`.
         store = DjangoStreamStore(using="overlay")
-        store.create("alias-close")
 
-        store.append("alias-close", b'{"x": 1}', AppendOptions(close=True))
+        store.create("alias-create-body", initial_data=b'{"x": 1}')
 
-        stream = store.get("alias-close")
+        assert [m.data for m in store.read("alias-create-body")[0]] == [b'{"x": 1}']
+
+    @requires_row_locks
+    def test_a_fenced_append_on_the_alias_opens_its_own_transaction(self) -> None:
+        # The sync inner method, not the async wrapper: the atomic lives here and
+        # `append_with_producer` only marshals into it, so this tests the site
+        # rather than the thread hop.
+        store = DjangoStreamStore(using="overlay")
+        store.create("alias-fenced")
+
+        result = store._append_with_producer_sync(
+            "alias-fenced",
+            b'{"x": 1}',
+            AppendOptions(producer_id="p", producer_epoch=1, producer_seq=0),
+        )
+
+        assert result.message is not None
+
+    @requires_row_locks
+    def test_a_fenced_close_on_the_alias_opens_its_own_transaction(self) -> None:
+        # A separate atomic from `append`'s — closing under fencing takes its own.
+        store = DjangoStreamStore(using="overlay")
+        store.create("alias-fenced-close")
+
+        result = store._close_with_producer_sync("alias-fenced-close", "p", 1, 0)
+
+        assert result is not None
+        stream = store.get("alias-fenced-close")
         assert stream is not None
         assert stream.closed

--- a/tests/test_django_rakaia/test_locking.py
+++ b/tests/test_django_rakaia/test_locking.py
@@ -148,6 +148,15 @@ class TestOpensItsOwnTransaction:
 
     Three tests, one per lock site — replacing the notional cover that ~160
     incidental non-transactional tests were providing.
+
+    A fourth question turned out to hide in the same blind spot: the transaction
+    must be opened **on the store's own alias**. A bare `transaction.atomic()`
+    binds to `default`, so a store on another alias ran its writes in autocommit
+    while opening an empty transaction on `default` — and `select_for_update`
+    checks the *target* connection, so on Postgres the alias was unusable for
+    writes at all. Under a plain `django_db` marker every one of these passes
+    either way, because pytest-django has already opened a transaction on each
+    declared alias. See `TestTheTransactionIsOpenedOnTheStoresAlias`.
     """
 
     def test_append_opens_its_own_transaction(self) -> None:
@@ -471,3 +480,96 @@ class TestTheWatermarkReadIsALockingRead:
         assert "FOR UPDATE" in reads[0].upper(), (
             f"the watermark read is not a locking read: {reads[0]}"
         )
+
+
+@pytest.mark.django_db(transaction=True, databases=["default", "overlay"])
+class TestTheTransactionIsOpenedOnTheStoresAlias:
+    """A store on a named alias must open its transaction *there*.
+
+    `transaction.atomic()` with no argument binds to `default`. A store pointed
+    at another alias therefore wrote in autocommit while opening an empty
+    transaction on `default` — three distinct failures from one missing keyword:
+    `select_for_update` raised on Postgres because it checks the target
+    connection; a failed append left its event and entry behind on SQLite, which
+    is the split-write class #159 exists to prevent; and the stray `BEGIN` on
+    `default` tripped `deny_database_access`, which is the whole point of the
+    alias.
+
+    `transaction=True` is what makes these visible. Under a plain `django_db`
+    marker pytest-django has already opened a transaction on every declared
+    alias, which silently supplies both the missing atomic and the absent
+    `BEGIN` — so the entire feature can be tested green while being unusable in
+    production.
+
+    `requires_row_locks` is applied **per test, not to the class**: only the cases
+    whose failure mode *is* the lock need a backend that has one. The rollback and
+    the guard fail on SQLite too, and skipping them there would drop the only
+    coverage of a defect that shows up on the default test run.
+    """
+
+    @requires_row_locks
+    def test_a_write_to_the_alias_succeeds_in_real_autocommit(self) -> None:
+        # On Postgres this raised `TransactionManagementError: select_for_update
+        # cannot be used outside of a transaction` before the fix.
+        store = DjangoStreamStore(using="overlay")
+        store.create("alias-txn")
+
+        store.append("alias-txn", b'{"x": 1}')
+
+        assert store.get("alias-txn") is not None
+
+    def test_a_failed_write_to_the_alias_rolls_back(self) -> None:
+        # The split-write case: without the alias on the atomic, the event and
+        # entry were already committed by the time the failure happened.
+        from unittest.mock import patch
+
+        from django_rakaia.models import StreamEntry, StreamEvent
+
+        store = DjangoStreamStore(using="overlay")
+        store.create("alias-rollback")
+
+        with (
+            patch.object(DjangoStreamStore, "_touch", side_effect=RuntimeError("boom")),
+            pytest.raises(RuntimeError, match="boom"),
+        ):
+            store.append("alias-rollback", b'{"x": 1}')
+
+        assert StreamEvent.objects.using("overlay").count() == 0
+        assert StreamEntry.objects.using("overlay").count() == 0
+
+    def test_writing_to_the_alias_does_not_touch_the_guarded_default(self) -> None:
+        # The claim `hermeticity.py` now makes: give the store the alias and a
+        # rebuild that *writes* inside the guard has nothing to work around. The
+        # stray `BEGIN` on `default` used to fail this.
+        from django_rakaia.hermeticity import deny_database_access
+
+        store = DjangoStreamStore(using="overlay")
+        store.create("alias-guarded")
+
+        with deny_database_access("default"):
+            store.append("alias-guarded", b'{"x": 1}')
+
+        assert [m.data for m in store.read("alias-guarded")[0]] == [b'{"x": 1}']
+
+    @requires_row_locks
+    def test_a_batch_write_to_the_alias_opens_its_own_transaction(self) -> None:
+        # `append_many` is a separate write door with its own atomic.
+        store = DjangoStreamStore(using="overlay")
+        store.create("alias-batch")
+
+        results = store.append_many(
+            "alias-batch", [(b'{"n": 1}', None), (b'{"n": 2}', None)]
+        )
+
+        assert [r.message is not None for r in results] == [True, True]
+
+    @requires_row_locks
+    def test_closing_on_the_alias_opens_its_own_transaction(self) -> None:
+        store = DjangoStreamStore(using="overlay")
+        store.create("alias-close")
+
+        store.append("alias-close", b'{"x": 1}', AppendOptions(close=True))
+
+        stream = store.get("alias-close")
+        assert stream is not None
+        assert stream.closed

--- a/tests/test_django_rakaia/test_rebuild_isolation.py
+++ b/tests/test_django_rakaia/test_rebuild_isolation.py
@@ -31,6 +31,7 @@ from django_rakaia.hermeticity import (
     assert_no_live_writes,
     deny_database_access,
 )
+from rakaia.effects import Upsert
 
 from .models import FinanceLine
 
@@ -205,3 +206,89 @@ class TestTheTwoGuardsComposeInEitherOrder:
         assert any("COUNT" in sql.upper() for sql in seen), (
             "the guard's own counts should still reach an unrelated wrapper"
         )
+
+
+class TestTheLogCanComeFromTheDisposableAliasToo:
+    """The drain is no longer the price of a hermetic rebuild.
+
+    `deny_database_access("default")` catches *every* statement on that alias,
+    including the store's own reads — which is correct, and used to be the whole
+    obstacle: the log lived on `default`, so reading it tripped the guard. The
+    documented answer was to copy the log into memory first, six lines, at every
+    call site.
+
+    With `DjangoStreamStore(using=...)` the log is on the alias being rebuilt
+    into, so the replay reads and writes one database and the guard has nothing to
+    catch. These two cases are the before and after of that claim, and the second
+    is what makes the first mean something: a pass proves nothing unless the same
+    guard is seen to fail.
+    """
+
+    def _seed(self, alias: str, path: str = "rebuild-me") -> None:
+        from django_rakaia.django_store import DjangoStreamStore
+
+        store = DjangoStreamStore(using=alias)
+        store.create(path)
+        store.append(path, b'{"n": 1}')
+        store.append(path, b'{"n": 2}')
+
+    def test_reading_the_log_from_the_alias_does_not_trip_the_guard(self):
+        from django_rakaia.django_store import DjangoStreamStore
+
+        self._seed("overlay")
+
+        with deny_database_access("default"):
+            messages, _ = DjangoStreamStore(using="overlay").read("rebuild-me")
+
+        assert [m.data for m in messages] == [b'{"n": 1}', b'{"n": 2}']
+
+    def test_reading_it_from_the_guarded_alias_still_trips(self):
+        # The armed-guard check the hermeticity docstring asks for, as a test
+        # rather than as discipline. Without this the case above would pass
+        # equally well if the guard had never been installed.
+        from django_rakaia.django_store import DjangoStreamStore
+        from django_rakaia.hermeticity import AmbientDatabaseAccess
+
+        self._seed("default")
+
+        with (
+            deny_database_access("default"),
+            pytest.raises(AmbientDatabaseAccess),
+        ):
+            DjangoStreamStore(using=None).read("rebuild-me")
+
+    def test_a_whole_replay_runs_inside_the_guard_with_no_drain(self):
+        # End to end: log on the alias, handlers replayed, projections written to
+        # the same alias, `default` never touched. This is the composition
+        # `hermeticity.py` describes in prose and nothing executed.
+        from django_rakaia.django_store import DjangoStreamStore
+        from django_rakaia.effect_executor import DjangoExecutor
+        from rakaia.registry import HandlerRegistry
+        from rakaia.replay import replay
+
+        self._seed("overlay", "fin")
+
+        registry = HandlerRegistry()
+        registry.register(
+            name="fin",
+            event_match="fin",
+            fn=lambda event: [
+                Upsert(
+                    model_label="test_django_rakaia.FinanceLine",
+                    lookup={"submission_id": str(event["n"])},
+                    defaults={"suku": "s", "delta": event["n"]},
+                )
+            ],
+            effective_from=0,
+        )
+
+        with assert_no_live_writes(FinanceLine), deny_database_access("default"):
+            replay(
+                DjangoStreamStore(using="overlay"),
+                "fin",
+                DjangoExecutor(using="overlay"),
+                handler_registry=registry,
+            )
+
+        assert FinanceLine.objects.using("overlay").count() == 2
+        assert FinanceLine.objects.using("default").count() == 0

--- a/tests/test_django_rakaia/test_using_seam.py
+++ b/tests/test_django_rakaia/test_using_seam.py
@@ -198,3 +198,239 @@ class TestTheStreamHeadFollowsItsAlias:
 
         default_stream = Stream.objects.using("default").get(stream_id="shared")
         assert default_stream.current_offset == format_offset(7)
+
+
+class TestTheLogFollowsItsAlias:
+    """`DjangoStreamStore(using=...)` — the log joins the seam the rest already sits on.
+
+    `DjangoExecutor` and `DjangoProjectionReader` can both be aimed at a named
+    database, which is what lets a rebuild be replayed into a throwaway one and
+    verified at full ORM fidelity (ADR 0003). The log could not, so the rebuild
+    could not read its own events from the guarded alias — and `hermeticity.py`
+    shipped a six-line drain-to-memory as a *docstring* instead.
+
+    This is the third adapter on an existing seam, not a new seam: two things
+    already vary across it.
+    """
+
+    def _store(self, alias: str | None = None):
+        from django_rakaia.django_store import DjangoStreamStore
+
+        return DjangoStreamStore(using=alias)
+
+    def test_create_puts_the_stream_on_the_named_alias(self):
+        from django_rakaia.models import Stream
+
+        self._store("overlay").create("s")
+
+        assert Stream.objects.using("overlay").filter(stream_id="s").exists()
+        assert not Stream.objects.using("default").filter(stream_id="s").exists()
+
+    def test_append_puts_the_event_and_entry_on_the_named_alias(self):
+        from django_rakaia.models import StreamEntry, StreamEvent
+
+        store = self._store("overlay")
+        store.create("s")
+        store.append("s", b'{"n": 1}')
+
+        assert StreamEvent.objects.using("overlay").count() == 1
+        assert StreamEntry.objects.using("overlay").count() == 1
+        assert StreamEvent.objects.using("default").count() == 0
+        assert StreamEntry.objects.using("default").count() == 0
+
+    def test_the_offset_high_water_is_allocated_on_the_named_alias(self):
+        # The watermark is the sole authority for a stream's head once advanced,
+        # so a rebuild whose offsets came off the live database would read its
+        # positions from production (#159, and the read side of #175).
+        from django_rakaia.models import StreamOffsetWatermark
+
+        store = self._store("overlay")
+        store.create("s")
+        store.append("s", b'{"n": 1}')
+
+        assert (
+            StreamOffsetWatermark.objects.using("overlay")
+            .filter(stream_path="s")
+            .exists()
+        )
+        assert (
+            not StreamOffsetWatermark.objects.using("default")
+            .filter(stream_path="s")
+            .exists()
+        )
+
+    def test_read_returns_what_that_alias_holds(self):
+        store = self._store("overlay")
+        store.create("s")
+        store.append("s", b'{"n": 1}')
+
+        messages, _ = store.read("s")
+        assert [m.data for m in messages] == [b'{"n": 1}']
+
+    def test_two_aliases_are_separate_logs_at_the_same_path(self):
+        default_store = self._store()
+        overlay_store = self._store("overlay")
+        default_store.create("shared")
+        overlay_store.create("shared")
+        default_store.append("shared", b'{"where": "default"}')
+        overlay_store.append("shared", b'{"where": "overlay"}')
+
+        assert [m.data for m in default_store.read("shared")[0]] == [
+            b'{"where": "default"}'
+        ]
+        assert [m.data for m in overlay_store.read("shared")[0]] == [
+            b'{"where": "overlay"}'
+        ]
+
+    def test_a_stream_on_another_alias_is_absent_not_empty(self):
+        # `has()` must not report a stream this store cannot read. An "exists but
+        # empty" answer is the one a resuming subscriber would misread.
+        self._store("overlay").create("s")
+
+        assert self._store("overlay").has("s")
+        assert not self._store("default").has("s")
+        assert self._store("default").get("s") is None
+
+    def test_the_envelope_survives_the_alias(self):
+        # `write_enveloped_event` derives its alias from the stream row it was
+        # handed, so the event has to land beside its entry or one save is split
+        # across two databases (#159).
+        from rakaia import AppendOptions
+
+        store = self._store("overlay")
+        store.create("s")
+        store.append(
+            "s",
+            b'{"n": 1}',
+            AppendOptions(label="update", metadata={"user": 7}, event_ts=1234.0),
+        )
+
+        messages, _ = store.read("s")
+        assert messages[0].label == "update"
+        assert messages[0].metadata == {"user": 7}
+        assert messages[0].event_ts == 1234.0
+
+    def test_listing_and_deleting_stay_on_the_alias(self):
+        overlay, default = self._store("overlay"), self._store()
+        overlay.create("only-overlay")
+        default.create("only-default")
+
+        assert overlay.list_paths() == ["only-overlay"]
+        assert default.list_paths() == ["only-default"]
+
+        assert overlay.delete("only-overlay") is True
+        assert default.has("only-default"), "deleting on one alias touched the other"
+
+    def test_the_head_is_reported_from_the_alias(self):
+        from django_rakaia.offsets import format_offset
+
+        overlay, default = self._store("overlay"), self._store()
+        overlay.create("shared")
+        default.create("shared")
+        for _ in range(3):
+            default.append("shared", b"{}")
+        overlay.append("shared", b"{}")
+
+        assert overlay.get_current_offset("shared") == format_offset(1)
+        assert default.get_current_offset("shared") == format_offset(3)
+
+
+class TestTheBulkAndFencedPathsFollowTheAliasToo:
+    """The two paths that do *not* go through `write_enveloped_event`.
+
+    A single append derives its alias from the stream row it was handed (#159),
+    so events and entries land correctly even without the store's own accessors.
+    Two paths bypass that: `append_many` bulk-creates events and entries
+    directly, and producer fencing reads and writes `StreamProducer`. Both were
+    green with the alias stripped out of those accessors until these cases
+    existed — the seam looked covered because the common path covers itself.
+    """
+
+    def _store(self, alias: str | None = None):
+        from django_rakaia.django_store import DjangoStreamStore
+
+        return DjangoStreamStore(using=alias)
+
+    def test_a_batch_lands_entirely_on_the_named_alias(self):
+        from django_rakaia.models import StreamEntry, StreamEvent
+
+        store = self._store("overlay")
+        store.create("s")
+        store.append_many("s", [(b'{"n": 1}', None), (b'{"n": 2}', None)])
+
+        assert StreamEvent.objects.using("overlay").count() == 2
+        assert StreamEntry.objects.using("overlay").count() == 2
+        assert StreamEvent.objects.using("default").count() == 0
+        assert StreamEntry.objects.using("default").count() == 0
+
+    def test_a_batch_is_readable_back_from_the_alias(self):
+        store = self._store("overlay")
+        store.create("s")
+        store.append_many("s", [(b'{"n": 1}', None), (b'{"n": 2}', None)])
+
+        assert [m.data for m in store.read("s")[0]] == [b'{"n": 1}', b'{"n": 2}']
+
+    def test_producer_state_is_recorded_on_the_named_alias(self):
+        from django_rakaia.models import StreamProducer
+        from rakaia import AppendOptions
+
+        store = self._store("overlay")
+        store.create("s")
+        store.append(
+            "s", b"{}", AppendOptions(producer_id="p", producer_epoch=1, producer_seq=0)
+        )
+
+        assert StreamProducer.objects.using("overlay").filter(producer_id="p").exists()
+        assert (
+            not StreamProducer.objects.using("default").filter(producer_id="p").exists()
+        )
+
+    def test_fencing_reads_the_state_from_its_own_alias(self):
+        # The consequence of getting this wrong: a producer fenced on one
+        # database would be admitted on another, because its state was invisible.
+        # Same producer id and epoch on both aliases, at different sequences.
+        from rakaia import AppendOptions
+
+        overlay, default = self._store("overlay"), self._store()
+        for store in (overlay, default):
+            store.create("s")
+            store.append(
+                "s",
+                b"{}",
+                AppendOptions(producer_id="p", producer_epoch=1, producer_seq=0),
+            )
+        overlay.append(
+            "s", b"{}", AppendOptions(producer_id="p", producer_epoch=1, producer_seq=1)
+        )
+
+        # seq 1 is a duplicate on overlay (already at 1) and the next in line on
+        # default (still at 0). One store must not see the other's progress.
+        dup = overlay.append(
+            "s", b"{}", AppendOptions(producer_id="p", producer_epoch=1, producer_seq=1)
+        )
+        fresh = default.append(
+            "s", b"{}", AppendOptions(producer_id="p", producer_epoch=1, producer_seq=1)
+        )
+        assert dup.message is None, "overlay should have seen seq 1 as a duplicate"
+        assert fresh.message is not None, "default should have accepted seq 1"
+
+
+class TestTheDefaultAliasIsUnchanged:
+    """No `using=` must behave exactly as before — this is a Tier 1 constructor."""
+
+    def test_no_argument_targets_the_default_database(self):
+        from django_rakaia.django_store import DjangoStreamStore
+        from django_rakaia.models import Stream
+
+        DjangoStreamStore().create("s")
+
+        assert Stream.objects.using("default").filter(stream_id="s").exists()
+
+    def test_using_none_is_the_same_as_omitting_it(self):
+        from django_rakaia.django_store import DjangoStreamStore
+
+        store = DjangoStreamStore(using=None)
+        store.create("s")
+        store.append("s", b'{"n": 1}')
+
+        assert [m.data for m in store.read("s")[0]] == [b'{"n": 1}']


### PR DESCRIPTION
Closes #180 — the first item from the #192 review, and the one that unblocks #184
and #186.

Rebuilding projections into a throwaway database is how we prove a rebuild is
trustworthy without touching production. The two pieces that write and read those
projections could both be aimed at another database; the log could not, so a
rebuild had to read its events from the live one — which the read guard correctly
refuses. The documented workaround was to copy the log into memory first, six
lines, at every call site, and it was tested nowhere because the store could not
be pointed anywhere else in order to test it.

`DjangoStreamStore(using=...)` puts the log on the seam the other two already sat
on, with every model access going through one alias-scoped accessor. `using=None`
behaves exactly as before. `hermeticity.py` stops documenting the drain, and a
test now runs a whole replay inside the guard — log, projections and handlers all
on one disposable alias — paired with a case that watches the same guard fail, so
the passing one means something.