### PR TITLE
A renamed effect field no longer loses references in silence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,24 @@ runnable demo for each.
 
 ## [Unreleased]
 
+### Fixed
+
+- **A renamed effect field no longer loses references in silence.** Substituting
+  a symbolic reference (`Ref`) used to work by trying three field names in turn —
+  `lookup`, `defaults`, `patch` — and asking each effect whether it had one. An
+  effect that did not answer to a name was skipped without a word, so renaming a
+  field, or adding a fifth kind of effect carrying a mapping the list had never
+  heard of, left references in it unresolved and wrote the placeholder object
+  itself to the database.
+
+  Each effect now names its own reference-bearing fields in code the type checker
+  reads, and the four kinds are matched exhaustively, so both cases are a
+  `just typecheck` failure instead of wrong data. Verified by mutation: renaming
+  `Retire.patch` produced **no** error inside the resolver before and produces two
+  now, and adding a fifth variant to `Effect` fails the exhaustiveness check.
+  `Retire.patch` and a `Delete`'s flat `Exclude` had no test coverage at all —
+  which is why those two renames were the silent ones — and now do. (#161 item 2)
+
 ### Added
 
 - **`DriftLedger` — one object that knows whether a rule's code has changed.**

--- a/src/rakaia/effects.py
+++ b/src/rakaia/effects.py
@@ -31,7 +31,7 @@ from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 from dataclasses import field as dc_field
 from dataclasses import replace as dc_replace
-from typing import Any, Protocol, runtime_checkable
+from typing import Any, NoReturn, Protocol, TypeVar, cast, runtime_checkable
 
 # =============================================================================
 # Symbolic refs — bind to a sibling effect's generated key
@@ -277,6 +277,26 @@ class DuplicateProducesError(Exception):
 # =============================================================================
 
 
+#: An effect, kept as its own concrete type through `RefResolver.resolve_effect`
+#: so a caller that hands in an `Update` gets an `Update` back.
+_EffectT = TypeVar("_EffectT", bound="Effect")
+
+#: The two shapes of `spare`, likewise kept concrete: a `Delete` may spare by
+#: flat lookup or composite key, a `Retire` only by composite key.
+_SpareT = TypeVar("_SpareT", bound="Exclude | SpareKeys | None")
+
+
+def _assert_never(value: NoReturn) -> NoReturn:
+    """Exhaustiveness check: a value pyright believes is unreachable.
+
+    `typing.assert_never` would say this, but it landed in 3.11 and this package
+    supports 3.10 with zero runtime dependencies, so it is written out. Passing
+    a value pyright can still narrow is an argument-type error, which is how a
+    new member of the `Effect` union becomes a build failure.
+    """
+    raise AssertionError(f"Unhandled effect variant: {type(value).__name__}")
+
+
 class RefResolver:
     """Resolves `Ref` placeholders against rows produced earlier in one batch.
 
@@ -290,10 +310,6 @@ class RefResolver:
     ``None``). The `CollectingExecutor` does *not* resolve — a dry run keeps the
     literal ``Ref`` values, which is correct.
     """
-
-    # Effect fields whose dict values may carry a Ref. Which of them a given
-    # variant has is decided by the variant's own type, not by a rule here.
-    _MAPPING_FIELDS = ("lookup", "defaults", "patch")
 
     def __init__(self) -> None:
         self._symbols: dict[str, Callable[[str], Any]] = {}
@@ -333,43 +349,85 @@ class RefResolver:
                 f"produced row has no attribute {value.field!r}."
             ) from exc
 
-    def _resolve_mapping(self, mapping: dict[str, Any] | None) -> dict[str, Any] | None:
+    def _resolve_lookup(self, mapping: dict[str, Any]) -> dict[str, Any]:
+        """A mapping with its `Ref` values substituted, or the mapping itself
+        (same object) when it carries none — so a caller can test by identity."""
         if not mapping or not any(isinstance(v, Ref) for v in mapping.values()):
-            return mapping  # unchanged (same object) — no Ref to substitute
+            return mapping
         return {k: self.resolve_value(v) for k, v in mapping.items()}
 
