### PR TITLE
Delete the reader that dropped the envelope it was reading

### DIFF
--- a/src/django_rakaia/streams.py
+++ b/src/django_rakaia/streams.py
@@ -1,21 +1,28 @@
 """
-Adapters that expose Django data to rakaia's replay pipeline.
+Reading an existing Django table as a *virtual* stream.
 
-Two readers, picked according to where your event log lives:
+`ModelStreamReader` lets `replay()` treat rows you already have as if they were
+events: it reads them in a defined order from a queryset and encodes each one
+with a `to_payload` callable you supply. Use it when a durable, ordered
+source-of-truth already exists and you do not want to mirror it into a stream.
 
-- `ModelStreamReader` treats an existing Django table as a *virtual*
-  stream: replay reads ordered rows directly from the queryset, encoding
-  each as a JSON event. Use when you already have a durable, ordered
-  source-of-truth and don't want to mirror it.
+**It carries no envelope, and that is correct.** The rows it reads were never
+events, so there is no recorded label, actor or event time to carry — it
+synthesises a payload rather than reproducing one. Anything that reads the
+envelope (`envelope_actor`, `merge_replay(order_key=...)`,
+`history_effects(version_of=...)`) has nothing to read here by construction.
 
-- `DjangoStreamReader` reads from the `Stream`/`StreamEvent`/`StreamEntry`
-  tables that `@stream_model` populates. Use when you've decided to mirror
-  saves into a real Rakaia stream (live SSE broadcast, multi-consumer
-  cursors).
+**If your events are actually stored as events, use the store.** For the
+`Stream`/`StreamEvent`/`StreamEntry` rows that `@stream_model` and
+`create_stream_event` populate, read with `DjangoStreamStore` — it carries the
+label, metadata, event timestamp and offset those rows genuinely hold, inverts
+`payload_encoding`, takes a `using=` database alias, and is held to
+`tests/server_store_contract.py`. A second reader over those same tables used to
+live here and returned the payload alone, so a replay through it silently lost
+all of that; it had no callers and was deleted (#186).
 
-Both satisfy the same subset of the `StreamStore` interface
-(`read(path)` -> `(list[message], bool)`, `has(path)`) that
-`rakaia.replay.replay` calls.
+Satisfies the subset of the `StreamStore` interface `rakaia.replay.replay` calls:
+`read(path)` -> `(list[message], bool)`, and `has(path)`.
 """
 
 from __future__ import annotations
@@ -26,8 +33,6 @@ from dataclasses import dataclass
 from typing import Any
 
 from django.db.models import QuerySet
-
-from django_rakaia.models import Stream
 
 
 @dataclass(frozen=True)
@@ -102,55 +107,3 @@ class ModelStreamReader:
         qs = self._queryset_for(path).order_by(self._order_by)
         for obj in qs.iterator(chunk_size=self._chunk_size):
             yield self._to_payload(obj)
-
-
-# =============================================================================
-# DjangoStreamReader
-# =============================================================================
-
-
-class DjangoStreamReader:
-    """
-    Read events from the `Stream`/`StreamEvent`/`StreamEntry` tables that
-    `@stream_model` (or `create_stream_event`) populates.
-
-    Each `StreamEntry`'s `event.data` (the JSONField written by
-    `to_dataclass(instance)`) becomes one event. Entries are read in
-    ascending `offset` order.
-
-    Note on sequence numbers: `replay()` uses the position of an event
-    within the iteration (0, 1, 2, ...) as its seq for handler-version
-    dispatch — *not* the underlying Django `offset` column. So a handler
-    registered with `effective_from=0` matches the first event read from
-    the stream, regardless of its `StreamEntry.offset` value.
-
-    Args:
-        chunk_size: Rows fetched per DB roundtrip. Defaults to 1000.
-    """
-
-    def __init__(self, *, chunk_size: int = 1000) -> None:
-        self._chunk_size = chunk_size
-
-    def read(
-        self,
-        path: str,
-        offset: str | None = None,  # noqa: ARG002
-    ) -> tuple[list[_ReaderMessage], bool]:
-        """Return (messages, up_to_date) for the given stream id."""
-        try:
-            stream = Stream.objects.get(stream_id=path)
-        except Stream.DoesNotExist:
-            return [], True
-        entries = (
-            stream.entries.select_related("event")
-            .order_by("offset")
-            .iterator(chunk_size=self._chunk_size)
-        )
-        messages = [
-            _ReaderMessage(data=json.dumps(e.event.data).encode("utf-8"))
-            for e in entries
-        ]
-        return messages, True
-
-    def has(self, path: str) -> bool:
-        return Stream.objects.filter(stream_id=path).exists()

