### PR TITLE
The event filter and page header stop showing an internal label

### DIFF
--- a/src/django_rakaia/admin.py
+++ b/src/django_rakaia/admin.py
@@ -12,7 +12,11 @@ from django.contrib import admin
 from django.utils.html import format_html, format_html_join
 from django.utils.safestring import SafeString, mark_safe
 
-from django_rakaia.event_message import decode_payload, event_label
+from django_rakaia.event_message import (
+    decode_payload,
+    event_label,
+    event_label_display,
+)
 from django_rakaia.models import Stream, StreamEntry, StreamEvent
 
 
@@ -72,8 +76,54 @@ def _event_badge(event_type: str) -> SafeString:
         '<span style="background-color: {}; color: white; padding: 3px 8px; '
         'border-radius: 3px; font-size: 11px; font-weight: bold;">{}</span>',
         _BADGE_COLORS.get(label, "#6c757d"),
-        label.upper() or "—",
+        event_label_display(event_type).upper(),
     )
+
+
+class EventTypeFilter(admin.SimpleListFilter):
+    """The event-type sidebar filter, showing labels rather than the column.
+
+    A *display-name* change, not a swap of the value. A filter has to put the
+    stored value in the querystring and match on the stored column, or it selects
+    nothing; only the text beside the link is presentational. So `lookups()`
+    pairs each stored `event_type` with what `event_label_display` says a reader
+    sees, and `queryset()` filters on the raw column.
+
+    Django's own `AllValuesFieldListFilter` — what `list_filter = ["event_type"]`
+    resolves to — prints the column, so the screen said `append` in the sidebar
+    while the badge one column over said "no label" for the same event (#210).
+    `parameter_name` is deliberately the field path, which is exactly the key
+    that filter used, so an existing bookmark or link keeps working.
+    """
+
+    title = "event type"
+    parameter_name = "event_type"
+
+    def lookups(self, request, model_admin):
+        stored = (
+            model_admin.get_queryset(request)
+            .order_by(self.parameter_name)
+            .values_list(self.parameter_name, flat=True)
+            .distinct()
+        )
+        return [(value, event_label_display(value)) for value in stored]
+
+    def queryset(self, request, queryset):  # noqa: ARG002 - Django's signature
+        value = self.value()
+        if value is None:
+            return queryset
+        return queryset.filter(**{self.parameter_name: value})
+
+
+class EntryEventTypeFilter(EventTypeFilter):
+    """`EventTypeFilter` for the entries list, which reaches its event.
+
+    Only the path differs, and it is one attribute because `parameter_name` is
+    both the querystring key and the ORM path — the same two roles Django's
+    field filter gives `field_path`.
+    """
+
+    parameter_name = "event__event_type"
 
 
 def _event_data_preview(data: Any, payload_encoding: str | None) -> str:
@@ -115,7 +165,7 @@ class StreamEventAdmin(admin.ModelAdmin):
         "stream_count",
         "created_at",
     ]
-    list_filter = ["event_type", "created_at"]
+    list_filter = [EventTypeFilter, "created_at"]
     search_fields = ["data"]
     readonly_fields = ["data", "event_type", "created_at", "streams_list"]
     ordering = ["-created_at"]
@@ -154,7 +204,7 @@ class StreamEntryAdmin(admin.ModelAdmin):
         "event_type_badge",
         "created_at",
     ]
-    list_filter = ["stream", "event__event_type", "created_at"]
+    list_filter = ["stream", EntryEventTypeFilter, "created_at"]
     search_fields = ["stream__stream_id", "event__data"]
     readonly_fields = ["stream", "event", "offset", "created_at"]
     ordering = ["-created_at"]
@@ -206,7 +256,7 @@ def register_stream_event_admin(event_model_class):
             "stream_count",
             "created_at",
         ]
-        list_filter = ["event_type", "created_at"]
+        list_filter = [EventTypeFilter, "created_at"]
         search_fields = ["data"]
         readonly_fields = ["data", "event_type", "created_at", "streams_list"]
         ordering = ["-created_at"]

--- a/src/django_rakaia/admin.py
+++ b/src/django_rakaia/admin.py
@@ -80,50 +80,53 @@ def _event_badge(event_type: str) -> SafeString:
     )
 
 
