### PR TITLE
One JSON shape for an event, and one timestamp for it

### DIFF
--- a/src/django_rakaia/channels_signals.py
+++ b/src/django_rakaia/channels_signals.py
@@ -14,7 +14,7 @@ from django.db import transaction
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 
-from .event_message import event_label, payload_fields
+from .event_message import event_view_of_entry
 from .models import StreamEntry
 
 
@@ -66,19 +66,13 @@ def frame_event(entry: StreamEntry) -> dict[str, Any]:
     `data`/`payload_encoding` pair rather than the decoded bytes `message_of`
     produces — see `payload_fields` for why passing the pair through is what
     makes the subscriber's inverse exact.
+
+    One line, because the assembly is `event_view` now and shared with both HTTP
+    surfaces. This function used to build the dict itself and published the
+    *event's* `created_at` where they published the *entry's* — the same event
+    with two timestamps, and the entry's is the one `read()` reports (#185).
     """
-    return {
-        "id": entry.event.id,
-        "offset": entry.offset,
-        # Inverted, not the raw column: publishing `event_type` directly sent
-        # subscribers the internal `"append"` sentinel where `read()` reports
-        # `""` for the same event (#153).
-        "event_type": event_label(entry.event.event_type),
-        "created_at": entry.event.created_at.isoformat()
-        if entry.event.created_at
-        else None,
-        **payload_fields(entry.event.data, entry.event.payload_encoding),
-    }
+    return event_view_of_entry(entry, event_id=True, offset=True)
 
 
 def broadcast_entries(stream_id: str, entries: Sequence[StreamEntry]) -> None:

--- a/src/django_rakaia/event_message.py
+++ b/src/django_rakaia/event_message.py
@@ -184,13 +184,17 @@ def event_view(
     a side effect of tidying their serialisation. `event_view_of_entry` is the
     adapter for callers that do hold an entry.
 
-    The identity keys are omitted when ``None`` — tested with ``is not None``, not
-    truthiness, so an ``offset=0`` or ``event_id=0`` would still be published. The
-    ORM never mints either (offsets and primary keys both start at 1), so this is
-    a property of the function rather than a reachable case, and it is pinned as
-    one. The surfaces genuinely differ in what they need. A channel frame identifies the event, a per-stream API already
+    The identity keys are opt-in because the surfaces genuinely differ in what
+    they need: a channel frame identifies the event, a per-stream API already
     knows its stream, and a cross-stream listing has to say which stream each
     event came from.
+
+    They are omitted on ``None`` specifically — ``is not None``, not truthiness —
+    so an ``offset=0`` or ``event_id=0`` is still published. The ORM mints
+    neither (offsets and primary keys both start at 1), so that is a property of
+    this function rather than a reachable row, and it is asserted as one.
+    ``created_at`` uses truthiness because a ``datetime`` is never falsy, so the
+    distinction cannot arise there.
     """
     view: dict[str, Any] = {}
     if event_id is not None:

--- a/src/django_rakaia/event_message.py
+++ b/src/django_rakaia/event_message.py
@@ -31,6 +31,8 @@ from rakaia.types import StreamMessage
 from .offsets import format_offset
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
+    from datetime import datetime
+
     from .models import StreamEntry
 
 # StreamEvent.event_type is required metadata for the dashboard; raw stream
@@ -154,10 +156,10 @@ def event_view(
     event_type: str,
     data: Any,
     payload_encoding: str | None,
-    created_at: Any,
-    event_id: Any = None,
-    offset: Any = None,
-    stream_id: Any = None,
+    created_at: datetime | None,
+    event_id: int | None = None,
+    offset: int | None = None,
+    stream_id: str | None = None,
 ) -> dict[str, Any]:
     """One event, as a JSON object. The wire counterpart to `message_of`.
 
@@ -182,8 +184,11 @@ def event_view(
     a side effect of tidying their serialisation. `event_view_of_entry` is the
     adapter for callers that do hold an entry.
 
-    The identity keys are omitted when ``None`` — the surfaces genuinely differ in
-    what they need. A channel frame identifies the event, a per-stream API already
+    The identity keys are omitted when ``None`` — tested with ``is not None``, not
+    truthiness, so an ``offset=0`` or ``event_id=0`` would still be published. The
+    ORM never mints either (offsets and primary keys both start at 1), so this is
+    a property of the function rather than a reachable case, and it is pinned as
+    one. The surfaces genuinely differ in what they need. A channel frame identifies the event, a per-stream API already
     knows its stream, and a cross-stream listing has to say which stream each
     event came from.
     """

