### PR TITLE
Write down the test mode that hid an unusable alias

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,24 @@
   `django_db(transaction=True)`; a plain `django_db` test runs inside a
   transaction pytest-django rolls back, so a lock taken outside the code's own
   `atomic()` still looks fine and a second connection can never see the rows.
+- **A plain `django_db` marker also hides a missing `using=` on
+  `transaction.atomic()`, and that failure is worse.** `transaction.atomic()`
+  with no argument binds to `default`, so code pointed at another alias writes in
+  autocommit while opening an empty transaction somewhere else — on Postgres
+  `select_for_update` checks the *target* connection and raises, and on SQLite a
+  failed write stays committed. Under `django_db(databases=[...])` pytest-django
+  has already opened a transaction on **every declared alias**, which silently
+  supplies both the missing `atomic()` and the absent `BEGIN`, so the whole
+  feature tests green while being unusable in production. That is how #180
+  shipped a broken alias past a full suite.
+  **Anything alias-aware wants `django_db(transaction=True, databases=[...])`**,
+  and is worth checking per site: strip `using=` from one `atomic()` at a time and
+  confirm the test named for it goes red. Aggregate mutation only proves that
+  *something* was covered.
+- **Apply `requires_row_locks` per test, not per class.** `test_locking.py` skips
+  wholesale on SQLite, so a class-level marker also skips failures that *are*
+  visible there — a non-rollback is, a `select_for_update` raise is not. Mark the
+  cases whose failure mode is the lock; leave the rest to run on both legs.
 - **Row locking is covered deliberately, not incidentally.** There are three
   `select_for_update()` sites (`models.py` offset watermark, `django_store.py`
   stream row, `effect_executor.py` retire capture). Around 290 tests touch one,

--- a/docs/dry-run-and-executors.md
+++ b/docs/dry-run-and-executors.md
@@ -199,8 +199,9 @@ stage-1 handler that resolves a reference another form created would find nothin
 (the reference was recorded, never applied), so the link can't be verified.
 
 The honest answer is not a bespoke in-memory shadow that imitates the ORM, but the
-**real** executor and reader pointed at a **disposable database**. Both
-`DjangoExecutor` and `DjangoProjectionReader` take a `using=` database alias:
+**real** store, executor and reader pointed at a **disposable database**. All
+three — `DjangoStreamStore`, `DjangoExecutor` and `DjangoProjectionReader` — take
+a `using=` database alias:
 
 ```python
 # settings: a throwaway alias — in-memory sqlite for fast/CI proofs,
@@ -208,13 +209,21 @@ The honest answer is not a bespoke in-memory shadow that imitates the ORM, but t
 DATABASES["rebuild"] = {"ENGINE": "django.db.backends.sqlite3", "NAME": ":memory:"}
 
 replay(
-    store, "submissions",
+    DjangoStreamStore(using="rebuild"), "submissions",  # the log comes from there too
     DjangoExecutor(using="rebuild"),                 # writes land in the scratch DB
     reader=DjangoProjectionReader(using="rebuild"),  # stage-1 reads them back
     handler_registry=reg,
 )
 # ...then diff the rebuilt rows against production and throw the scratch DB away.
 ```
+
+The store joined that list late (#180), and its absence was the whole obstacle in
+practice: `deny_database_access("default")` catches *every* statement on the alias
+it guards, including the store's own reads, so a rebuild whose log lived on
+`default` tripped its own guard. The documented workaround was to copy the log
+into an in-memory store first — six lines, at every call site, and untested,
+because the store could not be pointed anywhere else in order to test it. If you
+are following an older recipe that drains the log by hand, you no longer need to.
 
 Because it is the real ORM, you get full fidelity — constraints, defaults, joins,
 `__gte` — for free, with no query engine to write and nothing written to

--- a/tests/test_django_rakaia/test_locking.py
+++ b/tests/test_django_rakaia/test_locking.py
@@ -17,8 +17,8 @@ allocating locks. Locking is not what those tests are about, and converting them
 all to `transaction=True` would buy nothing that the handful here does not,
 while making every future run pay truncation teardown. See #148.
 
-**Two different failures hide in the fast test mode, and they need different
-tests.** Django's docs are explicit about both:
+**Three different failures hide in the fast test mode, and they need different
+tests.** Django's docs are explicit about the first two:
 
 * *"Evaluating a queryset with select_for_update() in autocommit mode on
   backends which support SELECT ... FOR UPDATE is a TransactionManagementError
@@ -30,11 +30,23 @@ tests.** Django's docs are explicit about both:
   that crutch.
 * A lock that is never contended proves nothing about serialisation.
   `TestStreamRowLock` and `TestRetireLock` contend it.
+* The transaction has to be opened on the **right database**. A bare
+  `transaction.atomic()` binds to `default`, so code pointed at another alias
+  writes in autocommit — and `django_db(databases=[...])` has pytest-django open
+  a transaction on *every declared alias*, which supplies the missing one just as
+  readily. `TestTheTransactionIsOpenedOnTheStoresAlias` removes that crutch too;
+  it is how #180 shipped an unusable alias past a full green suite.
 
-Both need `transaction=True`, and both need a backend that has row locks at all
-— on SQLite `select_for_update()` compiles to nothing and *"an error isn't
-raised"* either, so neither failure can be observed. Run with
+All three need `transaction=True`. The first two also need a backend that has row
+locks at all — on SQLite `select_for_update()` compiles to nothing and *"an error
+isn't raised"* either, so neither failure can be observed there. Run with
 `RAKAIA_TEST_DB=postgres` (the `test-postgres` CI job).
+
+**`requires_row_locks` goes on the test, not the class.** This whole file skips on
+SQLite if you mark a class with it, which would also skip the failures that *are*
+visible there: an aliased write that does not roll back fails on SQLite, while a
+`select_for_update` raise cannot happen at all. Marking per test keeps the
+SQLite-visible cases running on the default leg.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
Follow-up to #193, which shipped a store whose transactions bound to the default
database rather than its own alias — past a full green suite on both test legs.

The reason is not obvious and is now written down: a plain `django_db` marker has
pytest-django open a transaction on every declared alias, so it supplies the
missing one and an alias-aware feature can be entirely broken in production while
every test for it passes. CLAUDE.md covered the single-database version of this
already; it now covers the alias version, the fact that mutation has to be checked
per site rather than in aggregate, and that the row-lock skip marker belongs on a
test rather than a class.

Two stale claims fixed alongside: `test_locking.py` said two failures hide in the
fast test mode where there are three, and the dry-run guide still said only the
executor and reader take a database alias.