### PR TITLE
Restore DjangoStreamReader, and document what it drops

### DIFF
--- a/src/django_rakaia/streams.py
+++ b/src/django_rakaia/streams.py
@@ -1,28 +1,28 @@
 """
-Reading an existing Django table as a *virtual* stream.
+Adapters that expose Django data to rakaia's replay pipeline.
 
-`ModelStreamReader` lets `replay()` treat rows you already have as if they were
-events: it reads them in a defined order from a queryset and encodes each one
-with a `to_payload` callable you supply. Use it when a durable, ordered
-source-of-truth already exists and you do not want to mirror it into a stream.
+Two readers, picked according to where your event log lives:
 
-**It carries no envelope, and that is correct.** The rows it reads were never
-events, so there is no recorded label, actor or event time to carry — it
-synthesises a payload rather than reproducing one. Anything that reads the
-envelope (`envelope_actor`, `merge_replay(order_key=...)`,
-`history_effects(version_of=...)`) has nothing to read here by construction.
+- `ModelStreamReader` treats an existing Django table as a *virtual*
+  stream: replay reads ordered rows directly from the queryset, encoding
+  each as a JSON event. Use when you already have a durable, ordered
+  source-of-truth and don't want to mirror it.
 
-**If your events are actually stored as events, use the store.** For the
-`Stream`/`StreamEvent`/`StreamEntry` rows that `@stream_model` and
-`create_stream_event` populate, read with `DjangoStreamStore` — it carries the
-label, metadata, event timestamp and offset those rows genuinely hold, inverts
-`payload_encoding`, takes a `using=` database alias, and is held to
-`tests/server_store_contract.py`. A second reader over those same tables used to
-live here and returned the payload alone, so a replay through it silently lost
-all of that; it had no callers and was deleted (#186).
+- `DjangoStreamReader` reads from the `Stream`/`StreamEvent`/`StreamEntry`
+  tables that `@stream_model` populates. **Payload only** — see its own
+  warning. For those tables `DjangoStreamStore` is the fuller reader: same
+  rows, whole envelope, `payload_encoding` inverted, and a `using=` alias.
 
-Satisfies the subset of the `StreamStore` interface `rakaia.replay.replay` calls:
-`read(path)` -> `(list[message], bool)`, and `has(path)`.
+Both satisfy the same subset of the `StreamStore` interface
+(`read(path)` -> `(list[message], bool)`, `has(path)`) that
+`rakaia.replay.replay` calls — which is why the envelope loss above is silent:
+the interface `replay()` needs is satisfied either way.
+
+The difference between "reads rows that were never events" and "reads stored
+events but drops what they carry" is the one worth keeping straight.
+`ModelStreamReader` is the first: `to_payload` synthesises a dict from rows with
+no recorded label, actor or event time, so payload-only is correct there, not
+lossy. `DjangoStreamReader` is the second.
 """
 
 from __future__ import annotations
@@ -33,6 +33,8 @@ from dataclasses import dataclass
 from typing import Any
 
 from django.db.models import QuerySet
+
+from django_rakaia.models import Stream
 
 
 @dataclass(frozen=True)
@@ -107,3 +109,78 @@ class ModelStreamReader:
         qs = self._queryset_for(path).order_by(self._order_by)
         for obj in qs.iterator(chunk_size=self._chunk_size):
             yield self._to_payload(obj)
