### PR TITLE
Name the thing the two replays differ about

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,6 +140,28 @@ runnable demo for each.
 
 ### Changed
 
+- **A replay now says how far it gets before failing.** `replay` and
+  `merge_replay` share one staging pipeline, but `replay` kept a *second*
+  hand-written loop for its single-stage path, and the reason was real: it
+  decodes one event at a time, so a malformed event at offset N fails with the
+  first N already applied. `merge_replay` always read everything up front and
+  never said so. Nothing tested the difference, so the behaviour the second loop
+  existed to protect was uncovered.
+
+  That difference now has a name — `EventSource`, the events a replay will
+  dispatch, deliberately an `Iterable` rather than a `Sequence` — and one loop
+  serves both: `run_passes` consumes its source as it arrives when one pass will
+  do, and materialises it when it needs more than one. **No caller sees anything
+  different.** What changed is that the rule is written down: a single unstaged
+  pass applies the events before a malformed one; a staged replay or a merge
+  applies nothing, because more than one pass has to see every event and a merge
+  cannot know the order until every stream is read.
+
+  The pipeline tests used to import `build_pipeline` and `run_passes` and drive
+  them on a fabricated list of events. They now go through `replay` and
+  `merge_replay`, each shared behaviour run against both, since there is no
+  longer anything behind them worth reaching past (#189).
+
 - **A single append reads the stream row once, not twice.** Every
   `DjangoStreamStore.append` did two `SELECT`s of the same row: an unlocked one
   before the transaction opened, purely so that an expired stream would still be

--- a/docs/multi-stream-merge.md
+++ b/docs/multi-stream-merge.md
@@ -114,6 +114,12 @@ single-stream baseline uses, so the only variable is the event source.
   a backdated append would renumber later rows. Key it by `(stream_path, offset)`,
   which is stable under merge. (This is the subtle interaction with the #12 history
   read-model.)
+- **Nothing is applied unless everything decodes.** A merge has to read every
+  stream before it knows the order, so a malformed event — or one missing the
+  order key — in any stream fails before the first handler runs. A single-stream
+  `replay()` over one pass is the other way round: it decodes as it goes, so the
+  events before the bad one are already applied. Neither is wrong; they differ
+  because a merge has no choice.
 - **Resume** — a merged replay's cursor is a **vector of per-stream offsets**, not a
   single number; incremental/tailing merge needs a watermark per stream — the
   tie-in to the change_id/watermark sync quick win.

--- a/docs/staged-replay.md
+++ b/docs/staged-replay.md
@@ -159,6 +159,12 @@ Two rules keep it honest:
 2. **`refs` is read-only.** It exposes queries over materialized rows, not
    writes. All writes still flow through `Effect`s and the executor.
 
+One consequence worth knowing: staging changes how far a failing replay gets. A
+single-stage replay decodes one event at a time, so a malformed event at offset N
+raises with the first N already applied. A staged replay has to see the whole
+range before stage 1 can start, so it decodes everything first and the same event
+applies nothing at all.
+
 ## Self-healing replaces backfills
 
 Because the link is *derived* on every replay, a late reference event heals

--- a/src/rakaia/replay.py
+++ b/src/rakaia/replay.py
@@ -42,6 +42,21 @@ receives the `TouchedSubject`s the pass's handlers wrote, so one reducer can
 scope its recompute to what changed (incremental) or to everything (full
 rebuild). See `register_handler(stage=...)` and `register_reducer(...)`.
 
+**How far a replay gets before failing** follows from that, and is worth stating
+because it is observable and used not to be stated anywhere. A replay decodes
+ahead only as far as it must, so a malformed event partway through the range
+behaves differently in each shape:
+
+* a single unstaged pass over one stream decodes one event at a time, so the
+  events *before* the bad one are dispatched and applied;
+* a staged replay must see the whole range before its second pass starts, so it
+  decodes everything up front and applies nothing;
+* `merge_replay` cannot know the merged order until every stream is read, so it
+  too applies nothing — whether or not it is staged.
+
+Neither shape is wrong; the eager ones are eager because they have to be. See
+`EventSource`, which is the name that difference now has.
+
 Re-running the same range twice produces identical materialized state because
 every database effect is idempotent (an `Upsert` converges to the same row).
 """
@@ -50,7 +65,7 @@ from __future__ import annotations
 
 import inspect
 import json
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable, Iterator
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -179,6 +194,23 @@ class _ReplayCtx:
 #: business, not the pipeline's.
 PipelineEvent = tuple[int, str, dict]
 
+#: Every event a replay will dispatch, in dispatch order.
+#:
+#: An `Iterable`, not a `Sequence`, because **how much of the range a replay
+#: decodes before the first handler runs is observable, and it is the one thing
+#: the entry points differ about.** A source consumed one event at a time leaves
+#: the events before a malformed one already applied; a source materialised in
+#: full applies nothing at all. Neither is more correct — but a caller can only
+#: predict which it gets if the difference has a name, and until this one did,
+#: `replay()` carried a second hand-written loop to keep its half and
+#: `merge_replay()` quietly did the other thing.
+#:
+#: `run_passes` decodes ahead only as far as it must, so what a caller hands over
+#: decides: `replay()` yields a generator, while `merge_replay()` has no choice
+#: but a list, because the merged order is not known until every stream has been
+#: read.
+EventSource = Iterable[PipelineEvent]
+
 
 def build_pipeline(
     *,
@@ -235,7 +267,7 @@ def require_reader(ctx: _ReplayCtx, what: str = "Replay") -> None:
 
 
 def run_passes(
-    ctx: _ReplayCtx, events: Sequence[PipelineEvent], *, what: str = "Replay"
+    ctx: _ReplayCtx, events: EventSource, *, what: str = "Replay"
 ) -> ReplayResult:
     """Run `events` through every stage, in order, and return the result.
 
@@ -244,18 +276,32 @@ def run_passes(
     shape with a single `None` pass — `_run_stage_reducers(ctx, None)` is a no-op
     when nothing is registered, so the two cases need no branch.
 
+    **Decodes ahead only as far as it must**, which is the whole of what the
+    entry points used to differ about (see `EventSource`). One pass consumes the
+    source as it arrives, so a lazy source dispatches everything up to a
+    malformed event before failing. More than one pass has to see every event
+    before the second one starts, so a staged replay materialises the source
+    first and a malformed event anywhere applies nothing.
+
+    `events_processed` is what a single pass dispatched, so it counts each event
+    once however many stages ran.
+
     The events are already decoded and upcasted. What differs between `replay()`
     and `merge_replay()` — reading one stream in order versus k-way-merging
     several by an order key — happens before this, in the source. This is the
     part that was written twice.
     """
     require_reader(ctx, what)
-    passes: list[int | None] = list(ctx.handlers.stages()) if is_staged(ctx) else [None]
+    staged = is_staged(ctx)
+    source: EventSource = list(events) if staged else events
+    passes: list[int | None] = list(ctx.handlers.stages()) if staged else [None]
     for stage in passes:
-        for seq, match_str, event in events:
+        dispatched = 0
+        for seq, match_str, event in source:
             _dispatch_event(ctx, seq, match_str, event, stage)
+            dispatched += 1
+        ctx.result.events_processed = dispatched
         _run_stage_reducers(ctx, stage)
-    ctx.result.events_processed = len(events)
     return ctx.result
 
 
@@ -449,6 +495,11 @@ def replay(
     `TouchedSubject`s the pass's handlers wrote — to recompute aggregates. With
     only stage 0 handlers and no reducers, replay is a single pass, exactly as
     before.
+
+    How far it gets before failing: a single pass decodes one event at a time, so
+    a malformed event at offset N raises `ValueError` with the first N already
+    applied. A staged replay needs the whole range before its second pass, so it
+    decodes up front and the same event applies nothing. See `EventSource`.
     """
     match_str = event_match if event_match is not None else stream_path
     messages, _ = store.read(stream_path)
@@ -461,41 +512,29 @@ def replay(
         on_drift=on_drift,
     )
 
-    def _decode_upcast(seq: int, data: bytes) -> dict:
-        # Target version is resolved per event so content-routed upcasters
-        # (match_field) can key off the event body, not just the stream path.
-        return ctx.upcasters.upcast_to_current(
-            _decode_event(data, stream_path, seq),
-            match_str,
-            drift=ctx.drift,
-        )
-
-    def _in_range(seq: int) -> bool:
-        return seq >= start_seq and (end_seq is None or seq < end_seq)
-
-    if not is_staged(ctx):
-        # Single stage keeps its own streaming loop rather than going through
-        # `run_passes`. Not a micro-optimisation: decoding lazily means a
-        # malformed event at offset N fails *after* the first N-1 have been
-        # dispatched, which is the partial-progress behaviour replay had before
-        # staging existed. Materialising first would move that failure earlier.
+    def _decoded() -> Iterator[PipelineEvent]:
+        # A lazy `EventSource`: one event decoded and upcasted at a time, so a
+        # single-pass replay dispatches the events before a malformed one rather
+        # than nothing. `run_passes` materialises this itself when it needs more
+        # than one pass, which is why there is no second loop here.
         for seq, msg in enumerate(messages):
             if end_seq is not None and seq >= end_seq:
                 break
-            if not _in_range(seq):
+            if seq < start_seq:
                 continue
-            _dispatch_event(ctx, seq, match_str, _decode_upcast(seq, msg.data), None)
-            ctx.result.events_processed += 1
-        return ctx.result
+            # Target version is resolved per event so content-routed upcasters
+            # (match_field) can key off the event body, not just the stream path.
+            yield (
+                seq,
+                match_str,
+                ctx.upcasters.upcast_to_current(
+                    _decode_event(msg.data, stream_path, seq),
+                    match_str,
+                    drift=ctx.drift,
+                ),
+            )
 
-    require_reader(ctx, "Replay")
-    decoded: list[PipelineEvent] = []
-    for seq, msg in enumerate(messages):
-        if end_seq is not None and seq >= end_seq:
-            break
-        if _in_range(seq):
-            decoded.append((seq, match_str, _decode_upcast(seq, msg.data)))
-    return run_passes(ctx, decoded, what="Replay")
+    return run_passes(ctx, _decoded(), what="Replay")
 
 
 def merge_replay(
@@ -555,6 +594,11 @@ def merge_replay(
     Raises `ValueError` on duplicate `stream_paths`, when an event lacks the
     requested order key (payload field, or `event_ts` under `ENVELOPE_TS`), or
     when the order-key values aren't mutually comparable across events.
+
+    How far it gets before failing: **nothing is applied unless everything
+    decodes.** Unlike a single-pass `replay()`, a merge has to read every stream
+    to know the order, so a malformed event — or a missing order key — in any
+    stream fails before the first handler runs. See `EventSource`.
     """
     if len(set(stream_paths)) != len(stream_paths):
         raise ValueError(
@@ -608,7 +652,10 @@ def merge_replay(
         ) from exc
 
     # seq is the event's position in the merged order, not its offset in any
-    # one stream — which is exactly why the pipeline takes seq per event.
+    # one stream — which is exactly why the pipeline takes seq per event. A list
+    # rather than a lazy `EventSource` is forced, not chosen: the sort above has
+    # already read every stream, so a merge cannot dispatch anything until all of
+    # it decodes.
     merged: list[PipelineEvent] = [
         (seq, m, ev) for seq, (_, m, ev) in enumerate(tagged)
     ]

--- a/tests/test_rakaia/test_replay_pipeline.py
+++ b/tests/test_rakaia/test_replay_pipeline.py
@@ -1,41 +1,56 @@
-"""Staged replay, driven from a list of events — no store, no JSON, no upcasters.
+"""The staged pipeline both replay entry points share, tested through them.
 
 `replay()` reads one stream in order; `merge_replay()` k-way-merges several by an
-order key. Those are genuinely different jobs. Everything *after* them was the
-same and written twice: defaulting the registries, an identical `_upcaster_drift`
-closure, a `_ReplayCtx` with the same seven fields, the `any(stage > 0) or
-has_reducers()` test, the reader-required check, the stage-pass loop, and
-`events_processed`.
+order key. Everything *after* that is one shared pipeline: defaulting the
+registries, the reader-required check, one pass per stage, the reducers, the
+event count.
 
-Sixty-odd lines, in two different control-flow shapes — `replay` early-returns a
-streaming single-stage loop and raises the reader error *after* it, while
-`merge_replay` materialises everything and checks before. Any change to staging
-semantics had to be made twice, correctly, in two shapes that no longer looked
-alike.
+This file used to call `build_pipeline()` and `run_passes()` directly, on a
+fabricated list of decoded events — testing the machinery through a side door,
+which #189 filed because it is what a seam in the wrong place looks like. The
+seam was in the wrong place: `replay()` kept a *second* hand-written loop, for a
+reason it did not name — decoding one event at a time so a malformed event
+partway through leaves the events before it applied. Now that difference has a
+name (`EventSource`) and `run_passes` owns both shapes, there is nothing behind
+the entry points worth reaching past, so these tests go through them.
 
-The point of a separate pipeline is that the part which is genuinely shared can
-be tested on a fabricated list of decoded events. Every test here would
-previously have needed a real stream, real bytes, and a real registry with real
-source-hashed functions.
+Every shared behaviour is run against **both** entry points, because they are
+exactly the self-covering pair CLAUDE.md warns about: a mutation in the pipeline
+goes red through `replay()` while `merge_replay()` stays green, and either alone
+reads as covered.
 """
 
 from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
 
 import pytest
 
 from rakaia.effects import Upsert
 from rakaia.executors import CollectingExecutor
 from rakaia.registry import HandlerRegistry
-from rakaia.replay import build_pipeline, run_passes
+from rakaia.replay import ReplayResult, merge_replay, replay
+from rakaia.seed import seed_stream
+from rakaia.store import StreamStore
+
+#: The one match string every handler here registers against. `replay()` gets it
+#: as `event_match`; `merge_replay()` too, so both route merged and single-stream
+#: events through the same registry regardless of which stream they came from.
+MATCH = "s"
+
+#: A malformed event: valid bytes in a stream, not valid JSON.
+BAD_EVENT = b"not json {"
 
 
-def _effect(name: str, value):
+def _effect(name: str, value: Any) -> Upsert:
     return Upsert(
         model_label="app.Model", lookup={"name": name}, defaults={"value": value}
     )
 
 
-def _make_reducer(stage: int):
+def _make_reducer(stage: int) -> Callable[[Any], Upsert]:
     """A factory, not a default argument: a second *positional* parameter is how
     a reducer opts in to the touched-subjects arg, so `lambda r, _s=stage: ...`
     would silently be handed the touched tuple instead of the stage."""
@@ -47,7 +62,7 @@ def _registry(*, stages=(0,), reducers=()) -> HandlerRegistry:
     for stage in stages:
         registry.register(
             name=f"h{stage}",
-            event_match="s",
+            event_match=MATCH,
             fn=(lambda ev, *_a, _s=stage: _effect(f"{ev['id']}@{_s}", _s)),
             effective_from=0,
             stage=stage,
@@ -57,110 +72,267 @@ def _registry(*, stages=(0,), reducers=()) -> HandlerRegistry:
     return registry
 
 
-def _events(n: int):
-    """`(seq, match_str, decoded_event)` — what a pipeline consumes."""
-    return [(i, "s", {"id": f"e{i}"}) for i in range(n)]
+def _payloads(n: int) -> list[dict[str, Any]]:
+    """`n` events carrying their own id and merge key, so the merged order of a
+    two-stream replay is the same sequence a single-stream replay reads."""
+    return [{"id": f"e{i}", "ts": i} for i in range(n)]
 
 
-def _pipeline(registry, executor, *, reader=None):
-    return build_pipeline(
+@dataclass(frozen=True)
+class Entry:
+    """One of the two public replay entry points, with the seeding it needs.
+
+    Parametrising over this is what stops a pipeline mutation being covered on
+    one twin and green on the other.
+    """
+
+    name: str
+    """The word the reader-required error must name, which differs per entry."""
+
+    seed: Callable[[StreamStore, list[Any]], None]
+    run: Callable[..., ReplayResult]
+
+
+def _seed_one(store: StreamStore, events: list[Any]) -> None:
+    seed_stream("s", events, store=store)
+
+
+def _seed_split(store: StreamStore, events: list[Any]) -> None:
+    """Alternate the events between two streams, so the merge has to interleave
+    them by their order key rather than concatenate the streams."""
+    store.create("a")
+    store.create("b")
+    for i, event in enumerate(events):
+        seed_stream("a" if i % 2 == 0 else "b", [event], store=store)
+
+
+def _run_replay(store, registry, executor, *, reader=None) -> ReplayResult:
+    return replay(
+        store,
+        "s",
+        executor,
         handler_registry=registry,
-        upcaster_registry=None,
-        executor=executor,
+        event_match=MATCH,
         reader=reader,
-        on_drift="warn",
     )
 
 
+def _run_merge_replay(store, registry, executor, *, reader=None) -> ReplayResult:
+    return merge_replay(
+        store,
+        ["a", "b"],
+        executor,
+        order_key="ts",
+        handler_registry=registry,
+        event_match=MATCH,
+        reader=reader,
+    )
+
+
+ENTRIES = [
+    Entry(name="Replay", seed=_seed_one, run=_run_replay),
+    Entry(name="merge_replay", seed=_seed_split, run=_run_merge_replay),
+]
+
+both_entries = pytest.mark.parametrize(
+    "entry", ENTRIES, ids=[e.run.__name__.removeprefix("_run_") for e in ENTRIES]
+)
+
+
+@pytest.fixture
+def store() -> StreamStore:
+    return StreamStore()
+
+
+@both_entries
 class TestSingleStage:
-    def test_every_event_is_dispatched_once(self):
+    def test_every_event_is_dispatched_once(self, store, entry: Entry):
+        entry.seed(store, _payloads(3))
         ex = CollectingExecutor()
-        result = run_passes(_pipeline(_registry(), ex), _events(3))
+
+        result = entry.run(store, _registry(), ex)
+
         assert result.events_processed == 3
         assert len(ex.effects) == 3
 
-    def test_an_empty_event_list_is_a_no_op(self):
+    def test_an_empty_stream_is_a_no_op(self, store, entry: Entry):
+        entry.seed(store, [])
         ex = CollectingExecutor()
-        result = run_passes(_pipeline(_registry(), ex), [])
+
+        result = entry.run(store, _registry(), ex)
+
         assert result.events_processed == 0
         assert ex.effects == []
 
-    def test_events_are_dispatched_in_list_order(self):
+    def test_events_are_dispatched_in_order(self, store, entry: Entry):
+        entry.seed(store, _payloads(3))
         ex = CollectingExecutor()
-        run_passes(_pipeline(_registry(), ex), _events(3))
+
+        entry.run(store, _registry(), ex)
+
         assert [e.lookup["name"] for e in ex.effects] == ["e0@0", "e1@0", "e2@0"]
 
 
+@both_entries
 class TestStagedPasses:
-    def test_every_event_runs_through_stage_zero_before_stage_one(self):
+    def test_every_event_runs_through_stage_zero_before_stage_one(
+        self, store, entry: Entry
+    ):
         """The defining property of staged replay, and the one thing that was
         implemented twice."""
+        entry.seed(store, _payloads(2))
         ex = CollectingExecutor()
-        reader = object()
-        run_passes(_pipeline(_registry(stages=(0, 1)), ex, reader=reader), _events(2))
+
+        entry.run(store, _registry(stages=(0, 1)), ex, reader=object())
 
         stages = [e.defaults["value"] for e in ex.effects]
         assert stages == [0, 0, 1, 1], (
             "all of stage 0 must complete before stage 1 begins"
         )
 
-    def test_reducers_run_once_per_stage_after_that_stage(self):
+    def test_reducers_run_once_per_stage_after_that_stage(self, store, entry: Entry):
+        entry.seed(store, _payloads(3))
         ex = CollectingExecutor()
         registry = _registry(stages=(0,), reducers=(0,))
-        run_passes(_pipeline(registry, ex, reader=object()), _events(3))
+
+        entry.run(store, registry, ex, reader=object())
 
         names = [e.lookup["name"] for e in ex.effects]
         assert names == ["e0@0", "e1@0", "e2@0", "reduced@0"]
 
+    def test_each_event_is_counted_once_however_many_stages_ran(
+        self, store, entry: Entry
+    ):
+        """Two passes over three events is still three events processed."""
+        entry.seed(store, _payloads(3))
 
+        result = entry.run(
+            store, _registry(stages=(0, 1)), CollectingExecutor(), reader=object()
+        )
+
+        assert result.events_processed == 3
+
+
+@both_entries
 class TestTheReaderRequirement:
-    def test_a_staged_registry_without_a_reader_is_refused(self):
+    def test_a_staged_registry_without_a_reader_is_refused(self, store, entry: Entry):
+        entry.seed(store, _payloads(1))
         with pytest.raises(ValueError, match="reader"):
-            run_passes(_pipeline(_registry(stages=(0, 1)), CollectingExecutor()), [])
+            entry.run(store, _registry(stages=(0, 1)), CollectingExecutor())
 
-    def test_a_reducer_without_a_reader_is_refused(self):
+    def test_a_reducer_without_a_reader_is_refused(self, store, entry: Entry):
+        entry.seed(store, _payloads(1))
         registry = _registry(stages=(0,), reducers=(0,))
         with pytest.raises(ValueError, match="reader"):
-            run_passes(_pipeline(registry, CollectingExecutor()), [])
+            entry.run(store, registry, CollectingExecutor())
 
-    def test_a_single_stage_registry_needs_no_reader(self):
-        run_passes(_pipeline(_registry(), CollectingExecutor()), _events(1))
+    def test_a_single_stage_registry_needs_no_reader(self, store, entry: Entry):
+        entry.seed(store, _payloads(1))
+        entry.run(store, _registry(), CollectingExecutor())
 
-    def test_the_message_names_the_caller(self):
+    def test_the_message_names_the_caller(self, store, entry: Entry):
         """`replay` and `merge_replay` each had their own wording; the caller is
-        now a parameter so the guidance still points at the right function."""
-        with pytest.raises(ValueError, match="merge_replay"):
-            run_passes(
-                _pipeline(_registry(stages=(0, 1)), CollectingExecutor()),
-                [],
-                what="merge_replay",
-            )
+        a parameter of the shared check, so the guidance still points at the
+        function the user called."""
+        entry.seed(store, _payloads(1))
+        with pytest.raises(ValueError, match=entry.name):
+            entry.run(store, _registry(stages=(0, 1)), CollectingExecutor())
+
+    def test_the_refusal_precedes_any_dispatch(self, store, entry: Entry):
+        """Failing here beats failing inside the first handler that dereferences
+        `None`, so nothing may have been applied by the time it raises."""
+        entry.seed(store, _payloads(3))
+        ex = CollectingExecutor()
+        with pytest.raises(ValueError, match="reader"):
+            entry.run(store, _registry(stages=(0, 1)), ex)
+        assert ex.effects == []
 
 
+@both_entries
 class TestSeqIsCarriedThrough:
-    def test_the_seq_on_each_event_selects_the_handler_version(self):
-        """A pipeline event carries its own seq, so a merged replay can number
-        by merged position while a single-stream replay numbers by offset —
-        without the pipeline knowing which it is."""
+    def test_the_seq_on_each_event_selects_the_handler_version(
+        self, store, entry: Entry
+    ):
+        """A pipeline event carries its own seq, so a merged replay numbers by
+        merged position while a single-stream replay numbers by offset — and the
+        shared pipeline never learns which it is."""
         registry = HandlerRegistry()
         registry.register(
             name="v",
-            event_match="s",
+            event_match=MATCH,
             fn=lambda ev: _effect(ev["id"], "old"),
             effective_from=0,
             effective_to=2,
         )
         registry.register(
             name="v",
-            event_match="s",
+            event_match=MATCH,
             fn=lambda ev: _effect(ev["id"], "new"),
             effective_from=2,
         )
+        entry.seed(store, _payloads(4))
         ex = CollectingExecutor()
-        run_passes(_pipeline(registry, ex), _events(4))
+
+        entry.run(store, registry, ex)
+
         assert [e.defaults["value"] for e in ex.effects] == [
             "old",
             "old",
             "new",
             "new",
         ]
+
+
+class TestHowFarAReplayGetsBeforeFailing:
+    """`EventSource` — the thing the two entry points differ about, and the
+    reason `replay()` used to carry a second loop.
+
+    A malformed event is the cheapest way to observe it: how many of the good
+    events reached the executor before the failure is the whole difference.
+    """
+
+    def test_a_single_pass_replay_applies_the_events_before_a_malformed_one(
+        self, store
+    ):
+        seed_stream("s", [{"id": "e0"}, BAD_EVENT, {"id": "e2"}], store=store)
+        ex = CollectingExecutor()
+
+        with pytest.raises(ValueError, match="Cannot decode event"):
+            replay(store, "s", ex, handler_registry=_registry(), event_match=MATCH)
+
+        assert [e.lookup["name"] for e in ex.effects] == ["e0@0"], (
+            "a single pass decodes one event at a time, so the events before "
+            "the malformed one are already applied"
+        )
+
+    def test_a_staged_replay_applies_nothing_when_any_event_is_malformed(self, store):
+        seed_stream("s", [{"id": "e0"}, BAD_EVENT, {"id": "e2"}], store=store)
+        ex = CollectingExecutor()
+
+        with pytest.raises(ValueError, match="Cannot decode event"):
+            replay(
+                store,
+                "s",
+                ex,
+                handler_registry=_registry(stages=(0, 1)),
+                event_match=MATCH,
+                reader=object(),
+            )
+
+        assert ex.effects == [], (
+            "more than one pass has to see every event first, so nothing is "
+            "applied when any of them fails to decode"
+        )
+
+    def test_a_merge_applies_nothing_when_any_event_is_malformed(self, store):
+        _seed_split(store, [{"id": "e0", "ts": 0}, {"id": "e1", "ts": 1}])
+        store.append("a", BAD_EVENT)
+        ex = CollectingExecutor()
+
+        with pytest.raises(ValueError, match="Cannot decode event"):
+            _run_merge_replay(store, _registry(), ex)
+
+        assert ex.effects == [], (
+            "a merge cannot know the order until every stream is read, so a "
+            "malformed event anywhere applies nothing — even unstaged"
+        )


### PR DESCRIPTION
Replay had two versions of its middle. The single-stream one kept a second
hand-written loop because it reads events one at a time, and the merged one
always read everything before starting and never said so. Since neither
behaviour had a name, the tests could only get at them by importing the helpers
directly — checking the machinery through a side door instead of through replay.

The difference now has a name and one loop serves both: a replay reads ahead
only as far as it has to. Nothing a caller does behaves differently; what
changed is that the rule is written down — a plain replay applies the events
before a bad one, while a staged replay or a merge applies nothing, because both
have to see everything first. The tests go through the two entry points, each
shared behaviour run against both.

Closes #189.