### PR TITLE
A replay hands the executor a whole pass of changes at once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,23 +9,6 @@ runnable demo for each.
 
 ## [Unreleased]
 
-### Fixed
-
-- **A renamed effect field no longer loses references in silence.** Substituting
-  a symbolic reference (`Ref`) used to work by trying three field names in turn —
-  `lookup`, `defaults`, `patch` — and asking each effect whether it had one. An
-  effect that did not answer to a name was skipped without a word, so renaming a
-  field, or adding a fifth kind of effect carrying a mapping the list had never
-  heard of, left references in it unresolved and wrote the placeholder object
-  itself to the database.
-
-  Each effect now names its own reference-bearing fields in code the type checker
-  reads, and the four kinds are matched exhaustively, so both cases are a
-  `just typecheck` failure instead of wrong data. Verified by mutation: renaming
-  `Retire.patch` produced **no** error inside the resolver before and produces two
-  now, and adding a fifth variant to `Effect` fails the exhaustiveness check.
-  `Retire.patch` and a `Delete`'s flat `Exclude` had no test coverage at all —
-  which is why those two renames were the silent ones — and now do. (#161 item 2)
 
 ### Added
 
@@ -158,6 +141,23 @@ runnable demo for each.
 
 ### Changed
 
+- **A replay now hands the executor a whole stage's changes at once.** It used to
+  apply one event's worth at a time, so the batching added for a fanned-out
+  change could never do anything on the path that produces most of the changes —
+  a run of one is never collapsed. On the reported form save, nine events became
+  nine separate database transactions: eighteen of the hundred and thirty-five
+  statements the save issued were the opening and closing of those transactions.
+  Measured on the same shape, it is now one transaction and one statement.
+
+  Widening a batch is only safe if nothing can tell, so the batch is broken the
+  moment holding one more change back would alter the outcome: a write arriving
+  behind a delete, a second write to the same column of the same row, a repeated
+  correlation id, or a soft-delete that asked for notifications. Passes whose
+  handlers are handed a reader are left alone entirely — they can see the
+  database, so they keep applying event by event. One deliberate widening: a
+  reference to a row created by an earlier event in the same pass now resolves,
+  where it used to fail. (#207)
+
 - **A replay now says how far it gets before failing.** `replay` and
   `merge_replay` share one staging pipeline, but `replay` kept a *second*
   hand-written loop for its single-stage path, and the reason was real: it
@@ -246,6 +246,24 @@ runnable demo for each.
   surface (see `docs/public-api.md`), so this is a narrowing of what the log
   tolerates rather than a break. A consumer inserting its own rows should
   allocate through the stream.
+
+### Fixed
+
+- **A renamed effect field no longer loses references in silence.** Substituting
+  a symbolic reference (`Ref`) used to work by trying three field names in turn —
+  `lookup`, `defaults`, `patch` — and asking each effect whether it had one. An
+  effect that did not answer to a name was skipped without a word, so renaming a
+  field, or adding a fifth kind of effect carrying a mapping the list had never
+  heard of, left references in it unresolved and wrote the placeholder object
+  itself to the database.
+
+  Each effect now names its own reference-bearing fields in code the type checker
+  reads, and the four kinds are matched exhaustively, so both cases are a
+  `just typecheck` failure instead of wrong data. Verified by mutation: renaming
+  `Retire.patch` produced **no** error inside the resolver before and produces two
+  now, and adding a fifth variant to `Effect` fails the exhaustiveness check.
+  `Retire.patch` and a `Delete`'s flat `Exclude` had no test coverage at all —
+  which is why those two renames were the silent ones — and now do. (#161 item 2)
 
 ## [0.2.0] - 2026-08-15
 

--- a/src/rakaia/effects.py
+++ b/src/rakaia/effects.py
@@ -503,6 +503,64 @@ def _row_key(effect: RowEffect) -> tuple[str, str]:
     return (effect.model_label, canon_lookup)
 
 
+class _WrittenFields:
+    """Which columns of which rows a batch of effects already writes.
+
+    `check_disjoint_defaults` is this class walked once over a whole batch. The
+    replay orchestrator needs the same question asked *incrementally* — "would
+    adding this event's effects to the batch I am holding collide?" — before
+    there is a batch to check. Both go through here so the rule that decides
+    what a collision is has one home rather than two that can drift (#152).
+
+    `collides` only reports; `record` only remembers. Keeping the raise out of
+    both is what lets the orchestrator use the answer to flush early, while
+    `check_disjoint_defaults` keeps raising with the same message and the same
+    effect indices it always did.
+    """
+
+    def __init__(self) -> None:
+        # (model_label, canonical lookup) -> {column: index of the effect that
+        # first wrote it}
+        self._seen: dict[tuple[str, str], dict[str, int]] = {}
+
+    @staticmethod
+    def _writes(effect: Effect) -> tuple[tuple[str, str], dict[str, Any]] | None:
+        """The row and columns `effect` writes, or None if it writes none.
+
+        Only :class:`Upsert` and :class:`Update` carry `defaults`; a delete or a
+        retire names no column, and an effect with empty `defaults` writes
+        nothing to collide over.
+        """
+        if not isinstance(effect, (Upsert, Update)) or not effect.defaults:
+            return None
+        return _row_key(effect), effect.defaults
+
+    def collides(self, effect: Effect) -> tuple[str, int] | None:
+        """The first ``(column, earlier effect index)`` `effect` would overwrite,
+        or None if it is disjoint from everything recorded so far."""
+        writes = self._writes(effect)
+        if writes is None:
+            return None
+        row, defaults = writes
+        existing = self._seen.get(row)
+        if existing is None:
+            return None
+        for field_name in defaults:
+            if field_name in existing:
+                return (field_name, existing[field_name])
+        return None
+
+    def record(self, effect: Effect, idx: int) -> None:
+        """Remember that effect number `idx` writes these columns of this row."""
+        writes = self._writes(effect)
+        if writes is None:
+            return
+        row, defaults = writes
+        existing = self._seen.setdefault(row, {})
+        for field_name in defaults:
+            existing.setdefault(field_name, idx)
+
+
 def check_disjoint_defaults(effects: Iterable[Effect]) -> None:
     """
     Raise EffectCollisionError if two write effects targeting the same
@@ -514,17 +572,13 @@ def check_disjoint_defaults(effects: Iterable[Effect]) -> None:
     same column on the same row is always a bug. Delete and retire effects are
     ignored, as are effects without `defaults`.
     """
-    # field -> first-seen effect index, keyed by row
-    seen: dict[tuple[str, str], dict[str, int]] = {}
+    seen = _WrittenFields()
     for idx, eff in enumerate(effects):
-        if not isinstance(eff, (Upsert, Update)) or not eff.defaults:
-            continue
-        row = _row_key(eff)
-        existing = seen.setdefault(row, {})
-        for field in eff.defaults:
-            if field in existing:
-                raise EffectCollisionError(
-                    f"Effects #{existing[field]} and #{idx} both write field "
-                    f"{field!r} on {eff.model_label} {eff.lookup!r}"
-                )
-            existing[field] = idx
+        hit = seen.collides(eff)
+        if hit is not None:
+            field_name, first = hit
+            raise EffectCollisionError(
+                f"Effects #{first} and #{idx} both write field "
+                f"{field_name!r} on {eff.model_label} {eff.lookup!r}"
+            )
+        seen.record(eff, idx)

--- a/src/rakaia/replay.py
+++ b/src/rakaia/replay.py
@@ -86,6 +86,7 @@ from .effects import (
     Retire,
     Update,
     Upsert,
+    _WrittenFields,
 )
 from .protocols import ProjectionReader, ReadableStore
 from .registry import (
@@ -175,6 +176,10 @@ class _ReplayCtx:
     track_touched: bool = False
     touched: list[TouchedSubject] = field(default_factory=list)
     _touched_seen: set = field(default_factory=set)
+    # Set for the duration of a pass whose handlers take no reader, so that
+    # pass's effects can be batched. None means apply per event, which is what
+    # every reader-bearing pass and every reducer does. See `_StageBuffer`.
+    buffer: _StageBuffer | None = None
     # Carried so an event source can decode and upcast without re-deriving the
     # registry.
     upcasters: Any = None
@@ -296,11 +301,26 @@ def run_passes(
     source: EventSource = list(events) if staged else events
     passes: list[int | None] = list(ctx.handlers.stages()) if staged else [None]
     for stage in passes:
+        # Stage 0 handlers are called `fn(event)` with no reader, so nothing in
+        # the pass can observe a write that has not landed yet and the pass's
+        # effects can be batched. A stage > 0 handler *is* handed a reader, and
+        # both readers go straight to storage — a buffered write would be
+        # invisible to one, silently — so those passes keep applying per event.
+        ctx.buffer = _StageBuffer(ctx) if stage in (None, 0) else None
         dispatched = 0
-        for seq, match_str, event in source:
-            _dispatch_event(ctx, seq, match_str, event, stage)
-            dispatched += 1
+        try:
+            for seq, match_str, event in source:
+                _dispatch_event(ctx, seq, match_str, event, stage)
+                dispatched += 1
+        finally:
+            # In a `finally` because a lazy source that raises partway must
+            # still leave the events before it applied — the partial-progress
+            # behaviour `EventSource` exists to preserve. Without this, every
+            # buffered effect ahead of the bad event would be dropped.
+            _drain(ctx)
         ctx.result.events_processed = dispatched
+        # Reducers read the projections, so the stage's writes must have landed
+        # before the first one runs. `_drain` above is that boundary.
         _run_stage_reducers(ctx, stage)
     return ctx.result
 
@@ -384,6 +404,134 @@ def _synth_transitions(report: ApplyReport | None) -> list[ExternalEffect]:
     return out
 
 
+def _write_order_rank(effect: Effect) -> int:
+    """Where `effect` lands in the order an executor applies a batch.
+
+    Every executor applies a batch in three passes — every write, then every
+    delete, then every retire — so that a reconcile batch converges regardless
+    of the order its handlers emitted. That is exactly why effects from two
+    different events cannot simply be poured into one batch: doing so would
+    hoist a later event's write above an earlier event's delete.
+    """
+    if isinstance(effect, (Upsert, Update)):
+        return 0
+    if isinstance(effect, Delete):
+        return 1
+    return 2
+
+
+def _self_collides(effects: list[Effect]) -> bool:
+    """Whether one event's own effects already write the same column twice.
+
+    That is a bug the executor reports, and it must keep reporting it *for that
+    event alone* — so a self-colliding group is applied on its own, leaving
+    earlier events' effects committed exactly as they were before buffering.
+    """
+    seen = _WrittenFields()
+    for idx, eff in enumerate(effects):
+        if seen.collides(eff) is not None:
+            return True
+        seen.record(eff, idx)
+    return False
+
+
+class _StageBuffer:
+    """Effects held back so a stage reaches the executor as few batches as
+    possible — flushed early the moment holding one back would change anything.
+
+    Replay used to call ``executor.apply()`` once per event, so a batch of one
+    was the norm and the contiguous-`Update` collapsing in the Django executor
+    could never engage: a run of one is never collapsed. Nine events also meant
+    nine ``transaction.atomic()`` blocks, measured at 18 of the 135 statements
+    one form save issues (#207).
+
+    **The whole design is in when it flushes.** Widening the batch is only free
+    if the executor cannot tell, so each of these forces a flush first:
+
+    * **A write behind a delete.** See `_write_order_rank` — a batch is applied
+      writes-then-deletes-then-retires, so an incoming effect that ranks below
+      anything pending would be reordered across an event boundary.
+    * **A second write to the same column of the same row.** Ordinary between
+      events (event 2 supersedes event 1) and an error within one batch, which
+      `check_disjoint_defaults` raises with nothing applied. Consulted through
+      the same `_WrittenFields` that check uses, so there is one rule.
+    * **A repeated ``produces=`` id.** Two producers of one correlation id in a
+      batch is `DuplicateProducesError`; in separate events it is normal.
+    * **A retire that asked for notifications.** Its transitions are synthesised
+      from the report of the call that applied it, and `ReplayResult.external`
+      is documented in handler-emission order. Flushing on one keeps that list
+      byte-identical. Opted-in retires are rare, so this costs almost nothing.
+
+    Two things it deliberately does *not* try to preserve, both widenings rather
+    than changes: a `Ref` may now bind to a ``produces=`` row from an earlier
+    event in the same stage (it used to raise, because refs do not cross an
+    ``apply()`` call), and the executor sees fewer, larger batches.
+    """
+
+    def __init__(self, ctx: _ReplayCtx) -> None:
+        self._ctx = ctx
+        self._pending: list[Effect] = []
+        self._written = _WrittenFields()
+        self._produces: set[str] = set()
+        self._max_rank = -1
+
+    def add(self, effects: list[Effect]) -> None:
+        """Buffer one event's effects, flushing first if they cannot join."""
+        if not effects:
+            return
+        alone = _self_collides(effects)
+        if self._pending and (alone or self._conflicts(effects)):
+            self.flush()
+        for eff in effects:
+            self._written.record(eff, len(self._pending))
+            self._pending.append(eff)
+            if isinstance(eff, Upsert) and eff.produces is not None:
+                self._produces.add(eff.produces)
+            self._max_rank = max(self._max_rank, _write_order_rank(eff))
+        if alone or any(
+            isinstance(e, Retire) and e.transition is not None for e in effects
+        ):
+            self.flush()
+
+    def _conflicts(self, effects: list[Effect]) -> bool:
+        """Whether adding `effects` to what is pending would change behaviour.
+
+        Checked for the group as a whole, against what is pending only — an
+        event's effects collide with *each other* under the same rules the
+        executor already applies to a batch, and that stays the executor's to
+        report.
+        """
+        if min(_write_order_rank(e) for e in effects) < self._max_rank:
+            return True
+        if any(self._written.collides(e) is not None for e in effects):
+            return True
+        return any(
+            isinstance(e, Upsert)
+            and e.produces is not None
+            and e.produces in self._produces
+            for e in effects
+        )
+
+    def flush(self) -> None:
+        """Apply what is buffered as one batch, and reset."""
+        if not self._pending:
+            return
+        batch = self._pending
+        self._pending = []
+        self._written = _WrittenFields()
+        self._produces = set()
+        self._max_rank = -1
+        report = self._ctx.executor.apply(batch)
+        self._ctx.result.external.extend(_synth_transitions(report))
+
+
+def _drain(ctx: _ReplayCtx) -> None:
+    """Apply whatever the pass buffered, and go back to per-event application."""
+    if ctx.buffer is not None:
+        buffer, ctx.buffer = ctx.buffer, None
+        buffer.flush()
+
+
 def _apply_effects(ctx: _ReplayCtx, effects: list[AnyEffect]) -> None:
     """Route a batch: external effects to the result, the rest to the executor.
 
@@ -398,8 +546,14 @@ def _apply_effects(ctx: _ReplayCtx, effects: list[AnyEffect]) -> None:
             to_apply.append(e)
     if not to_apply:
         return
-    report = ctx.executor.apply(to_apply)
     ctx.result.effects_applied += len(to_apply)
+    if ctx.buffer is not None:
+        # Counted above rather than at flush time, so the number reads the same
+        # whether or not this pass batches. The buffer applies the batch and
+        # collects any transitions itself.
+        ctx.buffer.add(to_apply)
+        return
+    report = ctx.executor.apply(to_apply)
     # A retire that flipped rows (a real machine resolution) yields external
     # transitions — collect them alongside the handler-emitted ones.
     ctx.result.external.extend(_synth_transitions(report))

--- a/tests/test_django_rakaia/test_replay_batching_cost.py
+++ b/tests/test_django_rakaia/test_replay_batching_cost.py
@@ -1,0 +1,101 @@
+"""What buffering a stage actually buys, in statements (#207).
+
+The two claims from the issue, measured against the durable executor rather than
+asserted. Both are about a *replay*, which is the point: `test_update_batching.py`
+already shows the collapse working when a caller hands `apply()` a full fan-out
+itself, and it always did. What it could never do was engage from the path that
+generates the effects, because that path called `apply()` once per event and a run
+of one is never collapsed.
+"""
+
+from __future__ import annotations
+
+import pytest
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
+
+from django_rakaia.effect_executor import DjangoExecutor
+from rakaia.effects import Update
+from rakaia.registry import HandlerRegistry
+from rakaia.replay import replay
+from rakaia.seed import seed_stream
+from rakaia.store import StreamStore
+
+from .models import FinanceLine
+
+pytestmark = pytest.mark.django_db
+
+MODEL = "test_django_rakaia.FinanceLine"
+MATCH = "s"
+
+
+def _statements(ctx: CaptureQueriesContext, verb: str) -> list[str]:
+    return [
+        q["sql"]
+        for q in ctx.captured_queries
+        if q["sql"].lstrip().upper().startswith(verb)
+    ]
+
+
+def _replay_nine(executor) -> CaptureQueriesContext:
+    """Nine events, each fanning one identical `Update` at its own row — the
+    shape the issue measured on an SF 2.3 form save."""
+    ids = [f"r{i}" for i in range(9)]
+    for i in ids:
+        FinanceLine.objects.create(submission_id=i, suku="s", delta=0)
+
+    store = StreamStore()
+    seed_stream("s", [{"id": i} for i in ids], store=store)
+
+    registry = HandlerRegistry()
+    registry.register(
+        name="h",
+        event_match=MATCH,
+        fn=lambda ev: Update(
+            model_label=MODEL, lookup={"submission_id": ev["id"]}, defaults={"delta": 7}
+        ),
+        effective_from=0,
+        stage=0,
+    )
+
+    with CaptureQueriesContext(connection) as ctx:
+        replay(store, "s", executor, handler_registry=registry, event_match=MATCH)
+    return ctx
+
+
+def test_a_nine_event_replay_now_enters_one_transaction():
+    """Nine `apply()` calls meant nine SAVEPOINT/RELEASE pairs — 18 statements,
+    which the issue measured as 13% of a form save. One batch, one pair.
+
+    Mutation: leave `ctx.buffer` at None in `run_passes` and this reports nine.
+    """
+    ctx = _replay_nine(DjangoExecutor())
+
+    savepoints = _statements(ctx, "SAVEPOINT")
+    assert len(savepoints) == 1, "one atomic block for the stage, not one per event"
+    assert len(_statements(ctx, "RELEASE")) == 1
+
+
+def test_the_collapse_added_in_203_finally_engages_from_a_replay():
+    """The issue's actual complaint: the batching is unreachable from the path
+    that produces the effects. Nine updates, one statement.
+
+    Mutation: as above — without buffering each run has one member, the
+    `len(run) == 1` branch wins, and this reports nine UPDATEs.
+    """
+    ctx = _replay_nine(DjangoExecutor(batch_updates=True))
+
+    updates = _statements(ctx, "UPDATE")
+    assert len(updates) == 1
+    assert " IN (" in updates[0].upper()
+    assert set(FinanceLine.objects.values_list("delta", flat=True)) == {7}
+
+
+def test_the_rows_are_the_same_without_the_collapse_enabled():
+    """Buffering is not the collapse. With `batch_updates` off the statements
+    stay one per row — only the transaction count changes — and either way the
+    rows land identically."""
+    ctx = _replay_nine(DjangoExecutor())
+
+    assert len(_statements(ctx, "UPDATE")) == 9
+    assert set(FinanceLine.objects.values_list("delta", flat=True)) == {7}

--- a/tests/test_rakaia/test_replay_batching.py
+++ b/tests/test_rakaia/test_replay_batching.py
@@ -1,0 +1,382 @@
+"""A stage reaches the executor as few batches as possible — and no fewer (#207).
+
+Replay used to call ``executor.apply()`` once per event, so the batch was almost
+always a single effect: the contiguous-``Update`` collapsing in the Django
+executor could never engage, and nine events meant nine ``transaction.atomic()``
+blocks. Buffering a stage fixes both, but only if the executor cannot tell the
+difference — so most of what is worth testing here is the *flushes*, not the
+batching.
+
+Each test below trips one of the four things that force an early flush and
+asserts the batch boundary is where it must be. The mutations they are pinned by
+are named on each test; every one was applied and watched go red.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from rakaia.effects import (
+    ApplyReport,
+    Delete,
+    Effect,
+    EffectCollisionError,
+    Ref,
+    Retire,
+    Transition,
+    Update,
+    Upsert,
+    check_disjoint_defaults,
+)
+from rakaia.executors import InMemoryProjections
+from rakaia.registry import HandlerRegistry
+from rakaia.replay import replay
+from rakaia.seed import seed_stream
+from rakaia.store import StreamStore
+
+MATCH = "s"
+
+
+class BatchRecorder:
+    """An `Executor` that records the *shape* of what it was handed.
+
+    `CollectingExecutor` flattens, which is precisely the property under test
+    here — the flat list of effects is identical either way, and the whole
+    question is how many `apply()` calls carried it.
+    """
+
+    def __init__(self) -> None:
+        self.batches: list[list[Effect]] = []
+
+    def apply(self, effects) -> ApplyReport:
+        batch = list(effects)
+        # A real executor runs this before its first write, and the whole point
+        # of the buffer's collision arm is to keep it from seeing a pair it
+        # never saw before. A double that skipped it could not show that.
+        check_disjoint_defaults(batch)
+        self.batches.append(batch)
+        return ApplyReport()
+
+    @property
+    def sizes(self) -> list[int]:
+        return [len(b) for b in self.batches]
+
+    @property
+    def flat(self) -> list[Effect]:
+        return [e for b in self.batches for e in b]
+
+
+@pytest.fixture
+def store() -> StreamStore:
+    return StreamStore()
+
+
+def _registry(fn, *, stage: int = 0, name: str = "h") -> HandlerRegistry:
+    registry = HandlerRegistry()
+    registry.register(
+        name=name, event_match=MATCH, fn=fn, effective_from=0, stage=stage
+    )
+    return registry
+
+
+def _run(store, registry, executor, *, reader=None):
+    return replay(
+        store,
+        "s",
+        executor,
+        handler_registry=registry,
+        event_match=MATCH,
+        reader=reader,
+    )
+
+
+def _events(n: int) -> list[dict[str, Any]]:
+    return [{"id": f"e{i}", "n": i} for i in range(n)]
+
+
+class TestTheCommonCaseBecomesOneBatch:
+    def test_nine_events_writing_nine_rows_are_one_apply_call(self, store):
+        """The shape the issue measured: nine events, one effect each, nine
+        `apply()` calls. It is one now.
+
+        Mutation: make `run_passes` leave `ctx.buffer` at None and this reports
+        nine batches of one.
+        """
+        seed_stream("s", _events(9), store=store)
+        ex = BatchRecorder()
+
+        _run(
+            store,
+            _registry(lambda ev: Upsert("app.R", {"id": ev["id"]}, {"n": ev["n"]})),
+            ex,
+        )
+
+        assert ex.sizes == [9]
+
+    def test_the_effects_are_the_same_ones_in_the_same_order(self, store):
+        """Batching may not reorder or drop anything — only regroup."""
+        seed_stream("s", _events(5), store=store)
+        ex = BatchRecorder()
+
+        result = _run(
+            store,
+            _registry(lambda ev: Upsert("app.R", {"id": ev["id"]}, {"n": ev["n"]})),
+            ex,
+        )
+
+        assert [e.lookup["id"] for e in ex.flat] == ["e0", "e1", "e2", "e3", "e4"]
+        assert result.effects_applied == 5
+
+
+class TestWhatForcesAFlush:
+    def test_a_second_write_to_the_same_column_starts_a_new_batch(self, store):
+        """Two events superseding each other on one column is ordinary; the same
+        two in one batch is `EffectCollisionError` with nothing applied.
+
+        Mutation: drop the `_written.collides` arm of `_StageBuffer._conflicts`
+        and this raises instead of reporting two batches.
+        """
+        seed_stream("s", _events(2), store=store)
+        ex = BatchRecorder()
+
+        _run(
+            store,
+            _registry(lambda ev: Upsert("app.R", {"id": "same"}, {"n": ev["n"]})),
+            ex,
+        )
+
+        assert ex.sizes == [1, 1]
+
+    def test_a_write_after_a_delete_starts_a_new_batch(self, store):
+        """A batch is applied writes-then-deletes-then-retires, so pouring both
+        events into one would hoist the second event's write above the first
+        event's delete and the row would end up gone instead of present.
+
+        Mutation: drop the `_write_order_rank` arm of `_conflicts` and the
+        equivalence test below fails on the row's existence.
+        """
+        seed_stream("s", _events(2), store=store)
+        ex = BatchRecorder()
+
+        def fn(ev):
+            if ev["n"] == 0:
+                return Delete("app.R", {"id": "x"})
+            return Upsert("app.R", {"id": "x"}, {"n": 1})
+
+        _run(store, _registry(fn), ex)
+
+        assert ex.sizes == [1, 1]
+
+    def test_a_repeated_produces_id_starts_a_new_batch(self, store):
+        """Two producers of one correlation id in a batch is
+        `DuplicateProducesError`; in two events it is normal.
+
+        Mutation: drop the `_produces` arm of `_conflicts` and this raises.
+        """
+        seed_stream("s", _events(2), store=store)
+        ex = BatchRecorder()
+
+        _run(
+            store,
+            _registry(
+                lambda ev: Upsert(
+                    "app.R", {"id": ev["id"]}, {"n": ev["n"]}, produces="p"
+                )
+            ),
+            ex,
+        )
+
+        assert ex.sizes == [1, 1]
+
+    def test_a_retire_asking_for_notifications_ends_its_batch(self, store):
+        """Its transitions are synthesised from the report of the call that
+        applied it, and `ReplayResult.external` is documented in handler-emission
+        order — so the retire's batch must end at the retire.
+
+        Mutation: drop the `Transition` arm of `_StageBuffer.add` and the retire
+        joins the following event's batch.
+        """
+        seed_stream("s", _events(3), store=store)
+        ex = BatchRecorder()
+
+        def fn(ev):
+            if ev["n"] == 1:
+                return Retire(
+                    "app.R",
+                    {"id": "x"},
+                    patch={"gone_at": "t"},
+                    transition=Transition(kind="resolved", key_fields=("id",)),
+                )
+            return Upsert("app.R", {"id": ev["id"]}, {"n": ev["n"]})
+
+        _run(store, _registry(fn), ex)
+
+        # e0's upsert may share the retire's batch — a retire sorts *after*
+        # a write, so nothing is reordered. What must not happen is e2's upsert
+        # joining: the retire has to be the last effect in its batch, or its
+        # transitions would be synthesised after a later event's externals.
+        assert ex.sizes == [2, 1]
+        assert isinstance(ex.batches[0][-1], Retire)
+        assert isinstance(ex.batches[1][0], Upsert)
+
+    def test_an_events_own_colliding_effects_still_raise_on_their_own(self, store):
+        """A bug inside one event stays that event's bug: it is reported, and the
+        events before it stay applied, exactly as before buffering.
+
+        Mutation: drop `_self_collides` from `_StageBuffer.add` and the earlier
+        event's effect is rejected along with the bad one.
+        """
+        seed_stream("s", _events(2), store=store)
+        ex = BatchRecorder()
+
+        def fn(ev):
+            if ev["n"] == 0:
+                return Upsert("app.R", {"id": "e0"}, {"n": 0})
+            return [
+                Upsert("app.R", {"id": "bad"}, {"n": 1}),
+                Upsert("app.R", {"id": "bad"}, {"n": 2}),
+            ]
+
+        with pytest.raises(EffectCollisionError):
+            _run(store, _registry(fn), ex)
+
+        assert ex.sizes == [1], "the first event was applied before the bad one raised"
+        assert ex.flat[0].lookup == {"id": "e0"}
+
+
+class TestAReaderBearingPassIsNotBatched:
+    def test_stage_one_still_applies_per_event(self, store):
+        """A stage > 0 handler is handed a reader that goes straight to storage,
+        so a buffered write would be invisible to it — silently. Those passes
+        keep applying per event.
+
+        Mutation: batch every stage instead of `stage in (None, 0)` and the
+        stage-1 sizes become one batch of three.
+        """
+        seed_stream("s", _events(3), store=store)
+        proj = InMemoryProjections()
+        ex = BatchRecorder()
+
+        registry = HandlerRegistry()
+        registry.register(
+            name="h0",
+            event_match=MATCH,
+            fn=lambda ev: Upsert("app.R", {"id": ev["id"]}, {"n": ev["n"]}),
+            effective_from=0,
+            stage=0,
+        )
+        registry.register(
+            name="h1",
+            event_match=MATCH,
+            fn=lambda ev, _reader: Upsert("app.S", {"id": ev["id"]}, {"n": ev["n"]}),
+            effective_from=0,
+            stage=1,
+        )
+
+        _run(store, registry, ex, reader=proj)
+
+        assert ex.sizes == [3, 1, 1, 1], (
+            "stage 0 batches; stage 1 hands the reader out, so it does not"
+        )
+
+    def test_a_reducer_sees_the_stages_writes(self, store):
+        """The stage's buffer must be drained before the first reducer runs, or
+        the reducer reads a projection missing everything the pass just wrote.
+
+        Mutation: move `_drain` after `_run_stage_reducers` and this reads 0.
+        """
+        seed_stream("s", _events(4), store=store)
+        proj = InMemoryProjections()
+        seen: list[int] = []
+
+        registry = HandlerRegistry()
+        registry.register(
+            name="h0",
+            event_match=MATCH,
+            fn=lambda ev: Upsert("app.R", {"id": ev["id"]}, {"n": ev["n"]}),
+            effective_from=0,
+            stage=0,
+        )
+
+        def reducer(reader):
+            seen.append(len(list(reader.query("app.R"))))
+            return Upsert("app.Total", {"k": 1}, {"n": seen[-1]})
+
+        registry.register_reducer("r", stage=0, fn=reducer)
+
+        replay(
+            store,
+            "s",
+            proj,
+            handler_registry=registry,
+            event_match=MATCH,
+            reader=proj,
+        )
+
+        assert seen == [4]
+
+
+class TestBatchingChangesNoRow:
+    """The rows a batched replay leaves behind equal the rows the per-event path
+    left behind — checked against the executor that is also the reader, for the
+    four flush cases above plus a plain run."""
+
+    @pytest.mark.parametrize(
+        ("name", "fn"),
+        [
+            ("plain", lambda ev: Upsert("app.R", {"id": ev["id"]}, {"n": ev["n"]})),
+            ("same_column", lambda ev: Upsert("app.R", {"id": "same"}, {"n": ev["n"]})),
+            (
+                "delete_then_write",
+                lambda ev: (
+                    Delete("app.R", {"id": "x"})
+                    if ev["n"] % 2 == 0
+                    else Upsert("app.R", {"id": "x"}, {"n": ev["n"]})
+                ),
+            ),
+            (
+                "update_after_upsert",
+                lambda ev: [
+                    Upsert("app.R", {"id": ev["id"]}, {"n": ev["n"]}),
+                    Update("app.R", {"id": ev["id"]}, {"m": ev["n"] * 2}),
+                ],
+            ),
+        ],
+    )
+    def test_the_rows_match_applying_one_event_at_a_time(self, store, name, fn):
+        seed_stream("s", _events(6), store=store)
+
+        batched = InMemoryProjections()
+        _run(store, _registry(fn), batched)
+
+        # The control: the same effects, applied one event's worth at a time,
+        # which is what replay did before #207.
+        one_at_a_time = InMemoryProjections()
+        for event in _events(6):
+            out = fn(event)
+            one_at_a_time.apply(out if isinstance(out, list) else [out])
+
+        assert batched.rows("app.R") == one_at_a_time.rows("app.R"), name
+
+
+class TestRefsWidenRatherThanBreak:
+    def test_a_ref_may_now_bind_to_an_earlier_events_producer(self, store):
+        """A deliberate widening, recorded because it is a behaviour change: a
+        `Ref` to a `produces=` row in an earlier event of the same stage used to
+        raise, because refs do not cross an `apply()` call. Within one batch it
+        resolves.
+        """
+        seed_stream("s", _events(2), store=store)
+        proj = InMemoryProjections()
+
+        def fn(ev):
+            if ev["n"] == 0:
+                return Upsert("app.Parent", {"id": "p"}, {"n": 0}, produces="parent")
+            return Upsert("app.Child", {"id": "c"}, {"parent_id": Ref("parent")})
+
+        _run(store, _registry(fn), proj)
+
+        child = next(iter(proj.rows("app.Child")))
+        assert not isinstance(child["parent_id"], Ref)

--- a/tests/test_rakaia/test_replay_batching.py
+++ b/tests/test_rakaia/test_replay_batching.py
@@ -23,6 +23,7 @@ from rakaia.effects import (
     Delete,
     Effect,
     EffectCollisionError,
+    ExternalEffect,
     Ref,
     Retire,
     Transition,
@@ -66,6 +67,22 @@ class BatchRecorder:
     @property
     def flat(self) -> list[Effect]:
         return [e for b in self.batches for e in b]
+
+
+class FlippingExecutor(BatchRecorder):
+    """A `BatchRecorder` that also reports every opted-in retire as having
+    flipped one row, so `replay` has a transition to synthesise."""
+
+    def apply(self, effects) -> ApplyReport:
+        batch = list(effects)
+        super().apply(batch)
+        return ApplyReport(
+            retire_flips=[
+                (e, [dict(e.lookup)])
+                for e in batch
+                if isinstance(e, Retire) and e.transition is not None
+            ]
+        )
 
 
 @pytest.fixture
@@ -220,6 +237,37 @@ class TestWhatForcesAFlush:
         assert ex.sizes == [2, 1]
         assert isinstance(ex.batches[0][-1], Retire)
         assert isinstance(ex.batches[1][0], Upsert)
+
+    def test_a_transitions_notification_still_precedes_a_later_events_own(self, store):
+        """The ordering `ReplayResult.external` promises, and the only case the
+        transition flush is load-bearing for.
+
+        A retire's notifications are synthesised when its batch is applied, but
+        a handler's own external effect is recorded the moment the handler
+        returns. So if the retire were still sitting in the buffer while the
+        next event ran, that event's notification would be filed ahead of the
+        retire's — the list would come back in an order no handler produced.
+        Flushing on the retire is what keeps it honest.
+
+        Mutation: drop the `Transition` arm of `_StageBuffer.add` and the two
+        come back the other way round. The rank rule does not cover this — the
+        later event emits no database effect at all, so nothing forces a flush.
+        """
+        seed_stream("s", _events(2), store=store)
+
+        def fn(ev):
+            if ev["n"] == 0:
+                return Retire(
+                    "app.R",
+                    {"id": "x"},
+                    patch={"gone_at": "t"},
+                    transition=Transition(kind="resolved", key_fields=("id",)),
+                )
+            return ExternalEffect(kind="email", payload={"to": "later"})
+
+        result = _run(store, _registry(fn), FlippingExecutor())
+
+        assert [e.kind for e in result.external] == ["resolved", "email"]
 
     def test_an_events_own_colliding_effects_still_raise_on_their_own(self, store):
         """A bug inside one event stays that event's bug: it is reported, and the


### PR DESCRIPTION
A replay used to apply one event's worth of changes at a time. That meant the
work we did earlier to collapse a fanned-out change into a single statement could
never do anything on the path that produces most of the changes, because there was
only ever one change to collapse. It also meant a form save with nine events
opened nine separate database transactions: eighteen of the hundred and
thirty-five statements that save issued were just the opening and closing of them.
On the same shape it is now one transaction and one statement.

Widening a batch is only safe if nothing downstream can tell, so the batch is
broken the moment holding one more change back would alter the outcome — a write
arriving behind a delete, a second write to the same column of the same row, a
repeated identifier, or a soft-delete that asked for notifications. Passes whose
handlers can read the database are left alone entirely and still apply event by
event, because a change held back would be invisible to them.

Closes #207.