### PR TITLE
Two more admin screens showed a label no reader reports

### DIFF
--- a/src/django_rakaia/admin.py
+++ b/src/django_rakaia/admin.py
@@ -10,7 +10,7 @@ from typing import Any
 
 from django.contrib import admin
 from django.utils.html import format_html, format_html_join
-from django.utils.safestring import mark_safe
+from django.utils.safestring import SafeString, mark_safe
 
 from django_rakaia.event_message import decode_payload, event_label
 from django_rakaia.models import Stream, StreamEntry, StreamEvent
@@ -44,6 +44,66 @@ def _truncate(text: str) -> str:
     return text if len(text) <= _PREVIEW_CHARS else text[: _PREVIEW_CHARS - 3] + "..."
 
 
+_BADGE_COLORS = {
+    "create": "#28a745",
+    "update": "#ffc107",
+    "delete": "#dc3545",
+}
+
+
+def _event_badge(event_type: str) -> SafeString:
+    """The label badge for a stored ``event_type``. One home for three screens.
+
+    Goes through `event_label`, not the column: `event_type` holds a sentinel for
+    "a raw append, which carried no label", and rendering it raw showed `APPEND`
+    where every other reader of the same event reports no label at all.
+    `event_label`'s own docstring says callers rendering an event must use it
+    rather than the column (#153).
+
+    This exists as a function because the admin had three copies of the badge and
+    #195 fixed one of them, leaving the entries list and — worse — the badge a
+    consumer inherits when they register their own event model still printing the
+    sentinel (#201). The colour table was duplicated three times alongside it.
+    A labelless append shows an em-dash rather than a blank cell, because an
+    empty badge reads as a rendering fault.
+    """
+    label = event_label(event_type)
+    return format_html(
+        '<span style="background-color: {}; color: white; padding: 3px 8px; '
+        'border-radius: 3px; font-size: 11px; font-weight: bold;">{}</span>',
+        _BADGE_COLORS.get(label, "#6c757d"),
+        label.upper() or "—",
+    )
+
+
+def _event_data_preview(data: Any, payload_encoding: str | None) -> str:
+    """The payload as a reader sees it, not as the column happens to hold it.
+
+    A body that is not JSON is stored as text — or base64, when it is not valid
+    UTF-8 — and marked with `payload_encoding`, which `read()` inverts. Dumping
+    the column ignored that, so a binary payload rendered as its base64 with
+    nothing on screen saying so. `decode_payload` is the same inverse `read()`
+    uses, so the two now agree.
+
+    Shared with the badge's motive: the event-model factory carried its own stale
+    copy of this, still ignoring the encoding and still truncating by its own
+    rule, so the fix in #195 never reached the screens an app registers (#201).
+    """
+    if payload_encoding is not None:
+        payload = decode_payload(data, payload_encoding)
+        try:
+            shown = payload.decode("utf-8")
+        except UnicodeDecodeError:
+            # Genuinely not text. Say what it is rather than printing an
+            # encoding the viewer has no way to recognise.
+            return f"<{len(payload)} bytes, {payload_encoding}>"
+        return _truncate(shown)
+    try:
+        return _truncate(json.dumps(data, indent=2))
+    except (TypeError, ValueError):
+        return str(data)
+
+
 @admin.register(StreamEvent)
 class StreamEventAdmin(admin.ModelAdmin):
     """Admin interface for StreamEvent model."""
@@ -62,51 +122,12 @@ class StreamEventAdmin(admin.ModelAdmin):
     list_per_page = 50
 
     @admin.display(description="Type")
-    def event_type_badge(self, obj):
-        # Through `event_label`, not `obj.event_type`: the column stores a
-        # sentinel for "a raw append, which carried no label", and rendering it
-        # raw showed `APPEND` where every other reader of the same event reports
-        # no label at all. `event_label`'s own docstring says callers rendering
-        # an event must use it rather than the column (#153); this surface did
-        # not, so the admin and the audit trail disagreed.
-        label = event_label(obj.event_type)
-        colors = {
-            "create": "#28a745",
-            "update": "#ffc107",
-            "delete": "#dc3545",
-        }
-        color = colors.get(label, "#6c757d")
-        return format_html(
-            '<span style="background-color: {}; color: white; padding: 3px 8px; '
-            'border-radius: 3px; font-size: 11px; font-weight: bold;">{}</span>',
-            color,
-            label.upper() or "\u2014",
-        )
+    def event_type_badge(self, obj) -> SafeString:
+        return _event_badge(obj.event_type)
 
     @admin.display(description="Data")
     def data_preview(self, obj: StreamEvent) -> str:
-        """The payload as a reader sees it, not as the column happens to hold it.
-
-        A body that is not JSON is stored as text — or base64, when it is not
-        valid UTF-8 — and marked with `payload_encoding`, which `read()` inverts.
-        Dumping the column ignored that, so a binary payload rendered as its
-        base64 with nothing on screen saying so. `decode_payload` is the same
-        inverse `read()` uses, so the two now agree.
-        """
-        if obj.payload_encoding is not None:
-            payload = decode_payload(obj.data, obj.payload_encoding)
-            try:
-                shown = payload.decode("utf-8")
-            except UnicodeDecodeError:
-                # Genuinely not text. Say what it is rather than printing an
-                # encoding the viewer has no way to recognise.
-                return f"<{len(payload)} bytes, {obj.payload_encoding}>"
-            return _truncate(shown)
-        try:
-            data: Any = obj.data  # type: ignore[assignment]
-            return _truncate(json.dumps(data, indent=2))
-        except (TypeError, ValueError):
-            return str(obj.data)  # type: ignore[call-overload]
+        return _event_data_preview(obj.data, obj.payload_encoding)
 
     @admin.display(description="Streams")
     def stream_count(self, obj):
@@ -151,19 +172,8 @@ class StreamEntryAdmin(admin.ModelAdmin):
         return format_html('<a href="{}">Event #{}</a>', url, obj.event.id)
 
     @admin.display(description="Type")
-    def event_type_badge(self, obj):
-        colors = {
-            "create": "#28a745",
-            "update": "#ffc107",
-            "delete": "#dc3545",
-        }
-        color = colors.get(obj.event.event_type, "#6c757d")
-        return format_html(
-            '<span style="background-color: {}; color: white; padding: 3px 8px; '
-            'border-radius: 3px; font-size: 11px; font-weight: bold;">{}</span>',
-            color,
-            obj.event.event_type.upper(),
-        )
+    def event_type_badge(self, obj) -> SafeString:
+        return _event_badge(obj.event.event_type)
 
 
 def register_stream_event_admin(event_model_class):
@@ -203,29 +213,12 @@ def register_stream_event_admin(event_model_class):
         list_per_page = 50
 
         @admin.display(description="Type")
-        def event_type_badge(self, obj):
-            colors = {
-                "create": "#28a745",
-                "update": "#ffc107",
-                "delete": "#dc3545",
-            }
-            color = colors.get(obj.event_type, "#6c757d")
-            return format_html(
-                '<span style="background-color: {}; color: white; padding: 3px 8px; '
-                'border-radius: 3px; font-size: 11px; font-weight: bold;">{}</span>',
-                color,
-                obj.event_type.upper(),
-            )
+        def event_type_badge(self, obj) -> SafeString:
+            return _event_badge(obj.event_type)
 
         @admin.display(description="Data")
-        def data_preview(self, obj):
-            try:
-                data_str = json.dumps(obj.data, indent=2)
-                if len(data_str) > 100:
-                    data_str = data_str[:97] + "..."
-                return data_str.replace("\n", "<br>").replace(" ", "&nbsp;")
-            except (TypeError, ValueError):
-                return str(obj.data)
+        def data_preview(self, obj) -> str:
+            return _event_data_preview(obj.data, obj.payload_encoding)
 
         @admin.display(description="Streams")
         def stream_count(self, obj):

--- a/tests/test_django_rakaia/test_admin.py
+++ b/tests/test_django_rakaia/test_admin.py
@@ -16,6 +16,7 @@ from django_rakaia.admin import (
     register_stream_event_admin,
 )
 from django_rakaia.models import Stream, StreamEntry, StreamEvent