-class EventTypeFilter(admin.SimpleListFilter):
+class EventTypeFieldListFilter(admin.AllValuesFieldListFilter):
     """The event-type sidebar filter, showing labels rather than the column.
 
-    A *display-name* change, not a swap of the value. A filter has to put the
-    stored value in the querystring and match on the stored column, or it selects
-    nothing; only the text beside the link is presentational. So `lookups()`
-    pairs each stored `event_type` with what `event_label_display` says a reader
-    sees, and `queryset()` filters on the raw column.
+    `event_type` holds a sentinel for "a raw append, which carried no label", and
+    Django's own filter prints the column — so the sidebar said `append` beside a
+    badge that said the event had no label, one event described two ways on one
+    screen (#210).
 
-    Django's own `AllValuesFieldListFilter` — what `list_filter = ["event_type"]`
-    resolves to — prints the column, so the screen said `append` in the sidebar
-    while the badge one column over said "no label" for the same event (#210).
-    `parameter_name` is deliberately the field path, which is exactly the key
-    that filter used, so an existing bookmark or link keeps working.
+    This is a **display-name change and nothing else**, which is why it subclasses
+    the filter it replaces (`list_filter = ["event_type"]` resolves to
+    `AllValuesFieldListFilter`) and overrides only the text. A filter has to put
+    the *stored* value in the querystring and match on the stored column, or it
+    selects nothing; everything about which rows a link selects is inherited
+    rather than restated — the querystring key and value, the null choice, the
+    OR of a repeated parameter, and the fact that the choices for a related path
+    like ``event__event_type`` come from the event table without joining the
+    entries table to get them.
+
+    Written for a field path rather than as a `SimpleListFilter` for exactly that
+    reason: the hand-rolled version had to re-implement each of those, and got
+    two of them wrong — `?event_type=a&event_type=b` selected only `b`, and the
+    entries sidebar ran a `DISTINCT` over the fan-out table on every render.
     """
 
-    title = "event type"
-    parameter_name = "event_type"
+    def choices(self, changelist):
+        # Django yields "All" first, then one choice per non-null stored value in
+        # `lookup_choices` order, then the empty-value choice if some row is
+        # null. Only the middle group names a stored `event_type`, so only it is
+        # relabelled — and by position, so whatever Django put in the choice
+        # (query string, selected flag, and the " (N)" it appends when facet
+        # counts are on) is passed through untouched.
+        stored = [value for value in self.lookup_choices if value is not None]
+        # `or ()`: the stub types the base `choices()` as optional, because the
+        # abstract `ListFilter` declares it and returns nothing. This subclass's
+        # parent always yields.
+        for index, choice in enumerate(super().choices(changelist) or ()):
+            if 1 <= index <= len(stored):
+                value = str(stored[index - 1])
+                shown = str(choice["display"])
+                choice["display"] = event_label_display(value) + shown[len(value) :]
+            yield choice
 
-    def lookups(self, request, model_admin):
-        stored = (
-            model_admin.get_queryset(request)
-            .order_by(self.parameter_name)
-            .values_list(self.parameter_name, flat=True)
-            .distinct()
-        )
-        return [(value, event_label_display(value)) for value in stored]
 
-    def queryset(self, request, queryset):  # noqa: ARG002 - Django's signature
-        value = self.value()
-        if value is None:
-            return queryset
-        return queryset.filter(**{self.parameter_name: value})
-
-
-class EntryEventTypeFilter(EventTypeFilter):
-    """`EventTypeFilter` for the entries list, which reaches its event.
-
-    Only the path differs, and it is one attribute because `parameter_name` is
-    both the querystring key and the ORM path — the same two roles Django's
-    field filter gives `field_path`.
-    """
-
-    parameter_name = "event__event_type"
+# `list_filter` entries: the field path stays the field path — this only changes
+# what the sidebar prints next to each link.
+_EVENT_TYPE_FILTER = ("event_type", EventTypeFieldListFilter)
+_ENTRY_EVENT_TYPE_FILTER = ("event__event_type", EventTypeFieldListFilter)
 
 
 def _event_data_preview(data: Any, payload_encoding: str | None) -> str:
@@ -165,7 +168,7 @@ class StreamEventAdmin(admin.ModelAdmin):
         "stream_count",
         "created_at",
     ]
