### PR TITLE
One read of the stream row per append, not two

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,32 @@ runnable demo for each.
 
 ### Changed
 
+- **A single append reads the stream row once, not twice.** Every
+  `DjangoStreamStore.append` did two `SELECT`s of the same row: an unlocked one
+  before the transaction opened, purely so that an expired stream would still be
+  reaped when the write went on to report `StreamNotFound` — the reap is a
+  delete, and the rollback that reports the 404 would otherwise undo it — and
+  then the locked one the write actually decides against. The expiry now leaves
+  the transaction as a signal and is reaped on the far side of the rollback, so
+  the locked read does both jobs.
+
+  A steady-state append is **7 statements, down from 8** — `BEGIN`, the locked
+  stream read, the event `INSERT`, the locked high-water read, its `UPDATE`, the
+  entry `INSERT`, `COMMIT` — and each one of them now does something. The
+  reporter of #202 measured 13 against 0.2.0 and named three statements that
+  looked redundant; the other two, a high-water read repeated either side of a
+  get-or-create and a `MAX(offset)` scan beside the watermark it duplicates, both
+  went in #175 and are already absent from a steady-state append. The
+  set of statements is now pinned per append shape by
+  `tests/test_django_rakaia/test_append_query_cost.py`, because none of this
+  changes an observable outcome and so nothing else in the suite notices when a
+  statement comes back.
+
+  The first append to a path still costs four more: the high-water row has to be
+  created, and seeded from a `MAX(offset)` scan, because `high = 0` means either
+  "new path" or "install upgraded across migration 0005" and only the entry table
+  can tell those apart. That is once per path, ever.
+
 - **The value-equality rule moved to `django_rakaia.canonicalisation`.**
   `canonical_value`, `Normalizer`, `DEFAULT_NORMALIZERS` and the three
   `normalize_*` functions were defined in `verification.py`, which meant the write

--- a/src/django_rakaia/django_store.py
+++ b/src/django_rakaia/django_store.py
@@ -35,7 +35,8 @@ from __future__ import annotations
 import asyncio
 import json
 import time
-from collections.abc import Iterable
+from collections.abc import Iterable, Iterator
+from contextlib import contextmanager
 from datetime import datetime, timezone
 from typing import Any
 
