### PR TITLE
One home for what gets linted, and one version of the linter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,18 +31,40 @@ jobs:
       - name: Install dependencies
         run: uv sync --extra dev --extra django --extra docs --extra prod
 
+      - name: Install just
+        # So the api-reference gate below can call the same recipe a developer
+        # runs, rather than a second copy of it inlined here.
+        uses: extractions/setup-just@v3
+
       - name: Lint with ruff
-        run: uv run ruff check src/ tests/ examples/
+        # No path arguments: the scope lives in `[tool.ruff]` in pyproject.toml
+        # so this and `just lint` cannot check different trees. They used to,
+        # and `just check` passed on diffs that failed here.
+        run: uv run ruff check
 
       - name: Format check with ruff
-        run: uv run ruff format --check src/ tests/ examples/
+        run: uv run ruff format --check
 
       - name: Type check with pyright
         # A hard gate since #143. Django's synthesised attributes (reverse
         # accessors, implicit `id`, `annotate()` aliases) are declared on the
         # models and at the query sites rather than waved through, so a new
         # type error here is a real one. Keep it failing.
+        #
+        # Pinned to the lockfile's pyright, matching `just typecheck`: pyright
+        # nags to set this to `latest`, which would let CI and a developer
+        # typecheck against different releases.
+        env:
+          PYRIGHT_PYTHON_FORCE_VERSION: "1.1.411"
         run: uv run pyright src/
+
+      - name: Check the API reference is not stale
+        # `docs/api-reference.md` is generated from `__all__`. Without this step
+        # the only thing enforcing it was `just check`, which nobody is obliged
+        # to run: two PRs based on the same older main each bumped the exported
+        # name count to the same wrong value, both merges took that line, and
+        # main shipped a file the generator disagreed with (#215).
+        run: just api-reference-check
 
       - name: Run tests
         run: uv run pytest --cov=src/rakaia --cov=src/django_rakaia --cov-report=term-missing

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,11 +48,23 @@
   lock belongs in one of those two files, marked `transaction=True`, and must
   be shown to fail with the lock removed** — two earlier attempts passed with
   and without it, which is the failure mode these tests exist to avoid.