+from tests.test_django_rakaia.models import AppStreamEvent
 
 pytestmark = pytest.mark.django_db
 
@@ -177,3 +178,108 @@ class TestTheAdminAgreesWithEveryOtherReader:
         event = StreamEvent.objects.create(data={"n": 1}, event_type="create")
         preview = self._admin().data_preview(event)
         assert '"n"' in preview and "1" in preview
+
+
+class TestEveryAdminScreenAgrees:
+    """The same two questions, asked of each of the three screens.
+
+    #195 fixed the answer on the event list and left the entries list and the
+    factory an app registers its own event model with untouched — so a labelless
+    append still showed `APPEND` on two screens out of three, and the factory's
+    preview still printed a base64 body as base64 (#201). One test per screen,
+    because a test of the shared helper is exactly what would have missed this:
+    #195 had one, and both other screens were green throughout.
+
+    Each asks what the screen *renders*, not what it calls.
+    """
+
+    def _subclass_admin(self):
+        # The admin an app actually gets: `models.py` registers `AppStreamEvent`
+        # through `register_stream_event_admin` at import, so this is the same
+        # instance a consumer's site would serve.
+        return django_admin.site._registry[AppStreamEvent]
+
+    def _appended(self, label: str | None = None):
+        """One raw append through the store, and the entry it produced."""
+        from django_rakaia.django_store import DjangoStreamStore
+        from rakaia import AppendOptions
+
+        store = DjangoStreamStore()
+        store.create("s")
+        options = AppendOptions(label=label) if label is not None else None
+        store.append("s", b'{"n": 1}', options)
+        return store, StreamEntry.objects.get()
+
+    def test_the_entries_list_shows_no_label_for_a_labelless_append(self) -> None:
+        store, entry = self._appended()
+        badge = StreamEntryAdmin(StreamEntry, django_admin.site).event_type_badge(entry)
+
+        assert store.read("s")[0][0].label == ""
+        assert "APPEND" not in badge
+        # Deliberately absent, not blank — a blank badge reads as a bug.
+        assert "—" in badge
+
+    def test_the_entries_list_still_shows_a_real_label(self) -> None:
+        _, entry = self._appended(label="update")
+        badge = StreamEntryAdmin(StreamEntry, django_admin.site).event_type_badge(entry)
+        assert "UPDATE" in badge and "#ffc107" in badge
+
+    def test_a_registered_event_model_shows_no_label_for_a_labelless_append(
+        self,
+    ) -> None:
+        # The worst of the three: this is the copy a consumer inherits.
+        event = AppStreamEvent.objects.create(event_type="append", data={"n": 1})
+        badge = self._subclass_admin().event_type_badge(event)
+
+        assert "APPEND" not in badge
+        assert "—" in badge
+
+    def test_a_registered_event_model_still_shows_a_real_label(self) -> None:
+        event = AppStreamEvent.objects.create(event_type="delete", data={})
+        badge = self._subclass_admin().event_type_badge(event)
+        assert "DELETE" in badge and "#dc3545" in badge
+
+    def test_a_registered_event_model_does_not_preview_a_body_as_base64(self) -> None:
+        event = AppStreamEvent.objects.create(
+            data="//4AYmluYXJ5", event_type="append", payload_encoding="base64"
+        )
+        preview = self._subclass_admin().data_preview(event)
+
+        assert "//4AYmluYXJ5" not in preview, (
+            "the preview shows the stored base64 rather than saying what it is"
+        )
+        assert "base64" in preview and "9 bytes" in preview
+
+    def test_a_registered_event_model_previews_a_text_body_as_its_text(self) -> None:
+        event = AppStreamEvent.objects.create(
+            data="hello, world", event_type="append", payload_encoding="utf-8"
+        )
+        assert "hello, world" in self._subclass_admin().data_preview(event)
+
+    def test_a_registered_event_model_does_not_emit_raw_markup(self) -> None:
+        # It used to hand back `<br>`/`&nbsp;` in a plain string, which Django
+        # escapes — so the viewer read the tags rather than seeing the layout.
+        event = AppStreamEvent.objects.create(event_type="create", data={"a": 1})
+        preview = self._subclass_admin().data_preview(event)
+        assert "<br>" not in preview and "&nbsp;" not in preview
+        assert '"a": 1' in preview
+
+    def test_all_three_screens_render_one_append_the_same_way(self) -> None:
+        # The point of the shared helper: the next screen cannot disagree.
+        _, entry = self._appended()
+        event = entry.event
+
+        from_events = StreamEventAdmin(StreamEvent, django_admin.site)
+        from_entries = StreamEntryAdmin(StreamEntry, django_admin.site)
+        assert from_events.event_type_badge(event) == from_entries.event_type_badge(
+            entry
+        )
+
+        same = AppStreamEvent.objects.create(
+            event_type=event.event_type,
+            data=event.data,
+            payload_encoding=event.payload_encoding,
+        )
+        subclass = self._subclass_admin()
+        assert subclass.event_type_badge(same) == from_events.event_type_badge(event)
+        assert subclass.data_preview(same) == from_events.data_preview(event)

