### PR TITLE
One home for the order a write records its consequences in

### DIFF
--- a/src/django_rakaia/django_store.py
+++ b/src/django_rakaia/django_store.py
@@ -358,6 +358,75 @@ class DjangoStreamStore:
             raise StreamNotFound(f"Stream not found: {path}") from None
 
     @staticmethod
+    def _facts(stream: Stream) -> StreamFacts:
+        """A locked stream row as `rakaia.append_decision` sees it.
+
+        The one place a row is narrowed to the four fields admission is decided
+        from, so a fifth fact cannot reach one write path and miss another. It
+        was written out inline at every call site, and the omission that shape
+        invites has happened twice: `closed_by` was missing from the fencing
+        path (#167) and from the batch path (#181), and in both cases a producer
+        retrying its own closing append was told a bare "closed".
+
+        `_close_locked` deliberately does *not* use this: a close carries no body
+        and no `Stream-Seq`, so it builds `StreamFacts` with only the two fields
+        that can decide it. Passing the other two would be equivalent today —
+        `decide_append` skips both checks when the options carry neither — but it
+        would say they were relevant, and the next person would have to work out
+        that they are not.
+        """
+        return StreamFacts(
+            closed=stream.closed,
+            closed_by=stream.closed_by,
+            content_type=stream.content_type,
+            last_seq=stream.last_seq,
+        )
+
+    def _record_write(
+        self,
+        stream: Stream,
+        *,
+        producer_commits: Iterable[ProducerAccepted] = (),
+        last_seq: str | None = None,
+        closing_opts: Any = None,
+    ) -> None:
+        """Record what a write that has already landed leaves behind.
+
+        **The order is the rule, not a matter of style**, which is why it is
+        written down once here rather than learned from reading three
+        implementations (#183). Every step is downstream of the rows being
+        written, and must stay that way:
+
+        1. **Producer state, and only for a write that succeeded.** This is what
+           a later writer is fenced against, so advancing it for a write that
+           did not happen would reject the retry that legitimately follows. One
+           commit per producer, not per event: the batch rule hands back the last
+           accepted outcome for each, and `append_many` promises a query count
+           that does not grow with the batch.
+        2. **`Stream-Seq`**, and only when it moved. An unconditional save costs
+           a statement on every append that does not use the header, which is
+           most of them.
+        3. **The close**, after the events, because a close is the statement
+           that nothing further follows *these* rows. Closing first would make
+           the stream's own admission rule refuse the write it is part of.
+        4. **The TTL window**, last, because an expiry clock extended before the
+           write could be extended for a write that then failed — and every step
+           above is a write that can fail.
+
+        Callers pass what their own decision produced; a step whose argument is
+        absent is skipped, which is how `create` and a plain unfenced append
+        reach the same code as a fenced batch.
+        """
+        for result in producer_commits:
+            self._commit_producer(stream, result)
+        if last_seq is not None and last_seq != stream.last_seq:
+            stream.last_seq = last_seq
+            stream.save(update_fields=["last_seq"])
+        if closing_opts is not None:
+            self._close_from_append(stream, closing_opts)
+        self._touch(stream)
+
+    @staticmethod
     def _touch(stream: Stream) -> None:
         """Extend the sliding TTL window. No-op for a stream without a TTL."""
         if stream.ttl_seconds is not None:
@@ -564,12 +633,7 @@ class DjangoStreamStore:
             # reached different verdicts on the two stores while this method's
             # docstring claimed they matched.
             verdict = decide_append(
-                StreamFacts(
-                    closed=stream.closed,
-                    closed_by=stream.closed_by,
-                    content_type=stream.content_type,
-                    last_seq=stream.last_seq,
-                ),
+                self._facts(stream),
                 opts,
                 producer_state=self._producer_state(
                     stream, getattr(opts, "producer_id", None)
@@ -585,16 +649,17 @@ class DjangoStreamStore:
 
             messages = self._write(stream, data, opts)
 
-            if verdict.producer_result is not None:
-                self._commit_producer(stream, verdict.producer_result)
-
-            if getattr(opts, "seq", None) is not None:
-                stream.last_seq = opts.seq
-                stream.save(update_fields=["last_seq"])
             close = bool(getattr(opts, "close", False))
-            if close:
-                self._close_from_append(stream, opts)
-            self._touch(stream)
+            self._record_write(
+                stream,
+                producer_commits=(
+                    [verdict.producer_result]
+                    if isinstance(verdict.producer_result, ProducerAccepted)
+                    else []
+                ),
+                last_seq=getattr(opts, "seq", None),
+                closing_opts=opts if close else None,
+            )
             # A JSON-mode array append writes several messages; the result
             # carries the last, whose offset is the stream's new head — which
             # is what a caller resumes from.
@@ -748,60 +813,27 @@ class DjangoStreamStore:
     def _append_with_producer_sync(
         self, path: str, data: bytes, options: Any = None
     ) -> AppendResult:
-        opts = options if options is not None else AppendOptions()
-        producer_id = getattr(opts, "producer_id", None)
-        epoch = getattr(opts, "producer_epoch", None)
-        seq = getattr(opts, "producer_seq", None)
-        if producer_id is None or epoch is None or seq is None:
-            return self.append(path, data, opts)
+        """A fenced append *is* an append, so this is `append`.
 
-        # The row lock `_locked_write` takes is what makes fencing fence:
-        # validation reads the producer's last state, and two concurrent retries
-        # of the same (producer_id, epoch, seq) that both read before either
-        # commits would both be accepted — the exact duplicate write the fencing
-        # exists to prevent. Serialized on the stream row, the loser re-reads the
-        # winner's committed state. (The in-memory store's per-producer
-        # asyncio.Lock is this lock's in-process analogue.)
-        with self._locked_write(path) as stream:
-            # The same shared sequence `append` uses. This path used to run its
-            # own: fencing first, then closed, and it never read `closed_by` —
-            # so a closed stream answered with the fencing outcome instead of
-            # the close, and a producer retrying its own closing append was
-            # never recognised.
-            verdict = decide_append(
-                StreamFacts(
-                    closed=stream.closed,
-                    closed_by=stream.closed_by,
-                    content_type=stream.content_type,
-                    last_seq=stream.last_seq,
-                ),
-                opts,
-                producer_state=self._producer_state(stream, producer_id),
-                now=time.time(),
-            )
-            if not verdict.write:
-                return AppendResult(
-                    message=None,
-                    stream_closed=verdict.stream_closed,
-                    producer_result=verdict.producer_result,
-                )
-            result = verdict.producer_result
+        It was a second copy of it — the same nine steps in the same order, 39
+        lines, differing only in a local alias for `verdict.producer_result` and
+        the order of two keyword arguments. That is what #183 is about: the copy
+        is where the divergence gets in, and this one had already diverged twice
+        before the admission rule was shared (#154, #167).
 
-            messages = self._write(stream, data, opts)
-            if result is not None:
-                self._commit_producer(stream, result)
-            if getattr(opts, "seq", None) is not None:
-                stream.last_seq = opts.seq
-                stream.save(update_fields=["last_seq"])
-            close = bool(getattr(opts, "close", False))
-            if close:
-                self._close_from_append(stream, opts)
-            self._touch(stream)
-            return AppendResult(
-                message=messages[-1] if messages else None,
-                producer_result=result,
-                stream_closed=close,
-            )
+        The reason it looked like a separate method is real but belongs to
+        `append`, and is documented there: the row lock `_locked_write` takes is
+        what makes fencing fence, because two concurrent retries of the same
+        `(producer_id, epoch, seq)` that both read before either commits would
+        both be accepted. That is the same lock a plain append needs to allocate
+        an offset, so there was never a second sequence to run — only one that
+        additionally consults the producer's state, which `decide_append` does
+        for any options carrying the triple.
+
+        The signature stays because `append_with_producer` is part of the store
+        protocol; only the duplicate body is gone.
+        """
+        return self.append(path, data, options)
 
     def append_many(
         self, path: str, events: Iterable[tuple[bytes, Any]]
@@ -879,12 +911,7 @@ class DjangoStreamStore:
                 if (pid := getattr(o, "producer_id", None)) is not None
             }
             batch = decide_append_batch(
-                StreamFacts(
-                    closed=stream.closed,
-                    closed_by=stream.closed_by,
-                    content_type=stream.content_type,
-                    last_seq=stream.last_seq,
-                ),
+                self._facts(stream),
                 [options for _data, options in items],
                 producer_states={
                     pid: self._producer_state(stream, pid) for pid in producer_ids
@@ -951,23 +978,18 @@ class DjangoStreamStore:
             # receiver's existing timing on the `append` path.
             self._publish(stream.stream_id, entries)
 
-            # Persist the fencing state the batch established, so a later batch
-            # or append is fenced against this one. The bulk path did not do it
-            # at all, because it never asked the fence in the first place (#154).
-            # One write per *producer*, not per item: the rule hands back the
-            # last accepted outcome for each, which is the only state a later
-            # writer can be fenced against. Committing per item reached the same
-            # place through N `update_or_create`s, which broke the flat query
-            # cost this method exists for.
-            for result in batch.producer_commits.values():
-                self._commit_producer(stream, result)
-
-            if batch.last_seq != stream.last_seq:
-                stream.last_seq = batch.last_seq
-                stream.save(update_fields=["last_seq"])
-            if batch.closing_opts is not None:
-                self._close_from_append(stream, batch.closing_opts)
-            self._touch(stream)
+            # Steps 6-9, through the same method `append` uses, so a batch
+            # cannot record its consequences in a different order from a single
+            # write. The batch rule has already reduced the per-item outcomes to
+            # exactly what belongs here: one producer commit each rather than one
+            # per event, the sequence the last written item reached, and the
+            # options of whichever item closed the stream.
+            self._record_write(
+                stream,
+                producer_commits=batch.producer_commits.values(),
+                last_seq=batch.last_seq,
+                closing_opts=batch.closing_opts,
+            )
 
             # One result per input item, in input order. An item the rule
             # refused keeps its slot with the outcome to report, rather than

--- a/src/django_rakaia/django_store.py
+++ b/src/django_rakaia/django_store.py
@@ -414,8 +414,16 @@ class DjangoStreamStore:
            above is a write that can fail.
 
         Callers pass what their own decision produced; a step whose argument is
-        absent is skipped, which is how `create` and a plain unfenced append
-        reach the same code as a fenced batch.
+        absent is skipped, which is how a plain unfenced append reaches the same
+        code as a fenced batch.
+
+        `create` is the one write path that does not come through here, and
+        deliberately: its `initial_data` cannot be fenced, sequenced or closing —
+        the stream did not exist to have a producer, a `Stream-Seq` or a close
+        against — and it stamps `last_activity_at` on the row it inserts, so
+        every step would be a no-op or a second write of what `create` just
+        wrote. It is in the routing test below as the exception, not as an
+        omission.
         """
         for result in producer_commits:
             self._commit_producer(stream, result)

--- a/tests/test_django_rakaia/test_write_sequence.py
+++ b/tests/test_django_rakaia/test_write_sequence.py
@@ -88,6 +88,22 @@ class TestEveryWritePathRecordsThroughOneMethod:
 
         assert len(counted) == 1
 
+    def test_create_with_a_body_is_the_documented_exception(
+        self, counted: list[dict]
+    ) -> None:
+        """The one write path that does not come through it, asserted rather than
+        assumed: `create`'s `initial_data` has no producer, no `Stream-Seq` and
+        no close to record, and the row it inserts carries `last_activity_at`
+        already. Here so the docstring's exception is a checked claim — if
+        `create` ever grows one of those, this test is what says so."""
+        store = DjangoStreamStore()
+
+        store.create("s", content_type="application/json", initial_data=b'{"n": 1}')
+
+        assert counted == []
+        assert StreamEntry.objects.count() == 1
+        assert Stream.objects.get(stream_id="s").last_activity_at is not None
+
     def test_a_refused_write_records_nothing(self, counted: list[dict]) -> None:
         """Nothing landed, so there is nothing whose consequences to record —
         and advancing the producer here would reject the retry that legitimately

--- a/tests/test_django_rakaia/test_write_sequence.py
+++ b/tests/test_django_rakaia/test_write_sequence.py
@@ -1,0 +1,233 @@
+"""Every write path records its consequences through one method, in one order.
+
+#183: the durable store had four entry points that write an event, each
+repeating the same nine steps — expire, transaction, lock, admit, write, record
+the producer, save the sequence, close if asked, touch the clock. Two of them
+were near line-for-line copies. The order of those steps is a *rule*, and it was
+written down nowhere, so the only way to learn it was to read three
+implementations. That had already gone wrong: one entry point admitted less than
+the others (#154), and another never read `closed_by` (#167).
+
+Admission became shared first (#167 for a single write, #181 for a batch). What
+was left was the recording half, which is what `_record_write` now owns and this
+file pins. The two claims here are different in kind:
+
+* **Routing** — every write path goes *through* that method. This is the tripwire
+  a fifth entry point trips: hand-rolling the four steps still passes every
+  behavioural test in the suite, exactly as the two copies did for months.
+* **Order** — the steps happen in the order the method documents, asserted from
+  the outside where the order is observable.
+"""
+
+from __future__ import annotations
+
+import pytest
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
+
+from django_rakaia.django_store import DjangoStreamStore
+from django_rakaia.models import Stream, StreamEntry, StreamProducer
+from rakaia.types import AppendOptions, ProducerDuplicate, ProducerStaleEpoch
+
+pytestmark = pytest.mark.django_db
+
+
+def _producer(pid: str, epoch: int, seq: int, **kw) -> AppendOptions:
+    return AppendOptions(producer_id=pid, producer_epoch=epoch, producer_seq=seq, **kw)
+
+
+class TestEveryWritePathRecordsThroughOneMethod:
+    """The routing claim, per entry point.
+
+    Asserted by counting calls rather than by checking the rows: the rows are
+    identical whether a path calls the shared method or repeats its four steps
+    inline, which is precisely why the copies survived. What must be true is that
+    there is only one copy left.
+    """
+
+    @pytest.fixture
+    def counted(self, monkeypatch: pytest.MonkeyPatch) -> list[dict]:
+        calls: list[dict] = []
+        original = DjangoStreamStore._record_write
+
+        def recording(self, stream, **kwargs):
+            calls.append(kwargs)
+            return original(self, stream, **kwargs)
+
+        monkeypatch.setattr(DjangoStreamStore, "_record_write", recording)
+        return calls
+
+    def test_a_plain_append_records_through_it(self, counted: list[dict]) -> None:
+        store = DjangoStreamStore()
+        store.create("s", content_type="application/json")
+
+        store.append("s", b'{"n": 1}')
+
+        assert len(counted) == 1
+
+    def test_a_fenced_append_records_through_it(self, counted: list[dict]) -> None:
+        store = DjangoStreamStore()
+        store.create("s", content_type="application/json")
+
+        store.append("s", b'{"n": 1}', _producer("p", 1, 0))
+
+        assert len(counted) == 1
+
+    def test_a_batch_records_through_it_once_for_the_whole_batch(
+        self, counted: list[dict]
+    ) -> None:
+        """Once, not once per item: the recording is per *write*, and a batch is
+        one write. Per-item would restore the query cost `append_many` exists to
+        avoid."""
+        store = DjangoStreamStore()
+        store.create("s", content_type="application/json")
+
+        store.append_many(
+            "s", [(b'{"n": 1}', AppendOptions()), (b'{"n": 2}', AppendOptions())]
+        )
+
+        assert len(counted) == 1
+
+    def test_a_refused_write_records_nothing(self, counted: list[dict]) -> None:
+        """Nothing landed, so there is nothing whose consequences to record —
+        and advancing the producer here would reject the retry that legitimately
+        follows."""
+        store = DjangoStreamStore()
+        store.create("s", content_type="application/json")
+        store.close_stream("s")
+
+        result = store.append("s", b'{"n": 1}')
+
+        assert result.stream_closed and result.message is None
+        assert counted == []
+
+
+class TestAFencedAppendIsAnAppend:
+    """The 39 duplicated lines, gone.
+
+    `_append_with_producer_sync` ran its own copy of the same nine steps. It is
+    now `append`, and this is what stops the copy coming back: the assertion is
+    about the call, because a reintroduced copy would produce identical rows.
+    """
+
+    def test_the_fenced_entry_point_delegates(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        store = DjangoStreamStore()
+        store.create("s", content_type="application/json")
+        seen: list[tuple] = []
+        original = DjangoStreamStore.append
+
+        def recording(self, path, data, options=None):
+            seen.append((path, data, options))
+            return original(self, path, data, options)
+
+        monkeypatch.setattr(DjangoStreamStore, "append", recording)
+
+        opts = _producer("p", 1, 0)
+        store._append_with_producer_sync("s", b'{"n": 1}', opts)
+
+        assert seen == [("s", b'{"n": 1}', opts)]
+
+    def test_it_still_fences(self) -> None:
+        """Delegating must not have dropped the fencing — the reason the method
+        looked separate. `decide_append` consults the producer's state for any
+        options carrying the triple, whichever door they came through."""
+        store = DjangoStreamStore()
+        store.create("s", content_type="application/json")
+
+        first = store._append_with_producer_sync("s", b'{"n": 1}', _producer("p", 1, 0))
+        replay = store._append_with_producer_sync(
+            "s", b'{"n": 1}', _producer("p", 1, 0)
+        )
+        stale = store._append_with_producer_sync("s", b'{"n": 2}', _producer("p", 0, 1))
+
+        assert first.message is not None
+        assert isinstance(replay.producer_result, ProducerDuplicate)
+        assert isinstance(stale.producer_result, ProducerStaleEpoch)
+        assert StreamEntry.objects.count() == 1, "only the first write landed"
+
+
+class TestTheOrderIsTheRule:
+    """The steps whose position is observable from outside.
+
+    Not all four are. `_record_write` runs inside one transaction, so swapping
+    the close and the TTL touch produces identical rows — that ordering is
+    rationale for a reader, argued in the method's docstring, and deliberately
+    not asserted here. Claiming a test for it would be worse than having none:
+    the two steps below *are* pinned, and each was checked by breaking it.
+    """
+
+    def test_a_closing_append_lands_its_own_event(self) -> None:
+        """The close and the event it rides on are one atomic step: the caller
+        gets a message *and* `stream_closed`, not one or the other."""
+        store = DjangoStreamStore()
+        store.create("s", content_type="application/json")
+
+        result = store.append("s", b'{"n": 1}', AppendOptions(close=True))
+
+        assert result.message is not None, "the closing append's own event landed"
+        assert result.stream_closed is True
+        assert StreamEntry.objects.count() == 1
+        assert Stream.objects.get(stream_id="s").closed is True
+
+    def test_a_refused_fence_leaves_the_producer_where_it_was(self) -> None:
+        """Step 1 is conditional on the write, not on the attempt. If a refused
+        attempt advanced the row, the producer's next legitimate sequence would
+        look like a duplicate."""
+        store = DjangoStreamStore()
+        store.create("s", content_type="application/json")
+        store.append("s", b'{"n": 1}', _producer("p", 1, 0))
+        before = StreamProducer.objects.get(producer_id="p").last_seq
+
+        gap = store.append("s", b'{"n": 9}', _producer("p", 1, 7))
+
+        assert gap.message is None
+        assert StreamProducer.objects.get(producer_id="p").last_seq == before
+        # …and the sequence it skipped to is still available.
+        assert store.append("s", b'{"n": 2}', _producer("p", 1, 1)).message is not None
+
+    def test_the_sequence_is_saved_only_when_it_moves(self) -> None:
+        """Step 2 is conditional, and the cost is the only way to see it.
+
+        Saving unconditionally writes `None` over `None` for an append that sent
+        no `Stream-Seq` — same row, one extra statement, on the majority of
+        appends. So this counts statements rather than reading the column: a test
+        that only checked the value would pass with the condition deleted.
+        """
+        store = DjangoStreamStore()
+        store.create("s", content_type="application/json")
+        store.append("s", b'{"n": 0}')  # warm any lazy per-connection queries
+
+        with CaptureQueriesContext(connection) as without:
+            store.append("s", b'{"n": 1}')
+        with CaptureQueriesContext(connection) as with_seq:
+            store.append("s", b'{"n": 2}', AppendOptions(seq="5"))
+
+        def stream_updates(ctx) -> list[str]:
+            return [
+                q["sql"]
+                for q in ctx.captured_queries
+                if (q["sql"] or "").upper().startswith("UPDATE")
+                and "rakaia_stream" in (q["sql"] or "")
+                and "last_seq" in (q["sql"] or "")
+            ]
+
+        assert stream_updates(without) == []
+        assert len(stream_updates(with_seq)) == 1
+        assert Stream.objects.get(stream_id="s").last_seq == "5"
+
+    def test_a_batch_commits_one_producer_row_for_many_items(self) -> None:
+        """Step 1, batched: the last accepted outcome per producer is the only
+        state a later writer can be fenced against, so that is what is written.
+        One row, carrying the last item's sequence."""
+        store = DjangoStreamStore()
+        store.create("s", content_type="application/json")
+
+        store.append_many(
+            "s", [(b'{"n": %d}' % i, _producer("p", 1, i)) for i in range(3)]
+        )
+
+        rows = StreamProducer.objects.filter(producer_id="p")
+        assert rows.count() == 1
+        assert rows.get().last_seq == 2


### PR DESCRIPTION
Four entry points wrote an event, each repeating the same nine steps, and two were near line-for-line copies. The shared admission rule landed earlier; this finishes the other half — what a write records once it has landed. There is now one method that does it, and its docstring is the first written statement of why the order is what it is, which is what the issue asked for: the order is a rule, and it was learnable only by reading three implementations.

The fenced append shrinks to one line. It differed from a plain append only in a local variable name and the order of two keyword arguments, checked line by line before removing it; the reason it looked like a separate thing is real, and is now written down where it belongs.

The new tests pin the part the suite could not see — hand-rolling the steps inline passes every behavioural test, which is how the copies survived. Each was shown to fail when the thing it claims is broken. Two of the four orderings are deliberately *not* asserted and the test says so: inside one transaction they are unobservable, and claiming coverage for them would be worse than having none.

Closes #183.