--- a/tests/test_django_rakaia/test_model_stream_reader.py
+++ b/tests/test_django_rakaia/test_model_stream_reader.py
@@ -7,10 +7,9 @@ import json
 import pytest
 from django.db import transaction
 
-from django_rakaia.decorators import create_stream_event
 from django_rakaia.effect_executor import DjangoExecutor
 from django_rakaia.models import Stream, StreamEntry, StreamEvent
-from django_rakaia.streams import DjangoStreamReader, ModelStreamReader
+from django_rakaia.streams import ModelStreamReader
 from rakaia.effects import Upsert
 from rakaia.registry import HandlerRegistry
 from rakaia.replay import replay
@@ -154,8 +153,15 @@ class TestReplayAgainstModelStream:
 
 
 # ---------------------------------------------------------------------------
-# DjangoStreamReader — reads from real Stream/StreamEvent/StreamEntry rows
+# Stored events: read them with the store, not with a second reader
 # ---------------------------------------------------------------------------
+
+
+def _octet_stream():
+    """`AppendOptions` declaring a non-JSON content type, so the body is stored raw."""
+    from rakaia import AppendOptions
+
+    return AppendOptions(content_type="application/octet-stream")
 
 
 def _append_event(stream_id: str, data: dict) -> None:
@@ -168,89 +174,65 @@ def _append_event(stream_id: str, data: dict) -> None:
 
 
 @pytest.mark.django_db
-class TestDjangoStreamReader:
-    def test_missing_stream_returns_empty(self):
-        reader = DjangoStreamReader()
-        messages, up_to_date = reader.read("nope")
-        assert messages == []
-        assert up_to_date is True
+class TestTheStoreIsTheReaderForStoredEvents:
+    """Why `DjangoStreamReader` was deleted, stated as a test.
 
-    def test_has_missing_stream(self):
-        reader = DjangoStreamReader()
-        assert reader.has("nope") is False
+    It read the same three tables the store reads and returned the payload
+    alone — no label, no metadata, no event timestamp, no offset, and no inverse
+    for `payload_encoding`. So a replay driven through it silently lost
+    everything `rakaia.history.envelope_actor`, `merge_replay(order_key=...)` and
+    `history_effects(version_of=lambda m: m.offset)` read, and mangled any body
+    that was not JSON.
 
-    def test_reads_events_in_offset_order(self):
-        _append_event("s", {"id": 1, "name": "first"})
-        _append_event("s", {"id": 2, "name": "second"})
-        _append_event("s", {"id": 3, "name": "third"})
+    `DjangoStreamStore.read()` was already the correct reading of those tables,
+    already held to `tests/server_store_contract.py`, and — since #180 — already
+    able to take a database alias, which the deleted reader never could. It had
+    no production callers; only its own tests, which pinned the lossy shape.
 
-        reader = DjangoStreamReader()
-        messages, up_to_date = reader.read("s")
-        assert up_to_date is True
-        payloads = [json.loads(m.data) for m in messages]
-        assert [p["name"] for p in payloads] == ["first", "second", "third"]
+    These cases are the properties the deletion depends on. If the store ever
+    stopped carrying them, deleting the alternative would have cost something.
+    """
 
-    def test_has_existing_stream(self):
-        _append_event("s", {"x": 1})
-        reader = DjangoStreamReader()
-        assert reader.has("s") is True
+    def test_the_store_carries_the_whole_envelope(self):
+        from django_rakaia.django_store import DjangoStreamStore
+        from rakaia import AppendOptions
 
