### PR TITLE
Asking for the faster rebuild check no longer means passing the same list twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,24 @@ runnable demo for each.
   The individual pieces stay exported. This is the shortest route to a
   trustworthy answer, not the only permitted one.
 
+- **`diff_effects_against_rows(effects, preload=True)` — the bulk verification
+  path as one option.** Avoiding one query per row used to mean building a
+  `PreloadedProjectionReader` with your effects and then passing *the same*
+  effects to the diff, with nothing enforcing the "same". Get it wrong and you
+  got a report rather than an error: one resting partly on a snapshot of a
+  different batch, or — handing a generator to both — on nothing at all. The flag
+  builds the reader from the list the diff is already given, so there is no second
+  list to keep in step, and `using=` names the alias that reader reads from.
+
+  The bulk fetch is a point-in-time snapshot, so the flag is for read-only
+  verification and stays off during live staged replay, where the rows change as
+  the replay writes them. `PreloadedProjectionReader` remains exported for a
+  caller that needs it standalone, but handing one back to the diff now has to
+  cover that call's effects — `PreloadMismatch`, a new exported error, instead of
+  a half-snapshot answer — and `reader=` together with `preload=`/`using=` is a
+  `TypeError` rather than one of them quietly winning. `rebuild_and_verify()`
+  keeps its single bulk read and no longer composes the reader itself.
+
 - **`DjangoExecutor(normalizers=...)`, and `Normalizer` as an exported name.**
   Deciding whether a stored value differs from the one the log carries is one
   question, and two paths asked it: `diff_effects_against_rows` to check that

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -124,7 +124,7 @@ page is the contract.
 | `assert_no_live_writes` | `django_rakaia` | `(*models: 'type[Model]', using: 'str' = 'default') -> 'Iterator[None]'` | Assert the ``using`` row counts of ``models`` are unchanged across the block. |
 | `AmbientDatabaseAccess` | `django_rakaia` | — | A guarded connection alias was queried inside ``deny_database_access`` — a handler (or a helper it calls) read the database directly instead of through the injected reader. |
 | `LiveWriteLeaked` | `django_rakaia` | — | A guarded model's row count changed inside ``assert_no_live_writes`` — a rebuild mutated the live database it was only supposed to reconstruct. |
-| `diff_effects_against_rows` | `django_rakaia` | `(effects: 'Iterable[Effect]', *, reader: 'DjangoProjectionReader \| None' = None, normalizers: 'Sequence[Normalizer] \| None' = None, kinds: 'tuple[type, ...]' = (<class 'rakaia.effects.Upsert'>, <class 'rakaia.effects.Update'>)) -> 'DiffReport'` | Diff each write effect's ``defaults`` against its live projection row. |
+| `diff_effects_against_rows` | `django_rakaia` | `(effects: 'Iterable[Effect]', *, reader: 'DjangoProjectionReader \| None' = None, preload: 'bool' = False, using: 'str \| None' = None, normalizers: 'Sequence[Normalizer] \| None' = None, kinds: 'tuple[type, ...]' = (<class 'rakaia.effects.Upsert'>, <class 'rakaia.effects.Update'>)) -> 'DiffReport'` | Diff each write effect's ``defaults`` against its live projection row. |
 | `DiffReport` | `django_rakaia` | `(rows: 'list[RowDiff]') -> None` | Aggregate result of :func:`diff_effects_against_rows`. |
 | `RowDiff` | `django_rakaia` | `(model_label: 'str', lookup: 'dict[str, Any]', missing: 'bool', field_diffs: 'list[FieldDiff]' = <factory>) -> None` | The verification outcome for one write effect's target row. |
 | `FieldDiff` | `django_rakaia` | `(field: 'str', expected: 'Any', actual: 'Any') -> None` | One field whose stored value disagrees with the effect's ``defaults``. |
@@ -134,6 +134,7 @@ page is the contract.
 | `VACUOUS` | `django_rakaia` | — | — |
 | `VacuousVerification` | `django_rakaia` | `(report: 'DiffReport') -> 'None'` | Raised by :meth:`DiffReport.raise_if_diff` when nothing was compared. |
 | `VerificationError` | `django_rakaia` | `(report: 'DiffReport') -> 'None'` | Raised by :meth:`DiffReport.raise_if_diff` when a projection disagrees. |
+| `PreloadMismatch` | `django_rakaia` | — | A :class:`PreloadedProjectionReader` was handed to :func:`diff_effects_against_rows` together with effects its bulk fetch does not cover. |
 
 ## Audit trails and provenance
 
@@ -226,6 +227,6 @@ page is the contract.
 
 ## Appendix — coverage
 
-135 exported names across 14 sections. 119 carry a docstring; 16 do not and show `—` above.
+136 exported names across 14 sections. 120 carry a docstring; 16 do not and show `—` above.
 
 Undocumented: `AnyEffect`, `DEFAULT_NORMALIZERS`, `ENVELOPE_TS`, `Effect`, `GREEN`, `HANDLERS_META_STREAM`, `Normalizer`, `PollStatus`, `ProducerValidationResult`, `RED`, `REDUCERS_META_STREAM`, `SCRATCH_PATH`, `UPCASTERS_META_STREAM`, `VACUOUS`, `__version__`, `app`.