+
+
+# =============================================================================
+# DjangoStreamReader
+# =============================================================================
+
+
+class DjangoStreamReader:
+    """
+    Read events from the `Stream`/`StreamEvent`/`StreamEntry` tables that
+    `@stream_model` (or `create_stream_event`) populates.
+
+    Each `StreamEntry`'s `event.data` (the JSONField written by
+    `to_dataclass(instance)`) becomes one event. Entries are read in
+    ascending `offset` order.
+
+    Note on sequence numbers: `replay()` uses the position of an event
+    within the iteration (0, 1, 2, ...) as its seq for handler-version
+    dispatch — *not* the underlying Django `offset` column. So a handler
+    registered with `effective_from=0` matches the first event read from
+    the stream, regardless of its `StreamEntry.offset` value.
+
+    .. warning::
+
+       **This reader returns the payload only.** Its message type carries a
+       single ``data`` field — no ``label``, no ``metadata``, no ``event_ts``,
+       no ``offset`` — and it does not invert ``payload_encoding``. The rows it
+       reads *do* hold all of that, so replaying through this reader discards it:
+       anything reading the envelope (`rakaia.history.envelope_actor`,
+       `merge_replay(order_key=ENVELOPE_TS)`,
+       `history_effects(version_of=lambda m: m.offset)`) raises
+       ``AttributeError`` rather than seeing an absent value, and a body that was
+       not JSON comes back as its stored text or base64.
+
+       **For those tables, prefer `DjangoStreamStore`.** It reads the same rows,
+       carries the whole envelope, inverts the encoding, takes a ``using=``
+       database alias (#180), and is held to
+       ``tests/server_store_contract.py``. Two differences to know if you switch:
+       the store *raises* ``StreamNotFound`` where this returns ``([], True)``,
+       and its ``read()`` also touches the stream's TTL clock and reaps an
+       expired stream — this reader is pure and expiry-blind.
+
+       Kept because it has callers; the limitation is documented rather than
+       discovered (#186).
+
+    Args:
+        chunk_size: Rows fetched per DB roundtrip. Defaults to 1000.
+    """
+
+    def __init__(self, *, chunk_size: int = 1000) -> None:
+        self._chunk_size = chunk_size
+
+    def read(
+        self,
+        path: str,
+        offset: str | None = None,  # noqa: ARG002
+    ) -> tuple[list[_ReaderMessage], bool]:
+        """Return (messages, up_to_date) for the given stream id."""
+        try:
+            stream = Stream.objects.get(stream_id=path)
+        except Stream.DoesNotExist:
+            return [], True
+        entries = (
+            stream.entries.select_related("event")
+            .order_by("offset")
+            .iterator(chunk_size=self._chunk_size)
+        )
+        messages = [
+            _ReaderMessage(data=json.dumps(e.event.data).encode("utf-8"))
+            for e in entries
+        ]
+        return messages, True
+
+    def has(self, path: str) -> bool:
+        return Stream.objects.filter(stream_id=path).exists()

--- a/tests/test_django_rakaia/test_model_stream_reader.py
+++ b/tests/test_django_rakaia/test_model_stream_reader.py
@@ -7,9 +7,10 @@ import json
 import pytest
 from django.db import transaction
 
+from django_rakaia.decorators import create_stream_event
 from django_rakaia.effect_executor import DjangoExecutor
 from django_rakaia.models import Stream, StreamEntry, StreamEvent
-from django_rakaia.streams import ModelStreamReader
+from django_rakaia.streams import DjangoStreamReader, ModelStreamReader
 from rakaia.effects import Upsert
 from rakaia.registry import HandlerRegistry
 from rakaia.replay import replay
@@ -153,15 +154,8 @@ class TestReplayAgainstModelStream:
 
 
 # ---------------------------------------------------------------------------
-# Stored events: read them with the store, not with a second reader
+# DjangoStreamReader — reads from real Stream/StreamEvent/StreamEntry rows
 # ---------------------------------------------------------------------------
-
-
-def _octet_stream():
-    """`AppendOptions` declaring a non-JSON content type, so the body is stored raw."""
-    from rakaia import AppendOptions
-
-    return AppendOptions(content_type="application/octet-stream")
 
 
 def _append_event(stream_id: str, data: dict) -> None:
@@ -174,65 +168,175 @@ def _append_event(stream_id: str, data: dict) -> None:
 
 
 @pytest.mark.django_db