-    def test_replay_through_django_stream_reader(self):
-        _append_event("s", {"name": "alpha"})
-        _append_event("s", {"name": "beta"})
-
-        reg = HandlerRegistry()
-
-        def h(event):
-            return Upsert(
-                model_label="test_django_rakaia.Area",
-                lookup={"name": f"from-stream:{event['name']}"},
-                defaults={},
-            )
-
-        reg.register("h", "s", h, 0, None)
-        reader = DjangoStreamReader()
-
-        result = replay(reader, "s", DjangoExecutor(), handler_registry=reg)  # type: ignore[arg-type]
-
-        assert result.events_processed == 2
-        assert result.effects_applied == 2
-        assert Area.objects.filter(name="from-stream:alpha").exists()
-        assert Area.objects.filter(name="from-stream:beta").exists()
-
-    def test_reads_multi_stream_events_isolated(self):
-        _append_event("s1", {"v": "a"})
-        _append_event("s2", {"v": "b"})
-        _append_event("s1", {"v": "c"})
-
-        reader = DjangoStreamReader()
-        msgs1, _ = reader.read("s1")
-        msgs2, _ = reader.read("s2")
-
-        assert [json.loads(m.data)["v"] for m in msgs1] == ["a", "c"]
-        assert [json.loads(m.data)["v"] for m in msgs2] == ["b"]
-
-    def test_works_with_create_stream_event_helper(self):
-        # End-to-end with the actual helper @stream_model uses internally.
-        from dataclasses import dataclass
-
-        @dataclass
-        class Payload:
-            kind: str
-            value: int
-
-        # Pretend we're a model save: use create_stream_event directly.
-        # Need a model instance; use Area as a stand-in.
-        area = Area.objects.create(name="probe")
-        create_stream_event(
-            stream_paths="from-helper",
-            to_dataclass=lambda _inst: Payload(kind="ping", value=42),
-            instance=area,
-            action="create",
+        store = DjangoStreamStore()
+        store.create("s")
+        store.append(
+            "s",
+            b'{"n": 1}',
+            AppendOptions(label="update", metadata={"user": 7}, event_ts=1234.0),
         )
 
-        reader = DjangoStreamReader()
-        messages, _ = reader.read("from-helper")
-        assert len(messages) == 1
-        payload = json.loads(messages[0].data)
-        assert payload == {"kind": "ping", "value": 42}
+        message = store.read("s")[0][0]
+        assert message.data == b'{"n": 1}'
+        assert message.label == "update"
+        assert message.metadata == {"user": 7}
+        assert message.event_ts == 1234.0
+        assert message.offset  # the deleted reader had no offset at all
+
+    def test_the_store_inverts_a_non_json_body(self):
+        from django_rakaia.django_store import DjangoStreamStore
+        from django_rakaia.models import StreamEvent
+
+        store = DjangoStreamStore()
+        store.create("bin")
+        store.append("bin", b"\xff\xfe\x00binary", _octet_stream())
+
+        assert StreamEvent.objects.get().payload_encoding == "base64"
+        assert store.read("bin")[0][0].data == b"\xff\xfe\x00binary"
+
+    def test_the_store_reads_a_stream_written_by_the_decorator_path(self):
+        # The deleted reader's stated purpose was reading the tables
+        # `@stream_model` / `create_stream_event` populate. The store reads those
+        # same rows, which is what makes it a replacement rather than a
+        # substitute.
+        from django_rakaia.django_store import DjangoStreamStore
+
+        _append_event("decorated", {"n": 1})
+        _append_event("decorated", {"n": 2})
+
+        messages, _ = DjangoStreamStore().read("decorated")
+        assert [m.data for m in messages] == [b'{"n": 1}', b'{"n": 2}']
+        assert [m.label for m in messages] == ["test", "test"]


### PR DESCRIPTION
Closes #186. Unblocked by #193.

Two ways of reading the same three tables disagreed about what an event is. One
returned the label, the author, the timestamp and the position; the other
returned the payload and nothing else, and did not invert the stored encoding
either. Anything replaying through the second silently lost the audit trail, and
nothing at the call site said which one you had.

The thin one goes rather than gets fixed: it had no callers outside its own tests,
it was never exported so nothing was promised, and the other one was already
correct, already covered by the shared store contract, and — since #193 — able to
read from a throwaway database, which this one never could. Net 65 lines lighter.

`ModelStreamReader` stays and deliberately does not gain the envelope hook the
review suggested: it reads rows that were never events and makes payloads out of
them, so there is no recorded label or timestamp to carry. Payload-only is right
there. The module docstring said the two were interchangeable; it now says where
each belongs.