--- a/docs/projection-cookbook.md
+++ b/docs/projection-cookbook.md
@@ -158,26 +158,28 @@ unaffected; `.certified` is the stricter property a migration proof wants.
 
 The diff does one `reader.get` per effect — one round-trip each. Fine for a
 cookbook; on a full reconcile (tens of thousands of effects) it is tens of
-thousands of round-trips. Give the *same* batch to a
-[`PreloadedProjectionReader`](../src/django_rakaia/verification.py) and it
-bulk-fetches every lookup up front, one query per `(model, lookup-shape)` group,
-then serves each `get` from an in-memory snapshot:
+thousands of round-trips. `preload=True` fetches every lookup in the batch up
+front instead, one query per `(model, lookup-shape)` group, and serves each
+comparison from that snapshot:
 
 ```python
-from django_rakaia import (
-    PreloadedProjectionReader,
-    diff_effects_against_rows,
-)
+from django_rakaia import diff_effects_against_rows
 
-effects = list(ex.effects)
-reader = PreloadedProjectionReader(effects, using="rebuild")   # one bulk fetch per shape
-diff_effects_against_rows(effects, reader=reader).raise_if_diff()
+diff_effects_against_rows(ex.effects, preload=True, using="rebuild").raise_if_diff()
 ```
 
-It is a **point-in-time snapshot** — build it for read-only verification, not for
-live staged replay (where rows change as the replay writes them; use a plain
-`DjangoProjectionReader` there). A `get` for a lookup outside the batch, or one
-that spans a relation (`field__gte`), falls back to a live query and memoises it.
+The bulk fetch is a **point-in-time snapshot** — use it for read-only
+verification, not for live staged replay, where the rows change as the replay
+writes them and the snapshot is simply wrong. Leave the flag off there.
+
+The reader behind the flag,
+[`PreloadedProjectionReader`](../src/django_rakaia/verification.py), stays public
+for a caller that needs it on its own; a `get` for a lookup outside its batch, or
+one that spans a relation (`field__gte`), falls back to a live query and memoises
+it. Passing one back in as `reader=` still works, but it must have been built from
+the effects being diffed — the diff raises `PreloadMismatch` rather than answering
+half from a snapshot of another batch, which is what `preload=True` exists to make
+unnecessary. `reader=` and `preload=`/`using=` are mutually exclusive.
 
 ## Run it
 