--- a/tests/test_django_rakaia/test_admin.py
+++ b/tests/test_django_rakaia/test_admin.py
@@ -171,7 +171,10 @@ class TestTheAdminAgreesWithEveryOtherReader:
         event = StreamEvent.objects.create(
             data="hello, world", event_type="append", payload_encoding="utf-8"
         )
-        assert "hello, world" in self._admin().data_preview(event)
+        # Equality, not containment: the JSON form `'"hello, world"'` contains
+        # the text too, so containment passes on a screen that ignores the
+        # encoding entirely.
+        assert self._admin().data_preview(event) == "hello, world"
 
     def test_an_ordinary_json_payload_previews_exactly_as_before(self):
         # The common case must not change shape.
@@ -254,7 +257,10 @@ class TestEveryAdminScreenAgrees:
         event = AppStreamEvent.objects.create(
             data="hello, world", event_type="append", payload_encoding="utf-8"
         )
-        assert "hello, world" in self._subclass_admin().data_preview(event)
+        # Exactly the text, not `json.dumps` of it. `"hello, world" in ...` is
+        # satisfied by the quoted JSON form, so it cannot see a screen that
+        # ignores `payload_encoding` — a green mutation found that gap.
+        assert self._subclass_admin().data_preview(event) == "hello, world"
 
     def test_a_registered_event_model_does_not_emit_raw_markup(self) -> None:
         # It used to hand back `<br>`/`&nbsp;` in a plain string, which Django

--- a/tests/test_django_rakaia/test_admin.py
+++ b/tests/test_django_rakaia/test_admin.py
@@ -176,6 +176,16 @@ class TestTheAdminAgreesWithEveryOtherReader:
         # encoding entirely.
         assert self._admin().data_preview(event) == "hello, world"
 
+    def test_a_long_text_body_is_cut_to_the_same_budget_as_json(self):
+        # The two branches share `_truncate` so a list cell cannot blow out on
+        # one and not the other; only the JSON branch was pinned, so dropping
+        # the call on this one was invisible.
+        event = StreamEvent.objects.create(
+            data="x" * 500, event_type="append", payload_encoding="utf-8"
+        )
+        preview = self._admin().data_preview(event)
+        assert len(preview) == 100 and preview.endswith("...")
+
     def test_an_ordinary_json_payload_previews_exactly_as_before(self):
         # The common case must not change shape.
         event = StreamEvent.objects.create(data={"n": 1}, event_type="create")


### PR DESCRIPTION
The event list in the admin was fixed to stop showing the internal placeholder we use for an event that carried no label, but two other screens were missed: the entries list, and the one an app gets when it registers its own event model. Both still printed the placeholder, so a plain append showed as APPEND there. The registered-model screen also previewed a binary body as unlabelled gibberish and emitted markup that came out as visible tags.

All three screens now render the label and the payload through one shared piece of code instead of each keeping its own copy, so the next screen cannot disagree by forgetting. Each screen has its own test for both cases, and each fix was reverted on its own to check the test catches it.

Closes #201.