-    list_filter = [EventTypeFilter, "created_at"]
+    list_filter = [_EVENT_TYPE_FILTER, "created_at"]
     search_fields = ["data"]
     readonly_fields = ["data", "event_type", "created_at", "streams_list"]
     ordering = ["-created_at"]
@@ -204,7 +207,7 @@ class StreamEntryAdmin(admin.ModelAdmin):
         "event_type_badge",
         "created_at",
     ]
-    list_filter = ["stream", EntryEventTypeFilter, "created_at"]
+    list_filter = ["stream", _ENTRY_EVENT_TYPE_FILTER, "created_at"]
     search_fields = ["stream__stream_id", "event__data"]
     readonly_fields = ["stream", "event", "offset", "created_at"]
     ordering = ["-created_at"]
@@ -256,7 +259,7 @@ def register_stream_event_admin(event_model_class):
             "stream_count",
             "created_at",
         ]
-        list_filter = [EventTypeFilter, "created_at"]
+        list_filter = [_EVENT_TYPE_FILTER, "created_at"]
         search_fields = ["data"]
         readonly_fields = ["data", "event_type", "created_at", "streams_list"]
         ordering = ["-created_at"]

--- a/src/django_rakaia/event_message.py
+++ b/src/django_rakaia/event_message.py
@@ -101,6 +101,29 @@ def event_label(event_type: str) -> str:
     return "" if event_type == APPEND_EVENT_TYPE else event_type
 
 