--- a/src/django_rakaia/event_message.py
+++ b/src/django_rakaia/event_message.py
@@ -147,3 +147,79 @@ def message_of(entry: StreamEntry) -> StreamMessage:
         label=event_label(event.event_type),
         metadata=event.metadata or None,
     )
+
+
+def event_view(
+    *,
+    event_type: str,
+    data: Any,
+    payload_encoding: str | None,
+    created_at: Any,
+    event_id: Any = None,
+    offset: Any = None,
+    stream_id: Any = None,
+) -> dict[str, Any]:
+    """One event, as a JSON object. The wire counterpart to `message_of`.
+
+    Both reverse the same three storage facts; they differ only in how the
+    payload rides, because JSON cannot carry bytes — so this publishes the stored
+    ``data``/``payload_encoding`` pair and lets the consumer run `decode_payload`
+    itself (see `payload_fields` for why passing the pair through is what makes
+    that inverse exact).
+
+    Everything the two *can* agree on, they do. In particular ``created_at``
+    must be the **entry's**, which is what `message_of` reports as
+    `StreamMessage.timestamp` and therefore what `read()` surfaces. It is not
+    interchangeable with the event's: a message is per-stream, so one fanned-out
+    event has one transport time per stream that received it, and the event's own
+    ``created_at`` is a single value matching none of them exactly. Before this
+    existed the channel-layer frame published the event's while both HTTP
+    surfaces published the entry's — one event, two answers (#185).
+
+    **Takes facts, not a model.** Two of the three callers read through
+    ``.values()`` to fetch only the columns they need; requiring a `StreamEntry`
+    would have forced them onto full model instances and changed their queries as
+    a side effect of tidying their serialisation. `event_view_of_entry` is the
+    adapter for callers that do hold an entry.
+
+    The identity keys are omitted when ``None`` — the surfaces genuinely differ in
+    what they need. A channel frame identifies the event, a per-stream API already
+    knows its stream, and a cross-stream listing has to say which stream each
+    event came from.
+    """
+    view: dict[str, Any] = {}
+    if event_id is not None:
+        view["id"] = event_id
+    if stream_id is not None:
+        view["stream_id"] = stream_id
+    if offset is not None:
+        view["offset"] = offset
+    view["event_type"] = event_label(event_type)
+    view["created_at"] = created_at.isoformat() if created_at else None
+    view.update(payload_fields(data, payload_encoding))
+    return view
+
+
+def event_view_of_entry(
+    entry: StreamEntry,
+    *,
+    event_id: bool = False,
+    offset: bool = False,
+    stream_id: bool = False,
+) -> dict[str, Any]:
+    """`event_view` for a caller holding a `StreamEntry`.
+
+    Reads ``entry.event``; pass an entry fetched with ``select_related("event")``
+    to avoid a query per row, and with ``select_related("stream")`` too if you
+    ask for ``stream_id``.
+    """
+    event = entry.event
+    return event_view(
+        event_type=event.event_type,
+        data=event.data,
+        payload_encoding=event.payload_encoding,
+        created_at=entry.created_at,
+        event_id=event.id if event_id else None,
+        offset=entry.offset if offset else None,
+        stream_id=entry.stream.stream_id if stream_id else None,
+    )

--- a/src/django_rakaia/views.py
+++ b/src/django_rakaia/views.py
@@ -18,7 +18,7 @@ from django.views.decorators.http import require_GET
 
 from rakaia.types import InvalidOffset
 
-from .event_message import event_label, payload_fields
+from .event_message import event_label, event_view
 from .models import Stream, StreamEntry, StreamEvent
 from .offsets import parse_offset
 
@@ -101,16 +101,14 @@ def streams_index(_request: Any) -> HttpResponse:
         ],
         "event_types": list(event_types),
         "recent_events": [
-            {
-                "stream_id": e["stream__stream_id"],
-                "offset": e["offset"],
-                # Inverted, not the raw column: the sentinel means "an append
-                # with no envelope label", and a consumer of this API should see
-                # what `read()` reports, not the storage marker (#153).
-                "event_type": event_label(e["event__event_type"]),
-                "created_at": e["created_at"].isoformat() if e["created_at"] else None,
-                **payload_fields(e["event__data"], e["event__payload_encoding"]),
-            }
+            event_view(
+                event_type=e["event__event_type"],
+                data=e["event__data"],
+                payload_encoding=e["event__payload_encoding"],
+                created_at=e["created_at"],
+                stream_id=e["stream__stream_id"],
+                offset=e["offset"],
+            )
             for e in recent_entries
         ],
         "total_streams": stream_stats.count(),