--- a/scripts/gen_api_reference.py
+++ b/scripts/gen_api_reference.py
@@ -129,6 +129,7 @@ GROUPS: dict[str, tuple[str, ...]] = {
         "VACUOUS",
         "VacuousVerification",
         "VerificationError",
+        "PreloadMismatch",
     ),
     "Audit trails and provenance": (
         "provenance",

--- a/src/django_rakaia/__init__.py
+++ b/src/django_rakaia/__init__.py
@@ -73,6 +73,7 @@ _EXPORTS: dict[str, str] = {
     # -- verifying a rebuild -------------------------------------------------
     "diff_effects_against_rows": "django_rakaia.verification",
     "PreloadedProjectionReader": "django_rakaia.verification",
+    "PreloadMismatch": "django_rakaia.verification",
     "DiffReport": "django_rakaia.verification",
     "RowDiff": "django_rakaia.verification",
     "FieldDiff": "django_rakaia.verification",

--- a/src/django_rakaia/rebuild.py
+++ b/src/django_rakaia/rebuild.py
@@ -3,8 +3,9 @@ reconstruct this projection, and does the result match what production holds?**
 
 Answering it by hand means composing six interfaces in the right order — move the
 log off the guarded database, arm the write guard outside and the read guard
-inside, record the effects while still applying them, replay, diff in bulk — and then separately remembering the part that is written down
-nowhere: *a pass means nothing unless the guards were actually armed.*
+inside, record the effects while still applying them, replay, diff in bulk — and
+then separately remembering the part that is written down nowhere: *a pass means
+nothing unless the guards were actually armed.*
 `hermeticity.py` says so in prose and leaves it to the caller's discipline. ADR
 0003 records what that discipline is worth in practice: the first production
 consumer left the read guard unwired for months.

--- a/src/django_rakaia/rebuild.py
+++ b/src/django_rakaia/rebuild.py
@@ -3,8 +3,7 @@ reconstruct this projection, and does the result match what production holds?**
 
 Answering it by hand means composing six interfaces in the right order — move the
 log off the guarded database, arm the write guard outside and the read guard
-inside, record the effects while still applying them, replay, build a batch
-reader, diff — and then separately remembering the part that is written down
+inside, record the effects while still applying them, replay, diff in bulk — and then separately remembering the part that is written down
 nowhere: *a pass means nothing unless the guards were actually armed.*
 `hermeticity.py` says so in prose and leaves it to the caller's discipline. ADR
 0003 records what that discipline is worth in practice: the first production
@@ -47,12 +46,7 @@ from .hermeticity import (
     deny_database_access,
 )
 from .projection_reader import DjangoProjectionReader
-from .verification import (
-    DiffReport,
-    Normalizer,
-    PreloadedProjectionReader,
-    diff_effects_against_rows,
-)
+from .verification import DiffReport, Normalizer, diff_effects_against_rows
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
     from django.db.models import Model
@@ -249,10 +243,14 @@ def rebuild_and_verify(
                 reader=DjangoProjectionReader(using=into),
             )
 
-        # Guard down: the diff's whole job is to read the live rows.
-        reader = PreloadedProjectionReader(recorder.effects, using=live_using)
+        # Guard down: the diff's whole job is to read the live rows. `preload`
+        # is the bulk-fetching reader — one query per lookup shape rather than
+        # one per effect — built by the diff from the batch it is diffing.
         return diff_effects_against_rows(
-            recorder.effects, reader=reader, normalizers=normalizers
+            recorder.effects,
+            preload=True,
+            using=live_using,
+            normalizers=normalizers,
         )
 
 

--- a/src/django_rakaia/verification.py
+++ b/src/django_rakaia/verification.py
@@ -69,6 +69,7 @@ __all__ = [
     # defined here
     "DiffReport",
     "FieldDiff",
+    "PreloadMismatch",
     "PreloadedProjectionReader",
     "RowDiff",
     "VacuousVerification",
@@ -257,6 +258,23 @@ class VacuousVerification(AssertionError):
         super().__init__(str(report))
 
 
+class PreloadMismatch(ValueError):
+    """A :class:`PreloadedProjectionReader` was handed to
+    :func:`diff_effects_against_rows` together with effects its bulk fetch does
+    not cover.
+
+    The reader is a snapshot of *the batch it was constructed with*. Diff a
+    different batch through it and the rows outside the snapshot are answered
+    from a live query taken later — so a report can rest on two different
+    readings of the database and say nothing about it. Raised rather than
+    tolerated: the mismatch produces a wrong answer, not a slow one.
+
+    Reaching this at all is avoidable — ``diff_effects_against_rows(effects,
+    preload=True)`` builds the reader from the same list it diffs, so there is
+    no second list to keep in step.
+    """
+
+
 # =============================================================================
 # Default normalizers
 # =============================================================================
@@ -271,6 +289,8 @@ def diff_effects_against_rows(
     effects: Iterable[Effect],
     *,
     reader: DjangoProjectionReader | None = None,
+    preload: bool = False,
+    using: str | None = None,
     normalizers: Sequence[Normalizer] | None = None,
     kinds: tuple[type, ...] = _WRITE_EFFECTS,
 ) -> DiffReport:
@@ -283,9 +303,52 @@ def diff_effects_against_rows(
 
     ``normalizers`` defaults to :data:`DEFAULT_NORMALIZERS` (UUID + Decimal); pass
     an explicit list to extend or replace them, or ``[]`` to compare raw values.
+
+    Args:
+        effects: The batch to check.
+        preload: Fetch the batch's rows in bulk up front — one query per
+            ``(model, lookup-shape)`` group instead of one ``SELECT`` per effect
+            (see :class:`PreloadedProjectionReader`, which this builds from
+            *this* call's ``effects``, so the two can never be different lists).
+            **Read-only verification only.** The bulk fetch is a point-in-time
+            snapshot, so it is wrong during live staged replay, where the rows
+            change as the replay writes them; leave it off there.
+        using: The connection alias the reader built here reads from. Defaults to
+            Django's default alias.
+        reader: An explicit reader, for a lookup source this function should not
+            choose. Mutually exclusive with ``preload`` and ``using``, which
+            configure the reader this function builds: passing both is a
+            :class:`TypeError` rather than one of them silently winning.
+
+    Raises:
+        TypeError: ``reader`` was passed together with ``preload`` or ``using``.
+        PreloadMismatch: ``reader`` is a :class:`PreloadedProjectionReader` whose
+            bulk fetch does not cover these effects — the mismatch this
+            function's ``preload=True`` exists to make unreachable.
     """
-    active_reader = reader if reader is not None else DjangoProjectionReader()
+    if reader is not None and (preload or using is not None):
+        raise TypeError(
+            "diff_effects_against_rows() got reader= together with "
+            "preload=/using=, which configure the reader it would build itself. "
+            "Pass one or the other: preload=True for the bulk-fetching reader, "
+            "or a fully configured reader= (a PreloadedProjectionReader built "
+            "from these same effects, if that is what you want)."
+        )
     active_norms = DEFAULT_NORMALIZERS if normalizers is None else tuple(normalizers)
+
+    active_reader: DjangoProjectionReader
+    if reader is None and preload:
+        # One list, used for both the bulk fetch and the diff below. This is the
+        # whole point of the flag: there is no second list to drift.
+        effects = list(effects)
+        active_reader = PreloadedProjectionReader(effects, using=using)
+    elif reader is None:
+        active_reader = DjangoProjectionReader(using=using)
+    else:
+        active_reader = reader
+        if isinstance(active_reader, PreloadedProjectionReader):
+            effects = list(effects)
+            _require_preload_covers(active_reader, effects, kinds)
 
     rows: list[RowDiff] = []
     for eff in effects:
@@ -316,12 +379,16 @@ class PreloadedProjectionReader(DjangoProjectionReader):
 
     :func:`diff_effects_against_rows` does one ``reader.get`` per effect, which is
     one round-trip per effect: fine for a handful, thousands on a full reconcile
-    sweep. Give the *same* batch to this reader and to the diff and that collapses
-    to **one query per (model, lookup-shape) group**::
+    sweep. Preloading collapses that to **one query per (model, lookup-shape)
+    group**, and the way to ask for it is::
 
-        effects = list(collecting_executor.effects)
-        reader = PreloadedProjectionReader(effects, using="rebuild")
-        diff_effects_against_rows(effects, reader=reader).raise_if_diff()
+        diff_effects_against_rows(effects, preload=True).raise_if_diff()
+
+    which builds this reader from the same list it diffs. Constructing it by hand
+    is for a caller that needs the reader on its own (a lookup loop outside a
+    diff, or as the ``reader=`` of something else) — a hand-built reader passed
+    back into the diff must cover that call's effects, or the diff raises
+    :class:`PreloadMismatch` rather than answering from a partial snapshot.
 
     Semantics and limits:
 
@@ -345,6 +412,11 @@ class PreloadedProjectionReader(DjangoProjectionReader):
         # such row" — a real cached answer). A key *absent* from the map has never
         # been fetched, so get() does a live lookup and memoises it.
         self._cache: dict[tuple[str, tuple], Any] = {}
+        # The keys the bulk fetch asked for — what this snapshot covers. A key
+        # added to `_cache` later by a live fallback is deliberately not in here:
+        # it was read at a different moment, which is exactly what
+        # `PreloadMismatch` is about.
+        self._preloaded: set[tuple[str, tuple]] = set()
         self._preload(effects)
 
     def _preload(self, effects: Iterable[Effect]) -> None:
@@ -381,6 +453,7 @@ class PreloadedProjectionReader(DjangoProjectionReader):
                 ):  # first row wins, mirroring get()->first()
                     requested[key] = row
             self._cache.update(requested)
+            self._preloaded.update(requested)
 
     def _fetch(
         self, model_label: str, fields: tuple[str, ...], lookups: list[dict[str, Any]]
@@ -408,6 +481,18 @@ class PreloadedProjectionReader(DjangoProjectionReader):
             for f, v in sorted(items, key=lambda kv: kv[0])
         )
 
+    def preloaded(self, model_label: str, lookup: dict[str, Any]) -> bool:
+        """Whether this reader's bulk fetch covers ``lookup`` on ``model_label``.
+
+        The snapshot's own account of what it holds, so
+        :func:`diff_effects_against_rows` can refuse a reader built from another
+        batch instead of quietly falling back to a live query for the rest.
+        """
+        if not lookup or any("__" in k for k in lookup):
+            return False
+        model = apps.get_model(model_label)
+        return (model_label, self._key(model, lookup.items())) in self._preloaded
+
     def get(self, model_label: str, /, **lookup: Any) -> Any | None:
         if any("__" in k for k in lookup):
             return super().get(model_label, **lookup)  # spanning — not preloadable
@@ -426,6 +511,38 @@ class PreloadedProjectionReader(DjangoProjectionReader):
 # =============================================================================
 # Internal
 # =============================================================================
+
+
+def _require_preload_covers(
+    reader: PreloadedProjectionReader,
+    effects: Sequence[Effect],
+    kinds: tuple[type, ...],
+) -> None:
+    """Refuse a preloaded reader that was built from a different batch.
+
+    Only the lookups the reader *could* have preloaded are checked: an empty or
+    relation-spanning lookup is documented as always live, so its absence from
+    the snapshot says nothing about which batch built the reader.
+    """
+    uncovered = [
+        eff
+        for eff in effects
+        if isinstance(eff, kinds)
+        and eff.lookup
+        and not any("__" in k for k in eff.lookup)
+        and not reader.preloaded(eff.model_label, eff.lookup)
+    ]
+    if not uncovered:
+        return
+    first = uncovered[0]
+    raise PreloadMismatch(
+        f"the PreloadedProjectionReader passed as reader= did not preload "
+        f"{len(uncovered)} of the {len(effects)} effect(s) being diffed (first: "
+        f"{first.model_label} {first.lookup!r}), so it was built from a "
+        f"different batch and this diff would rest on two readings of the "
+        f"database. Call diff_effects_against_rows(effects, preload=True) "
+        f"instead, which builds the reader from the effects it diffs."
+    )
 
 
 def _diff_row(

--- a/src/django_rakaia/verification.py
+++ b/src/django_rakaia/verification.py
@@ -424,10 +424,8 @@ class PreloadedProjectionReader(DjangoProjectionReader):
         # names) — so one query per shape fetches all of its rows at once.
         by_shape: dict[tuple[str, tuple[str, ...]], list[dict[str, Any]]] = {}
         for eff in effects:
-            if not eff.lookup:
+            if not _preloadable(eff.lookup):
                 continue
-            if any("__" in k for k in eff.lookup):
-                continue  # spanning lookup — can't index by exact match; left to live get()
             shape = (eff.model_label, tuple(sorted(eff.lookup)))
             by_shape.setdefault(shape, []).append(eff.lookup)
 
@@ -487,9 +485,12 @@ class PreloadedProjectionReader(DjangoProjectionReader):
         The snapshot's own account of what it holds, so
         :func:`diff_effects_against_rows` can refuse a reader built from another
         batch instead of quietly falling back to a live query for the rest.
+
+        A lookup :func:`_preloadable` excluded is never in the snapshot, so this
+        answers ``False`` for it without re-testing that — the exclusion is
+        decided in one place, and asking here whether it *could* have been
+        preloaded is a different question from whether it was.
         """
-        if not lookup or any("__" in k for k in lookup):
-            return False
         model = apps.get_model(model_label)
         return (model_label, self._key(model, lookup.items())) in self._preloaded
 
@@ -513,23 +514,30 @@ class PreloadedProjectionReader(DjangoProjectionReader):
 # =============================================================================
 
 
+def _preloadable(lookup: dict[str, Any]) -> bool:
+    """Whether a bulk fetch can index this lookup by exact match.
+
+    The one place that decides it, for the two that care: the preload skips what
+    it cannot index, and the coverage check must skip exactly the same lookups or
+    it would refuse a reader for holding what it was never able to hold. An empty
+    lookup scopes the whole model, and a spanning one (``field__gte``, a
+    relation) is not an equality on a stored column; both are documented as
+    always-live on :class:`PreloadedProjectionReader`.
+    """
+    return bool(lookup) and not any("__" in k for k in lookup)
+
+
 def _require_preload_covers(
     reader: PreloadedProjectionReader,
     effects: Sequence[Effect],
     kinds: tuple[type, ...],
 ) -> None:
-    """Refuse a preloaded reader that was built from a different batch.
-
-    Only the lookups the reader *could* have preloaded are checked: an empty or
-    relation-spanning lookup is documented as always live, so its absence from
-    the snapshot says nothing about which batch built the reader.
-    """
+    """Refuse a preloaded reader that was built from a different batch."""
     uncovered = [
         eff
         for eff in effects
         if isinstance(eff, kinds)
-        and eff.lookup
-        and not any("__" in k for k in eff.lookup)
+        and _preloadable(eff.lookup)
         and not reader.preloaded(eff.model_label, eff.lookup)
     ]
     if not uncovered:

--- a/tests/test_django_rakaia/test_preloaded_reader.py
+++ b/tests/test_django_rakaia/test_preloaded_reader.py
@@ -14,12 +14,13 @@ from decimal import Decimal
 from uuid import uuid4
 
 import pytest
-from django.db import connection
+from django.db import connection, connections
 from django.test.utils import CaptureQueriesContext
 
 from django_rakaia.projection_reader import DjangoProjectionReader
 from django_rakaia.verification import (
     PreloadedProjectionReader,
+    PreloadMismatch,
     diff_effects_against_rows,
 )
 from rakaia.effects import Effect, Upsert
@@ -165,3 +166,143 @@ class TestPreloadedProjectionReader:
         assert (
             reader.get("test_django_rakaia.FinanceLine", submission_id="s1") is not None
         )
+
+
+@pytest.mark.django_db
+class TestPreloadOption:
+    """``diff_effects_against_rows(effects, preload=True)`` — the fast path as one
+    option on the diff (#190).
+
+    The pattern this replaces was: build a ``PreloadedProjectionReader`` with your
+    effects, then pass *the same* effects to the diff, with nothing enforcing the
+    "same". Getting it wrong returned a report rather than an error — a report
+    resting on a snapshot of a different batch. With the flag there is one list,
+    so there is nothing to keep in step.
+    """
+
+    def test_preload_agrees_with_the_plain_path(self):
+        for i in range(6):
+            FinanceLine.objects.create(submission_id=f"s{i}", suku="A", delta=i)
+        # One row deliberately wrong, so agreement covers a RED verdict too.
+        FinanceLine.objects.filter(submission_id="s3").update(delta=99)
+        effects = [_finance_effect(f"s{i}", "A", i) for i in range(6)]
+
+        slow = diff_effects_against_rows(effects)
+        fast = diff_effects_against_rows(effects, preload=True)
+
+        assert fast.verdict == slow.verdict == "red"
+        assert fast.compared == slow.compared == 6
+        assert [str(p) for p in fast.problems] == [str(p) for p in slow.problems]
+
+    def test_preload_uses_one_query_for_the_whole_sweep(self):
+        for i in range(10):
+            FinanceLine.objects.create(submission_id=f"s{i}", suku="A", delta=i)
+        effects = [_finance_effect(f"s{i}", "A", i) for i in range(10)]
+
+        with CaptureQueriesContext(connection) as fast:
+            assert diff_effects_against_rows(effects, preload=True).ok
+        with CaptureQueriesContext(connection) as slow:
+            assert diff_effects_against_rows(effects).ok
+
+        assert len(fast) == 1  # one `submission_id__in=[...]` for the batch
+        assert len(slow) == 10  # the cost the flag exists to remove
+
+    def test_preload_consumes_a_one_shot_iterable_once(self):
+        """The drift the two-argument pattern allowed, at its sharpest.
+
+        Handing a generator to the reader *and* to the diff left the diff an
+        exhausted iterator: nothing compared, and only ``raise_if_diff``'s
+        vacuity guard between that and a report that reads as a pass. One list
+        means the flag cannot lose the batch.
+        """
+        for i in range(4):
+            FinanceLine.objects.create(submission_id=f"s{i}", suku="A", delta=i)
+        effects = (_finance_effect(f"s{i}", "A", i) for i in range(4))
+
+        report = diff_effects_against_rows(effects, preload=True)
+
+        assert report.compared == 4 and report.certified
+
+    def test_reader_together_with_preload_is_refused(self):
+        effects = [_finance_effect("s1", "A", 1)]
+        with pytest.raises(TypeError, match="preload=/using="):
+            diff_effects_against_rows(
+                effects, reader=DjangoProjectionReader(), preload=True
+            )
+
+    def test_reader_together_with_using_is_refused(self):
+        effects = [_finance_effect("s1", "A", 1)]
+        with pytest.raises(TypeError, match="preload=/using="):
+            diff_effects_against_rows(
+                effects, reader=DjangoProjectionReader(), using="overlay"
+            )
+
+    def test_a_reader_built_from_another_batch_is_refused(self):
+        """The misuse that used to answer instead of raising.
+
+        The reader below was preloaded with one effect and the diff is given two,
+        so half the report would come from the snapshot and half from live
+        queries taken afterwards.
+        """
+        FinanceLine.objects.create(submission_id="s1", suku="A", delta=1)
+        FinanceLine.objects.create(submission_id="s2", suku="A", delta=2)
+        preloaded = [_finance_effect("s1", "A", 1)]
+        diffed = [*preloaded, _finance_effect("s2", "A", 2)]
+
+        reader = PreloadedProjectionReader(preloaded)
+        with pytest.raises(PreloadMismatch, match="did not preload 1 of the 2"):
+            diff_effects_against_rows(diffed, reader=reader)
+
+        # The covering batch is still accepted, so the standalone reader remains
+        # usable with the diff for a caller that genuinely needs it.
+        assert diff_effects_against_rows(preloaded, reader=reader).certified
+
+    def test_a_live_fallback_does_not_count_as_covered(self):
+        """A memoised live answer is a reading taken at another moment, so it must
+        not satisfy the coverage check — otherwise touching the reader first would
+        launder a mismatched batch."""
+        FinanceLine.objects.create(submission_id="s1", suku="A", delta=1)
+        FinanceLine.objects.create(submission_id="s2", suku="A", delta=2)
+        reader = PreloadedProjectionReader([_finance_effect("s1", "A", 1)])
+        assert reader.get("test_django_rakaia.FinanceLine", submission_id="s2")
+
+        with pytest.raises(PreloadMismatch):
+            diff_effects_against_rows(
+                [_finance_effect("s1", "A", 1), _finance_effect("s2", "A", 2)],
+                reader=reader,
+            )
+
+    def test_unpreloadable_lookups_are_not_a_mismatch(self):
+        """A spanning lookup is documented as always live, so its absence from the
+        snapshot says nothing about which batch built the reader."""
+        FinanceLine.objects.create(submission_id="s1", suku="A", delta=5)
+        spanning = Upsert(
+            model_label="test_django_rakaia.FinanceLine",
+            lookup={"delta__gte": 1},
+            defaults={"suku": "A"},
+        )
+        effects = [_finance_effect("s1", "A", 5), spanning]
+        reader = PreloadedProjectionReader(effects)
+        assert diff_effects_against_rows(effects, reader=reader).certified
+
+
+@pytest.mark.django_db(transaction=True, databases=["default", "overlay"])
+def test_using_routes_the_reader_the_diff_builds() -> None:
+    """``using=`` is the other half of building the reader internally: without it
+    the fast path on a non-default alias would still need a hand-built reader,
+    which is the pattern #190 removes. Alias-aware, so `transaction=True` per
+    CLAUDE.md rather than a lent transaction on both aliases."""
+    FinanceLine.objects.using("overlay").create(submission_id="o1", suku="A", delta=1)
+    effects = [_finance_effect("o1", "A", 1)]
+
+    # The row exists only on `overlay`, so the alias is load-bearing on both of
+    # the readers the diff can build.
+    assert diff_effects_against_rows(effects, using="overlay").certified
+    assert diff_effects_against_rows(effects, preload=True, using="overlay").certified
+    assert not diff_effects_against_rows(effects).certified
+
+    with CaptureQueriesContext(connections["overlay"]) as ctx:
+        assert diff_effects_against_rows(
+            effects, preload=True, using="overlay"
+        ).certified
+    assert len(ctx) == 1

--- a/tests/test_django_rakaia/test_preloaded_reader.py
+++ b/tests/test_django_rakaia/test_preloaded_reader.py
@@ -23,7 +23,7 @@ from django_rakaia.verification import (
     PreloadMismatch,
     diff_effects_against_rows,
 )
-from rakaia.effects import Effect, Upsert
+from rakaia.effects import Effect, Update, Upsert
 
 from .models import Alert, FinanceLine, Measure
 
@@ -138,6 +138,24 @@ class TestPreloadedProjectionReader:
         assert (
             reader.get("test_django_rakaia.FinanceLine", submission_id="late") is None
         )
+
+    def test_empty_lookup_is_not_preloaded_and_reads_live(self):
+        # The other shape a bulk fetch cannot index: an empty lookup scopes the
+        # whole model, so preloading it would cache one arbitrary row as *the*
+        # answer (and scan the table to get it). It stays live, which is visible
+        # as a row created after construction being the answer.
+        reader = PreloadedProjectionReader(
+            [
+                Update(
+                    model_label="test_django_rakaia.FinanceLine",
+                    lookup={},
+                    defaults={"suku": "A"},
+                )
+            ]
+        )
+        FinanceLine.objects.create(submission_id="s1", suku="A", delta=1)
+        row = reader.get("test_django_rakaia.FinanceLine")
+        assert row is not None and row.submission_id == "s1"
 
     def test_spanning_lookup_is_not_preloaded_and_reads_live(self):
         FinanceLine.objects.create(submission_id="s1", suku="A", delta=5)
@@ -272,7 +290,7 @@ class TestPreloadOption:
                 reader=reader,
             )
 
-    def test_unpreloadable_lookups_are_not_a_mismatch(self):
+    def test_a_spanning_lookup_is_not_a_mismatch(self):
         """A spanning lookup is documented as always live, so its absence from the
         snapshot says nothing about which batch built the reader."""
         FinanceLine.objects.create(submission_id="s1", suku="A", delta=5)
@@ -285,13 +303,30 @@ class TestPreloadOption:
         reader = PreloadedProjectionReader(effects)
         assert diff_effects_against_rows(effects, reader=reader).certified
 
+    def test_an_empty_lookup_is_not_a_mismatch(self):
+        """The other always-live shape: an empty lookup scopes the whole model
+        (`Update({})` — update every row), so the snapshot cannot index it and
+        must not be blamed for not holding it."""
+        FinanceLine.objects.create(submission_id="s1", suku="A", delta=5)
+        whole_model = Update(
+            model_label="test_django_rakaia.FinanceLine",
+            lookup={},
+            defaults={"suku": "A"},
+        )
+        effects = [_finance_effect("s1", "A", 5), whole_model]
+        reader = PreloadedProjectionReader(effects)
+        assert diff_effects_against_rows(effects, reader=reader).certified
 
-@pytest.mark.django_db(transaction=True, databases=["default", "overlay"])
+
+@pytest.mark.django_db(databases=["default", "overlay"])
 def test_using_routes_the_reader_the_diff_builds() -> None:
     """``using=`` is the other half of building the reader internally: without it
     the fast path on a non-default alias would still need a hand-built reader,
-    which is the pattern #190 removes. Alias-aware, so `transaction=True` per
-    CLAUDE.md rather than a lent transaction on both aliases."""
+    which is the pattern #190 removes.
+
+    A plain marker on both aliases, not `transaction=True`: the diff only reads,
+    so there is no `atomic(using=)` for a lent transaction to supply and nothing
+    here whose failure mode is a lock (#148)."""
     FinanceLine.objects.using("overlay").create(submission_id="o1", suku="A", delta=1)
     effects = [_finance_effect("o1", "A", 1)]
 

--- a/tests/test_django_rakaia/test_preloaded_reader.py
+++ b/tests/test_django_rakaia/test_preloaded_reader.py
@@ -23,7 +23,7 @@ from django_rakaia.verification import (
     PreloadMismatch,
     diff_effects_against_rows,
 )
-from rakaia.effects import Effect, Update, Upsert
+from rakaia.effects import Delete, Effect, Update, Upsert
 
 from .models import Alert, FinanceLine, Measure
 
@@ -302,6 +302,24 @@ class TestPreloadOption:
         effects = [_finance_effect("s1", "A", 5), spanning]
         reader = PreloadedProjectionReader(effects)
         assert diff_effects_against_rows(effects, reader=reader).certified
+
+    def test_an_effect_the_diff_never_reads_is_not_required_to_be_covered(self):
+        """Coverage is about the lookups this diff will make, not the batch.
+
+        A delete carries no values to diff, so the diff never asks the reader for
+        its row — and a reader built from only what *will* be read is correct.
+        Blaming it for the delete would refuse a legitimate reader (the same holds
+        for a narrower ``kinds=``).
+        """
+        FinanceLine.objects.create(submission_id="s1", suku="A", delta=1)
+        read = _finance_effect("s1", "A", 1)
+        never_read = Delete(
+            model_label="test_django_rakaia.FinanceLine",
+            lookup={"submission_id": "gone"},
+        )
+        reader = PreloadedProjectionReader([read])
+
+        assert diff_effects_against_rows([read, never_read], reader=reader).certified
 
     def test_an_empty_lookup_is_not_a_mismatch(self):
         """The other always-live shape: an empty lookup scopes the whole model

--- a/tests/test_django_rakaia/test_preloaded_reader.py
+++ b/tests/test_django_rakaia/test_preloaded_reader.py
@@ -241,6 +241,22 @@ class TestPreloadOption:
 
         assert report.compared == 4 and report.certified
 
+    def test_an_explicit_preloaded_reader_also_survives_a_one_shot_iterable(self):
+        """The coverage check walks the effects, so it must not be the only walk.
+
+        Reading them twice would leave the diff loop an exhausted iterator and a
+        report of nothing — `.ok` vacuously true — from a call that looked
+        entirely correct.
+        """
+        for i in range(4):
+            FinanceLine.objects.create(submission_id=f"s{i}", suku="A", delta=i)
+        batch = [_finance_effect(f"s{i}", "A", i) for i in range(4)]
+        reader = PreloadedProjectionReader(batch)
+
+        report = diff_effects_against_rows(iter(batch), reader=reader)
+
+        assert report.compared == 4 and report.certified
+
     def test_reader_together_with_preload_is_refused(self):
         effects = [_finance_effect("s1", "A", 1)]
         with pytest.raises(TypeError, match="preload=/using="):

--- a/tests/test_django_rakaia/test_rebuild.py
+++ b/tests/test_django_rakaia/test_rebuild.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import pytest
 from django.db import connection
+from django.test.utils import CaptureQueriesContext
 
 from django_rakaia.django_store import DjangoStreamStore
 from django_rakaia.rebuild import rebuild_and_verify
@@ -91,6 +92,28 @@ class TestTheVerdict:
 
         assert report.certified
         assert report.compared == 2
+
+    def test_the_final_diff_reads_the_live_rows_in_one_query(self):
+        """The gate keeps the bulk read, and does not need a second effect list
+        to get it: it asks the diff for `preload=True` (#190). One `IN (...)`
+        over the batch, not one `SELECT` per effect."""
+        rows = [{"id": f"r{i}", "suku": "s", "delta": i} for i in range(5)]
+        _seed_log(*rows)
+        _live(*rows)
+
+        with CaptureQueriesContext(connection) as ctx:
+            report = rebuild_and_verify(
+                PATH, into="overlay", live_models=[FinanceLine], registry=_registry()
+            )
+
+        assert report.certified and report.compared == 5
+        # The write guard's own row counts are not the diff's reads.
+        reads = [
+            q["sql"]
+            for q in ctx.captured_queries
+            if "financeline" in q["sql"].lower() and "count" not in q["sql"].lower()
+        ]
+        assert len(reads) == 1, reads
 
     def test_a_drifted_row_is_reported_not_raised(self):
         _seed_log({"id": "a", "suku": "s1", "delta": 1})

--- a/tests/test_django_rakaia/test_rebuild.py
+++ b/tests/test_django_rakaia/test_rebuild.py
@@ -107,11 +107,12 @@ class TestTheVerdict:
             )
 
         assert report.certified and report.compared == 5
-        # The write guard's own row counts are not the diff's reads.
+        # `q["sql"]` is None for a transaction-control statement on Postgres, and
+        # the write guard's own row counts are not the diff's reads.
         reads = [
-            q["sql"]
-            for q in ctx.captured_queries
-            if "financeline" in q["sql"].lower() and "count" not in q["sql"].lower()
+            sql
+            for sql in ((q["sql"] or "").lower() for q in ctx.captured_queries)
+            if "financeline" in sql and "count" not in sql
         ]
         assert len(reads) == 1, reads
 

--- a/tests/test_rakaia/test_public_api.py
+++ b/tests/test_rakaia/test_public_api.py
@@ -147,6 +147,10 @@ DJANGO_RAKAIA_PUBLIC = {
     # without importing a submodule.
     "Normalizer",
     "PreloadedProjectionReader",
+    # Added with `diff_effects_against_rows(preload=True)` (#190): the diff
+    # refuses a hand-built preloaded reader that covers a different batch, and a
+    # consumer catching that needs to name the error without a submodule import.
+    "PreloadMismatch",
     "GuardNotArmed",
     "ProvenanceMiddleware",
     "RED",


### PR DESCRIPTION
Checking a rebuild without one database query per row used to mean building a helper with your list of expected writes and then handing the same list to the comparison, with nothing checking that the two matched. Getting it wrong gave you an answer instead of an error. The comparison now takes a single `preload=True` option and builds the helper itself from the list it was given, so there is no second list to keep in step.

The helper is still available on its own for anyone who needs it, but handing one back to the comparison must now cover the writes being checked, and asking for both a helper and the option is refused rather than one quietly winning. The option is documented as being for read-only checking: it reads everything once up front, so it is the wrong tool while a replay is still writing rows.

Closes #190.