+# What a reader is shown where an event carried no label at all. The column
+# cannot hold "no label" — it holds `APPEND_EVENT_TYPE` — so every surface that
+# prints a label has to put *something* in its place: printing the sentinel says
+# the label was `append` (#153), and printing nothing reads as a rendering fault.
+NO_LABEL_DISPLAY = "—"
+
+
+def event_label_display(event_type: str) -> str:
+    """The envelope label for a stored ``event_type``, as text to *show*.
+
+    `event_label` answers what the label is — the empty string when there was
+    none, which is what a subscriber or an API consumer needs. A screen cannot
+    print the empty string, so this is the same answer with the labelless case
+    spelled out for a human.
+
+    One home for the placeholder because the admin has four surfaces that print
+    a label — the two badges, the two type filters and `StreamEvent.__str__` —
+    and #208 fixed only the badges. They must not be able to disagree about what
+    "no label" looks like.
+    """
+    return event_label(event_type) or NO_LABEL_DISPLAY
+
+
 def payload_fields(data: Any, payload_encoding: str | None) -> dict[str, Any]:
     """The stored payload as the `data`/`payload_encoding` pair a JSON wire carries.
 

--- a/src/django_rakaia/models.py
+++ b/src/django_rakaia/models.py
@@ -13,6 +13,7 @@ from django.db.models import Max
 
 from rakaia.types import ClosedBy
 
+from .event_message import event_label_display
 from .offsets import format_offset
 
 if TYPE_CHECKING:
@@ -332,7 +333,11 @@ class StreamEvent(models.Model):
         ordering = ["-created_at"]
 
     def __str__(self) -> str:
-        return f"Event #{self.id} ({self.event_type})"
+        # The label a reader sees, not the column: this is the change-form header
+        # and what any `readonly_fields` reference to an event renders, so
+        # printing the raw `event_type` said the label was `append` on a raw
+        # append that carried none (#210).
+        return f"Event #{self.id} ({event_label_display(self.event_type)})"
 
     def get_streams(self) -> list[str]:
         """Get all stream IDs this event appears in."""

--- a/tests/test_django_rakaia/test_admin.py
+++ b/tests/test_django_rakaia/test_admin.py
@@ -473,3 +473,95 @@ class TestTheTypeFilterShowsLabelsAndFiltersOnTheColumn:
         # pass against the raw column too.
         assert str(appended) == f"Event #{appended.id} ({NO_LABEL_DISPLAY})"
         assert str(created) == f"Event #{created.id} (create)"
+
+
+class TestRelabellingTheFilterChangedNothingElseAboutIt:
+    """Everything a link selects is Django's answer, not ours.
+
+    The first attempt at #210 rebuilt the filter as a `SimpleListFilter`, which
+    means re-implementing every behaviour of the one it replaced. Two came out
+    wrong: a repeated parameter — which Django ORs — selected only the last
+    value, and the entries sidebar listed its choices by joining the fan-out
+    table instead of reading the event table directly.
+
+    Each case here pins one of those against the plain field filter, which is
+    what the screens used before, so "display-only" is a tested claim rather
+    than an intention.
+    """
+
+    def _plain(self, model, list_filter):
+        class PlainFieldFilterAdmin(django_admin.ModelAdmin):
+            pass
+
+        PlainFieldFilterAdmin.list_filter = list_filter
+        return PlainFieldFilterAdmin(model, django_admin.site)
+
+    def _events(self):
+        for event_type in ("append", "create", "delete"):
+            event = StreamEvent.objects.create(event_type=event_type, data={})
+            if event_type != "delete":
+                # `delete` deliberately has no entry: the entries sidebar must
+                # still offer it, which is what says its choices come from the
+                # event table rather than a join.
+                StreamEntry.objects.create(
+                    stream=Stream.objects.get_or_create(stream_id="s")[0],
+                    event=event,
+                    offset=event.id,
+                )
+
+    def test_a_repeated_parameter_still_selects_both_types(self) -> None:
+        self._events()
+        query = "?event_type=append&event_type=create"
+        request = RequestFactory().get(f"/{query}")
+        request.user = _AdminUser()  # type: ignore[assignment]
+
+        admin = StreamEventAdmin(StreamEvent, django_admin.site)
+        changelist = admin.get_changelist_instance(request)
+        assert sorted(event.event_type for event in changelist.queryset) == [
+            "append",
+            "create",
+        ]
+
+    def test_a_repeated_parameter_selects_the_same_rows_as_before(self) -> None:
+        self._events()
+        query = "?event__event_type=append&event__event_type=create"
+        request = RequestFactory().get(f"/{query}")
+        request.user = _AdminUser()  # type: ignore[assignment]
+        other = RequestFactory().get(f"/{query}")
+        other.user = _AdminUser()  # type: ignore[assignment]
+
+        plain = self._plain(StreamEntry, ["event__event_type"])
+        admin = StreamEntryAdmin(StreamEntry, django_admin.site)
+        # Sorted: the two admins order their lists differently by design, and it
+        # is *which rows* the link selects that must not have moved.
+        now = sorted(e.pk for e in admin.get_changelist_instance(request).queryset)
+        before = sorted(e.pk for e in plain.get_changelist_instance(other).queryset)
+        assert now == before
+
+    def test_the_entries_sidebar_offers_a_type_no_entry_carries(self) -> None:
+        # Django's field filter reads the *event* table for a related path. A
+        # hand-rolled `lookups()` over the entries queryset both dropped this
+        # choice and made the sidebar scan the fan-out table.
+        self._events()
+        displays = [
+            display
+            for display, _ in _filter_choices(
+                StreamEntryAdmin(StreamEntry, django_admin.site), "event__event_type"
+            )
+        ]
+        assert displays == ["All", NO_LABEL_DISPLAY, "create", "delete"]
+
+    def test_facet_counts_survive_the_relabelling(self) -> None:
+        # With `?_facets=True` Django appends " (N)" to each choice. Relabelling
+        # replaces the value and keeps the count.
+        self._events()
+        assert _filter_choices(
+            StreamEventAdmin(StreamEvent, django_admin.site),
+            "event_type",
+            _facets="True",
+        ) == [
+            ("All", "?_facets=True"),
+            (f"{NO_LABEL_DISPLAY} (1)", "?_facets=True&event_type=append"),
+            ("create (1)", "?_facets=True&event_type=create"),
+            ("delete (1)", "?_facets=True&event_type=delete"),
+        ]

--- a/tests/test_django_rakaia/test_admin.py
+++ b/tests/test_django_rakaia/test_admin.py
@@ -8,6 +8,7 @@ short-data path), link builders, translation status, and the dynamic
 
 import pytest
 from django.contrib import admin as django_admin
+from django.test import RequestFactory
 
 from django_rakaia.admin import (
     StreamAdmin,
@@ -15,6 +16,7 @@ from django_rakaia.admin import (
     StreamEventAdmin,
     register_stream_event_admin,
 )
+from django_rakaia.event_message import NO_LABEL_DISPLAY
 from django_rakaia.models import Stream, StreamEntry, StreamEvent
 from tests.test_django_rakaia.models import AppStreamEvent
 
@@ -26,6 +28,49 @@ def _entry(stream_id: str, offset: int, event_type: str = "create", **data):
     event = StreamEvent.objects.create(event_type=event_type, data=data or {"k": "v"})
     entry = StreamEntry.objects.create(stream=stream, event=event, offset=offset)
     return stream, event, entry
+
+
+class _AdminUser:
+    """Enough of a staff user for `get_changelist_instance`, without a row.
+
+    Deliberately not a real `auth.User`: saving one fires the test app's
+    `post_save` receiver, which appends a `create` event — so the very screen
+    under test would gain rows, and its filter an extra choice.
+    """
+
+    is_active = True
+    is_staff = True
+    is_superuser = True
+
+    def has_perm(self, perm, obj=None) -> bool:  # noqa: ARG002
+        return True
+
+    def has_module_perms(self, app_label) -> bool:  # noqa: ARG002
+        return True
+
+
+def _changelist(model_admin, **query: str):
+    """The changelist a staff user's GET would build, filters and all."""
+    request = RequestFactory().get("/", query)
+    request.user = _AdminUser()  # type: ignore[assignment]
+    return request, model_admin.get_changelist_instance(request)
+
+
+def _filter_choices(model_admin, parameter_name: str, **query: str):
+    """`(display, query_string)` per choice of one filter, as the sidebar shows.
+
+    Goes through the real `ChangeList`, so it sees what the screen renders rather
+    than what a helper returns — the distinction that let #195 and #208 each fix
+    one surface and leave another printing the sentinel.
+    """
+    _, changelist = _changelist(model_admin, **query)
+    for spec in changelist.filter_specs:
+        if parameter_name in spec.expected_parameters():
+            return [
+                (str(choice["display"]), choice["query_string"])
+                for choice in spec.choices(changelist)
+            ]
+    raise AssertionError(f"no filter for {parameter_name!r} on {model_admin}")
 
 
 class TestStreamAdmin:
@@ -280,6 +325,21 @@ class TestEveryAdminScreenAgrees:
         assert "<br>" not in preview and "&nbsp;" not in preview
         assert '"a": 1' in preview
 
+    def test_the_smaller_surfaces_agree_with_the_badge(self) -> None:
+        # The two places #208 left behind, side by side with the badge that was
+        # fixed: the sidebar filter and the change-form header. All three
+        # describe one event, so all three must call it the same thing.
+        _, entry = self._appended()
+        event = entry.event
+
+        assert NO_LABEL_DISPLAY in StreamEventAdmin(
+            StreamEvent, django_admin.site
+        ).event_type_badge(event)
+        assert str(event) == f"Event #{event.id} ({NO_LABEL_DISPLAY})"
+        assert (NO_LABEL_DISPLAY, "?event_type=append") in _filter_choices(
+            StreamEventAdmin(StreamEvent, django_admin.site), "event_type"
+        )
+
     def test_all_three_screens_render_one_append_the_same_way(self) -> None:
         # The point of the shared helper: the next screen cannot disagree.
         _, entry = self._appended()
@@ -299,3 +359,117 @@ class TestEveryAdminScreenAgrees:
         subclass = self._subclass_admin()
         assert subclass.event_type_badge(same) == from_events.event_type_badge(event)
         assert subclass.data_preview(same) == from_events.data_preview(event)
