### PR TITLE
Show the event the admin actually has, not the columns it is stored in

### DIFF
--- a/src/django_rakaia/admin.py
+++ b/src/django_rakaia/admin.py
@@ -12,6 +12,7 @@ from django.contrib import admin
 from django.utils.html import format_html, format_html_join
 from django.utils.safestring import mark_safe
 
+from django_rakaia.event_message import decode_payload, event_label
 from django_rakaia.models import Stream, StreamEntry, StreamEvent
 
 
@@ -35,6 +36,14 @@ class StreamAdmin(admin.ModelAdmin):
         return last.offset if last else None
 
 
+_PREVIEW_CHARS = 100
+
+
+def _truncate(text: str) -> str:
+    """`text`, cut to the preview budget. One rule, so the two branches agree."""
+    return text if len(text) <= _PREVIEW_CHARS else text[: _PREVIEW_CHARS - 3] + "..."
+
+
 @admin.register(StreamEvent)
 class StreamEventAdmin(admin.ModelAdmin):
     """Admin interface for StreamEvent model."""
@@ -54,28 +63,48 @@ class StreamEventAdmin(admin.ModelAdmin):
 
     @admin.display(description="Type")
     def event_type_badge(self, obj):
+        # Through `event_label`, not `obj.event_type`: the column stores a
+        # sentinel for "a raw append, which carried no label", and rendering it
+        # raw showed `APPEND` where every other reader of the same event reports
+        # no label at all. `event_label`'s own docstring says callers rendering
+        # an event must use it rather than the column (#153); this surface did
+        # not, so the admin and the audit trail disagreed.
+        label = event_label(obj.event_type)
         colors = {
             "create": "#28a745",
             "update": "#ffc107",
             "delete": "#dc3545",
         }
-        color = colors.get(obj.event_type, "#6c757d")
+        color = colors.get(label, "#6c757d")
         return format_html(
             '<span style="background-color: {}; color: white; padding: 3px 8px; '
             'border-radius: 3px; font-size: 11px; font-weight: bold;">{}</span>',
             color,
-            obj.event_type.upper(),
+            label.upper() or "\u2014",
         )
 
     @admin.display(description="Data")
     def data_preview(self, obj: StreamEvent) -> str:
+        """The payload as a reader sees it, not as the column happens to hold it.
+
+        A body that is not JSON is stored as text — or base64, when it is not
+        valid UTF-8 — and marked with `payload_encoding`, which `read()` inverts.
+        Dumping the column ignored that, so a binary payload rendered as its
+        base64 with nothing on screen saying so. `decode_payload` is the same
+        inverse `read()` uses, so the two now agree.
+        """
+        if obj.payload_encoding is not None:
+            payload = decode_payload(obj.data, obj.payload_encoding)
+            try:
+                shown = payload.decode("utf-8")
+            except UnicodeDecodeError:
+                # Genuinely not text. Say what it is rather than printing an
+                # encoding the viewer has no way to recognise.
+                return f"<{len(payload)} bytes, {obj.payload_encoding}>"
+            return _truncate(shown)
         try:
-            # Explicitly type the JSONField data
             data: Any = obj.data  # type: ignore[assignment]
-            data_str = json.dumps(data, indent=2)
-            if len(data_str) > 100:
-                return data_str[:97] + "..."
-            return data_str
+            return _truncate(json.dumps(data, indent=2))
         except (TypeError, ValueError):
             return str(obj.data)  # type: ignore[call-overload]
 

--- a/tests/test_django_rakaia/test_admin.py
+++ b/tests/test_django_rakaia/test_admin.py
@@ -103,3 +103,77 @@ class TestRegisterStreamEventAdmin:
         register_stream_event_admin(StreamEvent)
         # Registering the base model must not touch the registry.
         assert set(django_admin.site._registry) == before
+
+
+class TestTheAdminAgreesWithEveryOtherReader:
+    """What the admin shows must be what `read()` reports.
+
+    The admin is a read surface like the SSE view and the channel frame, and
+    #153 made the primitives those surfaces need single: `event_label` inverts
+    the stored `"append"` sentinel back to the empty string, and `decode_payload`
+    inverts `payload_encoding`. The admin called neither, so it rendered the
+    sentinel as a label and printed a base64 body as base64.
+
+    Anyone comparing the admin against the audit trail saw two different answers
+    for one event, which is the whole failure #153 exists to prevent — in a
+    surface `event_message.py`'s own docstring names as fixed.
+    """
+
+    def _admin(self):
+        return StreamEventAdmin(StreamEvent, django_admin.site)
+
+    def test_a_labelless_append_shows_no_label_not_the_sentinel(self):
+        from django_rakaia.django_store import DjangoStreamStore
+
+        store = DjangoStreamStore()
+        store.create("s")
+        store.append("s", b'{"n": 1}')
+        event = StreamEvent.objects.get()
+
+        badge = self._admin().event_type_badge(event)
+        assert store.read("s")[0][0].label == ""
+        assert "APPEND" not in badge
+        # And says *something* — a blank cell reads as a rendering bug, so the
+        # absence of a label is shown deliberately. Asserted because "not APPEND"
+        # alone is satisfied by an empty badge.
+        assert "\u2014" in badge
+
+    def test_a_real_label_is_still_shown(self):
+        # The sentinel is the only value that inverts; a genuine label must
+        # survive, or the badge becomes useless.
+        from django_rakaia.django_store import DjangoStreamStore
+        from rakaia import AppendOptions
+
+        store = DjangoStreamStore()
+        store.create("s")
+        store.append("s", b"{}", AppendOptions(label="update"))
+        event = StreamEvent.objects.get()
+
+        assert "UPDATE" in self._admin().event_type_badge(event)
+
+    def test_a_base64_body_is_not_previewed_as_base64(self):
+        from django_rakaia.event_message import decode_payload
+
+        event = StreamEvent.objects.create(
+            data="//4AYmluYXJ5", event_type="append", payload_encoding="base64"
+        )
+        assert (
+            decode_payload(event.data, event.payload_encoding) == b"\xff\xfe\x00binary"
+        )
+
+        preview = self._admin().data_preview(event)
+        assert "//4AYmluYXJ5" not in preview, (
+            "the preview shows the stored base64 rather than saying what it is"
+        )
+
+    def test_a_text_body_is_previewed_as_its_text(self):
+        event = StreamEvent.objects.create(
+            data="hello, world", event_type="append", payload_encoding="utf-8"
+        )
+        assert "hello, world" in self._admin().data_preview(event)
+
+    def test_an_ordinary_json_payload_previews_exactly_as_before(self):
+        # The common case must not change shape.
+        event = StreamEvent.objects.create(data={"n": 1}, event_type="create")
+        preview = self._admin().data_preview(event)
+        assert '"n"' in preview and "1" in preview


### PR DESCRIPTION
Closes #179.

The admin built its own view of an event rather than using the shared one, and
disagreed with every other reader twice over. A plain append showed as APPEND,
because the stored label column holds a sentinel meaning "carried no label" that
readers invert and the admin printed raw. And a payload that was not valid text
is stored as base64 and marked as such — the preview ignored the marking and
printed the base64.

Both now use the same inverses `read()` uses, so the admin and the audit trail
give one answer for one event. A labelless append shows an em-dash rather than an
empty cell; a payload that does not decode to text is described by length and
encoding rather than printed unrecognisably.

This is the live half of #185, which proposes one assembly shared by all four read
surfaces. That issue fixes the cause; this one fixes the answer.