### PR TITLE
One home for each of a stream position's five rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,10 +22,17 @@ runnable demo for each.
 
   `OffsetFormat` now owns all five per store, as `COMPOUND` (the in-memory
   `{seq}_{byte}`) and `PLAIN` (the durable padded integer). The hand-picked
-  widths are written once each, and the pattern that validates a token is derived
-  from the widths that render it, so a format cannot be checked against a shape it
-  no longer produces. `ForeignOffset` is exported for consumers that catch it; it
-  subclasses `InvalidOffset`, which both stores already raised.
+  widths are written once each, and the shape that recognises a token is derived
+  from the field count that renders it, so a format cannot be checked against a
+  shape it no longer produces. `ForeignOffset` is exported for consumers that
+  catch it; it subclasses `InvalidOffset`, which both stores already raised.
+
+  The refusal is narrow on purpose: it fires only when both tokens are
+  recognisably from *different* rakaia stores, the one pair with no answer. A
+  format this library does not recognise — a third-party `CursorStore` issuing
+  ULIDs or timestamps, which `protocols` documents as a supported backend — is
+  still compared byte-wise, which is the ordering rule the protocol states for
+  any opaque offset.
 
 - **`DjangoExecutor(batch_updates=True)` collapses a fanned-out `Update` into one
   statement.** A handler that fans one change across many rows emits one `Update`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,22 @@ runnable demo for each.
 
 ### Added
 
+- **`rakaia.offsets` — a stream position's rules, one home each.** An offset has
+  about five rules: what the first one is, how wide it is, how to make the next
+  one, how to tell a valid one, and how to compare two. The durable store kept
+  four of its five in one file. The in-memory store had them spread across two
+  files with the field width written out three times — and a comment saying a
+  change must update them "in lockstep", which is a rule announcing that it has
+  no home. **The fifth, comparison, had no home in either**, so the one place
+  that needed it carried its own guess.
+
+  `OffsetFormat` now owns all five per store, as `COMPOUND` (the in-memory
+  `{seq}_{byte}`) and `PLAIN` (the durable padded integer). The hand-picked
+  widths are written once each, and the pattern that validates a token is derived
+  from the widths that render it, so a format cannot be checked against a shape it
+  no longer produces. `ForeignOffset` is exported for consumers that catch it; it
+  subclasses `InvalidOffset`, which both stores already raised.
+
 - **`DjangoExecutor(batch_updates=True)` collapses a fanned-out `Update` into one
   statement.** A handler that fans one change across many rows emits one `Update`
   per row — on purpose, so a verification pass can diff them one at a time — and

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -15,6 +15,34 @@ ones you are crossing.
 
 ---
 
+# Unreleased
+
+## `poll` refuses a cursor from another store instead of reporting `rewound`
+
+`rakaia.subscription.poll` compares your saved cursor against the stream head to
+decide whether the log was rebuilt beneath you. If the cursor came from a
+*different* store than the one being read, that comparison had no correct answer
+to give and gave a wrong one: an in-memory cursor four events into a stream was
+judged to be beyond a durable head at forty-two, because the two formats are
+padded to different widths and the comparison fell back to text order.
+
+It now raises `ForeignOffset` (a subclass of the existing `InvalidOffset`, so
+`except InvalidOffset` still catches it).
+
+**What changes for you.** Nothing, unless a cursor really is crossing stores —
+in which case you previously got `Poll(status="rewound")`, which instructs a
+consumer to discard its derived state and re-read the whole stream. The final
+state was correct; the stated reason was not. If you have a consumer branching on
+`.rewound`, it will now see an exception on that path instead. Clear the saved
+cursor when you change stores.
+
+Realistically this arises in a test that builds a cursor with the wrong store, or
+from a corrupted saved value — the in-memory store is for tests, demos and the
+conformance suite, so no deployment accumulates a cursor under it and then
+switches.
+
+---
+
 # 0.2.0
 
 Everything in this file so far. `0.1.0` was the initial groundwork and `0.2.0`

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -41,6 +41,12 @@ from a corrupted saved value — the in-memory store is for tests, demos and the
 conformance suite, so no deployment accumulates a cursor under it and then
 switches.
 
+**If you supply your own store, nothing changes at all.** The refusal fires only
+when rakaia can see that both tokens came from its own two formats and that those
+formats differ. A third-party `CursorStore` issuing ULIDs, timestamps or hex
+offsets matches neither, and its cursors are compared byte-wise exactly as before
+— which is the ordering rule the protocol states for any opaque offset.
+
 ---
 
 # 0.2.0

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -211,6 +211,7 @@ page is the contract.
 | `ContentTypeMismatch` | `rakaia` | — | An append's content type disagrees with the stream's. |
 | `InvalidJson` | `rakaia` | — | A JSON-mode payload did not parse. |
 | `InvalidOffset` | `rakaia` | — | An offset is syntactically valid but not one this store can read. |
+| `ForeignOffset` | `rakaia` | — | An offset was used where its format does not belong — passed to a store that did not issue it, or compared against one from another store. |
 | `EmptyJsonArray` | `rakaia` | — | A JSON-mode append carried an empty array. |
 | `SpareKeys` | `rakaia` | `(keys: 'list[dict[str, Any]]') -> None` | Spare rows from a delete or retire by composite natural key. |
 | `StreamConfigConflict` | `rakaia` | — | A create names an existing stream with a different configuration. |
@@ -222,16 +223,10 @@ page is the contract.
 | `UpcasterChainError` | `rakaia` | — | Cannot upcast: missing or ambiguous link in the upcaster chain. |
 | `UpcasterConflictError` | `rakaia` | — | Two upcasters were registered for the same (event_match, from_version). |
 
-## Everything else
-
-| Name | Import from | Signature | What it does |
-|---|---|---|---|
-| `ForeignOffset` | `rakaia` | — | An offset was used where its format does not belong — passed to a store that did not issue it, or compared against one from another store. |
-
 ---
 
 ## Appendix — coverage
 