@@ -239,16 +237,14 @@ def stream_events_api(_request: Any, stream_id: str) -> Any:
 
     # Serialize
     serialized_events = [
-        {
-            "id": e["event__id"],
-            "offset": e["offset"],
-            "event_type": event_label(e["event__event_type"]),
-            "created_at": e["created_at"].isoformat() if e["created_at"] else None,
-            # The stored pair, as the SSE frame sends it — this API used to
-            # publish an encoded payload with nothing to say it was encoded, so
-            # a base64 body was indistinguishable from text (#153).
-            **payload_fields(e["event__data"], e["event__payload_encoding"]),
-        }
+        event_view(
+            event_type=e["event__event_type"],
+            data=e["event__data"],
+            payload_encoding=e["event__payload_encoding"],
+            created_at=e["created_at"],
+            event_id=e["event__id"],
+            offset=e["offset"],
+        )
         for e in entries
     ]
 

--- a/tests/test_django_rakaia/test_event_view.py
+++ b/tests/test_django_rakaia/test_event_view.py
@@ -1,0 +1,240 @@
+"""One JSON shape for an event, shared by every surface that emits JSON.
+
+`message_of` is the single definition for surfaces that can carry bytes — the
+store's `read()`, and anything downstream of it. Surfaces that emit *JSON*
+cannot: `StreamMessage.data` is bytes, so they publish the stored
+`data`/`payload_encoding` pair and let the consumer run `decode_payload`
+itself. #153 made the primitives behind that single (`event_label`,
+`payload_fields`, `decode_payload`) but left each surface assembling its own
+dict, and three of them drifted — including on which timestamp they publish.
+
+`event_view` is the JSON-wire counterpart to `message_of`: one assembly, so the
+next surface is correct by construction rather than by having been reviewed.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from django_rakaia.django_store import DjangoStreamStore
+from django_rakaia.event_message import event_view_of_entry as event_view
+from django_rakaia.models import Stream, StreamEntry
+
+pytestmark = pytest.mark.django_db
+
+
+def _one_entry(path: str = "s", payload: bytes = b'{"n": 1}', **append_kwargs):
+    store = DjangoStreamStore()
+    store.create(path)
+    store.append(path, payload, **append_kwargs)
+    return StreamEntry.objects.select_related("event").get(stream__stream_id=path)
+
+
+class TestTheShape:
+    def test_it_publishes_the_stored_pair_not_decoded_bytes(self):
+        entry = _one_entry()
+        view = event_view(entry)
+        # JSON cannot carry bytes; the consumer inverts the pair itself.
+        assert view["data"] == {"n": 1}
+        assert "payload_encoding" not in view  # omitted when None, as before
+
+    def test_a_non_json_body_carries_its_encoding(self):
+        from rakaia import AppendOptions
+
+        entry = _one_entry(
+            "bin",
+            b"\xff\xfe\x00binary",
+            options=AppendOptions(content_type="application/octet-stream"),
+        )
+        view = event_view(entry)
+        assert view["payload_encoding"] == "base64"
+        assert view["data"] == "//4AYmluYXJ5"
+
+    def test_a_labelless_append_reports_no_label_not_the_sentinel(self):
+        view = event_view(_one_entry())
+        assert view["event_type"] == ""
+
+    def test_a_real_label_survives(self):
+        from rakaia import AppendOptions
+
+        entry = _one_entry(options=AppendOptions(label="update"))
+        assert event_view(entry)["event_type"] == "update"
+
+    def test_identity_keys_are_opt_in(self):
+        entry = _one_entry()
+        assert set(event_view(entry)) == {"event_type", "created_at", "data"}
+        assert "id" in event_view(entry, event_id=True)
+        assert "offset" in event_view(entry, offset=True)
+        assert "stream_id" in event_view(entry, stream_id=True)
+
+
+class TestItAgreesWithTheCanonicalReader:
+    """The property the whole exercise is for: one event, one description.
+
+    `read()` and a JSON surface differ in *how* they carry the payload — bytes
+    versus the stored pair — and in nothing else. Where they name the same fact
+    they must name it identically.
+    """
+
+    def test_the_timestamp_is_the_one_read_reports(self):
+        # The live divergence this closes. `frame_event` published the *event's*
+        # `created_at`; `message_of` uses the *entry's* for
+        # `StreamMessage.timestamp`, and that is the correct one — a message is
+        # per-stream, so a fan-out has one transport time per stream that
+        # received it.
+        store = DjangoStreamStore()
+        store.create("s")
+        store.append("s", b'{"n": 1}')
+        entry = StreamEntry.objects.select_related("event").get()
+
+        from datetime import datetime
+
+        view_ts = datetime.fromisoformat(event_view(entry)["created_at"]).timestamp()
+        assert view_ts == store.read("s")[0][0].timestamp
+
+    def test_the_label_is_the_one_read_reports(self):
+        store = DjangoStreamStore()
+        store.create("s")
+        store.append("s", b'{"n": 1}')
+        entry = StreamEntry.objects.select_related("event").get()
+
+        assert event_view(entry)["event_type"] == store.read("s")[0][0].label
+
+    def test_the_payload_round_trips_to_what_read_returns(self):
+        from django_rakaia.event_message import decode_payload
+        from rakaia import AppendOptions
+
+        store = DjangoStreamStore()
+        store.create("bin")
+        store.append(
+            "bin",
+            b"\xff\xfe\x00binary",
+            AppendOptions(content_type="application/octet-stream"),
+        )
+        entry = StreamEntry.objects.select_related("event").get()
+
+        view = event_view(entry)
+        assert decode_payload(view["data"], view.get("payload_encoding")) == (
+            store.read("bin")[0][0].data
+        )
+
+    def test_a_fan_out_reports_a_timestamp_per_stream(self):
+        # Why the entry's column cannot be collapsed into the event's: one event,
+        # two entries, two transport times — and each JSON view must report its
+        # own, matching that stream's `read()`.
+        from django_rakaia.django_store import write_enveloped_event
+
+        a = Stream.objects.create(stream_id="a")
+        b = Stream.objects.create(stream_id="b")
+        _event, entries = write_enveloped_event([a, b], {"n": 1})
+
+        views = [event_view(e) for e in entries]
+        assert views[0]["created_at"] != views[1]["created_at"]
+
+        store = DjangoStreamStore()
+        from datetime import datetime
+
+        for path, view in zip(("a", "b"), views, strict=True):
+            assert (
+                datetime.fromisoformat(view["created_at"]).timestamp()
+                == store.read(path)[0][0].timestamp
+            )
+
+
+class TestTheThreeSurfacesNowAgree:
+    """At the surfaces, not at the helper.
+
+    Testing `event_view` proves the assembly is right; it does not prove the
+    three callers use it. The divergence this issue is about was invisible to the
+    suite precisely because nothing asserted what a *frame* or an *API response*
+    reports — reverting `frame_event` to the event's timestamp left all 637
+    Django tests green. These attach at the surfaces instead.
+    """
+
+    def _stream_with_one_event(self, path: str = "s"):
+        store = DjangoStreamStore()
+        store.create(path)
+        store.append(path, b'{"n": 1}')
+        return store
+
+    def test_the_channel_frame_reports_what_read_reports(self):
+        from django_rakaia.channels_signals import frame_event
+
+        store = self._stream_with_one_event()
+        entry = StreamEntry.objects.select_related("event").get()
+
+        from datetime import datetime
+
+        frame = frame_event(entry)
+        assert (
+            datetime.fromisoformat(frame["created_at"]).timestamp()
+            == store.read("s")[0][0].timestamp
+        )
+        assert frame["event_type"] == store.read("s")[0][0].label
+
+    def test_the_frame_and_the_stream_api_agree_on_one_event(self):
+        # The two surfaces a consumer is most likely to compare: a live push and
+        # a poll of the same stream. They disagreed on `created_at` before this.
+        import json
+
+        from django.contrib.auth import get_user_model
+        from django.test import Client
+        from django.urls import reverse
+
+        from django_rakaia.channels_signals import frame_event
+
+        user = get_user_model().objects.create_user(username="d", password="pw")
+        client = Client()
+        client.force_login(user)
+        # The test app emits a stream event on every `auth.User` save, including
+        # the `last_login` update `force_login` performs, so clear those first.
+        StreamEntry.objects.all().delete()
+        Stream.objects.all().delete()
+
+        self._stream_with_one_event()
+        entry = StreamEntry.objects.select_related("event").get()
+        frame = frame_event(entry)
+
+        response = client.get(reverse("django_rakaia:stream_events_api", args=["s"]))
+        assert response.status_code == 200, response.status_code
+        api_event = json.loads(response.content)["events"][0]
+
+        assert api_event["created_at"] == frame["created_at"]
+        assert api_event["event_type"] == frame["event_type"]
+        assert api_event["data"] == frame["data"]
+        # Same identity too: both name the event, and the same offset.
+        assert api_event["id"] == frame["id"]
+        assert api_event["offset"] == frame["offset"]
+
+    def test_the_dashboard_listing_agrees_too(self):
+        # `recent_events` feeds a template rather than a JSON response, so it is
+        # asserted through the response context. It was the one caller whose
+        # `created_at` no mutation could reach — the cross-surface test above
+        # covers the per-stream API, not the index.
+        from django.contrib.auth import get_user_model
+        from django.test import Client
+        from django.urls import reverse
+
+        from django_rakaia.channels_signals import frame_event
+
+        user = get_user_model().objects.create_user(username="d2", password="pw")
+        client = Client()
+        client.force_login(user)
+        StreamEntry.objects.all().delete()
+        Stream.objects.all().delete()
+
+        self._stream_with_one_event()
+        entry = StreamEntry.objects.select_related("event").get()
+        frame = frame_event(entry)
+
+        response = client.get(reverse("django_rakaia:streams_index"))
+        assert response.status_code == 200
+        listed = response.context["recent_events"][0]
+
+        assert listed["created_at"] == frame["created_at"]
+        assert listed["event_type"] == frame["event_type"]
+        assert listed["data"] == frame["data"]
+        # This surface names the stream rather than the event — the one shape
+        # difference between the three, and deliberate.
+        assert listed["stream_id"] == "s"
+        assert "id" not in listed

--- a/tests/test_django_rakaia/test_event_view.py
+++ b/tests/test_django_rakaia/test_event_view.py
@@ -238,3 +238,66 @@ class TestTheThreeSurfacesNowAgree:
         # difference between the three, and deliberate.
         assert listed["stream_id"] == "s"
         assert "id" not in listed
+
+
+class TestTheWireFormatItself:
+    """The bytes, not just the values.
+
+    Every case above either compares one surface against another — so a format
+    change moves both together and cancels out — or parses with
+    `datetime.fromisoformat`, which accepts a space separator as readily as a
+    `T`. So swapping `isoformat()` for `str()` changed the published format on all
+    three surfaces and left the whole suite green. These assert the shape a
+    consumer actually parses.
+    """
+
+    def test_the_timestamp_is_iso_8601_with_a_t_separator(self):
+        from django_rakaia.event_message import event_view_of_entry
+
+        view = event_view_of_entry(_one_entry())
+        assert "T" in view["created_at"], view["created_at"]
+        assert " " not in view["created_at"], view["created_at"]
+
+    def test_the_key_order_is_identity_then_event_then_payload(self):
+        # This PR's claim is that both HTTP payloads stay byte-identical, and key
+        # order is part of the bytes. Unpinned, that claim decays on the next
+        # edit — a reordering of `event_view` survived a mutation pass.
+        from django_rakaia.event_message import event_view_of_entry
+
+        view = event_view_of_entry(
+            _one_entry(), event_id=True, offset=True, stream_id=True
+        )
+        assert list(view) == [
+            "id",
+            "stream_id",
+            "offset",
+            "event_type",
+            "created_at",
+            "data",
+        ]
+
+    def test_a_zero_identity_value_is_still_published(self):
+        # The omit rule is `is not None`, not truthiness. The ORM mints neither a
+        # zero offset nor a zero primary key, so this is a property of the
+        # function rather than a reachable row — which is exactly why it needs
+        # asserting here rather than through a surface.
+        from django_rakaia.event_message import event_view
+
+        view = event_view(
+            event_type="create",
+            data={"n": 1},
+            payload_encoding=None,
+            created_at=None,
+            event_id=0,
+            offset=0,
+        )
+        assert view["id"] == 0
+        assert view["offset"] == 0
+
+    def test_a_missing_timestamp_is_null_not_absent(self):
+        from django_rakaia.event_message import event_view
+
+        view = event_view(
+            event_type="create", data={}, payload_encoding=None, created_at=None
+        )
+        assert view["created_at"] is None


### PR DESCRIPTION
Closes #185.

Three surfaces turned an event into JSON and each assembled its own dict — the
live channel frame, the dashboard listing, and the per-stream API. #153 made the
small pieces they share single but left the assembly per-surface, so they drifted
again, this time on which timestamp they publish: the frame used the event's
`created_at`, both HTTP surfaces the entry's.

The entry's is right. `message_of` uses it for the message timestamp, so it is
what `read()` reports, and a message is per-stream — one fanned-out event has one
transport time per stream that received it, which a single event-level value
cannot express. So the frame was the outlier and unifying the assembly fixes it.
Both HTTP payloads come out byte-identical.

Tested at the surfaces rather than at the shared helper, because that is what
would have caught this: reverting the frame's timestamp left all 637 Django tests
green beforehand. There are now cases asserting what a frame, an API response and
the dashboard's template context each report, and that the three agree with
`read()`.