-- **pyright is a hard gate** and `src/` is expected at zero errors. Run it as
-  `PYRIGHT_PYTHON_FORCE_VERSION=latest uv run pyright src/` locally — plain
-  `uv run pyright` can object to its own pinned version. Django's synthesised
-  attributes are declared explicitly (see the `if TYPE_CHECKING` blocks in
-  `django_rakaia/models.py`) rather than waved through with ignores.
+- **pyright is a hard gate** and `src/` is expected at zero errors. Run
+  `just typecheck`, which pins `PYRIGHT_PYTHON_FORCE_VERSION` to the version in
+  the lockfile. Do **not** set it to `latest`, which this file used to advise:
+  pyright nags that a newer release exists, and taking its suggestion typechecks
+  against a different pyright than CI — the nag is cosmetic, the divergence is
+  not. Django's synthesised attributes are declared explicitly (see the
+  `if TYPE_CHECKING` blocks in `django_rakaia/models.py`) rather than waved
+  through with ignores.
+- **Lint and format take no path arguments.** `[tool.ruff]` in `pyproject.toml`
+  decides what is checked, so `just lint`, CI and your editor all see the same
+  tree. Passing paths reintroduces the split that let `just check` pass on a diff
+  CI rejected. `just lint` / `just fmt`; the rule set and every deliberate
+  `ignore` carries its reason inline in `pyproject.toml`.
+- **`docs/api-reference.md` is gated in CI** (`just api-reference-check`), not
+  only by `just check`. If you add or remove an exported name, run
+  `just api-reference` and commit the result — and rebase before merging, since
+  the count line at the bottom is a single line two branches will both rewrite.
 - To reproduce the **full** CI gate locally you also need the docs extra
   (`zensical` isn't in `dev`/`django`): `uv sync --extra dev --extra django --extra docs`,
   then `uv run zensical build`. Without `--extra docs` that step fails with

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ uvicorn rakaia:app --port 4437
 ```python
 from rakaia import create_app, StreamStore
 
-app = create_app()                  # in-memory store
+app = create_app()  # in-memory store
 app = create_app(store=StreamStore())
 ```
 
@@ -49,10 +49,12 @@ from dataclasses import dataclass
 from django.db import models
 from django_rakaia.decorators import stream_model
 
+
 @dataclass
 class RoomData:
     id: int
     name: str
+
 
 @stream_model(
     stream_paths=lambda obj: f"room:{obj.id}:messages",
@@ -98,17 +100,22 @@ idempotent `update_or_create`, so replay can be re-run safely.
 ```python
 from rakaia import Upsert, register_handler, register_upcaster
 
-@register_handler(name="mogrify", event_match="room:*:messages",
-                  effective_from=0, effective_to=10_000)
-def mogrify_v1(event):
-    return Upsert(model_label="myapp.Room",
-                  lookup={"id": event["room_id"]},
-                  defaults={"name": event["name"]})
 
-@register_handler(name="mogrify", event_match="room:*:messages",
-                  effective_from=10_000)
+@register_handler(
+    name="mogrify", event_match="room:*:messages", effective_from=0, effective_to=10_000
+)
+def mogrify_v1(event):
+    return Upsert(
+        model_label="myapp.Room",
+        lookup={"id": event["room_id"]},
+        defaults={"name": event["name"]},
+    )
+
+
+@register_handler(name="mogrify", event_match="room:*:messages", effective_from=10_000)
 def mogrify_v2(event):  # bugfix only for events from seq 10_000 onward
     ...
+
 
 @register_upcaster(event_match="room:*:messages", from_version=1)
 def upcast_v1_to_v2(event):  # schema-shape change handled separately

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -79,7 +79,7 @@ anything that hands the result to the ORM breaks:
 
 ```python
 stream = store.get(path)
-entries = StreamEntry.objects.filter(stream=stream)   # <-- TypeError
+entries = StreamEntry.objects.filter(stream=stream)  # <-- TypeError
 ```
 
 ```

--- a/docs/close-preconditions.md
+++ b/docs/close-preconditions.md
@@ -43,12 +43,17 @@ def close_preconditions(suku, refs) -> list[str]:
     ...
     return reasons
 
-def cycle_close(event, refs):                       # stage 2
+
+def cycle_close(event, refs):  # stage 2
     reasons = close_preconditions(event["suku"], refs)
-    return Upsert(model_label=CYCLE_CLOSE,
-                  lookup={"suku": event["suku"]},
-                  defaults={"status": "ACCEPTED" if not reasons else "REJECTED",
-                            "reasons": reasons})
+    return Upsert(
+        model_label=CYCLE_CLOSE,
+        lookup={"suku": event["suku"]},
+        defaults={
+            "status": "ACCEPTED" if not reasons else "REJECTED",
+            "reasons": reasons,
+        },
+    )
 ```
 
 Because the verdict is derived, not stored, appending the missing facts and
@@ -63,14 +68,24 @@ doubles on re-replay). The fix is the aggregate analogue of `reconcile_children`
 idempotent upsert.
 
 ```python
-def balance_rollup(refs):                           # stage 1 reduce step
+def balance_rollup(refs):  # stage 1 reduce step
     effects = []
     for suku in distinct_sukus(refs):
         rows = refs.filter(FINANCE_LINE, suku=suku)
-        effects.append(Upsert(model_label=BALANCE,
-            lookup={"suku": suku},
-            defaults={"operational": sum(r.delta for r in rows if r.account == "operational"),
-                      "infrastructure": sum(r.delta for r in rows if r.account == "infrastructure")}))
+        effects.append(
+            Upsert(
+                model_label=BALANCE,
+                lookup={"suku": suku},
+                defaults={
+                    "operational": sum(
+                        r.delta for r in rows if r.account == "operational"
+                    ),
+                    "infrastructure": sum(
+                        r.delta for r in rows if r.account == "infrastructure"
+                    ),
+                },
+            )
+        )
     return effects
 ```
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -50,7 +50,7 @@ store, build the app yourself:
 # wsgi_or_asgi.py
 from rakaia import StreamStore, create_app
 
-store = StreamStore()           # or your own implementation
+store = StreamStore()  # or your own implementation
 app = create_app(store=store)
 ```
 

--- a/docs/django-integration.md
+++ b/docs/django-integration.md
@@ -20,7 +20,7 @@
 ```python
 # settings.py
 INSTALLED_APPS = [
-    "daphne",            # ASGI server (must come before django.contrib.staticfiles)
+    "daphne",  # ASGI server (must come before django.contrib.staticfiles)
     "channels",
     "django_rakaia",
     # ...
@@ -86,7 +86,7 @@ The store is chosen by the `RAKAIA_STORE` Django setting via
 
 ```python
 # settings.py
-RAKAIA_STORE = "durable"   # DjangoStreamStore (persisted in the DB)
+RAKAIA_STORE = "durable"  # DjangoStreamStore (persisted in the DB)
 # RAKAIA_STORE = "memory"  # StreamStore (default — in-memory, process-local)
 ```
 

--- a/docs/dry-run-and-executors.md
+++ b/docs/dry-run-and-executors.md
@@ -152,7 +152,7 @@ from rakaia import CollectingExecutor
 from rakaia import replay
 
 ex = CollectingExecutor()
-replay(store, "orders", ex)          # zero writes
+replay(store, "orders", ex)  # zero writes
 
 print(f"{len(ex.effects)} effects would be applied")
 for effect in ex.effects:
@@ -185,7 +185,7 @@ a named alias — read or write — raises `AmbientDatabaseAccess`:
 from django_rakaia import deny_database_access
 
 with deny_database_access("default"):
-    replay(store, "orders", CollectingExecutor())   # a stray query now raises
+    replay(store, "orders", CollectingExecutor())  # a stray query now raises
 ```
 
 **`assert_no_live_writes(*models, using="default")`** is the narrower one: it
@@ -255,8 +255,8 @@ from django_rakaia import rebuild_and_verify
 
 report = rebuild_and_verify(
     "submissions",
-    into="rebuild",                            # a disposable alias
-    live_models=[Submission, ProjectLink],     # what you expect rebuilt
+    into="rebuild",  # a disposable alias
+    live_models=[Submission, ProjectLink],  # what you expect rebuilt
     registry=reg,
 )
 report.raise_if_diff()
@@ -305,8 +305,9 @@ a `using=` database alias:
 DATABASES["rebuild"] = {"ENGINE": "django.db.backends.sqlite3", "NAME": ":memory:"}
 
 replay(
-    DjangoStreamStore(using="rebuild"), "submissions",  # the log comes from there too
-    DjangoExecutor(using="rebuild"),                 # writes land in the scratch DB
+    DjangoStreamStore(using="rebuild"),
+    "submissions",  # the log comes from there too
+    DjangoExecutor(using="rebuild"),  # writes land in the scratch DB
     reader=DjangoProjectionReader(using="rebuild"),  # stage-1 reads them back
     handler_registry=reg,
 )

--- a/docs/event-envelope.md
+++ b/docs/event-envelope.md
@@ -46,7 +46,7 @@ from rakaia import AppendOptions
 
 store.append(
     "submissions/tf",
-    data,                                   # the JSON payload bytes
+    data,  # the JSON payload bytes
     AppendOptions(label="update", metadata={"user": 42, "url": "/forms/tf/9"}),
 )
 ```
@@ -77,7 +77,8 @@ store.append("submissions/tf", data, AppendOptions(label="update"))
 
 # one-time backfill → stamp the *original historical* time, not the append time
 store.append(
-    "submissions/tf", data,
+    "submissions/tf",
+    data,
     AppendOptions(label="update", event_ts=original_created_at.timestamp()),
 )
 ```
@@ -115,7 +116,7 @@ block merges it in automatically.
 from rakaia import provenance
 
 with provenance(user=request.user.pk, url=request.path):
-    obj.save()          # any append this triggers is now attributed to the user
+    obj.save()  # any append this triggers is now attributed to the user
 ```
 
 Explicit metadata on an individual `AppendOptions` still wins over the ambient
@@ -169,10 +170,13 @@ state they're about to overwrite, read from the current-state projection):
 from rakaia import append_if_changed, AppendOptions
 
 changed = append_if_changed(
-    store, "submissions/tf", data,
-    current=SubmissionRecord.objects
-        .filter(key=sub).values_list("fields", flat=True).first(),
-    snapshot_of=lambda ev: ev["fields"],       # compare just the form fields
+    store,
+    "submissions/tf",
+    data,
+    current=SubmissionRecord.objects.filter(key=sub)
+    .values_list("fields", flat=True)
+    .first(),
+    snapshot_of=lambda ev: ev["fields"],  # compare just the form fields
     options=AppendOptions(label="update"),
 )
 # changed is True if it appended, False if the save was a no-op.

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -192,7 +192,9 @@ forbids reading ambiently — bind it with `functools.partial`:
 
 ```python
 registry.register(
-    name="project", event_match="PROJECT", effective_from=0,
+    name="project",
+    event_match="PROJECT",
+    effective_from=0,
     fn=functools.partial(project_row, fk_exists=probe),
 )
 ```

--- a/docs/history-read-model.md
+++ b/docs/history-read-model.md
@@ -62,7 +62,7 @@ effects = project_latest(
         "actor_id": msg.metadata.get("user"),
         "updated_at": msg.timestamp,
     },
-    tombstone_labels=("delete", "cancel"),      # default: ("delete",)
+    tombstone_labels=("delete", "cancel"),  # default: ("delete",)
 )
 ```
 
@@ -81,15 +81,17 @@ from django_rakaia import materialize_history
 from rakaia import label_marker, envelope_actor
 
 materialize_history(
-    store, "submissions", "audit.SubmissionHistory",
+    store,
+    "submissions",
+    "audit.SubmissionHistory",
     subject_of=lambda ev: ev["submission_id"],
     defaults_of=lambda msg, ev: {
-        "marker": label_marker(msg.label),          # + / ~ / -
-        "actor_id": envelope_actor(msg, ev),        # who edited it
+        "marker": label_marker(msg.label),  # + / ~ / -
+        "actor_id": envelope_actor(msg, ev),  # who edited it
         "ts": msg.timestamp,
-        "snapshot": ev["fields"],                   # the full snapshot
+        "snapshot": ev["fields"],  # the full snapshot
     },
-    version_of=lambda m: int(m.offset),             # stable, never-renumbered key
+    version_of=lambda m: int(m.offset),  # stable, never-renumbered key
 )
 ```
 

--- a/docs/multi-stream-merge.md
+++ b/docs/multi-stream-merge.md
@@ -14,10 +14,10 @@ from django_rakaia import DjangoProjectionReader
 
 merge_replay(
     store,
-    ["forms/sf", "forms/tf", "forms/ff"],   # several streams
+    ["forms/sf", "forms/tf", "forms/ff"],  # several streams
     DjangoExecutor(),
-    order_key=ENVELOPE_TS,                   # merge on the first-class envelope ts
-    reader=DjangoProjectionReader(),        # required iff staged / reducers
+    order_key=ENVELOPE_TS,  # merge on the first-class envelope ts
+    reader=DjangoProjectionReader(),  # required iff staged / reducers
 )
 ```
 
@@ -85,7 +85,7 @@ def merge_streams(store, stream_paths, order_key="ts"):
     for path in stream_paths:
         for offset, event in enumerate(read_events(store, path)):
             tagged.append(((event[order_key], path, offset), event))
-    tagged.sort(key=lambda item: item[0])       # deterministic total order
+    tagged.sort(key=lambda item: item[0])  # deterministic total order
     return [event for _, event in tagged]
 ```
 

--- a/docs/pghistory-retirement.md
+++ b/docs/pghistory-retirement.md
@@ -69,14 +69,25 @@ log is not a special mechanism — it is just another projection of the log.
 
 ```python
 # per event, in stream order — the same fold replay() performs
-executor.apply([
-    Upsert(model_label="…SubmissionHistoryEntry",
-           lookup={"submission_id": key, "seq": seq},
-           defaults={"label": OP_TO_LABEL[op], "actor": actor, "ts": ts, "fields": fields}),
-    Upsert(model_label="…SubmissionRecord",
-           lookup={"submission_id": key},
-           defaults={"fields": fields, "actor": actor, "updated_at": ts}),
-])
+executor.apply(
+    [
+        Upsert(
+            model_label="…SubmissionHistoryEntry",
+            lookup={"submission_id": key, "seq": seq},
+            defaults={
+                "label": OP_TO_LABEL[op],
+                "actor": actor,
+                "ts": ts,
+                "fields": fields,
+            },
+        ),
+        Upsert(
+            model_label="…SubmissionRecord",
+            lookup={"submission_id": key},
+            defaults={"fields": fields, "actor": actor, "updated_at": ts},
+        ),
+    ]
+)
 ```
 
 ## Why the consumers are satisfied

--- a/docs/projection-cookbook.md
+++ b/docs/projection-cookbook.md
@@ -25,8 +25,9 @@ stages exist.
 ```python
 # cookbook/models.py
 class Project(models.Model):
-    code = models.CharField(max_length=32, unique=True)   # natural key
+    code = models.CharField(max_length=32, unique=True)  # natural key
     name = models.CharField(max_length=200, default="")
+
 
 class Task(models.Model):
     task_id = models.CharField(max_length=32, unique=True)  # natural key
@@ -50,6 +51,7 @@ task that needs it.
 # cookbook/handlers.py
 from rakaia import Upsert, register_handler, register_simple
 
+
 @register_simple(name="project", event_match="PROJECT", match_field="form_type")
 def project(event):
     # register_simple = the always-on "just project this" case — no
@@ -61,9 +63,11 @@ def project(event):
         defaults={"name": event["name"]},
     )
 
-@register_handler(name="task", event_match="TASK", effective_from=0,
-                  match_field="form_type", stage=1)
-def task(event, reader):                      # stage > 0 ⇒ fn(event, reader)
+
+@register_handler(
+    name="task", event_match="TASK", effective_from=0, match_field="form_type", stage=1
+)
+def task(event, reader):  # stage > 0 ⇒ fn(event, reader)
     linked = reader.get("cookbook.Project", code=event["project_code"])
     return Upsert(
         model_label="cookbook.Task",
@@ -81,8 +85,13 @@ def task(event, reader):                      # stage > 0 ⇒ fn(event, reader)
     instead of a `register(...)` per value:
 
     ```python
-    @register_handler(name="sweep", event_match={"TASK", "NOTE", "MILESTONE"},
-                      effective_from=0, match_field="form_type", stage=1)
+    @register_handler(
+        name="sweep",
+        event_match={"TASK", "NOTE", "MILESTONE"},
+        effective_from=0,
+        match_field="form_type",
+        stage=1,
+    )
     def sweep(event, reader): ...
     ```
 
@@ -117,8 +126,8 @@ from django_rakaia import diff_effects_against_rows
 ex = CollectingExecutor()
 replay(store, "cookbook", ex, reader=DjangoProjectionReader())
 
-report = diff_effects_against_rows(ex.effects)   # UUID/Decimal normalised by default
-assert report.certified, report                  # or: report.raise_if_diff()
+report = diff_effects_against_rows(ex.effects)  # UUID/Decimal normalised by default
+assert report.certified, report  # or: report.raise_if_diff()
 ```
 
 `diff_effects_against_rows` returns a `DiffReport` (`.verdict` / `.certified` /
@@ -216,12 +225,17 @@ fills in the real pk at apply time.
 from rakaia import Ref, Upsert
 
 return [
-    Upsert(model_label="cookbook.Project",
-           lookup={"code": event["code"]}, defaults={"name": event["name"]},
-           produces="proj"),                                  # names this row
-    Upsert(model_label="cookbook.Task",
-           lookup={"task_id": event["task_id"]},
-           defaults={"project_id": Ref("proj")}),             # → Project.pk
+    Upsert(
+        model_label="cookbook.Project",
+        lookup={"code": event["code"]},
+        defaults={"name": event["name"]},
+        produces="proj",
+    ),  # names this row
+    Upsert(
+        model_label="cookbook.Task",
+        lookup={"task_id": event["task_id"]},
+        defaults={"project_id": Ref("proj")},
+    ),  # → Project.pk
 ]
 ```
 
@@ -241,9 +255,12 @@ get full ORM fidelity without touching production:
 # settings: a throwaway alias (in-memory sqlite for CI, scratch Postgres for cut-over)
 DATABASES["rebuild"] = {"ENGINE": "django.db.backends.sqlite3", "NAME": ":memory:"}
 
-replay(store, "cookbook",
-       DjangoExecutor(using="rebuild"),
-       reader=DjangoProjectionReader(using="rebuild"))
+replay(
+    store,
+    "cookbook",
+    DjangoExecutor(using="rebuild"),
+    reader=DjangoProjectionReader(using="rebuild"),
+)
 # ...then diff the rebuilt rows against production and discard the scratch DB.
 ```
 

--- a/docs/projections-and-fan-out.md
+++ b/docs/projections-and-fan-out.md
@@ -22,8 +22,8 @@ the parent plus the child's index:
 ```python
 from rakaia import Upsert, register_handler
 
-@register_handler(name="activity_rows", event_match="submissions",
-                  effective_from=0)
+
+@register_handler(name="activity_rows", event_match="submissions", effective_from=0)
 def activity_rows(event: dict) -> list[Upsert]:
     sid = event["submission_id"]
     return [
@@ -73,8 +73,8 @@ flowchart LR
 ```python
 from rakaia import register_handler, reconcile_children
 
-@register_handler(name="activity_rows", event_match="submissions",
-                  effective_from=0)
+
+@register_handler(name="activity_rows", event_match="submissions", effective_from=0)
 def activity_rows(event: dict):
     return reconcile_children(
         model_label="submissions.ActivityProgress",
@@ -91,7 +91,7 @@ For `items=[A, B]` it returns two `Upsert` effects (indices 0 and 1) followed by
 Delete(
     model_label="submissions.ActivityProgress",
     lookup={"submission_id": sid},
-    spare=Exclude({"activity_index__in": [0, 1]}),   # spare the current children
+    spare=Exclude({"activity_index__in": [0, 1]}),  # spare the current children
 )
 ```
 
@@ -207,7 +207,7 @@ reconcile_aggregate(
     scope_lookup={},
     group_key="suku",
     groups={suku: {"ksp_total": total} for suku, total in recomputed.items()},
-    owns=["ksp_total"],            # <- multi-owner mode
+    owns=["ksp_total"],  # <- multi-owner mode
 )
 ```
 
@@ -225,8 +225,11 @@ reconcile, not the per-group upserts:
 
 ```python
 reconcile_aggregate(
-    "ida.SukuProjection", scope_lookup={}, group_key="suku",
-    groups=recomputed, owns=["ksp_total"],
+    "ida.SukuProjection",
+    scope_lookup={},
+    group_key="suku",
+    groups=recomputed,
+    owns=["ksp_total"],
     retire_filter={"report_id__in": touched_report_ids},
 )
 ```

--- a/docs/research/handler-types.md
+++ b/docs/research/handler-types.md
@@ -98,12 +98,36 @@ Emergent, and *doubly* so. In `rebuild_tf611.py` the whole precedence rule is fo
 consecutive statements:
 
 ```python
-result   = replay(store, TF611_STREAM,          executor, handler_registry=build_tf611_authoritative_registry(...), reader=reader)
+result = replay(
+    store,
+    TF611_STREAM,
+    executor,
+    handler_registry=build_tf611_authoritative_registry(...),
+    reader=reader,
+)
 if store.has(LOCATION_STREAM):
-             replay(store, LOCATION_STREAM,      executor, handler_registry=location_registry(),        reader=reader)
-status_result = replay(store, PROJECT_STATUS_STREAM, executor, handler_registry=project_status_registry(), reader=reader)
+    replay(
+        store,
+        LOCATION_STREAM,
+        executor,
+        handler_registry=location_registry(),
+        reader=reader,
+    )
+status_result = replay(
+    store,
+    PROJECT_STATUS_STREAM,
+    executor,
+    handler_registry=project_status_registry(),
+    reader=reader,
+)
 if store.has(STATUS_STREAM):
-             replay(store, STATUS_STREAM,        executor, handler_registry=status_registry(),          reader=reader)
+    replay(
+        store,
+        STATUS_STREAM,
+        executor,
+        handler_registry=status_registry(),
+        reader=reader,
+    )
 ```
 
 Two separate things are emergent here, and they should not be conflated:

--- a/docs/staged-replay.md
+++ b/docs/staged-replay.md
@@ -17,20 +17,27 @@ from rakaia import replay
 from django_rakaia import DjangoExecutor
 from django_rakaia import DjangoProjectionReader
 
-@register_handler(name="project", event_match="TF_6_1_1",
-                  match_field="form_type", stage=0)
-def project(event):                         # stage 0: build the reference
-    return Upsert(model_label="ida.Project",
-                  lookup={"suku": event["suku"], "output": event["output"]},
-                  defaults={"name": event["project_name"]})
 
-@register_handler(name="sf12", event_match="SF_1_2",
-                  match_field="form_type", stage=1)
-def sf12(event, refs):                      # stage 1: resolve via the reader
+@register_handler(
+    name="project", event_match="TF_6_1_1", match_field="form_type", stage=0
+)
+def project(event):  # stage 0: build the reference
+    return Upsert(
+        model_label="ida.Project",
+        lookup={"suku": event["suku"], "output": event["output"]},
+        defaults={"name": event["project_name"]},
+    )
+
+
+@register_handler(name="sf12", event_match="SF_1_2", match_field="form_type", stage=1)
+def sf12(event, refs):  # stage 1: resolve via the reader
     project = refs.get("ida.Project", suku=event["suku"], output=event["output"])
-    return Upsert(model_label="ida_forms.Sf_1_2",
-                  lookup={"submission_id": event["key"]},
-                  defaults={"project_id": project.pk if project else None})
+    return Upsert(
+        model_label="ida_forms.Sf_1_2",
+        lookup={"submission_id": event["key"]},
+        defaults={"project_id": project.pk if project else None},
+    )
+
 
 replay(store, "submissions", DjangoExecutor(), reader=DjangoProjectionReader())
 ```
@@ -53,13 +60,15 @@ projections and returning idempotent Effects (typically via
 from rakaia import register_reducer
 from rakaia import reconcile_aggregate
 
+
 @register_reducer(name="balance", stage=1)
-def balance(reader):                         # runs once, after stage-1 handlers
+def balance(reader):  # runs once, after stage-1 handlers
     totals = {}
     for line in reader.query("ida.FinanceLine"):
         totals[line.suku] = totals.get(line.suku, 0) + line.amount
-    return reconcile_aggregate("ida.Balance", {}, "suku",
-                               {s: {"total": t} for s, t in totals.items()})
+    return reconcile_aggregate(
+        "ida.Balance", {}, "suku", {s: {"total": t} for s, t in totals.items()}
+    )
 ```
 
 Because it **recomputes** from the current rows on every replay, re-running is a
@@ -106,20 +115,27 @@ stage *N > 0* receives a read-only `refs` accessor over the projections that
 earlier stages materialized.
 
 ```python
-@register_handler(name="project_registry", event_match="TF_6_1_1",
-                  match_field="form_type", stage=0)
+@register_handler(
+    name="project_registry", event_match="TF_6_1_1", match_field="form_type", stage=0
+)
 def project_registry(event):
-    return Upsert(model_label="ida.Project",
-                  lookup={"suku": event["suku"], "output": event["output"]},
-                  defaults={"name": event["project_name"]})
+    return Upsert(
+        model_label="ida.Project",
+        lookup={"suku": event["suku"], "output": event["output"]},
+        defaults={"name": event["project_name"]},
+    )
 
-@register_handler(name="sf12_link", event_match="SF_1_2",
-                  match_field="form_type", stage=1)
+
+@register_handler(
+    name="sf12_link", event_match="SF_1_2", match_field="form_type", stage=1
+)
 def sf12_link(event, refs):
     project = refs.get("ida.Project", suku=event["suku"], output=event["output"])
-    return Upsert(model_label="ida_forms.Sf_1_2",
-                  lookup={"submission_id": event["key"]},
-                  defaults={"project_id": project.pk if project else None})
+    return Upsert(
+        model_label="ida_forms.Sf_1_2",
+        lookup={"submission_id": event["key"]},
+        defaults={"project_id": project.pk if project else None},
+    )
 ```
 
 Because **stage 0 is applied in full before stage 1 begins**, the entire project

--- a/docs/subscriber-cursors.md
+++ b/docs/subscriber-cursors.md
@@ -23,10 +23,10 @@ any store that can `read` and expose its head offset — the in-memory
 ```python
 from rakaia import poll
 
-result = poll(store, "submissions", cursor=None)   # first poll: everything
+result = poll(store, "submissions", cursor=None)  # first poll: everything
 for msg in result.messages:
     apply(msg)
-cursor = result.cursor                              # persist this watermark
+cursor = result.cursor  # persist this watermark
 
 # later — only the delta since `cursor`
 result = poll(store, "submissions", cursor)
@@ -83,7 +83,7 @@ store = DjangoStreamStore()
 result = poll_consumer(store, consumer_id="reporting", stream_path="submissions")
 for msg in result.messages:
     apply(msg)
-commit_cursor("reporting", "submissions", result.cursor)   # after applying
+commit_cursor("reporting", "submissions", result.cursor)  # after applying
 ```
 
 `poll_consumer` loads the stored cursor and calls `poll`; `commit_cursor` upserts

--- a/docs/tree-reconcile.md
+++ b/docs/tree-reconcile.md
@@ -42,9 +42,11 @@ def reconcile_tree(submission_id, nodes):
     kept = [n["node_id"] for n in nodes]
     return [
         *[upsert(submission_id, n) for n in nodes],
-        Delete(model_label=NODE,
-               lookup={"submission_id": submission_id},   # whole subtree
-               spare=Exclude({"node_id__in": kept})),     # any depth
+        Delete(
+            model_label=NODE,
+            lookup={"submission_id": submission_id},  # whole subtree
+            spare=Exclude({"node_id__in": kept}),
+        ),  # any depth
     ]
 ```
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -118,10 +118,16 @@ from rakaia import CollectingExecutor, replay, seed_stream
 STREAM = "invoices"
 
 EVENTS = [
-    {"invoice_id": "INV-1", "customer": "Ana",
-     "items": [{"price": "10.00", "quantity": 3}]},
-    {"invoice_id": "INV-2", "customer": "Bo",
-     "items": [{"price": "5.00", "quantity": 2}, {"price": "1.50", "quantity": 4}]},
+    {
+        "invoice_id": "INV-1",
+        "customer": "Ana",
+        "items": [{"price": "10.00", "quantity": 3}],
+    },
+    {
+        "invoice_id": "INV-2",
+        "customer": "Bo",
+        "items": [{"price": "5.00", "quantity": 2}, {"price": "1.50", "quantity": 4}],
+    },
 ]
 
 
@@ -134,7 +140,9 @@ class Command(BaseCommand):
         # Rehearsal: work out every change, write none of them.
         preview = CollectingExecutor()
         replay(store=store, stream_path=STREAM, executor=preview)
-        self.stdout.write(f"Dry run: would apply {len(preview.effects)} changes, wrote nothing.")
+        self.stdout.write(
+            f"Dry run: would apply {len(preview.effects)} changes, wrote nothing."
+        )
 
         # For real this time.
         replay(store=store, stream_path=STREAM, executor=DjangoExecutor())

--- a/docs/versioned-handlers.md
+++ b/docs/versioned-handlers.md
@@ -96,6 +96,7 @@ from rakaia import register_handler, register_upcaster
 # Upcaster: rename `repeaterContribution` -> `contributions` (v1 -> v2)
 # ---------------------------------------------------------------------------
 
+
 @register_upcaster(event_match="submissions:SF_1_2", from_version=1)
 def upcast_sf12_v1_to_v2(event: dict) -> dict:
     """Older SF_1_2 submissions used `repeaterContribution`. Normalise
@@ -111,6 +112,7 @@ def upcast_sf12_v1_to_v2(event: dict) -> dict:
 # Bug: did not include tax. Stays in source so historical events still
 # replay against the calculation that was correct at the time.
 # ---------------------------------------------------------------------------
+
 
 @register_handler(
     name="sf12_cost_sync",
@@ -131,6 +133,7 @@ def sf12_cost_sync_v1(event: dict) -> Upsert:
 # ---------------------------------------------------------------------------
 # Handler v2: same intent, applies tax. Active from seq 5000 onward.
 # ---------------------------------------------------------------------------
+
 
 @register_handler(
     name="sf12_cost_sync",
@@ -153,6 +156,7 @@ def sf12_cost_sync_v2(event: dict) -> Upsert:
 # Runs alongside sf12_cost_sync on every event. Writes a different
 # `defaults` key, so no EffectCollisionError.
 # ---------------------------------------------------------------------------
+
 
 @register_handler(
     name="sf12_project_status",
@@ -178,20 +182,23 @@ upcasters will normalise on read.
 
 ```python
 import json
-from rakaia import StreamStore   # or your durable store of choice
+from rakaia import StreamStore  # or your durable store of choice
 
-store: StreamStore = ...               # singleton
+store: StreamStore = ...  # singleton
+
 
 def emit_submission_event(submission):
     store.append(
         f"submissions:{submission.form_type}",
-        json.dumps({
-            "schema_version": 2,
-            "key": str(submission.key),
-            "form_type": submission.form_type,
-            "status": submission.status,
-            "fields": submission.fields,
-        }).encode("utf-8"),
+        json.dumps(
+            {
+                "schema_version": 2,
+                "key": str(submission.key),
+                "form_type": submission.form_type,
+                "status": submission.status,
+                "fields": submission.fields,
+            }
+        ).encode("utf-8"),
     )
 ```
 
@@ -232,7 +239,7 @@ all, you'd retire v1 and register a new version covering `[0, 5000)`:
     name="sf12_cost_sync",
     event_match="submissions:SF_1_2",
     effective_from=0,
-    effective_to=5000,    # would overlap v1 — must retire v1 first
+    effective_to=5000,  # would overlap v1 — must retire v1 first
 )
 def sf12_cost_sync_v1b(event): ...
 ```
@@ -274,7 +281,7 @@ has nowhere to report to; hand it a ledger to ask the same question:
 ```python
 from rakaia import DriftLedger, upcast
 
-ledger = DriftLedger()                 # or DriftLedger(on_drift="raise")
+ledger = DriftLedger()  # or DriftLedger(on_drift="raise")
 event = upcast(raw, "submissions", drift=ledger)
 if ledger.drifted:
     ...  # ledger.warnings holds the RAKAIA_DRIFT lines
@@ -337,6 +344,7 @@ bare decorators, call `reset_default_registries()` between tests:
 import pytest
 from rakaia import reset_default_registries
 
+
 @pytest.fixture(autouse=True)
 def _isolate_registries():
     reset_default_registries()
@@ -380,10 +388,11 @@ recompute everything when it is the whole stream:
 ```python
 from rakaia import register_reducer, reconcile_aggregate
 
+
 @register_reducer(name="balance", stage=1)
 def balance(reader, touched):
     sukus = {t.lookup["suku"] for t in touched if t.model_label == "ida.Line"}
-    groups = _recompute_totals(reader, only=sukus)      # only the touched groups
+    groups = _recompute_totals(reader, only=sukus)  # only the touched groups
     return reconcile_aggregate("ida.Balance", {}, "suku", groups)
 ```
 

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -79,17 +79,22 @@ Fixing a rule forward never rewrites the past.
 ```python
 from rakaia import Upsert, register_handler
 
-@register_handler(name="order_totals", event_match="orders",
-                  effective_from=0, effective_to=3)      # tax-free era
-def order_totals_v1(event):
-    return Upsert(model_label="orders.OrderSummary",
-                  lookup={"order_id": event["order_id"]},
-                  defaults={"tax": 0})
 
-@register_handler(name="order_totals", event_match="orders",
-                  effective_from=3)                       # 10% from seq 3 on
-def order_totals_v2(event):
-    ...
+@register_handler(
+    name="order_totals", event_match="orders", effective_from=0, effective_to=3
+)  # tax-free era
+def order_totals_v1(event):
+    return Upsert(
+        model_label="orders.OrderSummary",
+        lookup={"order_id": event["order_id"]},
+        defaults={"tax": 0},
+    )
+
+
+@register_handler(
+    name="order_totals", event_match="orders", effective_from=3
+)  # 10% from seq 3 on
+def order_totals_v2(event): ...
 ```
 
 Each event flows to the handler version whose range covers its sequence number,
@@ -122,6 +127,7 @@ that migrates an event from one schema version to the next, applied on read
 ```python
 from rakaia import register_upcaster
 
+
 @register_upcaster(event_match="orders", from_version=1)
 def rename_qty(event):
     return {**event, "quantity": event.pop("qty")}
@@ -142,11 +148,12 @@ projection always converges to exactly the children the event describes.
 ```python
 from rakaia import reconcile_children
 
+
 def activity_rows(event):
     return reconcile_children(
         model_label="app.ActivityProgress",
         parent_lookup={"submission_id": event["id"]},
-        child_key="activity_index",   # each child keyed by its position
+        child_key="activity_index",  # each child keyed by its position
         items=event["activities"],
         defaults_fn=lambda a: {"progress": a["pct"]},
     )
@@ -207,11 +214,13 @@ earlier stages — deterministic and self-healing, no backfills.
 
 ```python
 @register_handler(name="sf12", event_match="SF_1_2", match_field="form_type", stage=1)
-def sf12(event, refs):                       # stage 1 gets a projection reader
+def sf12(event, refs):  # stage 1 gets a projection reader
     project = refs.get("ida.Project", suku=event["suku"], output=event["output"])
-    return Upsert(model_label="ida_forms.Sf_1_2",
-                  lookup={"submission_id": event["key"]},
-                  defaults={"project_id": project.pk if project else None})
+    return Upsert(
+        model_label="ida_forms.Sf_1_2",
+        lookup={"submission_id": event["key"]},
+        defaults={"project_id": project.pk if project else None},
+    )
 ```
 
 Replay makes two passes; the second reads what the first built:
@@ -262,7 +271,7 @@ shipped middleware opens the block for you.
 from rakaia import provenance
 
 with provenance(user=request.user.pk, url=request.path):
-    obj.save()          # every append inside is attributed to this user
+    obj.save()  # every append inside is attributed to this user
 ```
 
 ```mermaid
@@ -361,8 +370,8 @@ registry that failed to autodiscover. Read `verdict` instead, which separates
 
 ```python
 report = diff_effects_against_rows(ex.effects)
-assert report.certified, report      # not `report.ok` — see above
-report.raise_if_diff()               # raises VacuousVerification on an empty run
+assert report.certified, report  # not `report.ok` — see above
+report.raise_if_diff()  # raises VacuousVerification on an empty run
 ```
 
 Failures are checked *before* vacuity, so a real failure is never hidden behind
@@ -410,10 +419,13 @@ getting a handful of events into a stream, without Django in the picture.
 ```python
 from rakaia import AppendOptions, seed_stream
 
-store = seed_stream("submissions", [
-    ({"key": "s1", "a": 1}, AppendOptions(label="insert")),
-    ({"key": "s1", "a": 2}, AppendOptions(label="update")),
-])
+store = seed_stream(
+    "submissions",
+    [
+        ({"key": "s1", "a": 1}, AppendOptions(label="insert")),
+        ({"key": "s1", "a": 2}, AppendOptions(label="update")),
+    ],
+)
 ```
 
 Omit `store=` and you get a fresh in-memory one back; pass any `WritableStore`

--- a/examples/chat/chat_project/settings_prod.py
+++ b/examples/chat/chat_project/settings_prod.py
@@ -21,7 +21,7 @@ Environment variables:
 
 import os
 
-from .settings import *  # noqa: F401, F403
+from .settings import *  # noqa: F403
 
 DEBUG = False
 

--- a/examples/formkit_submissions/submission_stream/management/commands/demo_submission_stream.py
+++ b/examples/formkit_submissions/submission_stream/management/commands/demo_submission_stream.py
@@ -209,7 +209,7 @@ class Command(BaseCommand):
         self.stdout.write("-" * 60)
         for s in Submission.objects.all():
             self.stdout.write(
-                f"{s.key[:8]:<12}{s.status:>7}{str(s.user):>18}   {json.dumps(s.fields)}"
+                f"{s.key[:8]:<12}{s.status:>7}{s.user!s:>18}   {json.dumps(s.fields)}"
             )
         self.stdout.write("")
 

--- a/examples/formkit_submissions/submissions/mapping.py
+++ b/examples/formkit_submissions/submissions/mapping.py
@@ -44,7 +44,7 @@ def _progress(activity: dict[str, Any]) -> int:
 
 
 def total_budget(event: dict[str, Any]) -> Decimal:
-    return sum((_budget(a) for a in activities(event)), Decimal("0"))
+    return sum((_budget(a) for a in activities(event)), Decimal(0))
 
 
 def overall_progress(event: dict[str, Any]) -> Decimal:
@@ -53,13 +53,13 @@ def overall_progress(event: dict[str, Any]) -> Decimal:
     total = total_budget(event)
     if not acts or total == 0:
         return Decimal("0.00")
-    weighted = sum((_budget(a) * _progress(a) for a in acts), Decimal("0"))
+    weighted = sum((_budget(a) * _progress(a) for a in acts), Decimal(0))
     return (weighted / total).quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
 
 
 # The tolerance threshold introduced by the v2 policy.
-LENIENT_THRESHOLD = Decimal("90")
-STRICT_THRESHOLD = Decimal("100")
+LENIENT_THRESHOLD = Decimal(90)
+STRICT_THRESHOLD = Decimal(100)
 
 
 def visit_status(progress: Decimal, *, lenient: bool) -> str:

--- a/examples/orders/orders/handlers.py
+++ b/examples/orders/orders/handlers.py
@@ -53,7 +53,7 @@ def _subtotal(event: dict) -> Decimal:
     Always reads `quantity` — the v1->v2 upcaster guarantees the legacy `qty`
     key has already been renamed by the time a handler sees the event.
     """
-    total = Decimal("0")
+    total = Decimal(0)
     for item in event.get("items", []):
         total += Decimal(str(item["price"])) * Decimal(str(item["quantity"]))
     return total
@@ -88,7 +88,7 @@ def _totals_effect(event: dict, rate: Decimal) -> Effect:
 def order_totals_v1(event: dict) -> Effect | None:
     if _is_bonus(event):
         return None  # a loyalty-bonus event has no order to total
-    return _totals_effect(event, Decimal("0"))
+    return _totals_effect(event, Decimal(0))
 
 
 # ---------------------------------------------------------------------------

--- a/examples/orders/orders_project/settings_prod.py
+++ b/examples/orders/orders_project/settings_prod.py
@@ -13,7 +13,7 @@ Environment variables:
 
 import os
 
-from .settings import *  # noqa: F401, F403
+from .settings import *  # noqa: F403
 
 DEBUG = False
 

--- a/examples/partisipa_close/lifecycle/handlers.py
+++ b/examples/partisipa_close/lifecycle/handlers.py
@@ -77,10 +77,10 @@ def balance_rollup(refs: Any) -> list[Effect]:
     for suku in sukus:
         rows = [line for line in lines if line.suku == suku]
         operational = sum(
-            (r.delta for r in rows if r.account == "operational"), Decimal("0")
+            (r.delta for r in rows if r.account == "operational"), Decimal(0)
         )
         infrastructure = sum(
-            (r.delta for r in rows if r.account == "infrastructure"), Decimal("0")
+            (r.delta for r in rows if r.account == "infrastructure"), Decimal(0)
         )
         effects.append(
             Upsert(

--- a/examples/partisipa_merge/subproject/handlers.py
+++ b/examples/partisipa_merge/subproject/handlers.py
@@ -85,10 +85,10 @@ def balance_rollup(refs: Any) -> list[Effect]:
     for suku in sorted({line.suku for line in lines}):
         rows = [line for line in lines if line.suku == suku]
         operational = sum(
-            (r.delta for r in rows if r.account == "operational"), Decimal("0")
+            (r.delta for r in rows if r.account == "operational"), Decimal(0)
         )
         infrastructure = sum(
-            (r.delta for r in rows if r.account == "infrastructure"), Decimal("0")
+            (r.delta for r in rows if r.account == "infrastructure"), Decimal(0)
         )
         effects.append(
             Upsert(

--- a/examples/partisipa_repeaters/README.md
+++ b/examples/partisipa_repeaters/README.md
@@ -74,9 +74,11 @@ they're what makes `Total` double-count (60/65 instead of 35).
 ## The reconcile is one shipped Effect, scoped to the submission
 
 ```python
-Delete(model_label="repeaters.Node",
-       lookup={"submission_id": sid},           # the whole subtree, any depth
-       spare=Exclude({"node_id__in": current_node_ids}))
+Delete(
+    model_label="repeaters.Node",
+    lookup={"submission_id": sid},  # the whole subtree, any depth
+    spare=Exclude({"node_id__in": current_node_ids}),
+)
 ```
 
 This is the `Delete` + `Exclude` effect from #6 — the only new idea is scoping the

--- a/examples/polyglot/polyglot/management/commands/stress_translations.py
+++ b/examples/polyglot/polyglot/management/commands/stress_translations.py
@@ -272,7 +272,7 @@ class Command(BaseCommand):
                     scrambled = scramble_differently(source, rng)
                     try:
                         save(pk, scrambled, worker)
-                    except Exception as exc:  # noqa: BLE001
+                    except Exception as exc:
                         # A stress run reports what broke under load; it does not
                         # abort on the first "database is locked".
                         failures.append(f"{type(exc).__name__}: {exc}")

--- a/examples/polyglot/polyglot/models.py
+++ b/examples/polyglot/polyglot/models.py
@@ -28,7 +28,7 @@ from django.utils import timezone
 DEFAULT_LANG = "en"
 
 
-class MSG_IDX(enum.Enum):
+class MsgIdx(enum.Enum):
     SINGULAR = 0
     PLURAL = 1
 
@@ -60,6 +60,9 @@ class TranslatableManager(models.Manager["Translatable"]):
             f"No translated content found: langcode='{langcode}', msgid='{msgid}'",
             stacklevel=2,
         )
+        # An untranslated msgid is a miss, not an error: the caller gets None and
+        # decides. Said explicitly because the branch above returns a string.
+        return None
 
     def ngettext(
         self, singular: str, plural: str, number: int, langcode: str = DEFAULT_LANG
@@ -78,7 +81,7 @@ class TranslatableManager(models.Manager["Translatable"]):
             f"No translated content found: langcode='{langcode}', singular='{singular}', plural='{plural}'",
             stacklevel=2,
         )
-        return singular if msg_idx == MSG_IDX.SINGULAR.value else plural
+        return singular if msg_idx == MsgIdx.SINGULAR.value else plural
 
     def pgettext(self, context: str, msgid: str, langcode: str = DEFAULT_LANG):
         try:
@@ -118,7 +121,7 @@ class TranslatableManager(models.Manager["Translatable"]):
             f"No translated content found: langcode='{langcode}', context='{context}', singular='{singular}'",
             stacklevel=2,
         )
-        return singular if msg_idx == MSG_IDX.SINGULAR.value else plural
+        return singular if msg_idx == MsgIdx.SINGULAR.value else plural
 
 
 class Translatable(models.Model):

--- a/examples/polyglot/polyglot_project/settings_prod.py
+++ b/examples/polyglot/polyglot_project/settings_prod.py
@@ -8,7 +8,7 @@ Run with:
 
 import os
 
-from .settings import *  # noqa: F401, F403
+from .settings import *  # noqa: F403
 
 DEBUG = False
 

--- a/examples/projection_cookbook/cookbook/handlers.py
+++ b/examples/projection_cookbook/cookbook/handlers.py
@@ -37,7 +37,7 @@ def project(event: dict) -> Effect:
     match_field="form_type",
     stage=1,
 )
-def task(event: dict, reader) -> Effect:  # noqa: ANN001 - reader is a ProjectionReader
+def task(event: dict, reader) -> Effect:
     """Stage 1: upsert the Task and link it to its Project by ``code``.
 
     A stage > 0 handler is called ``fn(event, reader)``. Because stage 0 has

--- a/examples/protocol_streams/demo.py
+++ b/examples/protocol_streams/demo.py
@@ -109,30 +109,30 @@ def section_producer_fencing(store: StreamStore) -> None:
         )
         return result.producer_result
 
-    P = "writer-A"
+    producer = "writer-A"
 
     # A fresh producer must open its epoch at seq=0.
-    assert isinstance(send(P, epoch=1, seq=0), ProducerAccepted)
-    assert isinstance(send(P, epoch=1, seq=1), ProducerAccepted)
+    assert isinstance(send(producer, epoch=1, seq=0), ProducerAccepted)
+    assert isinstance(send(producer, epoch=1, seq=1), ProducerAccepted)
 
     # Re-sending an already-seen (epoch, seq) is a DUPLICATE, not a second write
     # — this is what makes a network retry safe (idempotent append).
-    dup = send(P, epoch=1, seq=1)
+    dup = send(producer, epoch=1, seq=1)
     assert isinstance(dup, ProducerDuplicate) and dup.last_seq == 1
 
     # Skipping a sequence number is refused: the writer lost a message.
-    gap = send(P, epoch=1, seq=5)
+    gap = send(producer, epoch=1, seq=5)
     assert isinstance(gap, ProducerSequenceGap)
     assert gap.expected_seq == 2 and gap.received_seq == 5
 
     # Fencing: a NEW epoch (a restarted/failed-over writer) must restart at seq=0.
-    assert isinstance(send(P, epoch=2, seq=0), ProducerAccepted)
+    assert isinstance(send(producer, epoch=2, seq=0), ProducerAccepted)
     # ...and a straggling write from the OLD epoch is a zombie — rejected so a
     # partitioned old primary can't corrupt the log after failover.
-    zombie = send(P, epoch=1, seq=2)
+    zombie = send(producer, epoch=1, seq=2)
     assert isinstance(zombie, ProducerStaleEpoch) and zombie.current_epoch == 2
     # A new epoch that forgets to restart its sequence is rejected too.
-    assert isinstance(send(P, epoch=3, seq=9), ProducerInvalidEpochSeq)
+    assert isinstance(send(producer, epoch=3, seq=9), ProducerInvalidEpochSeq)
 
     # Only the ACCEPTED writes materialised (2 in epoch 1 + 1 in epoch 2).
     messages, _ = store.read(path)

--- a/justfile
+++ b/justfile
@@ -402,20 +402,31 @@ test-cov:
     uv run pytest --cov=src/rakaia --cov=src/django_rakaia --cov-report=term-missing
 
 # Lint
+#
+# No path arguments, here or in CI: what gets linted is decided by
+# `[tool.ruff]` in pyproject.toml, so the two cannot disagree. They did —
+# this recipe checked `src/ tests/` while CI checked `src/ tests/ examples/`,
+# so `just check` went green on a diff that turned CI red, and neither of them
+# ever looked at `manage.py` or `runserver.py`.
 lint:
-    uv run ruff check src/ tests/
+    uv run ruff check
 
 # Format check (no writes)
 fmt-check:
-    uv run ruff format --check src/ tests/
+    uv run ruff format --check
 
 # Format in place
 fmt:
-    uv run ruff format src/ tests/
+    uv run ruff format
 
 # Type check
+#
+# `PYRIGHT_PYTHON_FORCE_VERSION` is set to the version the lockfile pins, not to
+# `latest`. pyright-python nags when a newer release exists and suggests
+# `latest`, which silently typechecks against a different pyright than CI — the
+# one thing a gate must not do. Bump this with the `pyright` pin in pyproject.
 typecheck:
-    uv run pyright src/
+    PYRIGHT_PYTHON_FORCE_VERSION=1.1.411 uv run pyright src/
 
 # Regenerate docs/api-reference.md from what the packages actually export.
 # Commit the result; `api-reference-check` fails if it drifts.

--- a/manage.py
+++ b/manage.py
@@ -7,8 +7,10 @@ import sys
 
 def main():
     """Run administrative tasks."""
-    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "tests.test_django_rakaia.dev_settings")
-    
+    os.environ.setdefault(
+        "DJANGO_SETTINGS_MODULE", "tests.test_django_rakaia.dev_settings"
+    )
+
     try:
         from django.core.management import execute_from_command_line
     except ImportError as exc:
@@ -17,7 +19,7 @@ def main():
             "available on your PYTHONPATH environment variable? Did you "
             "forget to activate a virtual environment?"
         ) from exc
-    
+
     execute_from_command_line(sys.argv)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,8 +43,15 @@ prod = [
     "whitenoise>=6.0",
 ]
 dev = [
-    "ruff>=0.8.0",
-    "pyright>=1.1.400",
+    # Floors sit at the versions CI resolves to, not at the oldest release that
+    # happens to work. A linter is a gate, and a gate whose rule set depends on
+    # who synced last is not one: ruff adds rules and changes fix behaviour every
+    # release, so an old ruff passes code that CI's ruff rejects. `uv.lock` pins
+    # the exact version for anyone using it; these floors are what stop a
+    # lock-less install from silently linting to a different standard. Bump them
+    # together with the lock.
+    "ruff>=0.16.4",
+    "pyright>=1.1.411",
     "pytest>=8.0.0",
     "pytest-asyncio>=0.24.0",
     "pytest-cov>=6.0.0",
@@ -91,7 +98,15 @@ include = [
 
 [tool.ruff]
 line-length = 88
-target-version = "py310"
+# No `target-version`: ruff reads `project.requires-python` above. Setting both
+# means two places to bump and one of them being wrong — the pyupgrade rules
+# would keep rewriting to a floor the package no longer claims.
+#
+# No path list either. `ruff check` and `ruff format` are run with no arguments
+# everywhere — CI, the justfile, an editor — so what gets linted is decided here
+# and cannot differ between them. It used to: CI linted `src/ tests/ examples/`
+# and `just lint` linted `src/ tests/`, so `just check` passed on a diff that
+# turned CI red, and `manage.py` and `runserver.py` were never linted by either.
 
 [tool.ruff.lint]
 select = [
@@ -104,13 +119,76 @@ select = [
     "UP",     # pyupgrade
     "ARG",    # flake8-unused-arguments
     "SIM",    # flake8-simplify
+    # Added together, each having been measured against the tree first rather
+    # than adopted on reputation. Most of these had *zero* violations here — they
+    # are regression gates on habits this codebase already keeps, which is the
+    # cheapest kind of rule to own.
+    "RUF",    # ruff's own rules
+    "ASYNC",  # flake8-async — this is an async server; blocking calls in async
+              # functions are the bug class it exists to catch
+    "DTZ",    # flake8-datetimez — naive datetimes, in a project whose whole job
+              # is ordering events by time
+    "LOG",    # flake8-logging
+    "G",      # flake8-logging-format
+    "PTH",    # flake8-use-pathlib
+    "PIE",    # flake8-pie
+    "PT",     # flake8-pytest-style
+    "RET",    # flake8-return
+    "RSE",    # flake8-raise
+    "TID",    # flake8-tidy-imports
+    "ISC",    # flake8-implicit-str-concat
+    "PERF",   # perflint
+    "FURB",   # refurb
+    "N",      # pep8-naming
+    "T20",    # flake8-print
+    "A",      # flake8-builtins
 ]
 ignore = [
     "E501",   # line too long (handled by formatter)
     "B008",   # do not perform function calls in argument defaults
     "B904",   # raise without from in except
     "SIM108", # use ternary operator
+    # --- deliberately not adopted, with the reason, so the next person does not
+    # --- re-litigate it from scratch ---
+    "RUF012", # mutable class attribute should be `ClassVar`. Wrong for Django:
+              # `list_display`, `Meta`, `fields` are all mutable class
+              # attributes by framework convention, and 133 of them are.
+    "N818",   # exception name should end in `Error`. `StreamNotFound`,
+              # `SequenceConflict`, `PreloadMismatch` are public API and the
+              # house style; renaming them is a breaking change to buy a suffix.
+    "PT018",  # break up a composite assertion. 44 sites where `assert a and b`
+              # reads as the one claim it is; splitting them would say less.
+    "PERF203", # `try`/`except` in a loop. The store contract tests need exactly
+              # that shape — one attempt per item, each allowed to fail.
+    "ISC001", # conflicts with the formatter, which owns string layout.
+    "RUF002", # ambiguous unicode in a docstring…
+    "RUF003", # …and in a comment. This project writes prose with real
+              # typography — em dashes, `×`, `∪` — and the homoglyph risk the
+              # rule guards against is about identifiers, not paragraphs.
+    "RUF022", # `__all__` is not sorted. Both `__all__` lists are grouped by
+              # subject with headings, which is documentation; alphabetising
+              # them would delete it.
+    "PT012",  # `pytest.raises()` block should be one statement. Several sites
+              # legitimately hold a second context manager (`transaction.atomic`)
+              # or must raise from inside the block being tested.
+    "PT011",  # broad `pytest.raises(ValueError)`…
+    "PT030",  # …and broad `pytest.warns(UserWarning)`. Every site binds the
+              # exception and then asserts on its message, which is what the
+              # rule is asking for and stricter than a `match=` regex — it says
+              # which substrings must appear and why.
 ]
+
+[tool.ruff.lint.per-file-ignores]
+# Printing *is* the interface here: `__main__.py` is a CLI, the examples are
+# runnable demos that narrate what they prove, and `scripts/` is developer
+# tooling. Keeping T20 selected everywhere else is what stops a debug `print`
+# reaching library code.
+"src/rakaia/__main__.py" = ["T201"]
+"examples/**" = ["T201", "T203"]
+"scripts/**" = ["T201"]
+# A Django `TestCase` in this example uses `assertEqual`/`assertRaises`, which is
+# the framework's own idiom rather than pytest's.
+"examples/formkit_submissions/**" = ["PT009", "PT027"]
 
 [tool.ruff.lint.isort]
 known-first-party = ["rakaia", "django_rakaia"]

--- a/runserver.py
+++ b/runserver.py
@@ -17,11 +17,11 @@ import django
 def main():
     """Run administrative tasks."""
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "tests.test_django_rakaia.settings")
-    
+
     django.setup()
-    
+
     from django.core.management import execute_from_command_line
-    
+
     execute_from_command_line(sys.argv)
 
 

--- a/scripts/gen_api_reference.py
+++ b/scripts/gen_api_reference.py
@@ -25,7 +25,7 @@ sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent / "src"))
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "tests.test_django_rakaia.settings")
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent))
 
-import django  # noqa: E402
+import django
 
 django.setup()
 

--- a/src/django_rakaia/checks.py
+++ b/src/django_rakaia/checks.py
@@ -18,7 +18,10 @@ from __future__ import annotations
 from typing import Any
 
 from django.conf import settings
-from django.core.checks import Error, Warning, register
+
+# `Warning` shadows the builtin, but it is Django's own check class and this
+# module's whole job is returning them; aliasing it would obscure that.
+from django.core.checks import Error, Warning, register  # noqa: A004
 
 from .store import BACKENDS, DEFAULT_BACKEND
 

--- a/src/django_rakaia/django_store.py
+++ b/src/django_rakaia/django_store.py
@@ -683,7 +683,7 @@ class DjangoStreamStore:
 
         messages: list[StreamMessage] = []
         for value, encoding in payloads:
-            event, (entry,) = write_enveloped_event(
+            _event, (entry,) = write_enveloped_event(
                 [stream],
                 value,
                 label=label,

--- a/src/django_rakaia/hermeticity.py
+++ b/src/django_rakaia/hermeticity.py
@@ -138,7 +138,7 @@ def deny_database_access(*aliases: str) -> Iterator[None]:
     def _blocker(alias: str):
         # Django calls the wrapper positionally as
         # (execute, sql, params, many, context); only `sql` is used here.
-        def _wrap(_execute, sql, _params, _many, _context):  # noqa: ANN001
+        def _wrap(_execute, sql, _params, _many, _context):
             raise AmbientDatabaseAccess(
                 f"replay touched the {alias!r} database directly "
                 f"(SQL: {_preview(sql)}). A hermetic rebuild reads only through "

--- a/src/rakaia/handler.py
+++ b/src/rakaia/handler.py
@@ -630,11 +630,8 @@ async def _handle_read(
 
     # Long-poll: wait if caught up and no messages
     client_caught_up = False
-    if (
-        offset == "now"
-        and len(messages) == 0
-        or effective_offset is not None
-        and effective_offset == stream.current_offset
+    if (offset == "now" and len(messages) == 0) or (
+        effective_offset is not None and effective_offset == stream.current_offset
     ):
         client_caught_up = True
 
@@ -863,7 +860,7 @@ async def _handle_sse(
                 up_to_date,
                 cursor,
                 cursor_opts,
-            )  # noqa: B023
+            )
 
         await send_body_chunk(send, buffer)
 
@@ -1069,22 +1066,21 @@ async def _handle_append(
                 },
             )
             return
-        else:
-            # Simple close without producer
-            close_result = await store.run_sync(store.close_stream, path)
-            if close_result is None:
-                await _send_error(send, 404, b"Stream not found", cors)
-                return
-            await send_response(
-                send,
-                204,
-                {
-                    **cors,
-                    STREAM_OFFSET_HEADER_RESP: close_result.final_offset,
-                    STREAM_CLOSED_HEADER_RESP: "true",
-                },
-            )
+        # Simple close without producer
+        close_result = await store.run_sync(store.close_stream, path)
+        if close_result is None:
+            await _send_error(send, 404, b"Stream not found", cors)
             return
+        await send_response(
+            send,
+            204,
+            {
+                **cors,
+                STREAM_OFFSET_HEADER_RESP: close_result.final_offset,
+                STREAM_CLOSED_HEADER_RESP: "true",
+            },
+        )
+        return
 
     # Empty body without close is an error
     if len(body) == 0:

--- a/src/rakaia/replay.py
+++ b/src/rakaia/replay.py
@@ -320,17 +320,21 @@ def _synth_transitions(report: ApplyReport | None) -> list[ExternalEffect]:
         if eff.transition is None:
             continue
         patch = eff.patch or {}
-        for identity in rows:
-            out.append(
-                ExternalEffect(
-                    kind=eff.transition.kind,
-                    # Spread patch first so the orchestrator's own `key`/`state`
-                    # always win: reconcile_by_key is a generic primitive, and a
-                    # patch column named `key` or `state` must not clobber the
-                    # row identity or the transition state.
-                    payload={**patch, "key": dict(identity), "state": "resolved"},
-                )
+        # `kind` is bound out here rather than read inside the generator: the
+        # `is None` check above narrows `eff.transition` in this scope only, and
+        # a generator body is a scope of its own.
+        kind = eff.transition.kind
+        out.extend(
+            ExternalEffect(
+                kind=kind,
+                # Spread patch first so the orchestrator's own `key`/`state`
+                # always win: reconcile_by_key is a generic primitive, and a
+                # patch column named `key` or `state` must not clobber the
+                # row identity or the transition state.
+                payload={**patch, "key": dict(identity), "state": "resolved"},
             )
+            for identity in rows
+        )
     return out
 
 

--- a/tests/store_contract.py
+++ b/tests/store_contract.py
@@ -34,6 +34,7 @@ per append, and usable as a resume token. See #39.
 from __future__ import annotations
 
 import json
+from itertools import pairwise
 
 import pytest
 
@@ -178,7 +179,7 @@ class StoreContract:
         offsets = [m.offset for m in store.read("s")[0]]
         assert offsets == sorted(offsets)
         assert len(set(offsets)) == len(offsets)  # no duplicates
-        assert all(a < b for a, b in zip(offsets, offsets[1:], strict=False))
+        assert all(a < b for a, b in pairwise(offsets))
 
     def test_offset_is_an_opaque_resume_token(self, store):
         # An offset round-trips as a resume token without any numeric parsing:
@@ -230,7 +231,7 @@ class StoreContract:
         assert bulk_msgs[2].event_ts == 1_600_000_000.5
         assert isinstance(bulk_msgs[0].event_ts, float)
         offsets = [m.offset for m in bulk_msgs]
-        assert all(a < b for a, b in zip(offsets, offsets[1:], strict=False))
+        assert all(a < b for a, b in pairwise(offsets))
 
     def test_append_many_empty_is_noop(self, store):
         store.create("s")

--- a/tests/test_django_rakaia/dev_settings.py
+++ b/tests/test_django_rakaia/dev_settings.py
@@ -10,7 +10,7 @@ from pathlib import Path
 BASE_DIR = Path(__file__).resolve().parent.parent.parent
 
 # Import test settings as base FIRST
-from tests.test_django_rakaia.settings import *  # noqa: F401, F403, E402
+from tests.test_django_rakaia.settings import *  # noqa: F403, E402
 
 # Override for development
 DEBUG = True

--- a/tests/test_django_rakaia/test_canonicalisation_layering.py
+++ b/tests/test_django_rakaia/test_canonicalisation_layering.py
@@ -324,7 +324,7 @@ class TestVerificationStillExportsWhatItDefines:
 
     def test_star_import_yields_every_exported_name(self):
         namespace: dict[str, object] = {}
-        exec("from django_rakaia.verification import *", namespace)  # noqa: S102
+        exec("from django_rakaia.verification import *", namespace)
 
         from django_rakaia import verification
 
@@ -358,7 +358,7 @@ class TestVerificationStillExportsWhatItDefines:
     @pytest.mark.parametrize("name", BACK_COMPAT_REEXPORTS)
     def test_a_reexported_name_survives_a_star_import(self, name):
         namespace: dict[str, object] = {}
-        exec("from django_rakaia.verification import *", namespace)  # noqa: S102
+        exec("from django_rakaia.verification import *", namespace)
         assert name in namespace
 
     @pytest.mark.parametrize("name", BACK_COMPAT_REEXPORTS)

--- a/tests/test_django_rakaia/test_concurrent_appends.py
+++ b/tests/test_django_rakaia/test_concurrent_appends.py
@@ -58,7 +58,7 @@ def _run(*targets: Any) -> None:
         def inner() -> None:
             try:
                 fn()
-            except BaseException as exc:  # noqa: BLE001 - re-raised below
+            except BaseException as exc:
                 errors.append(exc)
             finally:
                 connections.close_all()

--- a/tests/test_django_rakaia/test_locking.py
+++ b/tests/test_django_rakaia/test_locking.py
@@ -95,7 +95,7 @@ def _run(*targets: Any) -> None:
         def inner() -> None:
             try:
                 fn()
-            except BaseException as exc:  # noqa: BLE001 - re-raised below
+            except BaseException as exc:
                 errors.append(exc)
             finally:
                 connections.close_all()

--- a/tests/test_django_rakaia/test_update_batching.py
+++ b/tests/test_django_rakaia/test_update_batching.py
@@ -776,10 +776,10 @@ class TestASubclassIsNotItsBaseType:
 
     def test_a_str_subclass_that_lies_about_equality_is_not_gathered(self):
         class Sneaky(str):
-            def __eq__(self, other):  # noqa: D105
+            def __eq__(self, other):
                 return True  # "I am every string"
 
-            def __hash__(self):  # noqa: D105
+            def __hash__(self):
                 return 0
 
         FinanceLine.objects.create(submission_id="a", suku="", delta=0)

--- a/tests/test_rakaia/test_append_decision.py
+++ b/tests/test_rakaia/test_append_decision.py
@@ -73,7 +73,7 @@ class TestClosed:
         assert isinstance(verdict.producer_result, ProducerDuplicate)
 
     @pytest.mark.parametrize(
-        "producer_id,epoch,seq",
+        ("producer_id", "epoch", "seq"),
         [
             ("other", 2, 7),  # different producer
             ("p", 3, 7),  # same producer, later epoch

--- a/tests/test_rakaia/test_drift_ledger.py
+++ b/tests/test_rakaia/test_drift_ledger.py
@@ -176,8 +176,10 @@ class TestMergeReplayAsksTheSameQuestion:
         assert result.events_processed == 10
         current = hash_function_source(_upcaster)
         assert result.warnings == [
-            f"RAKAIA_DRIFT upcaster={version.dotted_path!r} "
-            f"stored={STORED[:12]} current={current[:12]}"
+            (
+                f"RAKAIA_DRIFT upcaster={version.dotted_path!r} "
+                f"stored={STORED[:12]} current={current[:12]}"
+            )
         ]
 
     def test_strict_drift_raises_from_a_merge_too(

--- a/tests/test_rakaia/test_producer_response.py
+++ b/tests/test_rakaia/test_producer_response.py
@@ -73,7 +73,7 @@ class TestTheRefusalTable:
         )
 
     def test_an_invalid_epoch_opening_is_400(self):
-        status, body, headers = producer_response(
+        status, body, _headers = producer_response(
             ProducerInvalidEpochSeq(), producer_epoch=1
         )
         assert status == 400

--- a/tests/test_rakaia/test_public_api.py
+++ b/tests/test_rakaia/test_public_api.py
@@ -237,8 +237,10 @@ class TestImportingTheDjangoPackageStaysCheap:
             [
                 sys.executable,
                 "-c",
-                "import sys, django_rakaia; "
-                "print('django_rakaia.models' in sys.modules)",
+                (
+                    "import sys, django_rakaia; "
+                    "print('django_rakaia.models' in sys.modules)"
+                ),
             ],
             capture_output=True,
             text=True,

--- a/tests/test_rakaia/test_replay.py
+++ b/tests/test_rakaia/test_replay.py
@@ -254,7 +254,7 @@ class TestUpcasting:
 
         def h(event):
             captured.append(event)
-            return None
+            return
 
         handlers.register("h", "s", h, 0, None)
         seed_stream("s", [{"id": 1, "schema_version": 1}], store=store)
@@ -285,7 +285,7 @@ class TestRangeBounds:
 
         def h(event):
             captured.append(event["id"])
-            return None
+            return
 
         reg.register("h", "s", h, 0, None)
         seed_stream("s", [{"id": i} for i in range(5)], store=store)
@@ -304,7 +304,7 @@ class TestRangeBounds:
 
         def h(event):
             captured.append(event["id"])
-            return None
+            return
 
         reg.register("h", "s", h, 0, None)
         seed_stream("s", [{"id": i} for i in range(5)], store=store)

--- a/tests/test_rakaia/test_store.py
+++ b/tests/test_rakaia/test_store.py
@@ -511,7 +511,7 @@ class TestLongPoll:
         store.close_stream("foo")
         stream = store.get("foo")
         assert stream is not None
-        messages, timed_out, closed = await store.wait_for_messages(
+        _messages, _timed_out, closed = await store.wait_for_messages(
             "foo", offset=stream.current_offset, timeout_seconds=0.1
         )
         assert closed is True

--- a/uv.lock
+++ b/uv.lock
@@ -59,10 +59,10 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "cryptography", marker = "python_full_version < '3.11'" },
-    { name = "hyperlink", marker = "python_full_version < '3.11'" },
-    { name = "setuptools", marker = "python_full_version < '3.11'" },
-    { name = "txaio", version = "25.9.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "cryptography" },
+    { name = "hyperlink" },
+    { name = "setuptools" },
+    { name = "txaio", version = "25.9.2", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/38/f2/8dffb3b709383ba5b47628b0cc4e43e8d12d59eecbddb62cfccac2e7cf6a/autobahn-24.4.2.tar.gz", hash = "sha256:a2d71ef1b0cf780b6d11f8b205fd2c7749765e65795f2ea7d823796642ee92c9", size = 482700, upload-time = "2024-08-02T09:26:48.241Z" }
 wheels = [
@@ -78,15 +78,15 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "cbor2", marker = "python_full_version >= '3.11'" },
-    { name = "cffi", marker = "python_full_version >= '3.11'" },
-    { name = "cryptography", marker = "python_full_version >= '3.11'" },
-    { name = "hyperlink", marker = "python_full_version >= '3.11'" },
-    { name = "msgpack", marker = "python_full_version >= '3.11' and platform_python_implementation == 'CPython'" },
-    { name = "py-ubjson", marker = "python_full_version >= '3.11'" },
-    { name = "txaio", version = "25.12.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "u-msgpack-python", marker = "python_full_version >= '3.11' and platform_python_implementation != 'CPython'" },
-    { name = "ujson", marker = "python_full_version >= '3.11'" },
+    { name = "cbor2" },
+    { name = "cffi" },
+    { name = "cryptography" },
+    { name = "hyperlink" },
+    { name = "msgpack", marker = "platform_python_implementation == 'CPython'" },
+    { name = "py-ubjson" },
+    { name = "txaio", version = "25.12.2", source = { registry = "https://pypi.org/simple" } },
+    { name = "u-msgpack-python", marker = "platform_python_implementation != 'CPython'" },
+    { name = "ujson" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/54/d5/9adf0f5b9eb244e58e898e9f3db4b00c09835ef4b6c37d491886e0376b4f/autobahn-25.12.2.tar.gz", hash = "sha256:754c06a54753aeb7e8d10c5cbf03249ad9e2a1a32bca8be02865c6f00628a98c", size = 13893652, upload-time = "2025-12-15T11:13:19.086Z" }
 wheels = [
@@ -531,9 +531,9 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "asgiref", marker = "python_full_version < '3.12'" },
-    { name = "sqlparse", marker = "python_full_version < '3.12'" },
-    { name = "tzdata", marker = "python_full_version < '3.12' and sys_platform == 'win32'" },
+    { name = "asgiref" },
+    { name = "sqlparse" },
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/bd/55/b9445fc0695b03746f355c05b2eecc54c34e05198c686f4fc4406b722b52/django-5.2.12.tar.gz", hash = "sha256:6b809af7165c73eff5ce1c87fdae75d4da6520d6667f86401ecf55b681eb1eeb", size = 10860574, upload-time = "2026-03-03T13:56:05.509Z" }
 wheels = [
@@ -548,9 +548,9 @@ resolution-markers = [
     "python_full_version >= '3.12'",
 ]
 dependencies = [
-    { name = "asgiref", marker = "python_full_version >= '3.12'" },
-    { name = "sqlparse", marker = "python_full_version >= '3.12'" },
-    { name = "tzdata", marker = "python_full_version >= '3.12' and sys_platform == 'win32'" },
+    { name = "asgiref" },
+    { name = "sqlparse" },
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/80/e1/894115c6bd70e2c8b66b0c40a3c367d83a5a48c034a4d904d31b62f7c53a/django-6.0.3.tar.gz", hash = "sha256:90be765ee756af8a6cbd6693e56452404b5ad15294f4d5e40c0a55a0f4870fe1", size = 10872701, upload-time = "2026-03-03T13:55:15.026Z" }
 wheels = [
@@ -587,7 +587,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -1080,15 +1080,15 @@ wheels = [
 
 [[package]]
 name = "pyright"
-version = "1.1.408"
+version = "1.1.411"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "nodeenv" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/74/b2/5db700e52554b8f025faa9c3c624c59f1f6c8841ba81ab97641b54322f16/pyright-1.1.408.tar.gz", hash = "sha256:f28f2321f96852fa50b5829ea492f6adb0e6954568d1caa3f3af3a5f555eb684", size = 4400578, upload-time = "2026-01-08T08:07:38.795Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/ab/265f7dc69d28113ebba19092e57b075f41543b2ed048429c5f56e2b88eac/pyright-1.1.411.tar.gz", hash = "sha256:d885a0551f2e763b089a02702174e7f4ba77548cddabc972ab86d1f7f1b0f998", size = 4112861, upload-time = "2026-06-25T02:14:06.37Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0c/82/a2c93e32800940d9573fb28c346772a14778b84ba7524e691b324620ab89/pyright-1.1.408-py3-none-any.whl", hash = "sha256:090b32865f4fdb1e0e6cd82bf5618480d48eecd2eb2e70f960982a3d9a4c17c1", size = 6399144, upload-time = "2026-01-08T08:07:37.082Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/49/385be530a6a5b78d1cbcd5c2e38debc8959a2fc6bdb716f4e581002979fc/pyright-1.1.411-py3-none-any.whl", hash = "sha256:dc7c72a8e2700c55baa127554040e067041ea53ccfd50bf96308cc4291c7d5d9", size = 6181526, upload-time = "2026-06-25T02:14:04.691Z" },
 ]
 
 [[package]]
@@ -1270,12 +1270,12 @@ requires-dist = [
     { name = "markdown", marker = "extra == 'docs'", specifier = ">=3.10.2" },
     { name = "psycopg", extras = ["binary"], marker = "extra == 'postgres'", specifier = ">=3.1" },
     { name = "pymdown-extensions", marker = "extra == 'docs'", specifier = ">=11.0.1" },
-    { name = "pyright", marker = "extra == 'dev'", specifier = ">=1.1.400" },
+    { name = "pyright", marker = "extra == 'dev'", specifier = ">=1.1.411" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=6.0.0" },
     { name = "pytest-django", marker = "extra == 'dev'", specifier = ">=4.9.0" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.8.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.16.4" },
     { name = "uvicorn", marker = "extra == 'dev'", specifier = ">=0.30.0" },
     { name = "whitenoise", marker = "extra == 'prod'", specifier = ">=6.0" },
     { name = "zensical", marker = "extra == 'docs'", specifier = ">=0.0.51" },
@@ -1299,27 +1299,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.15.6"
+version = "0.16.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/51/df/f8629c19c5318601d3121e230f74cbee7a3732339c52b21daa2b82ef9c7d/ruff-0.15.6.tar.gz", hash = "sha256:8394c7bb153a4e3811a4ecdacd4a8e6a4fa8097028119160dffecdcdf9b56ae4", size = 4597916, upload-time = "2026-03-12T23:05:47.51Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/00/8f/d8074b1f25e003164087a8bfe79a0f1a3945135764dbb6aaab04103dcaf9/ruff-0.16.4.tar.gz", hash = "sha256:13171aa9d9af2240ee3504e639de73122c67e74036de5ba2e1d01422cd17e3dc", size = 4899731, upload-time = "2026-08-20T17:43:59.196Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9e/2f/4e03a7e5ce99b517e98d3b4951f411de2b0fa8348d39cf446671adcce9a2/ruff-0.15.6-py3-none-linux_armv6l.whl", hash = "sha256:7c98c3b16407b2cf3d0f2b80c80187384bc92c6774d85fefa913ecd941256fff", size = 10508953, upload-time = "2026-03-12T23:05:17.246Z" },
-    { url = "https://files.pythonhosted.org/packages/70/60/55bcdc3e9f80bcf39edf0cd272da6fa511a3d94d5a0dd9e0adf76ceebdb4/ruff-0.15.6-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:ee7dcfaad8b282a284df4aa6ddc2741b3f4a18b0555d626805555a820ea181c3", size = 10942257, upload-time = "2026-03-12T23:05:23.076Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/f9/005c29bd1726c0f492bfa215e95154cf480574140cb5f867c797c18c790b/ruff-0.15.6-py3-none-macosx_11_0_arm64.whl", hash = "sha256:3bd9967851a25f038fc8b9ae88a7fbd1b609f30349231dffaa37b6804923c4bb", size = 10322683, upload-time = "2026-03-12T23:05:33.738Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/74/2f861f5fd7cbb2146bddb5501450300ce41562da36d21868c69b7a828169/ruff-0.15.6-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:13f4594b04e42cd24a41da653886b04d2ff87adbf57497ed4f728b0e8a4866f8", size = 10660986, upload-time = "2026-03-12T23:05:53.245Z" },
-    { url = "https://files.pythonhosted.org/packages/c1/a1/309f2364a424eccb763cdafc49df843c282609f47fe53aa83f38272389e0/ruff-0.15.6-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e2ed8aea2f3fe57886d3f00ea5b8aae5bf68d5e195f487f037a955ff9fbaac9e", size = 10332177, upload-time = "2026-03-12T23:05:56.145Z" },
-    { url = "https://files.pythonhosted.org/packages/30/41/7ebf1d32658b4bab20f8ac80972fb19cd4e2c6b78552be263a680edc55ac/ruff-0.15.6-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:70789d3e7830b848b548aae96766431c0dc01a6c78c13381f423bf7076c66d15", size = 11170783, upload-time = "2026-03-12T23:06:01.742Z" },
-    { url = "https://files.pythonhosted.org/packages/76/be/6d488f6adca047df82cd62c304638bcb00821c36bd4881cfca221561fdfc/ruff-0.15.6-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:542aaf1de3154cea088ced5a819ce872611256ffe2498e750bbae5247a8114e9", size = 12044201, upload-time = "2026-03-12T23:05:28.697Z" },
-    { url = "https://files.pythonhosted.org/packages/71/68/e6f125df4af7e6d0b498f8d373274794bc5156b324e8ab4bf5c1b4fc0ec7/ruff-0.15.6-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1c22e6f02c16cfac3888aa636e9eba857254d15bbacc9906c9689fdecb1953ab", size = 11421561, upload-time = "2026-03-12T23:05:31.236Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/9f/f85ef5fd01a52e0b472b26dc1b4bd228b8f6f0435975442ffa4741278703/ruff-0.15.6-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:98893c4c0aadc8e448cfa315bd0cc343a5323d740fe5f28ef8a3f9e21b381f7e", size = 11310928, upload-time = "2026-03-12T23:05:45.288Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/26/b75f8c421f5654304b89471ed384ae8c7f42b4dff58fa6ce1626d7f2b59a/ruff-0.15.6-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:70d263770d234912374493e8cc1e7385c5d49376e41dfa51c5c3453169dc581c", size = 11235186, upload-time = "2026-03-12T23:05:50.677Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/d4/d5a6d065962ff7a68a86c9b4f5500f7d101a0792078de636526c0edd40da/ruff-0.15.6-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:55a1ad63c5a6e54b1f21b7514dfadc0c7fb40093fa22e95143cf3f64ebdcd512", size = 10635231, upload-time = "2026-03-12T23:05:37.044Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/56/7c3acf3d50910375349016cf33de24be021532042afbed87942858992491/ruff-0.15.6-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:8dc473ba093c5ec238bb1e7429ee676dca24643c471e11fbaa8a857925b061c0", size = 10340357, upload-time = "2026-03-12T23:06:04.748Z" },
-    { url = "https://files.pythonhosted.org/packages/06/54/6faa39e9c1033ff6a3b6e76b5df536931cd30caf64988e112bbf91ef5ce5/ruff-0.15.6-py3-none-musllinux_1_2_i686.whl", hash = "sha256:85b042377c2a5561131767974617006f99f7e13c63c111b998f29fc1e58a4cfb", size = 10860583, upload-time = "2026-03-12T23:05:58.978Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/1e/509a201b843b4dfb0b32acdedf68d951d3377988cae43949ba4c4133a96a/ruff-0.15.6-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:cef49e30bc5a86a6a92098a7fbf6e467a234d90b63305d6f3ec01225a9d092e0", size = 11410976, upload-time = "2026-03-12T23:05:39.955Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/25/3fc9114abf979a41673ce877c08016f8e660ad6cf508c3957f537d2e9fa9/ruff-0.15.6-py3-none-win32.whl", hash = "sha256:bbf67d39832404812a2d23020dda68fee7f18ce15654e96fb1d3ad21a5fe436c", size = 10616872, upload-time = "2026-03-12T23:05:42.451Z" },
-    { url = "https://files.pythonhosted.org/packages/89/7a/09ece68445ceac348df06e08bf75db72d0e8427765b96c9c0ffabc1be1d9/ruff-0.15.6-py3-none-win_amd64.whl", hash = "sha256:aee25bc84c2f1007ecb5037dff75cef00414fdf17c23f07dc13e577883dca406", size = 11787271, upload-time = "2026-03-12T23:05:20.168Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/d0/578c47dd68152ddddddf31cd7fc67dc30b7cdf639a86275fda821b0d9d98/ruff-0.15.6-py3-none-win_arm64.whl", hash = "sha256:c34de3dd0b0ba203be50ae70f5910b17188556630e2178fd7d79fc030eb0d837", size = 11060497, upload-time = "2026-03-12T23:05:25.968Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/80/779895ef584e089d22f2c6df0d0e99a65ec2df0805f1fffd439415b8c1f0/ruff-0.16.4-py3-none-linux_armv6l.whl", hash = "sha256:df4075f71ddac40b9934af60c3ec8a53047dd5a5fdc43224e6e4e8e9a27cb6f7", size = 10006909, upload-time = "2026-08-20T17:43:16.888Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/e6/f553199b5e8927a05cb5c422d921fd0656b29ab976e91c44802107c6b0da/ruff-0.16.4-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:0c95538517af68004306b0fb3214ff2f2af67a65092aee77cd9eb86db6656604", size = 10240201, upload-time = "2026-08-20T17:43:19.337Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/70/4a6dc4bb34da4dee35e30f09bbd1bfbdd26f33b62fb9b8df31f08a199cd2/ruff-0.16.4-py3-none-macosx_11_0_arm64.whl", hash = "sha256:963f83df8e69e575b64d67dd447ebbc917db41a14bf38d4593a4183e7aaa8255", size = 9835122, upload-time = "2026-08-20T17:43:21.708Z" },
+    { url = "https://files.pythonhosted.org/packages/24/12/c6e22d686372c15bcb7af99831f1a1be96df696491babf4f24e4f942c527/ruff-0.16.4-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:32a5057c7ff3f6e6480a48fccfb3a412a690f48a3d03ac5cf08177d6c2da3ade", size = 9977162, upload-time = "2026-08-20T17:43:24.236Z" },
+    { url = "https://files.pythonhosted.org/packages/46/49/72b10ec912f5ab5854992eaf7aa7cd36729b6937d9dc4e0fb41b3bf428ec/ruff-0.16.4-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b3dce8d9b0c57c265b91885a66a567d8ea1372e8eb4e250fa8e5e3f579e99cff", size = 9829789, upload-time = "2026-08-20T17:43:26.966Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/80/0f30e32e7f6ee26edc39075502db9d368d788a44a79b55f763eb4ab03796/ruff-0.16.4-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7dc651db49283c69f8e72c834eec4fe5573e4c646856aebece0ce385dceb2a80", size = 10527949, upload-time = "2026-08-20T17:43:29.384Z" },
+    { url = "https://files.pythonhosted.org/packages/52/3d/86e8ad3542169e56cac3859a343afdb9df2ad54d35a59ce1e67baee83421/ruff-0.16.4-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3817b87dbcabc92f13b05019257c5b89b5b4d51b5fb20f56fb5235ceb723cd07", size = 11333695, upload-time = "2026-08-20T17:43:31.872Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/16/481c29b380c20a0054a8261066665e1b3488e23636c49d0a43e75975b9bb/ruff-0.16.4-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e9fce1499134b2c8c68e5166f95705a5812062bb93aacc5f9873bb1a27084bc7", size = 10727741, upload-time = "2026-08-20T17:43:34.596Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/b6/56bc0b8cf45b54b28b3a5e6381c8945d51b5b18adf659454c32295209a31/ruff-0.16.4-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f2d812e482f5a7e02eee26cd73d2a37ebbdf47d795ea63ba1b89110ae93e9fb3", size = 10286522, upload-time = "2026-08-20T17:43:37.288Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/8b/b345b4fb110f2fbe2bd31eabd271e5e8b3b7e4ee6c0e02f2dc6be78db000/ruff-0.16.4-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:6baaf984aa7976edf93d3b627fe2d1d22ee94bbca05fa6f90fc76d73924e3454", size = 10584182, upload-time = "2026-08-20T17:43:39.984Z" },
+    { url = "https://files.pythonhosted.org/packages/29/e5/827b34041c35f58774a9681a4213994c164fc987800f4dddabcf451da0bf/ruff-0.16.4-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:bdfcf0b28662eb890372d50f92c283bb94e67e7635ed93c7fd533970acff7b2b", size = 10134195, upload-time = "2026-08-20T17:43:42.351Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/10/d0bffcdd6729b87afc82ba0ef377173356a7dc8e972f5179968cf2fdf98c/ruff-0.16.4-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:b66b02cb9b04f537643cadf5768e5f98dc461890d530cb67113d71c8c76e605d", size = 9825821, upload-time = "2026-08-20T17:43:44.532Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/32/0db2a863b796ca62d83e92a07a3ccf00921b14db02059347576a2fda3d4b/ruff-0.16.4-py3-none-musllinux_1_2_i686.whl", hash = "sha256:8528bf9a4b291a60bf02ea453511e8ce6215bd2b982ee80405b66b008b6c30a0", size = 10267658, upload-time = "2026-08-20T17:43:46.989Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/a0/fbdeb59e48c6261f523e56c8f12e9c08fbe693786595cc7e3959207a9232/ruff-0.16.4-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:fbd85d2875fdd67e833213a651f613bbf25303abf6aa822a5121f4531195678d", size = 10697071, upload-time = "2026-08-20T17:43:49.891Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/28/0c6dd865859c6d17bc8ccc34cb72b0e02d6c7eb25e8a1e22b5bea681e2c0/ruff-0.16.4-py3-none-win32.whl", hash = "sha256:312769988007aaeb8e189b443ccdd03c0e6374489e053467be6d96518ebff76e", size = 10021687, upload-time = "2026-08-20T17:43:52.281Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/03/e724450f621698117f9aa6dd241c94d0274ae96781378dc86745ae29f0e7/ruff-0.16.4-py3-none-win_amd64.whl", hash = "sha256:05d9d27a18c4bcbefada602480ec9e01e0bc949d432e0ced5df77edac195919c", size = 10567657, upload-time = "2026-08-20T17:43:54.78Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/fe/da8b9e1347696bb22120b77280ec5ce25d500ca5cb39d5ad6e5c18de19c1/ruff-0.16.4-py3-none-win_arm64.whl", hash = "sha256:a3a61621c9b6f6a89573e938a080e648f1695baa3f58570a3a707bc51ff65a21", size = 10451579, upload-time = "2026-08-20T17:43:57.135Z" },
 ]
 
 [[package]]
@@ -1360,8 +1360,8 @@ name = "taskgroup"
 version = "0.2.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "exceptiongroup" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f0/8d/e218e0160cc1b692e6e0e5ba34e8865dbb171efeb5fc9a704544b3020605/taskgroup-0.2.2.tar.gz", hash = "sha256:078483ac3e78f2e3f973e2edbf6941374fbea81b9c5d0a96f51d297717f4752d", size = 11504, upload-time = "2025-01-03T09:24:13.761Z" }
 wheels = [


### PR DESCRIPTION
Two gates could disagree with themselves. `just lint` checked a narrower set of paths than CI did, so the local gate passed on diffs CI rejected, and neither of them ever looked at `manage.py` or `runserver.py`. And the generated API reference was only enforced by `just check`, which nobody is obliged to run — which is how main ended up last week with a file its own generator disagreed with. Both now have one home: ruff takes its paths from `pyproject.toml`, and the reference check runs in CI.

Ruff moves to the current stable release, and the rule set grows by seventeen groups. Each was measured against this tree first rather than adopted on reputation: most had no violations at all and are simply gates on habits the code already keeps, and the ones deliberately left out carry the reason inline so nobody has to work it out again. **23 files in this branch are the new formatter rather than any rule change** — the how-to-verify is in the commit message.