-    def _resolve_spare(self, spare: Any) -> Any:
+    def _resolve_mapping(self, mapping: dict[str, Any] | None) -> dict[str, Any] | None:
+        """`_resolve_lookup` for a field that may be absent (an `Upsert`'s or
+        `Update`'s ``defaults``)."""
+        return mapping if mapping is None else self._resolve_lookup(mapping)
+
+    def _resolve_spare(self, spare: _SpareT) -> _SpareT:
         """Substitute Refs inside a `spare`, returning it unchanged when there
-        is nothing to substitute (so the caller can compare by identity)."""
+        is nothing to substitute (so the caller can compare by identity).
+
+        Generic in the spare's own type because the two effects that have one do
+        not have the *same* one: a `Delete` may spare by flat lookup or by
+        composite key, a `Retire` only by composite key. Returning the declared
+        union instead would make `dc_replace(retire, spare=...)` a type error.
+        """
         if isinstance(spare, Exclude):
-            resolved = self._resolve_mapping(spare.lookup)
-            return spare if resolved is spare.lookup else Exclude(lookup=resolved or {})
+            resolved = self._resolve_lookup(spare.lookup)
+            if resolved is spare.lookup:
+                return spare
+            return cast("_SpareT", Exclude(lookup=resolved))
         if isinstance(spare, SpareKeys):
-            keys = [self._resolve_mapping(k) for k in spare.keys]
+            keys = [self._resolve_lookup(k) for k in spare.keys]
             if all(n is o for n, o in zip(keys, spare.keys, strict=True)):
                 return spare
-            return SpareKeys(keys=[k or {} for k in keys])
+            return cast("_SpareT", SpareKeys(keys=keys))
         return spare
 
-    def resolve_effect(self, effect: Any) -> Any:
+    def resolve_effect(self, effect: _EffectT) -> _EffectT:
         """Return `effect` with every `Ref` value substituted, or `effect`
-        itself (unchanged) when it carries no refs — the common fast path."""
-        changed: dict[str, Any] = {}
-        for name in self._MAPPING_FIELDS:
-            if not hasattr(effect, name):
-                continue
-            original = getattr(effect, name)
-            resolved = self._resolve_mapping(original)
-            if resolved is not original:
-                changed[name] = resolved
-        spare = getattr(effect, "spare", None)
-        if spare is not None:
-            resolved_spare = self._resolve_spare(spare)
-            if resolved_spare is not spare:
-                changed["spare"] = resolved_spare
-        if not changed:
-            return effect
-        return dc_replace(effect, **changed)
+        itself (unchanged) when it carries no refs — the common fast path.
+
+        **Each variant names its own ref-bearing fields, in code pyright checks.**
+        This used to walk a tuple of three field-name *strings* with `hasattr`,
+        which reintroduced the "which fields does this variant have?" reasoning
+        that one-type-per-operation removed — and got it wrong silently: a
+        renamed field made `hasattr` return False, so the `Ref` was never
+        substituted and the placeholder object itself was written to the
+        database. Reading `effect.patch` instead of ``getattr(effect, "patch")``
+        makes that rename a type error, and `_assert_never` makes a *new* effect
+        variant one too, which nothing caught before (#161 item 2).
+
+        Mutation this is pinned by: rename `Retire.patch`, and
+        `just typecheck` fails here rather than the suite passing.
+        """
+        if isinstance(effect, (Upsert, Update)):
+            lookup = self._resolve_lookup(effect.lookup)
+            defaults = self._resolve_mapping(effect.defaults)
+            if lookup is effect.lookup and defaults is effect.defaults:
+                return effect
+            return cast(
+                "_EffectT", dc_replace(effect, lookup=lookup, defaults=defaults)
+            )
+        if isinstance(effect, Delete):
+            lookup = self._resolve_lookup(effect.lookup)
+            spare = self._resolve_spare(effect.spare)
+            if lookup is effect.lookup and spare is effect.spare:
+                return effect
+            return cast("_EffectT", dc_replace(effect, lookup=lookup, spare=spare))
+        if isinstance(effect, Retire):
+            lookup = self._resolve_lookup(effect.lookup)
+            patch = self._resolve_lookup(effect.patch)
+            spare = self._resolve_spare(effect.spare)
+            if (
+                lookup is effect.lookup
+                and patch is effect.patch
+                and spare is effect.spare
+            ):
+                return effect
+            return cast(
+                "_EffectT",
+                dc_replace(effect, lookup=lookup, patch=patch, spare=spare),
+            )
+        _assert_never(effect)
 
 
 # =============================================================================

--- a/tests/test_rakaia/test_refs.py
+++ b/tests/test_rakaia/test_refs.py
@@ -13,6 +13,7 @@ import pytest
 from rakaia.effects import (
     Delete,
     DuplicateProducesError,
+    Exclude,
     Ref,
     RefResolver,
     Retire,
@@ -132,3 +133,96 @@ class TestRefResolver:
         )
         resolved = resolver.resolve_effect(eff)
         assert resolved.spare == SpareKeys([{"project_id": 3}])