-136 exported names across 15 sections. 120 carry a docstring; 16 do not and show `—` above.
+136 exported names across 14 sections. 120 carry a docstring; 16 do not and show `—` above.
 
 Undocumented: `AnyEffect`, `DEFAULT_NORMALIZERS`, `ENVELOPE_TS`, `Effect`, `GREEN`, `HANDLERS_META_STREAM`, `Normalizer`, `PollStatus`, `ProducerValidationResult`, `RED`, `REDUCERS_META_STREAM`, `SCRATCH_PATH`, `UPCASTERS_META_STREAM`, `VACUOUS`, `__version__`, `app`.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -222,10 +222,16 @@ page is the contract.
 | `UpcasterChainError` | `rakaia` | — | Cannot upcast: missing or ambiguous link in the upcaster chain. |
 | `UpcasterConflictError` | `rakaia` | — | Two upcasters were registered for the same (event_match, from_version). |
 
+## Everything else
+
+| Name | Import from | Signature | What it does |
+|---|---|---|---|
+| `ForeignOffset` | `rakaia` | — | An offset was used where its format does not belong — passed to a store that did not issue it, or compared against one from another store. |
+
 ---
 
 ## Appendix — coverage
 
-135 exported names across 14 sections. 119 carry a docstring; 16 do not and show `—` above.
+136 exported names across 15 sections. 120 carry a docstring; 16 do not and show `—` above.
 
 Undocumented: `AnyEffect`, `DEFAULT_NORMALIZERS`, `ENVELOPE_TS`, `Effect`, `GREEN`, `HANDLERS_META_STREAM`, `Normalizer`, `PollStatus`, `ProducerValidationResult`, `RED`, `REDUCERS_META_STREAM`, `SCRATCH_PATH`, `UPCASTERS_META_STREAM`, `VACUOUS`, `__version__`, `app`.