-class TestTheStoreIsTheReaderForStoredEvents:
-    """Why `DjangoStreamReader` was deleted, stated as a test.
+class TestDjangoStreamReader:
+    def test_missing_stream_returns_empty(self):
+        reader = DjangoStreamReader()
+        messages, up_to_date = reader.read("nope")
+        assert messages == []
+        assert up_to_date is True
 
-    It read the same three tables the store reads and returned the payload
-    alone — no label, no metadata, no event timestamp, no offset, and no inverse
-    for `payload_encoding`. So a replay driven through it silently lost
-    everything `rakaia.history.envelope_actor`, `merge_replay(order_key=...)` and
-    `history_effects(version_of=lambda m: m.offset)` read, and mangled any body
-    that was not JSON.
+    def test_has_missing_stream(self):
+        reader = DjangoStreamReader()
+        assert reader.has("nope") is False
 
-    `DjangoStreamStore.read()` was already the correct reading of those tables,
-    already held to `tests/server_store_contract.py`, and — since #180 — already
-    able to take a database alias, which the deleted reader never could. It had
-    no production callers; only its own tests, which pinned the lossy shape.
+    def test_reads_events_in_offset_order(self):
+        _append_event("s", {"id": 1, "name": "first"})
+        _append_event("s", {"id": 2, "name": "second"})
+        _append_event("s", {"id": 3, "name": "third"})
 
-    These cases are the properties the deletion depends on. If the store ever
-    stopped carrying them, deleting the alternative would have cost something.
+        reader = DjangoStreamReader()
+        messages, up_to_date = reader.read("s")
+        assert up_to_date is True
+        payloads = [json.loads(m.data) for m in messages]
+        assert [p["name"] for p in payloads] == ["first", "second", "third"]
+
+    def test_has_existing_stream(self):
+        _append_event("s", {"x": 1})
+        reader = DjangoStreamReader()
+        assert reader.has("s") is True
+
+    def test_replay_through_django_stream_reader(self):
+        _append_event("s", {"name": "alpha"})
+        _append_event("s", {"name": "beta"})
+
+        reg = HandlerRegistry()
+
+        def h(event):
+            return Upsert(
+                model_label="test_django_rakaia.Area",
+                lookup={"name": f"from-stream:{event['name']}"},
+                defaults={},
+            )
+
+        reg.register("h", "s", h, 0, None)
+        reader = DjangoStreamReader()
+
+        result = replay(reader, "s", DjangoExecutor(), handler_registry=reg)  # type: ignore[arg-type]
+
+        assert result.events_processed == 2
+        assert result.effects_applied == 2
+        assert Area.objects.filter(name="from-stream:alpha").exists()
+        assert Area.objects.filter(name="from-stream:beta").exists()
+
+    def test_reads_multi_stream_events_isolated(self):
+        _append_event("s1", {"v": "a"})
+        _append_event("s2", {"v": "b"})
+        _append_event("s1", {"v": "c"})
+
+        reader = DjangoStreamReader()
+        msgs1, _ = reader.read("s1")
+        msgs2, _ = reader.read("s2")
+
+        assert [json.loads(m.data)["v"] for m in msgs1] == ["a", "c"]
+        assert [json.loads(m.data)["v"] for m in msgs2] == ["b"]
+
+    def test_works_with_create_stream_event_helper(self):
+        # End-to-end with the actual helper @stream_model uses internally.
+        from dataclasses import dataclass
+
+        @dataclass
+        class Payload:
+            kind: str
+            value: int
+
+        # Pretend we're a model save: use create_stream_event directly.
+        # Need a model instance; use Area as a stand-in.
+        area = Area.objects.create(name="probe")
+        create_stream_event(
+            stream_paths="from-helper",
+            to_dataclass=lambda _inst: Payload(kind="ping", value=42),
+            instance=area,
+            action="create",
+        )
+
+        reader = DjangoStreamReader()
+        messages, _ = reader.read("from-helper")
+        assert len(messages) == 1
+        payload = json.loads(messages[0].data)
+        assert payload == {"kind": "ping", "value": 42}
+
+
+@pytest.mark.django_db
+class TestTheTwoReadersOfTheSameTablesDiffer:
+    """What `DjangoStreamReader` drops and `DjangoStreamStore` keeps.
+
+    Both read `Stream`/`StreamEvent`/`StreamEntry`, and both satisfy the subset
+    of the store interface `replay()` calls — which is exactly why the difference
+    is silent at the call site. Nothing in the type or the signature says one
+    carries the envelope and the other does not.
+
+    Pinned rather than left as prose because the reader is kept (#186): a caller
+    choosing between them needs the difference to be a fact they can look up, and
+    a future change that quietly made the store lossy too would take this class
+    with it.
     """
+
+    def _seed_via_the_real_helper(self, path: str = "decorated"):
+        """Write through `create_stream_event` — the path both readers claim to serve.
+
+        Deliberately not a raw ORM insert. An earlier version of this test built
+        the rows by hand and so never exercised the helper it was named for,
+        while reading as though it had.
+        """
+        from .models import AreaData
+
+        area = Area.objects.create(name="a")
+        create_stream_event(
+            stream_paths=path,
+            to_dataclass=lambda obj: AreaData(id=obj.id, name=obj.name),
+            instance=area,
+            action="create",
+        )
+        return area
 
     def test_the_store_carries_the_whole_envelope(self):
         from django_rakaia.django_store import DjangoStreamStore
+
+        self._seed_via_the_real_helper()
+
+        message = DjangoStreamStore().read("decorated")[0][0]
+        assert json.loads(message.data)["name"] == "a"
+        assert message.label == "create"
+        assert message.event_ts is not None
+        assert message.offset
+
+    def test_the_reader_carries_the_payload_and_nothing_else(self):
+        from django_rakaia.streams import DjangoStreamReader
+
+        self._seed_via_the_real_helper()
+
+        message = DjangoStreamReader().read("decorated")[0][0]
+        assert json.loads(message.data)["name"] == "a"
+        # Not "is None" — the fields do not exist, so reading one raises. That is
+        # the shape of the loss: an envelope consumer fails rather than degrades.
+        for field in ("label", "metadata", "event_ts", "offset"):
+            assert not hasattr(message, field), f"{field} unexpectedly present"
+
+    def test_only_the_store_inverts_a_non_json_body(self):
+        from django_rakaia.django_store import DjangoStreamStore
+        from django_rakaia.models import StreamEvent
+        from django_rakaia.streams import DjangoStreamReader
         from rakaia import AppendOptions
 
         store = DjangoStreamStore()
-        store.create("s")
-        store.append(
-            "s",
-            b'{"n": 1}',
-            AppendOptions(label="update", metadata={"user": 7}, event_ts=1234.0),
-        )
-
-        message = store.read("s")[0][0]
-        assert message.data == b'{"n": 1}'
-        assert message.label == "update"
-        assert message.metadata == {"user": 7}
-        assert message.event_ts == 1234.0
-        assert message.offset  # the deleted reader had no offset at all
-
-    def test_the_store_inverts_a_non_json_body(self):
-        from django_rakaia.django_store import DjangoStreamStore
-        from django_rakaia.models import StreamEvent
-
-        store = DjangoStreamStore()
         store.create("bin")
-        store.append("bin", b"\xff\xfe\x00binary", _octet_stream())
-
+        store.append(
+            "bin",
+            b"\xff\xfe\x00binary",
+            AppendOptions(content_type="application/octet-stream"),
+        )
         assert StreamEvent.objects.get().payload_encoding == "base64"
+
         assert store.read("bin")[0][0].data == b"\xff\xfe\x00binary"
+        # The reader hands back the stored base64 as if it were the payload.
+        assert DjangoStreamReader().read("bin")[0][0].data == b'"//4AYmluYXJ5"'
 
-    def test_the_store_reads_a_stream_written_by_the_decorator_path(self):
-        # The deleted reader's stated purpose was reading the tables
-        # `@stream_model` / `create_stream_event` populate. The store reads those
-        # same rows, which is what makes it a replacement rather than a
-        # substitute.
+    def test_they_disagree_about_a_missing_stream(self):
+        # The other difference a caller switching between them would hit.
         from django_rakaia.django_store import DjangoStreamStore
+        from django_rakaia.streams import DjangoStreamReader
+        from rakaia.types import StreamNotFound
 
-        _append_event("decorated", {"n": 1})
-        _append_event("decorated", {"n": 2})
-
-        messages, _ = DjangoStreamStore().read("decorated")
-        assert [m.data for m in messages] == [b'{"n": 1}', b'{"n": 2}']
-        assert [m.label for m in messages] == ["test", "test"]
+        assert DjangoStreamReader().read("nope") == ([], True)
+        with pytest.raises(StreamNotFound):
+            DjangoStreamStore().read("nope")


### PR DESCRIPTION
Reverts #196, which should not have deleted this class.

The case for deleting rested on it having no production callers. That was true of
this repository and says nothing about consumers: a grep cannot see their code,
and the class was importable. Being absent from `__all__` makes it free to
*change* under the tier policy, not safe to assume unused — I treated one as the
other.

Restored as it was, plus what the deletion was actually about. This reader returns
the payload and nothing else, while the rows it reads carry a label, metadata, an
event timestamp and a position — and both readers satisfy the interface `replay()`
needs, which is why the loss is invisible at the call site. That is now written on
the class, with a pointer to the store for those tables and the two differences
that matter if you switch, and pinned by four tests instead of left as prose.

Also fixes a defect in #196's own tests that its review found: the case named for
the decorator path built its rows by raw ORM and never called
`create_stream_event`. It does now.