+
+
+class TestEveryRefBearingFieldIsReached:
+    """One case per (variant, ref-bearing field), because the resolver used to
+    find them by string.
+
+    `Retire.patch` and `Delete.spare`'s flat `Exclude` had no case at all, which
+    is exactly why renaming either was silent: `hasattr` returned False, the
+    `Ref` was never substituted, and the placeholder object itself went to the
+    database. `lookup` and `defaults` were covered, so those two renames already
+    broke something; these two did not (#161 item 2).
+
+    Mutation these are pinned by: with the resolver's per-variant dispatch
+    replaced by the old three-string walk, renaming `Retire.patch` leaves the
+    whole suite green. With the dispatch, it is a `just typecheck` failure.
+    """
+
+    @staticmethod
+    def _accessor(row):
+        return lambda field: row[field]
+
+    def test_a_ref_in_a_retires_patch_is_substituted(self):
+        resolver = RefResolver()
+        resolver.record("proj", self._accessor({"pk": 11}))
+        eff = Retire(
+            model_label="app.Alert",
+            lookup={"stream_key": "k"},
+            patch={"resolved_by_id": Ref("proj"), "resolved_at": "t"},
+        )
+        resolved = resolver.resolve_effect(eff)
+        assert resolved.patch == {"resolved_by_id": 11, "resolved_at": "t"}
+
+    def test_a_ref_in_a_deletes_flat_exclude_is_substituted(self):
+        resolver = RefResolver()
+        resolver.record("proj", self._accessor({"pk": 5}))
+        eff = Delete(
+            model_label="app.Row",
+            lookup={"parent_id": "p1"},
+            spare=Exclude(lookup={"project_id": Ref("proj")}),
+        )
+        resolved = resolver.resolve_effect(eff)
+        assert resolved.spare == Exclude(lookup={"project_id": 5})
+
+    def test_a_ref_in_a_retires_lookup_is_substituted(self):
+        resolver = RefResolver()
+        resolver.record("proj", self._accessor({"pk": 9}))
+        eff = Retire(
+            model_label="app.Alert",
+            lookup={"project_id": Ref("proj")},
+            patch={"resolved_at": "t"},
+        )
+        resolved = resolver.resolve_effect(eff)
+        assert resolved.lookup == {"project_id": 9}
+        assert resolved.patch == {"resolved_at": "t"}
+
+    def test_a_ref_in_a_deletes_lookup_is_substituted(self):
+        resolver = RefResolver()
+        resolver.record("proj", self._accessor({"pk": 4}))
+        eff = Delete(model_label="app.Row", lookup={"project_id": Ref("proj")})
+        assert resolver.resolve_effect(eff).lookup == {"project_id": 4}
+
+    def test_an_update_keeps_its_own_type(self):
+        # The resolver is generic in the effect type, so a caller that hands in
+        # an `Update` gets an `Update` back — `_flush_updates` relies on it.
+        resolver = RefResolver()
+        resolver.record("proj", self._accessor({"pk": 2}))
+        eff = Update(
+            model_label="app.Row",
+            lookup={"project_id": Ref("proj")},
+            defaults={"n": 1},
+        )
+        resolved = resolver.resolve_effect(eff)
+        assert isinstance(resolved, Update)
+        assert resolved.lookup == {"project_id": 2}
+
+    def test_an_effect_with_no_refs_anywhere_is_returned_unchanged(self):
+        # The identity fast path has to hold for every variant, not just the
+        # upsert the older test used — each now takes its own branch.
+        resolver = RefResolver()
+        for eff in (
+            Upsert(model_label="app.R", lookup={"a": 1}, defaults={"b": 2}),
+            Update(model_label="app.R", lookup={"a": 1}, defaults={"b": 2}),
+            Delete(
+                model_label="app.R", lookup={"a": 1}, spare=Exclude(lookup={"b": 2})
+            ),
+            Retire(
+                model_label="app.R",
+                lookup={"a": 1},
+                patch={"b": 2},
+                spare=SpareKeys([{"c": 3}]),
+            ),
+        ):
+            assert resolver.resolve_effect(eff) is eff


### PR DESCRIPTION
When one change to the database needs the identifier of a row another change is
about to create, it leaves a placeholder that gets filled in just before the
write. Finding those placeholders worked by trying three field names in turn and
asking each change whether it had one. Anything that did not answer to a name was
skipped without a word, so renaming a field — or adding a new kind of change
carrying a field the list had never heard of — left the placeholders unfilled and
wrote the placeholder object itself into the database.

Each kind of change now says which of its own fields can hold a placeholder, in a
form the type checker reads, so both cases fail the build instead of producing
wrong data. Two of the fields had never been covered by a test at all, which is
exactly why those two were the silent ones; they are covered now.

Closes item 2 of #161.