--- a/scripts/gen_api_reference.py
+++ b/scripts/gen_api_reference.py
@@ -185,6 +185,7 @@ GROUPS: dict[str, tuple[str, ...]] = {
         "ContentTypeMismatch",
         "InvalidJson",
         "InvalidOffset",
+        "ForeignOffset",
         "EmptyJsonArray",
         "SpareKeys",
         "StreamConfigConflict",

--- a/src/django_rakaia/offsets.py
+++ b/src/django_rakaia/offsets.py
@@ -1,48 +1,39 @@
-"""The durable store's offset format: how to render one, and how to read one.
+"""The durable store's offset format, as this package's callers want it.
 
-Its own module because it has three callers at two different layers — the
-store (`django_store`), the model property that reports a stream head
-(`models.Stream.current_offset`), and the dashboard views that accept an
-offset from a client. Keeping it here is what stops the model layer from
-importing out of the store layer for its own property, and stops a view from
-pulling in the whole store just to read a query parameter.
+The format itself — the width, the padding, what counts as one of this store's
+tokens — lives in `rakaia.offsets` as `PLAIN`, alongside the in-memory store's
+`COMPOUND` and the ordering rule that refuses to compare across the two (#182).
+Both stores had four of the five offset rules written down separately and the
+fifth, comparison, written down nowhere, which is why it guessed.
+
+What stays here are the two integer-facing helpers this package's three callers
+want: the store (`django_store`), the model property that reports a stream head
+(`models.Stream.current_offset`), and the dashboard views that accept an offset
+from a client. Keeping them here is what stops the model layer from importing out
+of the store layer for its own property, and stops a view from pulling in the
+whole store just to read a query parameter.
 """
 
 from __future__ import annotations
 
-import re
-
-from rakaia.types import InvalidOffset
-
-# Offsets are rendered zero-padded so they sort byte-wise lexicographically, as
-# the Durable Streams protocol requires (§3, §5.2). 20 digits covers a
-# BigAutoField's range (< 2**63). Reads still parse them numerically, so the
-# padding is transparent to filtering.
-_OFFSET_WIDTH = 20
-
-# This store's offsets, and nothing else. See `parse_offset`.
-_PLAIN_INTEGER_OFFSET = re.compile(r"^\d+$")
+from rakaia.offsets import PLAIN
 
 
 def format_offset(value: int) -> str:
     """Render an integer offset as the protocol's opaque, sortable string."""
-    return f"{value:0{_OFFSET_WIDTH}d}"
+    return PLAIN.render(value)
 
 
 def parse_offset(offset: str) -> int:
     """The entry offset `offset` denotes, in the durable store's own format.
 
-    Strict on purpose. `int()` alone would accept far more than this store
-    ever issues — it treats underscores as digit separators, so the in-memory
-    store's compound `{seq}_{byte}` offset parses cleanly into an unrelated
-    number, and a resume read would quietly return the wrong window instead of
-    failing. `VALID_OFFSET_PATTERN` cannot catch that either: it is a shared
-    syntactic guard, and the protocol makes offsets opaque rather than uniform
-    (§6), so only the issuing store can say whether a token is one of its own.
+    Strict on purpose, and `PLAIN` is what makes it so. `int()` alone would
+    accept far more than this store ever issues — it treats underscores as digit
+    separators, so the in-memory store's compound `{seq}_{byte}` offset parses
+    cleanly into an unrelated number, and a resume read would quietly return the
+    wrong window instead of failing.
+
+    Raises `ForeignOffset`, which subclasses `InvalidOffset` — so an existing
+    ``except InvalidOffset`` is unaffected.
     """
-    if not _PLAIN_INTEGER_OFFSET.match(offset):
-        raise InvalidOffset(
-            f"Not an offset this store issued: {offset!r}. Durable-store "
-            f"offsets are plain integers."
-        )
-    return int(offset)
+    return PLAIN.key(offset)[0]

--- a/src/rakaia/__init__.py
+++ b/src/rakaia/__init__.py
@@ -47,6 +47,7 @@ from .history import (
     history_effects,
     label_marker,
 )
+from .offsets import ForeignOffset
 from .projections import (
     project_latest,
     reconcile_aggregate,
@@ -190,6 +191,7 @@ __all__ = [
     "ContentTypeMismatch",
     "InvalidJson",
     "EmptyJsonArray",
+    "ForeignOffset",
     "InvalidOffset",
     # Cursor
     "calculate_cursor",

--- a/src/rakaia/handler.py
+++ b/src/rakaia/handler.py
@@ -32,6 +32,7 @@ from ._asgi import (
 )
 from .cursor import CursorOptions, generate_response_cursor
 from .json_mode import is_json_content_type
+from .offsets import ForeignOffset
 from .protocols import StreamServerStore
 from .store import StreamStore
 from .types import (
@@ -84,6 +85,11 @@ STORE_FAILURE_STATUS: dict[type[StreamError], tuple[int, bytes]] = {
     InvalidJson: (400, b"Invalid JSON"),
     EmptyJsonArray: (400, b"Empty arrays are not allowed"),
     InvalidOffset: (400, b"Invalid offset"),
+    # Listed explicitly even though `_status_for` walks the MRO and would find
+    # `InvalidOffset` anyway: the closed-set test insists on a decision per
+    # failure, which is the point of it. A later offset failure might warrant 409
+    # or 410, and inheriting silently is how that would go unnoticed.
+    ForeignOffset: (400, b"Invalid offset"),
 }
 
 

--- a/src/rakaia/offsets.py
+++ b/src/rakaia/offsets.py
@@ -81,10 +81,16 @@ class OffsetFormat:
 
     @property
     def pattern(self) -> re.Pattern[str]:
-        """Exactly this format's tokens, and nothing else.
+        """This format's *shape*: how many numeric fields, joined by ``_``.
 
-        Built from `widths` rather than written alongside it, so a format cannot
-        be validated against a shape it no longer renders.
+        Built from `widths` so the field count cannot drift from what `render`
+        produces. It deliberately does **not** pin each field's width: the widths
+        are a padding and sort rule for offsets this store issues, not an input
+        filter. Clients send unpadded offsets — the dashboard's ``?after=42`` is
+        one — and both regexes this replaced accepted them, so tightening to
+        ``\\d{20}`` here would reject requests that work today. What the shape
+        does settle is the only question `owns` is asked: which of the two stores
+        a token belongs to, one field against two.
         """
         return re.compile("^" + "_".join(r"\d+" for _ in self.widths) + "$")
 

--- a/src/rakaia/offsets.py
+++ b/src/rakaia/offsets.py
@@ -20,13 +20,19 @@ compare offsets from **the same store**. Two stores' offsets are not on one
 scale — an in-memory ``{seq}_{byte}`` counts events and bytes, a durable offset
 is an entry id — so there is no correct cross-store answer to compute. The old
 fallback compared them as text, where ``'0000000000000000_0000000000000008'``
-sorts *above* ``'00000000000000000042'`` because ``'0' < '3'`` settles it before
-any digit that means anything is reached. A cursor four events into a stream was
-reported as being beyond a head at forty-two.
+sorts *above* ``'00000000000000000042'``: the first sixteen characters are zeros
+in both, and at the seventeenth the compound token has ``'_'`` (0x5F) against the
+plain one's ``'0'`` (0x30), so it wins there — before either token has reached a
+digit that means anything. A cursor four events into a stream was reported as
+being beyond a head at forty-two.
 
-So the answer is to refuse. `after` raises `ForeignOffset` unless both tokens are
-in the same recognised format, which is the same judgement each store already
-made alone — see the `owns` docstring for why only a format can make it.
+So the answer is to refuse — but only for *that* pair. `after` raises
+`ForeignOffset` when both tokens are recognised and their formats differ, which
+is the same judgement each store already made alone (see the `owns` docstring for
+why only a format can make it). It does **not** refuse a token it merely does not
+recognise: the protocol's own rule is that an opaque offset sorts byte-wise, a
+third-party `CursorStore` is a documented seam, and its ULID or timestamp offsets
+are no less orderable for being unfamiliar.
 
 **How a mismatched pair actually arises.** Not from a production migration: the
 in-memory store is for tests, demos and the conformance runs, so no deployment
@@ -173,19 +179,39 @@ def format_of(token: str) -> OffsetFormat | None:
 def after(a: str, b: str) -> bool:
     """Whether offset `a` sorts strictly after `b`.
 
+    Refuses **only** the pair that has no answer: two tokens this library can see
+    are from *different* rakaia stores. Everything else is ordered, and by the
+    rule the protocol already states — an offset is "opaque, lexicographically
+    sortable" (§6), so byte order is the contract for any format, including one
+    this library has never seen.
+
+    That last part is deliberate and is a correction. `protocols` promises a
+    third-party `CursorStore` plugs in, and its offsets may be ULIDs, timestamps
+    or hex — none of which match `COMPOUND` or `PLAIN`. Refusing every
+    unrecognised token would have broken that seam for the sake of a pair that
+    only arises from misuse, and would have blamed a store switch that never
+    happened. So an unrecognised pair falls back to the byte-wise comparison the
+    protocol mandates.
+
+    Recognised same-format pairs get `key` instead of byte order, which is a
+    strict improvement rather than a different rule: it agrees with byte order on
+    every token a store *renders* (that is what the padding is for) and is also
+    right for the unpadded ones a client may send — see `pattern`.
+
     Raises:
-        ForeignOffset: if either token is unrecognised, or the two come from
-            different formats. There is no cross-store ordering to return — see
-            this module's docstring — and the alternative to raising is the
-            confident wrong answer this replaced.
+        ForeignOffset: if both tokens are recognised and come from different
+            formats. There is no cross-store ordering to return — see this
+            module's docstring — and the alternative to raising is the confident
+            wrong answer this replaced.
     """
     fmt_a, fmt_b = format_of(a), format_of(b)
-    if fmt_a is None or fmt_b is None or fmt_a is not fmt_b:
+    if fmt_a is not None and fmt_b is not None and fmt_a is not fmt_b:
         raise ForeignOffset(
-            f"Cannot order {a!r} against {b!r}: "
-            f"{'unrecognised offset format' if fmt_a is None or fmt_b is None else f'{fmt_a.name} against {fmt_b.name}'}"
-            f". An offset is opaque and only comparable within the store that "
-            f"issued it, so there is no answer here to compute — clear the saved "
-            f"position before switching stores."
+            f"Cannot order {a!r} against {b!r}: {fmt_a.name} against "
+            f"{fmt_b.name}. An offset is opaque and only comparable within the "
+            f"store that issued it, so there is no answer here to compute — "
+            f"clear the saved position before switching stores."
         )
-    return fmt_a.key(a) > fmt_b.key(b)
+    if fmt_a is not None and fmt_b is not None:
+        return fmt_a.key(a) > fmt_b.key(b)
+    return a > b

--- a/src/rakaia/offsets.py
+++ b/src/rakaia/offsets.py
@@ -1,0 +1,185 @@
+"""What a stream position is, per store — all five rules in one place each.
+
+An offset has about five rules: what the first one is, how wide it is, how to
+make the next one, how to tell a valid one, and how to compare two. Both stores
+implement the same idea in different bytes, so there is a real shared shape here;
+it had simply never been written down. Before this module:
+
+* the durable store kept four of its five in `django_rakaia/offsets.py`;
+* the in-memory store had them spread across `types.py` and `store.py`, with the
+  field width written out three times — and a comment saying a change must
+  update "the fields (and ``INITIAL_OFFSET``) in lockstep", which is a rule
+  announcing that it has no home; and
+* **the fifth rule, comparison, had no home in either.** So the one place that
+  needed it — `subscription.poll`, deciding whether a saved cursor sits beyond
+  the stream head — carried its own guess.
+
+**Why the comparison could not be got right by trying harder.** The protocol
+makes an offset *opaque* (§6): `protocols.ReadableStore` tells consumers to
+compare offsets from **the same store**. Two stores' offsets are not on one
+scale — an in-memory ``{seq}_{byte}`` counts events and bytes, a durable offset
+is an entry id — so there is no correct cross-store answer to compute. The old
+fallback compared them as text, where ``'0000000000000000_0000000000000008'``
+sorts *above* ``'00000000000000000042'`` because ``'0' < '3'`` settles it before
+any digit that means anything is reached. A cursor four events into a stream was
+reported as being beyond a head at forty-two.
+
+So the answer is to refuse. `after` raises `ForeignOffset` unless both tokens are
+in the same recognised format, which is the same judgement each store already
+made alone — see the `owns` docstring for why only a format can make it.
+
+**How a mismatched pair actually arises.** Not from a production migration: the
+in-memory store is for tests, demos and the conformance runs, so no deployment
+accumulates a cursor under it and then switches. The reachable causes are a test
+that builds a cursor with the wrong store, and a saved cursor that has been
+corrupted or hand-edited. Refusing turns both into an error naming the offset
+instead of a `rewound` result, which claims the log was rebuilt and tells the
+consumer to discard its derived state.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+from .types import InvalidOffset
+
+__all__ = [
+    "COMPOUND",
+    "FORMATS",
+    "PLAIN",
+    "ForeignOffset",
+    "OffsetFormat",
+    "after",
+    "format_of",
+]
+
+
+class ForeignOffset(InvalidOffset):
+    """An offset was used where its format does not belong — passed to a store
+    that did not issue it, or compared against one from another store.
+
+    Subclasses `InvalidOffset` on purpose: both stores already raised that for a
+    token they did not recognise, so every existing ``except InvalidOffset``
+    still catches this.
+    """
+
+
+@dataclass(frozen=True)
+class OffsetFormat:
+    """One store's offset format, and every rule about its tokens.
+
+    ``widths`` is one entry per zero-padded numeric field, in order — so it is
+    both the shape and the size limit. The limit is a choice rather than a
+    consequence (nothing forces 16 or 20), and this is the one place it is
+    written, so widening one is an edit here instead of an edit in three places
+    that have to agree.
+    """
+
+    name: str
+    widths: tuple[int, ...]
+
+    @property
+    def pattern(self) -> re.Pattern[str]:
+        """Exactly this format's tokens, and nothing else.
+
+        Built from `widths` rather than written alongside it, so a format cannot
+        be validated against a shape it no longer renders.
+        """
+        return re.compile("^" + "_".join(r"\d+" for _ in self.widths) + "$")
+
+    def owns(self, token: str) -> bool:
+        """Whether `token` is one this format issues.
+
+        Only a format can answer this, which is why the check cannot be shared
+        across stores as a single syntactic guard. `types.VALID_OFFSET_PATTERN`
+        deliberately accepts **both** shapes — it is the protocol server's guard
+        on what a client may send — so it cannot tell a durable offset from an
+        in-memory one. Nor can `int()`: it reads ``_`` as a digit separator, so
+        the in-memory ``{seq}_{byte}`` parses cleanly into an unrelated number.
+        """
+        return bool(self.pattern.match(token))
+
+    def require(self, token: str) -> None:
+        """Raise `ForeignOffset` unless `token` is one this format issues."""
+        if not self.owns(token):
+            raise ForeignOffset(
+                f"Not an offset the {self.name} store issued: {token!r}. Its "
+                f"offsets have the form "
+                f"{'_'.join('{' + str(w) + ' digits}' for w in self.widths)}. "
+                f"An offset is opaque and only comparable within the store that "
+                f"issued it — clear the saved position before switching stores."
+            )
+
+    def key(self, token: str) -> tuple[int, ...]:
+        """`token` as an orderable tuple, most significant field first."""
+        self.require(token)
+        return tuple(int(part) for part in token.split("_"))
+
+    def render(self, *fields: int) -> str:
+        """The token for these field values, zero-padded to this format's widths.
+
+        Padding is what makes offsets sort byte-wise lexicographically, which the
+        protocol requires (§3, §5.2) and which is what keeps them monotonic
+        across a delete-and-recreate. A width is a *minimum*, not a cap: the
+        ordering guarantee holds only while every field stays below its width, so
+        a store that could exceed one must widen it here.
+        """
+        if len(fields) != len(self.widths):
+            raise ValueError(
+                f"{self.name} offsets have {len(self.widths)} field(s), "
+                f"got {len(fields)}: {fields!r}"
+            )
+        return "_".join(f"{v:0{w}d}" for v, w in zip(fields, self.widths, strict=True))
+
+    def first(self) -> str:
+        """The offset a brand-new stream starts at: every field zero."""
+        return self.render(*(0 for _ in self.widths))
+
+
+#: The in-memory `StreamStore`: ``{read_seq}_{byte_offset}``.
+#:
+#: 16 digits each. Both bounds are unreachable rather than generous — the byte
+#: offset is capped by the process's memory (this store holds every message in
+#: RAM, so 10**16 bytes ≈ 10 PB is impossible) and so is 10**16 recreations of
+#: one path.
+COMPOUND = OffsetFormat(name="in-memory", widths=(16, 16))
+
+#: `DjangoStreamStore`: a single zero-padded entry id.
+#:
+#: 20 digits covers a ``BigAutoField``'s range (< 2**63). Reads parse it
+#: numerically, so the padding is transparent to filtering.
+PLAIN = OffsetFormat(name="durable", widths=(20,))
+
+#: Every format rakaia issues. Order matters only for `format_of`'s search, and
+#: the patterns are disjoint (one field versus two), so it does not.
+FORMATS: tuple[OffsetFormat, ...] = (COMPOUND, PLAIN)
+
+
+def format_of(token: str) -> OffsetFormat | None:
+    """The format that issued `token`, or ``None`` if no format claims it."""
+    for fmt in FORMATS:
+        if fmt.owns(token):
+            return fmt
+    return None
+
+
+def after(a: str, b: str) -> bool:
+    """Whether offset `a` sorts strictly after `b`.
+
+    Raises:
+        ForeignOffset: if either token is unrecognised, or the two come from
+            different formats. There is no cross-store ordering to return — see
+            this module's docstring — and the alternative to raising is the
+            confident wrong answer this replaced.
+    """
+    fmt_a, fmt_b = format_of(a), format_of(b)
+    if fmt_a is None or fmt_b is None or fmt_a is not fmt_b:
+        raise ForeignOffset(
+            f"Cannot order {a!r} against {b!r}: "
+            f"{'unrecognised offset format' if fmt_a is None or fmt_b is None else f'{fmt_a.name} against {fmt_b.name}'}"
+            f". An offset is opaque and only comparable within the store that "
+            f"issued it, so there is no answer here to compute — clear the saved "
+            f"position before switching stores."
+        )
+    return fmt_a.key(a) > fmt_b.key(b)

--- a/src/rakaia/store.py
+++ b/src/rakaia/store.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import re
 import time
 from collections.abc import Iterable
 from datetime import datetime, timezone
@@ -23,14 +22,13 @@ from .json_mode import (
     normalize_content_type,
     process_json_append,
 )
+from .offsets import COMPOUND
 from .producer import is_producer_state_expired
 from .types import (
-    INITIAL_OFFSET,
     AppendOptions,
     AppendResult,
     CloseResult,
     ContentTypeMismatch,
-    InvalidOffset,
     ProducerAccepted,
     ProducerValidationResult,
     SequenceConflict,
@@ -40,15 +38,13 @@ from .types import (
     StreamNotFound,
 )
 
-# NB: this module generates offsets (the `{seq}_{byte}` format) but never
-# *validates* them, so it deliberately does not import `VALID_OFFSET_PATTERN`.
-# Offset validation lives in the protocol server (`handler`), which uses the
-# one pattern from `.types` (#41).
+# This module neither renders nor validates the offset format itself: both are
+# `COMPOUND`'s job (`rakaia.offsets`). It still does not import
+# `VALID_OFFSET_PATTERN` — that is the protocol server's syntactic guard on what
+# a *client* may send, and it accepts both stores' shapes by design (#41), so it
+# cannot tell a foreign offset from one of ours.
 
 _log = logging.getLogger("rakaia.store")
-
-# This store's offsets, and nothing else. See `StreamStore._check_offset`.
-_COMPOUND_OFFSET = re.compile(r"^\d+_\d+$")
 
 
 class StreamStore:
@@ -179,7 +175,7 @@ class StreamStore:
         # INITIAL_OFFSET (generation 0).
         prior = self._retired_seq.get(path)
         initial_offset = (
-            INITIAL_OFFSET if prior is None else f"{prior + 1:016d}_{0:016d}"
+            COMPOUND.first() if prior is None else COMPOUND.render(prior + 1, 0)
         )
         stream = Stream(
             path=path,
@@ -666,17 +662,14 @@ class StreamStore:
             # Storing the payload unframed (#155) therefore leaves every offset
             # exactly where it was; only `StreamMessage.data` changes.
             byte_offset += len(payload) + (1 if json_mode else 0)
-            # Offsets are `{read_seq}_{byte_offset}`, each zero-padded to 16
-            # digits so they sort byte-wise lexicographically (the protocol's
-            # requirement, and what keeps offsets monotonic across recreate).
-            # `:016d` is a minimum width, not a cap: the ordering guarantee holds
-            # only while both fields stay < 10**16. That bound is unreachable
-            # here — the byte offset is capped by the process's memory (this
-            # store holds every message in RAM, so 10**16 bytes = ~10 PB is
-            # impossible) and 10**16 recreations of one path equally so. A
-            # durable backend that could exceed it must widen the fields (and
-            # INITIAL_OFFSET) in lockstep.
-            new_offset = f"{read_seq:016d}_{byte_offset:016d}"
+            # `COMPOUND` owns the shape, the field widths and the padding
+            # that makes offsets sort byte-wise (see `rakaia.offsets`). The
+            # widths used to be written out here, again where a recreated path
+            # picks up its first offset, and a third time inside the
+            # `INITIAL_OFFSET` literal — with a comment saying a change had to
+            # update all three "in lockstep", which is a rule announcing it has
+            # no home (#182).
+            new_offset = COMPOUND.render(read_seq, byte_offset)
 
             message = StreamMessage(
                 data=payload,
@@ -705,11 +698,7 @@ class StreamStore:
         offsets opaque rather than uniform (§6), so only the issuing store can
         judge — `VALID_OFFSET_PATTERN` accepts both formats by design.
         """
-        if not _COMPOUND_OFFSET.match(offset):
-            raise InvalidOffset(
-                f"Not an offset this store issued: {offset!r}. In-memory-store "
-                f"offsets have the compound {{seq}}_{{byte}} form."
-            )
+        COMPOUND.require(offset)
 
     def _find_offset_index(self, stream: Stream, offset: str) -> int:
         """Find first message with offset > given offset (lexicographic)."""

--- a/src/rakaia/subscription.py
+++ b/src/rakaia/subscription.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Literal
 
+from .offsets import after as offsets_after
 from .protocols import CursorStore
 from .types import StreamMessage
 
@@ -120,23 +121,15 @@ def _tail(messages: list[StreamMessage], fallback: str) -> str:
     return messages[-1].offset if messages else fallback
 
 
-def _offset_key(offset: str) -> tuple[int, ...] | None:
-    """Parse a rakaia offset into an orderable tuple of ints, or None.
-
-    Both stores now emit zero-padded, lexicographically-sortable offsets (the
-    in-memory ``{seq}_{bytes}`` and the Django store's padded integer, #34), so
-    plain string order already matches. Comparing the parsed ints is kept as a
-    defensive fallback that also tolerates a non-padded offset (``"9"`` vs
-    ``"10"``) should any store or older cursor produce one."""
-    try:
-        return tuple(int(part) for part in offset.split("_"))
-    except ValueError:
-        return None
-
-
 def _after(a: str, b: str) -> bool:
-    """True if offset `a` sorts strictly after `b` (chronologically later)."""
-    ka, kb = _offset_key(a), _offset_key(b)
-    if ka is None or kb is None or len(ka) != len(kb):
-        return a > b  # unparseable/mismatched shape: fall back to lexicographic
-    return ka > kb
+    """True if offset `a` sorts strictly after `b` (chronologically later).
+
+    Delegates to `offsets.after`, which raises `ForeignOffset` rather than
+    guessing when the two tokens come from different stores. This used to hold
+    its own parse-and-compare, with a lexicographic fallback for the case it
+    could not line up — and that fallback answered *wrongly* rather than
+    uncertainly, because a padded compound offset sorts below a padded plain one
+    on its first character. See `rakaia.offsets` for why there is nothing correct
+    to return there.
+    """
+    return offsets_after(a, b)

--- a/src/rakaia/subscription.py
+++ b/src/rakaia/subscription.py
@@ -125,11 +125,12 @@ def _after(a: str, b: str) -> bool:
     """True if offset `a` sorts strictly after `b` (chronologically later).
 
     Delegates to `offsets.after`, which raises `ForeignOffset` rather than
-    guessing when the two tokens come from different stores. This used to hold
-    its own parse-and-compare, with a lexicographic fallback for the case it
-    could not line up — and that fallback answered *wrongly* rather than
-    uncertainly, because a padded compound offset sorts below a padded plain one
-    on its first character. See `rakaia.offsets` for why there is nothing correct
-    to return there.
+    guessing when the two tokens are recognisably from different stores. This used
+    to hold its own parse-and-compare, with a lexicographic fallback for the case
+    it could not line up — and for that one pair the fallback answered *wrongly*
+    rather than uncertainly: a padded compound offset sorts *above* a padded plain
+    one, decided by the ``'_'`` at its seventeenth character. See `rakaia.offsets`
+    for why there is nothing correct to return there, and why byte order is still
+    the right answer for a store this library does not recognise.
     """
     return offsets_after(a, b)

--- a/tests/test_rakaia/test_offset_format.py
+++ b/tests/test_rakaia/test_offset_format.py
@@ -1,0 +1,137 @@
+"""A stream position's rules, and what happens when two stores' positions meet.
+
+Five rules govern an offset: what the first one is, how wide it is, how to make
+the next one, how to tell a valid one, and how to compare two. The durable store
+keeps four of them in one file. The in-memory store has them spread across two
+files with the width written out three times, and the fifth — comparison — had no
+home at all, which is why it guessed.
+
+The protocol makes an offset **opaque**: `protocols.ReadableStore` tells consumers
+to compare offsets from *the same store*. So there is no correct answer to
+"is this in-memory offset after that durable one" to go and compute. The only
+honest answers are to refuse, or to guess; it guessed.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from rakaia.offsets import COMPOUND, PLAIN, ForeignOffset, after, format_of
+from rakaia.store import StreamStore
+from rakaia.subscription import poll
+from rakaia.types import INITIAL_OFFSET
+
+
+class TestComparingAcrossFormats:
+    def test_it_refuses_rather_than_guessing(self):
+        # 4 events consumed in the in-memory store, against a durable head of 42.
+        mem = "0000000000000000_0000000000000008"
+        durable = "00000000000000000042"
+        with pytest.raises(ForeignOffset):
+            after(mem, durable)
+
+    def test_the_guess_it_used_to_make_was_wrong(self):
+        # Kept as a statement of the defect: lexicographically the in-memory
+        # token sorts *above* the durable one, because '0' < '3' decides it
+        # before any digit that means anything is reached. So the old fallback
+        # answered "yes, the cursor is beyond the head" for a cursor four events
+        # into a stream whose head is at forty-two.
+        mem = "0000000000000000_0000000000000008"
+        durable = "00000000000000000042"
+        assert (mem > durable) is True  # what `a > b` returned
+        assert format_of(mem) is COMPOUND
+        assert format_of(durable) is PLAIN
+
+    def test_an_unrecognised_token_is_refused_too(self):
+        with pytest.raises(ForeignOffset):
+            after("not-an-offset", "00000000000000000042")
+
+    def test_within_one_format_it_still_answers(self):
+        assert after("00000000000000000042", "00000000000000000009") is True
+        assert after("0000000000000000_0000000000000008", INITIAL_OFFSET) is True
+        assert after(INITIAL_OFFSET, "0000000000000000_0000000000000008") is False
+
+    def test_equal_offsets_are_not_after_each_other(self):
+        assert after(INITIAL_OFFSET, INITIAL_OFFSET) is False
+
+
+class TestPollRefusesAForeignCursor:
+    """The public seam. Today this reports `rewound` — "the log was rebuilt
+    beneath you, reset your derived state" — for a cursor that is simply from
+    another store. The data converges after the re-read, so nothing is corrupted;
+    the consumer is told the wrong reason and does a full re-read for it."""
+
+    def test_a_cursor_from_another_store_raises(self):
+        store = StreamStore()
+        store.create("s")
+        for i in range(4):
+            store.append("s", f"m{i}".encode())
+
+        with pytest.raises(ForeignOffset):
+            poll(store, "s", "00000000000000000042")
+
+    def test_a_cursor_from_this_store_is_unaffected(self):
+        store = StreamStore()
+        store.create("s")
+        for i in range(4):
+            store.append("s", f"m{i}".encode())
+
+        result = poll(store, "s", INITIAL_OFFSET)
+        assert result.status == "advanced"
+        assert len(result.messages) == 4
+
+
+class TestTheWidthHasOneHome:
+    def test_the_first_offset_is_the_format_saying_so(self):
+        # `types.INITIAL_OFFSET` is a literal, and the two places that build a
+        # compound offset wrote `:016d` out by hand. A change to the width had to
+        # be made in three places in lockstep — which the code says out loud, in
+        # a comment, rather than preventing.
+        assert COMPOUND.first() == INITIAL_OFFSET
+
+    def test_the_format_renders_what_the_store_renders(self):
+        assert COMPOUND.render(0, 0) == INITIAL_OFFSET
+        assert COMPOUND.render(3, 128) == f"{3:016d}_{128:016d}"
+        assert PLAIN.render(42) == "00000000000000000042"
+
+
+class TestRefusalIsCheckedAtEveryLevel:
+    """The three mutations that survived a first pass, each now pinned.
+
+    Worth naming: dropping the `is None` half of `after`'s guard leaves the
+    *one*-unknown case still raising — via `None is not PLAIN` — so it looks
+    covered. It is the two-unknown case that then falls through to
+    `None.key(...)` and raises `AttributeError` instead of `ForeignOffset`.
+    """
+
+    def test_two_unrecognised_tokens_are_refused_not_crashed_on(self):
+        with pytest.raises(ForeignOffset):
+            after("garbage", "rubbish")
+
+    def test_a_format_rejects_the_other_store_s_token(self):
+        with pytest.raises(ForeignOffset):
+            COMPOUND.require("00000000000000000042")
+        with pytest.raises(ForeignOffset):
+            PLAIN.require("0000000000000000_0000000000000008")
+
+    def test_the_store_rejects_a_foreign_offset_on_read(self):
+        """Why `require` has to raise, not merely report.
+
+        Accepting a durable offset here does not fail loudly: this store compares
+        offsets as text, and a plain integer sorts *below* every compound token,
+        so the read matches everything and a resume returns the whole stream —
+        or, with the guard disabled, wedges a long-poll waiting on a position
+        that can never arrive. Disabling `require` and running the full suite
+        hangs rather than failing, which is how this case was found.
+        """
+        store = StreamStore()
+        store.create("s")
+        store.append("s", b"m")
+        with pytest.raises(ForeignOffset):
+            store.read("s", "00000000000000000042")
+
+    def test_render_refuses_the_wrong_number_of_fields(self):
+        with pytest.raises(ValueError, match="2 field"):
+            COMPOUND.render(1)
+        with pytest.raises(ValueError, match="1 field"):
+            PLAIN.render(1, 2)

--- a/tests/test_rakaia/test_offset_format.py
+++ b/tests/test_rakaia/test_offset_format.py
@@ -32,19 +32,19 @@ class TestComparingAcrossFormats:
 
     def test_the_guess_it_used_to_make_was_wrong(self):
         # Kept as a statement of the defect: lexicographically the in-memory
-        # token sorts *above* the durable one, because '0' < '3' decides it
-        # before any digit that means anything is reached. So the old fallback
-        # answered "yes, the cursor is beyond the head" for a cursor four events
-        # into a stream whose head is at forty-two.
+        # token sorts *above* the durable one. Both are zeros for sixteen
+        # characters; at the seventeenth the compound token has '_' (0x5F)
+        # against the plain one's '0' (0x30), which settles it before either has
+        # reached a digit that means anything. So the old fallback answered "yes,
+        # the cursor is beyond the head" for a cursor four events into a stream
+        # whose head is at forty-two.
         mem = "0000000000000000_0000000000000008"
         durable = "00000000000000000042"
         assert (mem > durable) is True  # what `a > b` returned
+        assert mem[:16] == durable[:16]
+        assert (mem[16], durable[16]) == ("_", "0")
         assert format_of(mem) is COMPOUND
         assert format_of(durable) is PLAIN
-
-    def test_an_unrecognised_token_is_refused_too(self):
-        with pytest.raises(ForeignOffset):
-            after("not-an-offset", "00000000000000000042")
 
     def test_within_one_format_it_still_answers(self):
         assert after("00000000000000000042", "00000000000000000009") is True
@@ -53,6 +53,45 @@ class TestComparingAcrossFormats:
 
     def test_equal_offsets_are_not_after_each_other(self):
         assert after(INITIAL_OFFSET, INITIAL_OFFSET) is False
+
+    def test_a_recognised_pair_is_ordered_numerically_not_byte_wise(self):
+        # Byte order and `key` agree on every token a store *renders* — that is
+        # what the padding buys. They part company on the unpadded tokens a
+        # client may send, where '9' outranks '4' and 9 does not outrank 42. Only
+        # `key` is right, which is why a recognised pair does not simply fall
+        # through to the byte-wise comparison the unrecognised pairs use.
+        assert ("9" > "42") is True
+        assert after("9", "42") is False
+        assert after("42", "9") is True
+
+
+class TestAThirdPartyStoreIsStillOrdered:
+    """The refusal has to be narrow, and this is why.
+
+    `protocols` promises a third-party `CursorStore` plugs in, and the protocol
+    says an offset is opaque and sorts byte-wise — so a store whose offsets are
+    ULIDs or timestamps matches neither `COMPOUND` nor `PLAIN` and is still
+    perfectly orderable. A first cut refused every unrecognised token, which
+    broke that seam for the sake of a pair that only arises from misuse, and told
+    the operator to clear a cursor because of a store switch that never happened.
+    """
+
+    def test_two_unrecognised_offsets_compare_byte_wise(self):
+        assert after("2026-08-21T00:00:05Z", "2026-08-21T00:00:03Z") is True
+        assert after("2026-08-21T00:00:03Z", "2026-08-21T00:00:05Z") is False
+        assert after("01ARZ3NDEKTSV4", "01ARZ3NDEKTSV4") is False
+
+    def test_poll_works_against_a_store_this_library_never_saw(self):
+        store = _HeadOnlyStore("2026-08-21T00:00:05Z")
+        # Behind the head, so the comparison must return False and let the read
+        # happen — not refuse for the crime of an unfamiliar format.
+        with pytest.raises(AssertionError, match="read"):
+            poll(store, "s", "2026-08-21T00:00:03Z")
+
+    def test_a_rewound_third_party_cursor_still_reports_rewound(self):
+        store = _HeadOnlyStore("2026-08-21T00:00:03Z", allow_read=True)
+        result = poll(store, "s", "2026-08-21T00:00:05Z")
+        assert result.status == "rewound"
 
 
 class _HeadOnlyStore:
@@ -67,14 +106,17 @@ class _HeadOnlyStore:
     can produce the refusal is the comparison rule.
     """
 
-    def __init__(self, head: str) -> None:
+    def __init__(self, head: str, *, allow_read: bool = False) -> None:
         self.head = head
+        self.allow_read = allow_read
 
     def get_current_offset(self, _path: str) -> str | None:
         return self.head
 
     def read(self, _path: str, offset: str | None = None, _limit: int | None = None):
-        raise AssertionError(f"read() reached with offset={offset!r}")
+        if not self.allow_read:
+            raise AssertionError(f"read() reached with offset={offset!r}")
+        return [], None
 
 
 class TestPollRefusesAForeignCursor:
@@ -142,17 +184,15 @@ class TestTheWidthHasOneHome:
 
 
 class TestRefusalIsCheckedAtEveryLevel:
-    """The three mutations that survived a first pass, each now pinned.
+    """The mutations that survived a first pass, each now pinned."""
 
-    Worth naming: dropping the `is None` half of `after`'s guard leaves the
-    *one*-unknown case still raising — via `None is not PLAIN` — so it looks
-    covered. It is the two-unknown case that then falls through to
-    `None.key(...)` and raises `AttributeError` instead of `ForeignOffset`.
-    """
-
-    def test_two_unrecognised_tokens_are_refused_not_crashed_on(self):
-        with pytest.raises(ForeignOffset):
-            after("garbage", "rubbish")
+    def test_an_unknown_token_does_not_crash_the_comparison(self):
+        # The guard names two formats in its message, so it must not fire on a
+        # pair where one or both are `None` — that path is byte order, not a
+        # refusal, and certainly not `None.key(...)`.
+        assert after("rubbish", "garbage") is True
+        assert after("garbage", "rubbish") is False
+        assert after("00000000000000000042", "garbage") is False  # '0' < 'g'
 
     def test_a_format_rejects_the_other_store_s_token(self):
         with pytest.raises(ForeignOffset):

--- a/tests/test_rakaia/test_offset_format.py
+++ b/tests/test_rakaia/test_offset_format.py
@@ -55,11 +55,46 @@ class TestComparingAcrossFormats:
         assert after(INITIAL_OFFSET, INITIAL_OFFSET) is False
 
 
+class _HeadOnlyStore:
+    """A `CursorStore` whose head is a *durable* offset.
+
+    Needed because neither real store can reach the direction the defect actually
+    took: against `StreamStore` the comparison of a plain cursor to a compound
+    head happens to return False, so `poll` falls through to `read`, and it is
+    `StreamStore._check_offset` that refuses. That makes the seam look covered
+    while `_after` is not exercised at all. Here the head is `PLAIN`, the cursor
+    is `COMPOUND`, and `read` asserts rather than answers — so the only thing that
+    can produce the refusal is the comparison rule.
+    """
+
+    def __init__(self, head: str) -> None:
+        self.head = head
+
+    def get_current_offset(self, _path: str) -> str | None:
+        return self.head
+
+    def read(self, _path: str, offset: str | None = None, _limit: int | None = None):
+        raise AssertionError(f"read() reached with offset={offset!r}")
+
+
 class TestPollRefusesAForeignCursor:
-    """The public seam. Today this reports `rewound` — "the log was rebuilt
-    beneath you, reset your derived state" — for a cursor that is simply from
-    another store. The data converges after the re-read, so nothing is corrupted;
-    the consumer is told the wrong reason and does a full re-read for it."""
+    """The public seam, and the one place the fifth rule is load-bearing."""
+
+    def test_a_foreign_cursor_is_refused_before_the_read(self):
+        # The defect, in the direction it occurred: '..._0000000000000008' sorts
+        # *above* '00000000000000000042' as text, because '_' outranks '0' at the
+        # seventeenth character. The old `a > b` therefore said "yes, beyond the
+        # head" and returned `rewound` for a consumer four events in.
+        store = _HeadOnlyStore("00000000000000000042")
+        with pytest.raises(ForeignOffset):
+            poll(store, "s", "0000000000000000_0000000000000008")
+
+    def test_the_same_seam_still_compares_within_one_format(self):
+        # Guards against a refusal that refuses everything: a durable cursor
+        # genuinely behind a durable head must reach the read, not raise.
+        store = _HeadOnlyStore("00000000000000000042")
+        with pytest.raises(AssertionError, match="read"):
+            poll(store, "s", "00000000000000000009")
 
     def test_a_cursor_from_another_store_raises(self):
         store = StreamStore()
@@ -93,6 +128,17 @@ class TestTheWidthHasOneHome:
         assert COMPOUND.render(0, 0) == INITIAL_OFFSET
         assert COMPOUND.render(3, 128) == f"{3:016d}_{128:016d}"
         assert PLAIN.render(42) == "00000000000000000042"
+
+    def test_a_width_pads_output_without_filtering_input(self):
+        # The widths govern what a store *renders*, so that offsets sort. They
+        # are not a request filter: clients send unpadded offsets (the dashboard
+        # takes `?after=42`), both regexes this replaced accepted them, and
+        # tightening `pattern` to `\d{20}` would break that. What `owns` decides
+        # is which store a token came from — one field against two.
+        assert PLAIN.owns("42")
+        assert COMPOUND.owns("3_128")
+        assert not PLAIN.owns("3_128")
+        assert not COMPOUND.owns("42")
 
 
 class TestRefusalIsCheckedAtEveryLevel:

--- a/tests/test_rakaia/test_public_api.py
+++ b/tests/test_rakaia/test_public_api.py
@@ -60,6 +60,7 @@ RAKAIA_PUBLIC = {
     "ContentTypeMismatch",
     "EmptyJsonArray",
     "InvalidJson",
+    "ForeignOffset",
     "InvalidOffset",
     "SequenceConflict",
     "StreamConfigConflict",


### PR DESCRIPTION
Closes #182. Closes #178. Addresses #138.

A stream position has about five rules: what the first one is, how wide it is, how to make the next one, how to tell a valid one, and how to compare two. One store keeps four of its five in a single file. The other has them scattered across two files with the size written out three times, under a comment saying a change has to update all three together — which is a rule telling you it has no home.

The fifth rule, comparing two positions, had no home in either. So the one place that needed it made its own guess, and the guess was wrong: a reader four events into a stream could be told it was past the end of a stream of forty-two. It now refuses to answer rather than guessing, because there is no correct answer to give — the two stores count different things.