+
+
+class TestTheTypeFilterShowsLabelsAndFiltersOnTheColumn:
+    """The sidebar beside the badge, and the header above the change form.
+
+    #208 fixed the badges and deliberately left these: a filter needs the
+    *stored* value to build its query, so the label can only be the text of the
+    link. That made the two disagree — one event read as an em-dash in the table
+    and `append` in the filter next to it (#210).
+
+    So each case asserts both halves: the display is the label, and the value in
+    the querystring is still the column's. Rendered through a real `ChangeList`,
+    because a test of the filter class in isolation is the shape that missed this
+    twice.
+    """
+
+    def _events(self):
+        """One labelless append and one labelled event, through the store."""
+        from django_rakaia.django_store import DjangoStreamStore
+        from rakaia import AppendOptions
+
+        store = DjangoStreamStore()
+        store.create("s")
+        store.append("s", b'{"n": 1}')
+        store.append("s", b'{"n": 2}', AppendOptions(label="create"))
+        appended, created = StreamEvent.objects.order_by("id")
+        return appended, created
+
+    def _event_admin(self):
+        return StreamEventAdmin(StreamEvent, django_admin.site)
+
+    def _entry_admin(self):
+        return StreamEntryAdmin(StreamEntry, django_admin.site)
+
+    def test_the_event_filter_shows_the_label_not_the_stored_type(self) -> None:
+        self._events()
+        assert _filter_choices(self._event_admin(), "event_type") == [
+            ("All", "?"),
+            (NO_LABEL_DISPLAY, "?event_type=append"),
+            ("create", "?event_type=create"),
+        ]
+
+    def test_the_entries_filter_shows_the_label_not_the_stored_type(self) -> None:
+        self._events()
+        assert _filter_choices(self._entry_admin(), "event__event_type") == [
+            ("All", "?"),
+            (NO_LABEL_DISPLAY, "?event__event_type=append"),
+            ("create", "?event__event_type=create"),
+        ]
+
+    def test_a_registered_event_models_filter_shows_the_label(self) -> None:
+        # The factory an app registers its own event model through: the copy
+        # #201 found still printing the sentinel after #195 fixed the built-in
+        # screens. Same mistake, same place to make it again.
+        AppStreamEvent.objects.create(event_type="append", data={"n": 1})
+        AppStreamEvent.objects.create(event_type="create", data={"n": 2})
+        admin = django_admin.site._registry[AppStreamEvent]
+
+        assert _filter_choices(admin, "event_type") == [
+            ("All", "?"),
+            (NO_LABEL_DISPLAY, "?event_type=append"),
+            ("create", "?event_type=create"),
+        ]
+
+    def test_the_querystring_is_exactly_what_the_plain_field_filter_built(
+        self,
+    ) -> None:
+        # The constraint from the issue: a display-name change, not a swap of the
+        # value. Proved against the filter that was there before — a throwaway
+        # admin with `list_filter = ["event_type"]`, i.e. Django's
+        # `AllValuesFieldListFilter` — so an existing bookmark still selects the
+        # same rows.
+        self._events()
+
+        class PlainFieldFilterAdmin(django_admin.ModelAdmin):
+            list_filter = ["event_type"]
+
+        before = _filter_choices(
+            PlainFieldFilterAdmin(StreamEvent, django_admin.site), "event_type"
+        )
+        after = _filter_choices(self._event_admin(), "event_type")
+
+        assert [q for _, q in before] == [q for _, q in after]
+        # And the display is the only thing that moved.
+        assert [d for d, _ in before] == ["All", "append", "create"]
+
+    def test_the_event_filter_still_selects_the_labelless_append(self) -> None:
+        appended, _ = self._events()
+        _, changelist = _changelist(self._event_admin(), event_type="append")
+        assert list(changelist.queryset) == [appended]
+
+    def test_the_event_filter_still_selects_a_labelled_event(self) -> None:
+        _, created = self._events()
+        _, changelist = _changelist(self._event_admin(), event_type="create")
+        assert list(changelist.queryset) == [created]
+
+    def test_the_event_filter_selects_everything_when_unset(self) -> None:
+        appended, created = self._events()
+        _, changelist = _changelist(self._event_admin())
+        assert set(changelist.queryset) == {appended, created}
+
+    def test_the_entries_filter_still_selects_the_labelless_append(self) -> None:
+        appended, _ = self._events()
+        _, changelist = _changelist(self._entry_admin(), event__event_type="append")
+        assert [entry.event for entry in changelist.queryset] == [appended]
+
+    def test_the_change_form_header_shows_the_label_not_the_stored_type(self) -> None:
+        appended, created = self._events()
+        # `StreamEvent.__str__` — the change-form header, and what a
+        # `readonly_fields` reference to an event renders. Exact equality: the
+        # sentinel is not a substring of the label here, so containment would
+        # pass against the raw column too.
+        assert str(appended) == f"Event #{appended.id} ({NO_LABEL_DISPLAY})"
+        assert str(created) == f"Event #{created.id} (create)"


### PR DESCRIPTION
Two small places on the stream admin screens still printed the internal placeholder for an event that carried no label, so the same event read as a dash in the table and as "append" in the filter next to it. The filter beside the badges and the header above the change form now both say what every other reader of that event says.

The filter still puts the stored value in the address bar and matches on it — only the text of the link changed — so an existing bookmark selects exactly the rows it used to.

Closes #210.