### PR TITLE
Decide a batch write with one rule, not one per store

### DIFF
--- a/src/django_rakaia/django_store.py
+++ b/src/django_rakaia/django_store.py
@@ -43,7 +43,11 @@ from typing import Any
 from asgiref.sync import sync_to_async
 from django.db import transaction
 
-from rakaia.append_decision import AppendVerdict, StreamFacts, decide_append
+from rakaia.append_decision import (
+    StreamFacts,
+    decide_append,
+    decide_append_batch,
+)
 from rakaia.context import merge_provenance
 from rakaia.json_mode import (
     format_json_response,
@@ -848,84 +852,60 @@ class DjangoStreamStore:
         Fencing used to be the exception: this method hand-rolled a shorter
         admission check that read content type and ``Stream-Seq`` and nothing
         else, so a batch was never fenced and never recorded the producer state
-        it established (#154). Both now go through the shared rule.
+        it established (#154). Then the per-item rule was shared but the
+        *batch* rule was still written twice, and the two versions disagreed
+        (#181) — this one short-circuited a closed stream before consulting the
+        rule, so a producer re-sending the append that closed the stream was
+        told a bare "closed" instead of "duplicate". Both levels now go through
+        ``rakaia.append_decision``.
         """
         items = list(events)
         if not items:
             return []
 
         with self._locked_write(path) as stream:
-            if stream.closed:
-                return [AppendResult(message=None, stream_closed=True) for _ in items]
-
-            # Admission, decided by the same rule the other three write doors
-            # use. This loop used to hand-roll a shorter version — content type
-            # and Stream-Seq only — which meant a batch was never fenced: a
-            # producer displaced by a newer epoch was refused item-by-item
-            # through `append` and silently accepted in bulk (#154).
-            #
-            # The facts advance across the batch exactly as they would across a
-            # loop of `append`: `last_seq` moves with each accepted item, and a
-            # producer's state moves with each accepted fenced write. Conflicts
-            # still raise (they are caller errors and the whole batch is
-            # abandoned); fencing outcomes are returned per item, so an item the
-            # fence refuses becomes a refusal in its own slot rather than
+            # Admission, decided by the same rule the in-memory store's batch
+            # path uses, so the two cannot drift on what a batch may do. It owns
+            # both batch-level rules: all-or-nothing on a conflict, and how the
+            # facts advance from item to item — `Stream-Seq` and producer state
+            # only for items actually written, and a close taking effect for the
+            # items after it. Conflicts propagate out (caller errors, and the
+            # whole batch is abandoned); fencing outcomes come back per item, so
+            # a refused item becomes a refusal in its own slot rather than
             # aborting its siblings.
-            now = time.time()
-            last_seq = stream.last_seq
-            producer_states = {
-                pid: self._producer_state(stream, pid)
-                for pid in {getattr(o, "producer_id", None) for _d, o in items} - {None}
+            producer_ids = {
+                pid
+                for _d, o in items
+                if (pid := getattr(o, "producer_id", None)) is not None
             }
-            verdicts: list[AppendVerdict] = []
-            cut = len(items)
-            for i, (_data, options) in enumerate(items):
-                producer_id = getattr(options, "producer_id", None)
-                verdict = decide_append(
-                    StreamFacts(
-                        closed=False,
-                        closed_by=stream.closed_by,
-                        content_type=stream.content_type,
-                        last_seq=last_seq,
-                    ),
-                    options,
-                    producer_state=producer_states.get(producer_id),
-                    now=now,
-                )
-                verdicts.append(verdict)
-                if not verdict.write:
-                    continue
-                seq = getattr(options, "seq", None)
-                if seq is not None:
-                    last_seq = seq
-                if verdict.producer_result is not None and producer_id is not None:
-                    # Advance the in-batch view of this producer, so a second
-                    # item from the same producer is fenced against the first
-                    # rather than against the pre-batch row.
-                    producer_states[producer_id] = ProducerState(
-                        epoch=getattr(options, "producer_epoch", 0) or 0,
-                        last_seq=getattr(options, "producer_seq", 0) or 0,
-                        last_updated=now,
-                    )
-                if getattr(options, "close", False):
-                    cut = i + 1
-                    break
+            batch = decide_append_batch(
+                StreamFacts(
+                    closed=stream.closed,
+                    closed_by=stream.closed_by,
+                    content_type=stream.content_type,
+                    last_seq=stream.last_seq,
+                ),
+                [options for _data, options in items],
+                producer_states={
+                    pid: self._producer_state(stream, pid) for pid in producer_ids
+                },
+                now=time.time(),
+            )
+            verdicts = batch.verdicts
 
-            # An item the fence refused is not written, but it keeps its slot in
+            # An item the rule refused is not written, but it keeps its slot in
             # the results so callers still get one answer per input item.
             admitted = [
-                (item, v)
-                for item, v in zip(items[:cut], verdicts[:cut], strict=False)
-                if v.write
+                (item, v) for item, v in zip(items, verdicts, strict=True) if v.write
             ]
             written = [item for item, _v in admitted]
-            refused = items[cut:]
 
-            if not written:
-                # Every item was refused — by the fence, or by a close earlier in
-                # the batch. There is nothing to allocate an offset block for,
-                # and asking for a block of zero is an error. Each item still
-                # gets its own answer.
+            if not batch.writes_anything:
+                # Every item was refused — by the fence, by a close earlier in
+                # the batch, or because the stream was already closed. There is
+                # nothing to allocate an offset block for, and asking for a
+                # block of zero is an error. Each item still gets its own
+                # answer, fencing outcome included.
                 return [
                     AppendResult(
                         message=None,
@@ -933,7 +913,7 @@ class DjangoStreamStore:
                         producer_result=v.producer_result,
                     )
                     for v in verdicts
-                ] + [AppendResult(message=None, stream_closed=True) for _ in refused]
+                ]
 
             # Mirror `append`'s per-event envelope mapping and payload encoding.
             # `merge_provenance` is evaluated per item so ambient provenance is
@@ -979,27 +959,20 @@ class DjangoStreamStore:
                 if verdict.producer_result is not None:
                     self._commit_producer(stream, verdict.producer_result)
 
-            if last_seq != stream.last_seq:
-                stream.last_seq = last_seq
+            if batch.last_seq != stream.last_seq:
+                stream.last_seq = batch.last_seq
                 stream.save(update_fields=["last_seq"])
-            closing = cut < len(items) or bool(
-                written and getattr(written[-1][1], "close", False)
-            )
-            if closing:
-                self._close_from_append(stream, written[-1][1])
+            if batch.closing_opts is not None:
+                self._close_from_append(stream, batch.closing_opts)
             self._touch(stream)
 
-            # One result per input item, in input order. An item the fence
+            # One result per input item, in input order. An item the rule
             # refused keeps its slot with the outcome to report, rather than
             # vanishing from the results and shifting every later item's answer
             # onto the wrong input.
             persisted = iter(entries)
             results: list[AppendResult] = []
-            for i, (_data, options) in enumerate(items):
-                if i >= cut:
-                    results.append(AppendResult(message=None, stream_closed=True))
-                    continue
-                verdict = verdicts[i]
+            for (_data, options), verdict in zip(items, verdicts, strict=True):
                 if not verdict.write:
                     results.append(
                         AppendResult(

--- a/src/django_rakaia/django_store.py
+++ b/src/django_rakaia/django_store.py
@@ -951,13 +951,16 @@ class DjangoStreamStore:
             # receiver's existing timing on the `append` path.
             self._publish(stream.stream_id, entries)
 
-            # Persist the fencing state each accepted item established, so a
-            # later batch or append is fenced against this one. `append` does
-            # this via `_commit_producer`; the bulk path did not do it at all,
-            # because it never asked the fence in the first place (#154).
-            for _item, verdict in admitted:
-                if verdict.producer_result is not None:
-                    self._commit_producer(stream, verdict.producer_result)
+            # Persist the fencing state the batch established, so a later batch
+            # or append is fenced against this one. The bulk path did not do it
+            # at all, because it never asked the fence in the first place (#154).
+            # One write per *producer*, not per item: the rule hands back the
+            # last accepted outcome for each, which is the only state a later
+            # writer can be fenced against. Committing per item reached the same
+            # place through N `update_or_create`s, which broke the flat query
+            # cost this method exists for.
+            for result in batch.producer_commits.values():
+                self._commit_producer(stream, result)
 
             if batch.last_seq != stream.last_seq:
                 stream.last_seq = batch.last_seq

--- a/src/rakaia/append_decision.py
+++ b/src/rakaia/append_decision.py
@@ -34,10 +34,36 @@ persist — so a new backend implements *storage*, not protocol semantics.
 Conflicts are *raised* (`ContentTypeMismatch`, `SequenceConflict`) because they
 are caller errors; fencing outcomes are *returned* because they are protocol
 results carrying their own statuses and headers.
+
+## Batches
+
+`decide_append_batch` is the same question asked of a whole batch, and it is
+here for the same reason: both stores had grown their own version and the two
+genuinely disagreed (#181). A batch adds exactly two rules to the per-item one,
+and both are easy to get subtly wrong in isolation:
+
+- **All-or-nothing on a conflict.** Every item is decided before any of them is
+  written, so a conflict refuses the batch rather than leaving a written prefix.
+  The durable store's single transaction can only behave that way; the
+  in-memory store has to be told to.
+- **The facts advance across the batch**, exactly as they would across a loop of
+  `append` — which is what `append_many` promises on both backends. That means
+  they advance *only for an item that is actually written*: an item the fence
+  refuses takes no `Stream-Seq`, and does not move its producer's sequence. It
+  also means an item with `close=True` closes the stream *for the items after
+  it*, which then see a closed stream with a `closed_by` — so a producer
+  re-sending its own closing append later in the same batch is recognised as a
+  duplicate rather than told a bare "closed".
+
+Each of those three was live: the in-memory store advanced `Stream-Seq` on
+refused items (raising a conflict on a sequence nothing had taken), and the
+durable store short-circuited a closed stream and its own post-close items
+before consulting the rule at all (losing the duplicate).
 """
 
 from __future__ import annotations
 
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from typing import Any
 
@@ -46,6 +72,7 @@ from .producer import validate_producer
 from .types import (
     ClosedBy,
     ContentTypeMismatch,
+    ProducerAccepted,
     ProducerDuplicate,
     ProducerState,
     ProducerStreamClosed,
@@ -152,3 +179,102 @@ def decide_append(
         raise SequenceConflict(f"Sequence conflict: {seq} <= {facts.last_seq}")
 
     return AppendVerdict(write=True, producer_result=producer_result)
+
+
+@dataclass(frozen=True)
+class BatchVerdict:
+    """The decision for a whole batch: one verdict per input item, in order.
+
+    ``verdicts`` is always the same length as the items handed in, so a store
+    can zip it back against its inputs — an item the batch refuses keeps its
+    slot rather than vanishing and shifting every later item's answer onto the
+    wrong input.
+
+    ``closing_opts`` is the options object of the item that closed the stream,
+    or None if nothing in the batch closed it. A store needs it to record
+    *which* producer tuple did the closing.
+    """
+
+    verdicts: list[AppendVerdict]
+    last_seq: str | None = None
+    closing_opts: Any = None
+
+    @property
+    def writes_anything(self) -> bool:
+        """Whether any item is to be written. A store that allocates an offset
+        block up front must check this: a block of zero is an error."""
+        return any(v.write for v in self.verdicts)
+
+
+def decide_append_batch(
+    facts: StreamFacts,
+    items: Sequence[Any],
+    *,
+    producer_states: Mapping[str, ProducerState | None] | None = None,
+    now: float,
+) -> BatchVerdict:
+    """Decide a whole batch, as a loop of :func:`decide_append` over advancing
+    facts. See the "Batches" section of the module docstring for the two rules
+    this adds and why they are here rather than in each store.
+
+    ``items`` is the per-item options, in order — the same objects
+    ``decide_append`` takes, and ``None`` for a raw append with no options.
+    ``producer_states`` is the pre-batch state for every producer id appearing
+    in the batch; a missing key is read as "no state", the same as ``None``.
+
+    Nothing is mutated: ``producer_states`` is copied, and the caller's
+    ``facts`` is untouched. A conflict propagates out of the loop, which is what
+    makes the batch all-or-nothing — the caller has decided nothing by the time
+    it sees the exception, so it writes nothing.
+    """
+    states = dict(producer_states or {})
+    closed = facts.closed
+    closed_by = facts.closed_by
+    last_seq = facts.last_seq
+    closing_opts: Any = None
+
+    verdicts: list[AppendVerdict] = []
+    for opts in items:
+        producer_id = getattr(opts, "producer_id", None)
+        verdict = decide_append(
+            StreamFacts(
+                closed=closed,
+                closed_by=closed_by,
+                content_type=facts.content_type,
+                last_seq=last_seq,
+            ),
+            opts,
+            producer_state=states.get(producer_id) if producer_id is not None else None,
+            now=now,
+        )
+        verdicts.append(verdict)
+        if not verdict.write:
+            # Refused, so it is not written, so it moves nothing. This is the
+            # half the in-memory store's own scan got wrong: it advanced
+            # `last_seq` here, and a later item then collided with a sequence
+            # no write had ever taken.
+            continue
+
+        seq = getattr(opts, "seq", None)
+        if seq is not None:
+            last_seq = seq
+        if producer_id is not None and isinstance(
+            verdict.producer_result, ProducerAccepted
+        ):
+            # The state the store will commit after this item lands, so the
+            # next item from the same producer is fenced against this one
+            # rather than against the pre-batch row.
+            states[producer_id] = verdict.producer_result.proposed_state
+        if getattr(opts, "close", False):
+            # The rest of the batch observes the stream this item leaves
+            # behind, closing tuple included.
+            closed = True
+            closing_opts = opts
+            if producer_id is not None:
+                closed_by = ClosedBy(
+                    producer_id=producer_id,
+                    epoch=getattr(opts, "producer_epoch", None) or 0,
+                    seq=getattr(opts, "producer_seq", None) or 0,
+                )
+
+    return BatchVerdict(verdicts=verdicts, last_seq=last_seq, closing_opts=closing_opts)

--- a/src/rakaia/append_decision.py
+++ b/src/rakaia/append_decision.py
@@ -64,7 +64,7 @@ before consulting the rule at all (losing the duplicate).
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 
 from .json_mode import normalize_content_type
@@ -193,11 +193,19 @@ class BatchVerdict:
     ``closing_opts`` is the options object of the item that closed the stream,
     or None if nothing in the batch closed it. A store needs it to record
     *which* producer tuple did the closing.
+
+    ``producer_commits`` is the fencing state the batch establishes: the *last*
+    accepted outcome per producer id, which is the only one worth persisting.
+    Committing each accepted item's outcome in turn reaches the same final state
+    but costs a write per item, and ``append_many`` promises a query count that
+    does not grow with the batch — so the rule hands back the one commit per
+    producer instead of leaving each store to work that out.
     """
 
     verdicts: list[AppendVerdict]
     last_seq: str | None = None
     closing_opts: Any = None
+    producer_commits: dict[str, ProducerAccepted] = field(default_factory=dict)
 
     @property
     def writes_anything(self) -> bool:
@@ -232,6 +240,7 @@ def decide_append_batch(
     closed_by = facts.closed_by
     last_seq = facts.last_seq
     closing_opts: Any = None
+    commits: dict[str, ProducerAccepted] = {}
 
     verdicts: list[AppendVerdict] = []
     for opts in items:
@@ -263,8 +272,12 @@ def decide_append_batch(
         ):
             # The state the store will commit after this item lands, so the
             # next item from the same producer is fenced against this one
-            # rather than against the pre-batch row.
+            # rather than against the pre-batch row. Overwriting the entry in
+            # `commits` is what keeps the store's writes one-per-producer: a
+            # later accepted item from the same producer supersedes this one,
+            # and only the last state is worth persisting.
             states[producer_id] = verdict.producer_result.proposed_state
+            commits[producer_id] = verdict.producer_result
         if getattr(opts, "close", False):
             # The rest of the batch observes the stream this item leaves
             # behind, closing tuple included.
@@ -277,4 +290,9 @@ def decide_append_batch(
                     seq=getattr(opts, "producer_seq", None) or 0,
                 )
 
-    return BatchVerdict(verdicts=verdicts, last_seq=last_seq, closing_opts=closing_opts)
+    return BatchVerdict(
+        verdicts=verdicts,
+        last_seq=last_seq,
+        closing_opts=closing_opts,
+        producer_commits=commits,
+    )

--- a/src/rakaia/store.py
+++ b/src/rakaia/store.py
@@ -14,7 +14,7 @@ from collections.abc import Iterable
 from datetime import datetime, timezone
 from typing import Any
 
-from .append_decision import StreamFacts, decide_append
+from .append_decision import StreamFacts, decide_append, decide_append_batch
 from .context import merge_provenance
 from .json_mode import (
     format_json_response,
@@ -28,10 +28,8 @@ from .types import (
     AppendOptions,
     AppendResult,
     CloseResult,
-    ContentTypeMismatch,
     ProducerAccepted,
     ProducerValidationResult,
-    SequenceConflict,
     Stream,
     StreamConfigConflict,
     StreamMessage,
@@ -346,35 +344,40 @@ class StreamStore:
         the whole batch before anything is written. The durable store's single
         transaction can only be all-or-nothing on a conflict, and the two
         stores must agree — a plain loop here would leave the prefix written.
+
+        That admissibility scan is `rakaia.append_decision.decide_append_batch`,
+        shared with the durable store, so the two cannot drift on what a *batch*
+        is allowed to do any more than they can on a single append. It used to
+        be hand-rolled here, and it advanced its `Stream-Seq` view on items the
+        fence would refuse — so a batch whose first item was fenced out raised a
+        conflict against a sequence nothing had written (#181). The verdicts are
+        deliberately discarded: this store then *is* a loop of `append`, which
+        re-derives each one against really-advanced state. The shared rule is
+        called for its all-or-nothing pre-flight, which a loop cannot give.
         """
         items = list(events)
         if not items:
             return []
         stream = self._get_if_not_expired(path)
-        if stream is not None and not stream.closed:
-            last_seq = stream.last_seq
-            for _data, options in items:
-                opts = options or AppendOptions()
-                if (
-                    opts.content_type
-                    and stream.content_type
-                    and normalize_content_type(opts.content_type)
-                    != normalize_content_type(stream.content_type)
-                ):
-                    raise ContentTypeMismatch(
-                        f"Content-type mismatch: expected "
-                        f"{stream.content_type}, got {opts.content_type}"
-                    )
-                if opts.seq is not None:
-                    if last_seq is not None and opts.seq <= last_seq:
-                        raise SequenceConflict(
-                            f"Sequence conflict: {opts.seq} <= {last_seq}"
-                        )
-                    last_seq = opts.seq
-                if opts.close:
-                    # Items after a close observe the closed stream and are
-                    # refused, not validated.
-                    break
+        if stream is not None:
+            producer_ids = {
+                pid
+                for _d, o in items
+                if (pid := getattr(o, "producer_id", None)) is not None
+            }
+            decide_append_batch(
+                StreamFacts(
+                    closed=stream.closed,
+                    closed_by=stream.closed_by,
+                    content_type=stream.content_type,
+                    last_seq=stream.last_seq,
+                ),
+                [options for _data, options in items],
+                producer_states={
+                    pid: self._producer_state(stream, pid) for pid in producer_ids
+                },
+                now=time.time(),
+            )
         return [self.append(path, data, options) for data, options in items]
 
     async def append_with_producer(

--- a/tests/server_store_contract.py
+++ b/tests/server_store_contract.py
@@ -331,6 +331,99 @@ class ServerStoreContract:
         messages, _ = store.read("s")
         assert len(messages) == 2, "the item after the close must not be written"
 
+    async def test_append_many_does_not_advance_seq_for_a_refused_item(self, store):
+        """An item the fence refuses is not written, so it cannot move
+        `Stream-Seq` for the items after it.
+
+        A loop of `append` gets this for free: `last_seq` is only assigned after
+        a write lands. A batch has to say so, because its admission scan walks
+        every item before anything is written — and if the scan advances the seq
+        view on an item that will never be written, a later legitimate item
+        collides with a sequence nothing ever took. #181: the two stores
+        hand-rolled that scan separately and only one of them got this right.
+        """
+        await self._sync(store.create, "s")
+        await store.append_with_producer("s", b'{"n": 0}', self._producer("p", 2, 0))
+        results = await self._sync(
+            store.append_many,
+            "s",
+            [
+                # Stale epoch: refused, so its seq="9" is never taken.
+                (
+                    b'{"n": 1}',
+                    AppendOptions(
+                        producer_id="p", producer_epoch=1, producer_seq=0, seq="9"
+                    ),
+                ),
+                (b'{"n": 2}', AppendOptions(seq="3")),
+            ],
+        )
+        assert isinstance(results[0].producer_result, ProducerStaleEpoch)
+        assert results[0].message is None
+        assert results[1].message is not None, (
+            "seq='3' is free: the refused item never took seq='9'"
+        )
+        stream = await self._sync(store.get, "s")
+        assert stream.last_seq == "3"
+
+    async def test_append_many_to_a_closed_stream_recognises_the_closing_producer(
+        self, store
+    ):
+        """A batch is admitted on the same terms as a single append, including
+        the idempotent re-send of the append that closed the stream.
+
+        `append` reports that tuple as a duplicate so the producer can tell "my
+        close landed" from "someone else closed this". A batch that answers a
+        bare "closed" to the same tuple tells the producer to give up on a write
+        that in fact succeeded.
+        """
+        await self._sync(store.create, "s")
+        closing = AppendOptions(
+            producer_id="p", producer_epoch=1, producer_seq=0, close=True
+        )
+        await store.append_with_producer("s", b'{"n": 1}', closing)
+
+        results = await self._sync(store.append_many, "s", [(b'{"n": 1}', closing)])
+
+        assert results[0].stream_closed is True
+        assert results[0].message is None
+        assert isinstance(results[0].producer_result, ProducerDuplicate)
+
+    async def test_append_many_items_after_a_close_are_admitted_like_a_loop(
+        self, store
+    ):
+        """The items after an in-batch close observe the stream the close left
+        behind — including the closing tuple, so a producer re-sending its own
+        closing append inside the same batch is told it is a duplicate rather
+        than a bare "closed"."""
+        await self._sync(store.create, "s")
+        closing = AppendOptions(
+            producer_id="p", producer_epoch=1, producer_seq=0, close=True
+        )
+        results = await self._sync(
+            store.append_many, "s", [(b'{"n": 1}', closing), (b'{"n": 1}', closing)]
+        )
+
+        assert results[0].message is not None and results[0].stream_closed
+        assert results[1].message is None and results[1].stream_closed
+        assert isinstance(results[1].producer_result, ProducerDuplicate)
+
+    async def test_append_many_fences_the_second_item_against_the_first(self, store):
+        """Within one batch a producer's state advances item by item, so a
+        second item repeating the first item's sequence is a duplicate — the
+        same answer a loop of `append` gives."""
+        await self._sync(store.create, "s")
+        opts = self._producer("p", 1, 0)
+        results = await self._sync(
+            store.append_many, "s", [(b'{"n": 1}', opts), (b'{"n": 2}', opts)]
+        )
+
+        assert isinstance(results[0].producer_result, ProducerAccepted)
+        assert isinstance(results[1].producer_result, ProducerDuplicate)
+        assert results[1].message is None
+        messages, _ = await self._sync(store.read, "s")
+        assert len(messages) == 1, "the duplicate must not be written"
+
     # =========================================================================
     # Close
     # =========================================================================

--- a/tests/server_store_contract.py
+++ b/tests/server_store_contract.py
@@ -285,6 +285,29 @@ class ServerStoreContract:
         messages, _ = store.read("s")
         assert messages == []
 
+    def test_a_closed_stream_refuses_a_conflicting_batch_rather_than_raising(
+        self, store
+    ):
+        """Closed outranks both conflicts, for a batch as for a single append.
+
+        `test_append_many_to_a_closed_stream_refuses_every_item` uses a clean
+        batch, so it cannot see a store that forgets the stream is closed while
+        scanning for conflicts: such a store raises `SequenceConflict` here and
+        answers the clean batch correctly, which is a refusal turned into a 400
+        on one backend and not the other — #181's own shape.
+        """
+        store.create("s", content_type="application/json")
+        store.append("s", b'{"n": 1}', AppendOptions(seq="5", close=True))
+
+        results = store.append_many(
+            "s",
+            [
+                (b'{"n": 2}', AppendOptions(seq="1")),
+                (b"raw", AppendOptions(content_type="text/plain")),
+            ],
+        )
+        assert all(r.stream_closed and r.message is None for r in results)
+
     def test_append_many_validates_content_type_per_item(self, store):
         store.create("s", content_type="text/plain")
         with pytest.raises(ContentTypeMismatch):

--- a/tests/server_store_contract.py
+++ b/tests/server_store_contract.py
@@ -346,6 +346,32 @@ class ServerStoreContract:
         assert messages == [], "a refused batch must write nothing"
         assert store.get("s").last_seq is None
 
+    def test_a_batch_conflicting_with_the_stream_writes_nothing(self, store):
+        """The same rule, against the sequence the stream already had.
+
+        The sibling above starts from a fresh stream, so its conflict is between
+        two items of the batch — which a store that never read the stream's own
+        `Stream-Seq` still catches. This one puts an *admissible* item in front
+        of an item that conflicts with the pre-batch value, which is the only
+        arrangement that can leave a written prefix behind. Getting it wrong
+        breaks all-or-nothing on one backend and not the other: the durable
+        store's transaction rolls the prefix back whatever it decided.
+        """
+        store.create("s")
+        store.append("s", b'{"id": 0}', AppendOptions(seq="5"))
+
+        with pytest.raises(SequenceConflict):
+            store.append_many(
+                "s",
+                [
+                    (b'{"id": 1}', None),
+                    (b'{"id": 2}', AppendOptions(seq="3")),
+                ],
+            )
+        messages, _ = store.read("s")
+        assert len(messages) == 1, "the admissible item must not have been written"
+        assert store.get("s").last_seq == "5"
+
     def test_append_many_advances_seq_like_a_loop_of_append(self, store):
         store.create("s")
         store.append_many(

--- a/tests/server_store_contract.py
+++ b/tests/server_store_contract.py
@@ -300,6 +300,29 @@ class ServerStoreContract:
         with pytest.raises(SequenceConflict):
             store.append_many("s", [(b'{"id": 2}', AppendOptions(seq="5"))])
 
+    def test_a_seq_conflict_late_in_a_batch_writes_nothing(self, store):
+        """All-or-nothing, on the *other* conflict.
+
+        A single-item batch cannot tell a refusal apart from a refusal that
+        happened to leave nothing behind, and the content-type case above is the
+        only multi-item one — so a store could scan for content type, skip
+        `Stream-Seq` entirely, and stay green while a conflicting batch left its
+        prefix written. The durable store's transaction rolls back either way;
+        the in-memory store has nothing to roll back and must refuse up front.
+        """
+        store.create("s")
+        with pytest.raises(SequenceConflict):
+            store.append_many(
+                "s",
+                [
+                    (b'{"id": 1}', AppendOptions(seq="2")),
+                    (b'{"id": 2}', AppendOptions(seq="1")),
+                ],
+            )
+        messages, _ = store.read("s")
+        assert messages == [], "a refused batch must write nothing"
+        assert store.get("s").last_seq is None
+
     def test_append_many_advances_seq_like_a_loop_of_append(self, store):
         store.create("s")
         store.append_many(

--- a/tests/test_django_rakaia/test_append_query_cost.py
+++ b/tests/test_django_rakaia/test_append_query_cost.py
@@ -182,3 +182,42 @@ class TestAppendQueryCost:
             store.append_many("s", [(b'{"n": 1}', AppendOptions())] * batch)
 
         assert _shapes(ctx) == _STEADY_STATE_APPEND, _data_queries(ctx)
+
+    @pytest.mark.parametrize("batch", [1, 4, 20])
+    def test_a_fenced_append_many_is_flat_in_the_batch_size(self, batch: int) -> None:
+        """Producer fencing costs one read and one write per *producer*, not per
+        item, so the flat-cost claim survives a fenced batch too.
+
+        Both halves are easy to lose. The state is read once because the batch
+        rule is asked for the whole batch at once and advances its own view from
+        item to item; it is written once because the rule hands back the last
+        accepted outcome per producer, which is the only state a later writer can
+        be fenced against. Committing each accepted item in turn reaches the same
+        final state through N `update_or_create`s -- correct, and invisible to
+        every other test in the suite.
+        """
+        store = self._warm()
+        items = [
+            (
+                b'{"n": 1}',
+                AppendOptions(producer_id="p", producer_epoch=0, producer_seq=i),
+            )
+            for i in range(batch)
+        ]
+        with CaptureQueriesContext(connection) as ctx:
+            results = store.append_many("s", items)
+
+        assert all(r.message is not None for r in results)
+        assert _shapes(ctx) == [
+            "SELECT rakaia_stream",
+            # The producer's pre-batch state, read once for the whole batch.
+            "SELECT rakaia_streamproducer",
+            "INSERT rakaia_streamevent",
+            "SELECT rakaia_streamoffsetwatermark",
+            "UPDATE rakaia_streamoffsetwatermark",
+            "INSERT rakaia_streamentry",
+            # `update_or_create`: the existence probe, then the write. Once --
+            # an INSERT here because this producer is new to the stream.
+            "SELECT rakaia_streamproducer",
+            "INSERT rakaia_streamproducer",
+        ], _data_queries(ctx)

--- a/tests/test_rakaia/test_append_decision.py
+++ b/tests/test_rakaia/test_append_decision.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 import pytest
 
-from rakaia.append_decision import StreamFacts, decide_append
+from rakaia.append_decision import StreamFacts, decide_append, decide_append_batch
 from rakaia.types import (
     AppendOptions,
     ClosedBy,
@@ -232,3 +232,125 @@ class TestOrdering:
                 ),
                 producer_state=state,
             )
+
+
+def _decide_batch(facts=None, items=(), *, producer_states=None):
+    return decide_append_batch(
+        facts or StreamFacts(),
+        list(items),
+        producer_states=producer_states,
+        now=NOW,
+    )
+
+
+class TestBatchAdmissibility:
+    """The batch rule, same treatment: no store, no database.
+
+    Both stores hand-rolled this and the two disagreed (#181). Each case below
+    is one of the ways they disagreed, or one of the rules that stops them
+    disagreeing again.
+    """
+
+    def test_one_verdict_per_item_in_order(self):
+        batch = _decide_batch(items=[AppendOptions(), None, AppendOptions()])
+        assert len(batch.verdicts) == 3
+        assert all(v.write for v in batch.verdicts)
+        assert batch.writes_anything is True
+
+    def test_an_empty_batch_decides_nothing(self):
+        batch = _decide_batch()
+        assert batch.verdicts == []
+        assert batch.writes_anything is False
+
+    def test_stream_seq_advances_across_the_batch(self):
+        batch = _decide_batch(items=[AppendOptions(seq="1"), AppendOptions(seq="2")])
+        assert all(v.write for v in batch.verdicts)
+        assert batch.last_seq == "2"
+
+    def test_a_conflict_inside_the_batch_propagates(self):
+        """All-or-nothing: the caller has decided nothing when it sees this, so
+        it writes nothing. A plain loop of `append` would leave a prefix."""
+        with pytest.raises(SequenceConflict):
+            _decide_batch(items=[AppendOptions(seq="2"), AppendOptions(seq="1")])
+
+    def test_a_refused_item_does_not_advance_stream_seq(self):
+        """The in-memory store's own scan advanced it here, so a batch whose
+        first item was fenced out raised a conflict against a sequence nothing
+        had ever written."""
+        state = ProducerState(epoch=5, last_seq=0, last_updated=NOW)
+        batch = _decide_batch(
+            items=[
+                AppendOptions(
+                    producer_id="p", producer_epoch=1, producer_seq=0, seq="9"
+                ),
+                AppendOptions(seq="3"),
+            ],
+            producer_states={"p": state},
+        )
+        assert isinstance(batch.verdicts[0].producer_result, ProducerStaleEpoch)
+        assert batch.verdicts[0].write is False
+        assert batch.verdicts[1].write is True
+        assert batch.last_seq == "3"
+
+    def test_a_producer_is_fenced_against_its_own_earlier_item(self):
+        opts = AppendOptions(producer_id="p", producer_epoch=0, producer_seq=0)
+        batch = _decide_batch(items=[opts, opts])
+        assert isinstance(batch.verdicts[0].producer_result, ProducerAccepted)
+        assert isinstance(batch.verdicts[1].producer_result, ProducerDuplicate)
+        assert batch.verdicts[1].write is False
+
+    def test_a_refused_item_does_not_advance_its_producer(self):
+        """A gap is refused and takes no sequence, so the next item from the
+        same producer is still judged against the pre-batch state."""
+        batch = _decide_batch(
+            items=[
+                AppendOptions(producer_id="p", producer_epoch=0, producer_seq=4),
+                AppendOptions(producer_id="p", producer_epoch=0, producer_seq=0),
+            ]
+        )
+        assert isinstance(batch.verdicts[0].producer_result, ProducerSequenceGap)
+        assert isinstance(batch.verdicts[1].producer_result, ProducerAccepted)
+        assert batch.verdicts[1].write is True
+
+    def test_a_close_refuses_the_items_after_it(self):
+        closing = AppendOptions(close=True)
+        batch = _decide_batch(items=[AppendOptions(), closing, AppendOptions()])
+        assert [v.write for v in batch.verdicts] == [True, True, False]
+        assert batch.verdicts[2].stream_closed is True
+        assert batch.closing_opts is closing
+
+    def test_a_close_records_which_tuple_closed_the_stream(self):
+        """So the items after it can recognise a re-send of that same closing
+        append as a duplicate — the answer a loop of `append` gives, and the
+        one the durable store lost by short-circuiting on `closed`."""
+        closing = AppendOptions(
+            producer_id="p", producer_epoch=0, producer_seq=0, close=True
+        )
+        batch = _decide_batch(items=[closing, closing])
+        assert batch.verdicts[0].write is True
+        assert batch.verdicts[1].write is False
+        assert batch.verdicts[1].stream_closed is True
+        assert isinstance(batch.verdicts[1].producer_result, ProducerDuplicate)
+        assert batch.closing_opts is closing
+
+    def test_an_already_closed_stream_still_gets_a_verdict_per_item(self):
+        batch = _decide_batch(
+            StreamFacts(closed=True, closed_by=ClosedBy("p", epoch=0, seq=0)),
+            items=[
+                AppendOptions(producer_id="p", producer_epoch=0, producer_seq=0),
+                AppendOptions(),
+            ],
+        )
+        assert batch.writes_anything is False
+        assert isinstance(batch.verdicts[0].producer_result, ProducerDuplicate)
+        assert isinstance(batch.verdicts[1].producer_result, ProducerStreamClosed)
+
+    def test_the_callers_producer_states_are_not_mutated(self):
+        """The rule is pure: a store must be free to abandon the whole batch on
+        a conflict without having had its own state advanced under it."""
+        states = {"p": None}
+        _decide_batch(
+            items=[AppendOptions(producer_id="p", producer_epoch=0, producer_seq=0)],
+            producer_states=states,
+        )
+        assert states == {"p": None}

--- a/tests/test_rakaia/test_append_decision.py
+++ b/tests/test_rakaia/test_append_decision.py
@@ -345,6 +345,41 @@ class TestBatchAdmissibility:
         assert isinstance(batch.verdicts[0].producer_result, ProducerDuplicate)
         assert isinstance(batch.verdicts[1].producer_result, ProducerStreamClosed)
 
+    def test_the_batch_commits_one_state_per_producer(self):
+        """The last accepted outcome per producer, not one per accepted item.
+
+        A store persists exactly these, so the count of writes it owes does not
+        grow with the batch. Three accepted items from one producer leave one
+        commit, carrying the third item's sequence.
+        """
+        batch = _decide_batch(
+            items=[
+                AppendOptions(producer_id="p", producer_epoch=0, producer_seq=i)
+                for i in range(3)
+            ]
+        )
+        assert all(v.write for v in batch.verdicts)
+        assert list(batch.producer_commits) == ["p"]
+        assert batch.producer_commits["p"].proposed_state.last_seq == 2
+
+    def test_each_producer_in_a_batch_gets_its_own_commit(self):
+        batch = _decide_batch(
+            items=[
+                AppendOptions(producer_id="a", producer_epoch=0, producer_seq=0),
+                AppendOptions(producer_id="b", producer_epoch=0, producer_seq=0),
+            ]
+        )
+        assert sorted(batch.producer_commits) == ["a", "b"]
+
+    def test_a_refused_producer_leaves_no_commit(self):
+        """Nothing was written, so there is nothing to persist — a commit here
+        would advance a producer whose write never landed."""
+        batch = _decide_batch(
+            items=[AppendOptions(producer_id="p", producer_epoch=0, producer_seq=4)]
+        )
+        assert isinstance(batch.verdicts[0].producer_result, ProducerSequenceGap)
+        assert batch.producer_commits == {}
+
     def test_the_callers_producer_states_are_not_mutated(self):
         """The rule is pure: a store must be free to abandon the whole batch on
         a conflict without having had its own state advanced under it."""


### PR DESCRIPTION
Deciding whether a single write is allowed has been one shared rule since #167, which is what stops the two storage backends drifting. Deciding whether a *batch* is allowed was still written twice, and the two versions really did disagree — in both directions. One of them refused a batch over a sequence number nothing had actually written; the other, when the stream was already closed, told a writer "closed" where the single-write path would have told it "that was your own write, it landed". A caller had to know which backend it was talking to in order to predict what a batch would do.

There is now one rule for a batch too, sitting next to the one for a single write: what makes a batch admissible, and how the picture of the stream moves along from one item to the next. Both backends call it. #167 had already done the per-item half of this; what was left was the batch level, which is what this finishes. The four new tests run against both backends, and each was failing on exactly one of them before the change.

Closes #181.