@@ -168,6 +169,19 @@ def write_enveloped_event(
 _POLL_INTERVAL_SECONDS = 0.05
 
 
+class _StreamExpired(Exception):
+    """Internal: the locked stream row had aged out. Never leaves this module.
+
+    Raised inside a write transaction and caught immediately outside it, which
+    is the only way the reap can survive the rollback that reporting the expiry
+    causes. `DjangoStreamStore._locked_write` is the whole of its lifetime.
+    """
+
+    def __init__(self, path: str) -> None:
+        super().__init__(path)
+        self.path = path
+
+
 class DjangoStreamStore:
     """A durable store backed by the django_rakaia ORM models.
 
@@ -261,19 +275,13 @@ class DjangoStreamStore:
 
         return False
 
-    def _get_if_not_expired(
-        self, path: str, *, for_update: bool = False
-    ) -> Stream | None:
+    def _get_if_not_expired(self, path: str) -> Stream | None:
         """The live stream at `path`, deleting it first if it has expired.
 
-        `for_update` locks the stream row for the enclosing transaction, so a
-        writer's closed/Stream-Seq/producer checks and its write are one
-        atomic step against concurrent writers. Only valid inside
-        `transaction.atomic()`; a no-op on backends without row locks (SQLite).
+        The unlocked read, for the read paths. A writer wants
+        `_locked_write`, which takes the row lock in the same single SELECT.
         """
-        base = self._streams()
-        qs = base.select_for_update() if for_update else base
-        stream = qs.filter(stream_id=path).first()
+        stream = self._streams().filter(stream_id=path).first()
         if stream is None:
             return None
         if self._is_expired(stream):
@@ -281,8 +289,8 @@ class DjangoStreamStore:
             return None
         return stream
 
-    def _require(self, path: str, *, for_update: bool = False) -> Stream:
-        stream = self._get_if_not_expired(path, for_update=for_update)
+    def _require(self, path: str) -> Stream:
+        stream = self._get_if_not_expired(path)
         if stream is None:
             raise StreamNotFound(f"Stream not found: {path}")
         return stream
@@ -290,12 +298,60 @@ class DjangoStreamStore:
     def _reap_if_expired(self, path: str) -> None:
         """Expire-and-delete `path` now, outside any write transaction.
 
-        The write paths call this before opening `transaction.atomic()`:
-        `_require`'s expiry delete *inside* the transaction is rolled back by
-        the very `StreamNotFound` unwind that reports it, so the write path
-        would otherwise never actually reap.
+        `create` calls this before opening `transaction.atomic()`. Its own
+        in-transaction reap does normally survive — it goes on to insert the
+        replacement row and commit — but not if the `initial_data` it was given
+        then fails validation, and the rollback that reports *that* takes the
+        reap with it.
+
+        The append paths do not need it: `_locked_write` carries the expiry out
+        of the transaction itself, and so reaps with one read of the stream row
+        rather than two (#202).
         """
         self._get_if_not_expired(path)
+
+    @contextmanager
+    def _locked_write(self, path: str) -> Iterator[Stream]:
+        """Open a write transaction on `path`'s locked, live stream row.
+
+        The single door every append and fenced close goes through. It yields
+        the `Stream` inside `transaction.atomic()` with the row locked, so a
+        writer's closed / content-type / producer checks and its write are one
+        indivisible step against concurrent writers. Raises `StreamNotFound`
+        for an absent *or* expired stream, and the expired one is reaped.
+
+        **One read of the stream row, not two.** Reaping an expired stream and
+        locking a live one look like two different jobs — the reap has to
+        commit, and a write transaction that ends in `StreamNotFound` rolls
+        back — so the write paths used to do both: an unlocked read to reap
+        before `atomic()`, then the locked read inside it. That is one wasted
+        SELECT on *every* append, to handle a case that is rare and already
+        handled by every read path (#202).
+
+        Instead the locked read decides, and the expiry leaves the transaction
+        as `_StreamExpired` — a signal, not an outcome — to be reaped on the
+        far side of the rollback and reported as `StreamNotFound`. Nothing has
+        been written at that point, so there is nothing for the rollback to
+        lose. `TestExpiryReaping` is what holds this to actually deleting the
+        row; it is the test that caught the version of this that reported 404s
+        forever without ever reaping.
+
+        Only for the *write* paths. A reader wants `_require`, which does not
+        lock and does not need a transaction.
+        """
+        try:
+            with transaction.atomic(using=self._using):
+                stream = (
+                    self._streams().select_for_update().filter(stream_id=path).first()
+                )
+                if stream is None:
+                    raise StreamNotFound(f"Stream not found: {path}")
+                if self._is_expired(stream):
+                    raise _StreamExpired(path)
+                yield stream
+        except _StreamExpired:
+            self.delete(path)
+            raise StreamNotFound(f"Stream not found: {path}") from None
 
     @staticmethod
     def _touch(stream: Stream) -> None:
@@ -409,12 +465,21 @@ class DjangoStreamStore:
     def _close_with_producer_sync(
         self, path: str, producer_id: str, epoch: int, seq: int
     ) -> CloseResult | None:
-        self._reap_if_expired(path)
-        with transaction.atomic(using=self._using):
-            stream = self._get_if_not_expired(path, for_update=True)
-            if stream is None:
-                return None
+        # An absent or expired stream is reported as `None` here, not raised —
+        # `close_stream` promises that — so the one `StreamNotFound`
+        # `_locked_write` can raise is translated back. Nothing inside the block
+        # raises it.
+        try:
+            return self._close_locked(path, producer_id, epoch, seq)
+        except StreamNotFound:
+            return None
 
+    def _close_locked(
+        self, path: str, producer_id: str, epoch: int, seq: int
+    ) -> CloseResult:
+        """The fenced close itself, on the locked row. Split out only so its
+        `StreamNotFound` has somewhere to be caught."""
+        with self._locked_write(path) as stream:
             # A close is admitted on the same terms as a fenced append with no
             # body, so it asks the same question: an already-closed stream is
             # reported, never re-closed — a different producer's close must not
@@ -469,9 +534,10 @@ class DjangoStreamStore:
         persisted: `label` maps to `event_type` (a raw append keeps the stable
         `"append"` label) and `metadata` to the JSON column.
 
-        Runs in a transaction so `get_next_offset()` can lock the stream row:
-        concurrent appends serialize on offset allocation instead of racing to
-        the same value and failing `unique_together(stream, offset)`.
+        Runs in the transaction `_locked_write` opens, so `get_next_offset()`
+        can lock the offset high-water: concurrent appends serialize on offset
+        allocation instead of racing to the same value and failing
+        `unique_together(stream, offset)`.
 
         Admission (closed / content-type / producer fencing / Stream-Seq) is
         decided by `rakaia.append_decision`, shared with the in-memory store, so
@@ -487,10 +553,7 @@ class DjangoStreamStore:
           step, and the result reports `stream_closed=True`.
         """
         opts = options if options is not None else AppendOptions()
-        self._reap_if_expired(path)
-        with transaction.atomic(using=self._using):
-            stream = self._require(path, for_update=True)
-
+        with self._locked_write(path) as stream:
             # Admission is decided in `rakaia.append_decision`, shared with the
             # in-memory store. This path used to inline its own shorter sequence
             # and ignore `opts.producer_id` entirely, so the same options
@@ -688,17 +751,14 @@ class DjangoStreamStore:
         if producer_id is None or epoch is None or seq is None:
             return self.append(path, data, opts)
 
-        self._reap_if_expired(path)
-        with transaction.atomic(using=self._using):
-            # The row lock is what makes fencing fence: validation reads the
-            # producer's last state, and two concurrent retries of the same
-            # (producer_id, epoch, seq) that both read before either commits
-            # would both be accepted — the exact duplicate write the fencing
-            # exists to prevent. Serialized on the stream row, the loser
-            # re-reads the winner's committed state. (The in-memory store's
-            # per-producer asyncio.Lock is this lock's in-process analogue.)
-            stream = self._require(path, for_update=True)
-
+        # The row lock `_locked_write` takes is what makes fencing fence:
+        # validation reads the producer's last state, and two concurrent retries
+        # of the same (producer_id, epoch, seq) that both read before either
+        # commits would both be accepted — the exact duplicate write the fencing
+        # exists to prevent. Serialized on the stream row, the loser re-reads the
+        # winner's committed state. (The in-memory store's per-producer
+        # asyncio.Lock is this lock's in-process analogue.)
+        with self._locked_write(path) as stream:
             # The same shared sequence `append` uses. This path used to run its
             # own: fencing first, then closed, and it never read `closed_by` —
             # so a closed stream answered with the fencing outcome instead of
@@ -794,10 +854,7 @@ class DjangoStreamStore:
         if not items:
             return []
 
-        self._reap_if_expired(path)
-        with transaction.atomic(using=self._using):
-            stream = self._require(path, for_update=True)
-
+        with self._locked_write(path) as stream:
             if stream.closed:
                 return [AppendResult(message=None, stream_closed=True) for _ in items]
 

--- a/tests/test_django_rakaia/test_append_query_cost.py
+++ b/tests/test_django_rakaia/test_append_query_cost.py
@@ -66,6 +66,26 @@ def _shapes(ctx: CaptureQueriesContext) -> list[str]:
     return shapes
 
 
+# What one steady-state append is, statement by statement. Named once because
+# three tests assert it, and a change to the append path should have to edit it
+# in one place — deliberately — rather than in whichever test failed first.
+_STEADY_STATE_APPEND = [
+    # The admission checks and the write are one step, so the row is read under
+    # a lock -- once. It used to be read twice: an unlocked read before the
+    # transaction to reap an expired stream, then the locked one inside it
+    # (#202).
+    "SELECT rakaia_stream",
+    "INSERT rakaia_streamevent",
+    # The high-water, under its own lock, and advanced. No `MAX(offset)` scan
+    # beside it: the watermark is authoritative once advanced, and re-deriving
+    # the head would be the one statement here whose cost grows with the length
+    # of the stream.
+    "SELECT rakaia_streamoffsetwatermark",
+    "UPDATE rakaia_streamoffsetwatermark",
+    "INSERT rakaia_streamentry",
+]
+
+
 @pytest.mark.django_db(transaction=True)
 class TestAppendQueryCost:
     def _warm(self, path: str = "s") -> DjangoStreamStore:
@@ -88,38 +108,32 @@ class TestAppendQueryCost:
         with CaptureQueriesContext(connection) as ctx:
             store.append("s", b'{"n": 1}', AppendOptions(label="x"))
 
-        assert _shapes(ctx) == [
-            # The admission checks and the write are one step, so the row is
-            # read under a lock -- once. It used to be read twice: an unlocked
-            # read before the transaction to reap an expired stream, then the
-            # locked one inside it (#202).
-            "SELECT rakaia_stream",
-            "INSERT rakaia_streamevent",
-            # The high-water, under its own lock, and advanced. No `MAX(offset)`
-            # scan beside it: the watermark is authoritative once advanced, and
-            # re-deriving the head would be the one statement here whose cost
-            # grows with the length of the stream.
-            "SELECT rakaia_streamoffsetwatermark",
-            "UPDATE rakaia_streamoffsetwatermark",
-            "INSERT rakaia_streamentry",
-        ], _data_queries(ctx)
+        assert _shapes(ctx) == _STEADY_STATE_APPEND, _data_queries(ctx)
 
-    def test_the_cost_does_not_grow_with_the_stream(self) -> None:
-        """Append 50 more and the 50th costs what the 1st did.
+    def test_the_fiftieth_append_costs_what_the_second_did(self) -> None:
+        """The steady state stays the steady state fifty offsets in.
 
-        The guard against a re-derived offset: a `MAX(offset)` scan or an
-        entry-table count would keep every assertion above true while making
-        each append dearer than the last on a long stream.
+        The guard against an offset re-derived from the entry table: a
+        `MAX(offset)` scan or a count would leave the append landing at the
+        right offset with the right envelope, and the only statement whose cost
+        grows with the stream is the one nothing else here would notice.
+
+        It asserts the *named* statements, not merely that the 50th matches the
+        2nd. Matching the 2nd is blind to exactly the mutation this test is
+        for — a scan issued on every append is a constant, present in both —
+        and would have gone green on it while five other tests in this file went
+        red. What is left that this catches and `test_one_append_is_five_
+        statements` does not is a statement that appears only once a stream is
+        long: a scan behind a size threshold, a paging read, an index the
+        planner abandons.
         """
         store = self._warm()
-        with CaptureQueriesContext(connection) as first:
-            store.append("s", b'{"n": 1}')
-        for n in range(2, 50):
+        for n in range(1, 50):
             store.append("s", b'{"n": %d}' % n)
         with CaptureQueriesContext(connection) as fiftieth:
             store.append("s", b'{"n": 50}')
 
-        assert _shapes(fiftieth) == _shapes(first)
+        assert _shapes(fiftieth) == _STEADY_STATE_APPEND, _data_queries(fiftieth)
 
     def test_an_append_that_closes_costs_one_more_update(self) -> None:
         """`Stream-Closed: true` adds the close, and nothing else.
@@ -130,14 +144,9 @@ class TestAppendQueryCost:
         with CaptureQueriesContext(connection) as ctx:
             store.append("s", b'{"last": 1}', AppendOptions(close=True))
 
-        assert _shapes(ctx) == [
-            "SELECT rakaia_stream",
-            "INSERT rakaia_streamevent",
-            "SELECT rakaia_streamoffsetwatermark",
-            "UPDATE rakaia_streamoffsetwatermark",
-            "INSERT rakaia_streamentry",
-            "UPDATE rakaia_stream",
-        ], _data_queries(ctx)
+        assert _shapes(ctx) == [*_STEADY_STATE_APPEND, "UPDATE rakaia_stream"], (
+            _data_queries(ctx)
+        )
 
     def test_a_refused_append_writes_nothing_and_reads_once(self) -> None:
         """A closed stream is refused for the price of the read that refuses it.
@@ -169,10 +178,4 @@ class TestAppendQueryCost:
         with CaptureQueriesContext(connection) as ctx:
             store.append_many("s", [(b'{"n": 1}', AppendOptions())] * batch)
 
-        assert _shapes(ctx) == [
-            "SELECT rakaia_stream",
-            "INSERT rakaia_streamevent",
-            "SELECT rakaia_streamoffsetwatermark",
-            "UPDATE rakaia_streamoffsetwatermark",
-            "INSERT rakaia_streamentry",
-        ], _data_queries(ctx)
+        assert _shapes(ctx) == _STEADY_STATE_APPEND, _data_queries(ctx)

--- a/tests/test_django_rakaia/test_append_query_cost.py
+++ b/tests/test_django_rakaia/test_append_query_cost.py
@@ -14,10 +14,13 @@ stream row, one of the high-water, one insert each for the event and the entry,
 one update of the high-water. Naming the tables is what makes a failure say
 which statement came back rather than only that the total moved.
 
-**Transaction control is filtered out**, because it is not portable: Postgres
-reports `BEGIN`/`COMMIT` through the cursor and SQLite does not, so a raw total
-would be two different numbers on the two CI legs. `_data_queries` keeps the
-statements that touch a table.
+**Transaction control is filtered out** — `_data_queries` keeps the statements
+that touch a table. Not for portability: both legs report `BEGIN` and `COMMIT`
+through the cursor, so today the raw totals agree. It is the savepoints that are
+conditional, and on nothing these tests are about. An append wrapped in a
+caller's own `atomic()` nests, and a first append to a path opens one around the
+high-water get-or-create — so a `SAVEPOINT`/`RELEASE` pair says something about
+who called the append, not about what the append cost.
 
 `transaction=True`, like every other test that reaches a `select_for_update()`
 here: the counts are measured against a real transaction the store opened

--- a/tests/test_django_rakaia/test_append_query_cost.py
+++ b/tests/test_django_rakaia/test_append_query_cost.py
@@ -1,0 +1,178 @@
+"""What one append costs in queries, pinned statement by statement.
+
+A durable append is a handful of statements, and every one of them is easy to
+duplicate by accident: an admission check that re-reads the row it was handed, a
+high-water read repeated either side of a get-or-create, an offset re-derived
+from a `MAX()` scan over an answer already held in one row. None of that changes
+a single assertion in the rest of the suite — the append still lands, at the
+right offset, with the right envelope — so the cost drifts up silently and is
+only ever noticed from the outside, by someone reading their own query log
+(#202, which reported 13 and found three duplicates in it).
+
+So these tests assert the *set of statements*, not a number: one read of the
+stream row, one of the high-water, one insert each for the event and the entry,
+one update of the high-water. Naming the tables is what makes a failure say
+which statement came back rather than only that the total moved.
+
+**Transaction control is filtered out**, because it is not portable: Postgres
+reports `BEGIN`/`COMMIT` through the cursor and SQLite does not, so a raw total
+would be two different numbers on the two CI legs. `_data_queries` keeps the
+statements that touch a table.
+
+`transaction=True`, like every other test that reaches a `select_for_update()`
+here: the counts are measured against a real transaction the store opened
+itself, not one pytest-django lent it.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
+
+from django_rakaia.django_store import DjangoStreamStore
+from rakaia.types import AppendOptions
+
+# BEGIN / COMMIT / SAVEPOINT / RELEASE SAVEPOINT / ROLLBACK, in the shapes
+# Django's backends emit them.
+_TRANSACTION_CONTROL = re.compile(
+    r"^\s*(BEGIN|COMMIT|ROLLBACK|SAVEPOINT|RELEASE\s+SAVEPOINT)\b", re.IGNORECASE
+)
+
+
+def _data_queries(ctx: CaptureQueriesContext) -> list[str]:
+    """The captured statements that touch a table, oldest first."""
+    return [
+        q["sql"]
+        for q in ctx.captured_queries
+        if q["sql"] and not _TRANSACTION_CONTROL.match(q["sql"])
+    ]
+
+
+def _shapes(ctx: CaptureQueriesContext) -> list[str]:
+    """Each data statement as `VERB table`, e.g. `SELECT rakaia_stream`.
+
+    Enough to tell one statement of an append from another, and stable across
+    backends — Postgres quotes identifiers and SQLite quotes them too, but the
+    parameter placeholders and casts differ.
+    """
+    shapes = []
+    for sql in _data_queries(ctx):
+        verb = sql.split(None, 1)[0].upper()
+        tables = re.findall(r'"(rakaia_\w+)"', sql)
+        shapes.append(f"{verb} {tables[0] if tables else '?'}")
+    return shapes
+
+
+@pytest.mark.django_db(transaction=True)
+class TestAppendQueryCost:
+    def _warm(self, path: str = "s") -> DjangoStreamStore:
+        """A store with `path` created and appended to once.
+
+        The *first* append to a path is deliberately dearer: it creates the
+        high-water row and seeds it from a `MAX(offset)` scan, because a
+        `high` of 0 means either "new path" or "install upgraded across
+        migration 0005", and only the entry table can tell those apart (see
+        `Stream.get_next_offset_block`). That is paid once per path, ever.
+        These tests measure the steady state every append after it pays.
+        """
+        store = DjangoStreamStore()
+        store.create(path)
+        store.append(path, b'{"n": 0}')
+        return store
+
+    def test_one_append_is_five_statements(self) -> None:
+        store = self._warm()
+        with CaptureQueriesContext(connection) as ctx:
+            store.append("s", b'{"n": 1}', AppendOptions(label="x"))
+
+        assert _shapes(ctx) == [
+            # The admission checks and the write are one step, so the row is
+            # read under a lock -- once. It used to be read twice: an unlocked
+            # read before the transaction to reap an expired stream, then the
+            # locked one inside it (#202).
+            "SELECT rakaia_stream",
+            "INSERT rakaia_streamevent",
+            # The high-water, under its own lock, and advanced. No `MAX(offset)`
+            # scan beside it: the watermark is authoritative once advanced, and
+            # re-deriving the head would be the one statement here whose cost
+            # grows with the length of the stream.
+            "SELECT rakaia_streamoffsetwatermark",
+            "UPDATE rakaia_streamoffsetwatermark",
+            "INSERT rakaia_streamentry",
+        ], _data_queries(ctx)
+
+    def test_the_cost_does_not_grow_with_the_stream(self) -> None:
+        """Append 50 more and the 50th costs what the 1st did.
+
+        The guard against a re-derived offset: a `MAX(offset)` scan or an
+        entry-table count would keep every assertion above true while making
+        each append dearer than the last on a long stream.
+        """
+        store = self._warm()
+        with CaptureQueriesContext(connection) as first:
+            store.append("s", b'{"n": 1}')
+        for n in range(2, 50):
+            store.append("s", b'{"n": %d}' % n)
+        with CaptureQueriesContext(connection) as fiftieth:
+            store.append("s", b'{"n": 50}')
+
+        assert _shapes(fiftieth) == _shapes(first)
+
+    def test_an_append_that_closes_costs_one_more_update(self) -> None:
+        """`Stream-Closed: true` adds the close, and nothing else.
+
+        In particular it does not re-read the stream row it is closing.
+        """
+        store = self._warm()
+        with CaptureQueriesContext(connection) as ctx:
+            store.append("s", b'{"last": 1}', AppendOptions(close=True))
+
+        assert _shapes(ctx) == [
+            "SELECT rakaia_stream",
+            "INSERT rakaia_streamevent",
+            "SELECT rakaia_streamoffsetwatermark",
+            "UPDATE rakaia_streamoffsetwatermark",
+            "INSERT rakaia_streamentry",
+            "UPDATE rakaia_stream",
+        ], _data_queries(ctx)
+
+    def test_a_refused_append_writes_nothing_and_reads_once(self) -> None:
+        """A closed stream is refused for the price of the read that refuses it.
+
+        The expiry reap moved *out* of the transaction and into a rollback
+        (`_locked_write`), so this is also the case where a second stream read
+        would be easiest to reintroduce: nothing else here touches the row.
+        """
+        store = self._warm()
+        store.close_stream("s")
+        with CaptureQueriesContext(connection) as ctx:
+            result = store.append("s", b'{"late": 1}')
+
+        assert result.message is None and result.stream_closed
+        assert _shapes(ctx) == ["SELECT rakaia_stream"], _data_queries(ctx)
+
+    @pytest.mark.parametrize("batch", [1, 4, 20])
+    def test_append_many_is_flat_in_the_batch_size(self, batch: int) -> None:
+        """The claim in `append_many`'s docstring, held to the query log.
+
+        One transaction, one high-water lock, one `bulk_create` each for the
+        events and the entries -- so a batch of 20 issues exactly what a batch
+        of 1 does. This is the property that took a nine-event save from ~95
+        queries to ~20 for the reporter of #202, and it is worth pinning: a
+        per-item `save()` slipped into the loop would leave every other test
+        passing.
+        """
+        store = self._warm()
+        with CaptureQueriesContext(connection) as ctx:
+            store.append_many("s", [(b'{"n": 1}', AppendOptions())] * batch)
+
+        assert _shapes(ctx) == [
+            "SELECT rakaia_stream",
+            "INSERT rakaia_streamevent",
+            "SELECT rakaia_streamoffsetwatermark",
+            "UPDATE rakaia_streamoffsetwatermark",
+            "INSERT rakaia_streamentry",
+        ], _data_queries(ctx)

--- a/tests/test_django_rakaia/test_django_store.py
+++ b/tests/test_django_rakaia/test_django_store.py
@@ -479,6 +479,30 @@ class TestExpiryReaping:
             store.append("s", b'{"id": 1}')
         assert not Stream.objects.filter(stream_id="s").exists()
 
+    def test_a_create_whose_body_is_rejected_still_reaps(self):
+        """`create`'s own reap has to survive its own rollback too.
+
+        `create` reaps inside its transaction and normally gets away with it: it
+        goes on to insert the replacement row and commit, so the delete commits
+        with it. Not if the `initial_data` it was handed then fails validation —
+        `_payloads_for` raises before any row is written, and the rollback that
+        reports the bad body takes the reap with it. That is the one case
+        `create`'s pre-transaction `_reap_if_expired` is still there for, and
+        deleting the call left the whole suite green until this test existed.
+        """
+        import time
+
+        from rakaia.types import InvalidJson
+
+        store = DjangoStreamStore()
+        store.create("s", content_type="application/json", ttl_seconds=0)
+        time.sleep(0.01)
+        with pytest.raises(InvalidJson):
+            store.create(
+                "s", content_type="application/json", initial_data=b"not json at all"
+            )
+        assert not Stream.objects.filter(stream_id="s").exists()
+
 
 @pytest.mark.django_db(transaction=True)
 @pytest.mark.asyncio

--- a/tests/test_django_rakaia/test_django_store.py
+++ b/tests/test_django_rakaia/test_django_store.py
@@ -485,8 +485,9 @@ class TestExpiryReaping:
         `create` reaps inside its transaction and normally gets away with it: it
         goes on to insert the replacement row and commit, so the delete commits
         with it. Not if the `initial_data` it was handed then fails validation —
-        `_payloads_for` raises before any row is written, and the rollback that
-        reports the bad body takes the reap with it. That is the one case
+        `_payloads_for` raises before any *event* row is written, having already
+        inserted the replacement stream row, and the rollback that reports the
+        bad body takes the reap back out with it. That is the one case
         `create`'s pre-transaction `_reap_if_expired` is still there for, and
         deleting the call left the whole suite green until this test existed.
         """

--- a/tests/test_django_rakaia/test_django_store.py
+++ b/tests/test_django_rakaia/test_django_store.py
@@ -458,11 +458,15 @@ def test_get_store_returns_durable_when_setting_set(settings):
 @pytest.mark.django_db(transaction=True)
 class TestExpiryReaping:
     def test_a_refused_append_still_reaps_the_expired_row(self):
-        """The reap must run outside the write transaction.
+        """The reap must survive the write transaction's rollback.
 
-        `_require`'s expiry delete inside `transaction.atomic()` is rolled
-        back by the very `StreamNotFound` unwind that reports it — the write
-        path raised 404s forever without ever actually deleting the row.
+        An expiry delete issued inside `transaction.atomic()` is undone by the
+        very `StreamNotFound` unwind that reports it — the write path raised
+        404s forever without ever actually deleting the row. It was fixed once
+        with a second, unlocked read of the stream row before the transaction
+        opened, and again — without that read — by carrying the expiry out of
+        the transaction as a signal and reaping past the rollback
+        (`_locked_write`, #202). This test is what both had to satisfy.
         """
         import time
 

--- a/tests/test_django_rakaia/test_locking.py
+++ b/tests/test_django_rakaia/test_locking.py
@@ -5,9 +5,9 @@ There are exactly three `select_for_update()` calls in this package:
 
 * `models.py` — `Stream.get_next_offset_block`, the offset watermark. Raced in
   `test_concurrent_appends.py`.
-* `django_store.py` — `_live_stream(..., for_update=True)`, the stream row. It
-  is what makes a writer's closed / content-type / producer checks and its write
-  one indivisible step.
+* `django_store.py` — `_locked_write`, the stream row. It is what makes a
+  writer's closed / content-type / producer checks and its write one indivisible
+  step, and it is the door every append and fenced close goes through.
 * `effect_executor.py` — `DjangoExecutor._retire`, which captures the rows a
   retire is about to flip so it can report exactly those.
 
@@ -222,7 +222,7 @@ class TestOpensItsOwnTransaction:
 @requires_row_locks
 @pytest.mark.django_db(transaction=True)
 class TestStreamRowLock:
-    """`_live_stream(..., for_update=True)` serialises writers on one stream.
+    """`_locked_write` serialises writers on one stream.
 
     The property is not "appends are ordered" — the offset watermark gives that
     — but that a writer's *decision* (is this stream closed? does the content


### PR DESCRIPTION
Every append to the durable store looked up the same stream twice — once before the write began, and once when the write actually started. The first lookup was only there so that a stream which had aged out still got cleaned up, because the cleanup was otherwise undone when the append gave up and reported the stream as missing. One lookup now does both jobs, and an append that finds an aged-out stream still cleans it up.

Closes #202, which reported thirteen database queries per append and named three that looked like duplicates. Measured against `main` today it is eight, not thirteen: two of the three went in #175. This removes the third, leaving seven, and every one of them now does something. There is a new test that writes down what each kind of append costs, statement by statement, because none of this changes anything a caller can see — the cost can drift back up without any other test noticing.