### PR TITLE
Prepare 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to Rakaia are documented here. The format is based on
 New here? The [guided tour](docs/whats-new.md) walks these capabilities with a
 runnable demo for each.
 
-## [Unreleased]
+## [0.3.0] - 2026-08-23
 
 
 ### Added

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -15,7 +15,45 @@ ones you are crossing.
 
 ---
 
-# Unreleased
+# 0.3.0
+
+## A replay applies a whole pass of effects at once, not one event at a time
+
+`replay()` used to call `executor.apply()` once per event. It now buffers a pass's
+effects and hands them over in as few batches as it can, breaking the batch
+whenever holding one more back would change the outcome — a write arriving behind
+a delete, a second write to the same column of the same row, a repeated
+`produces=` id, or a retire that asked for notifications. Passes whose handlers
+receive a reader are not batched at all, because a buffered write would be
+invisible to them.
+
+**What changes for you.** For most consumers, only the transaction and statement
+count: on a nine-event save this went from nine `transaction.atomic()` blocks to
+one, and with `DjangoExecutor(batch_updates=True)` from nine `UPDATE`s to one. The
+rows written, and the order they are written in, are unchanged — there is a test
+that replays the same effects both ways and compares.
+
+Three cases are worth checking against your own code:
+
+- **A custom executor sees fewer, larger batches.** If yours does per-call work —
+  opens a connection, logs a line, counts calls in a test — the count drops. The
+  flat sequence of effects it receives is identical.
+- **A `Ref` to an earlier event's `produces=` row now resolves.** It used to raise
+  `UnresolvedRefError`, because refs do not cross an `apply()` call and each event
+  was its own call. Within one pass they can now be in the same batch. This is a
+  widening: code that worked still works, and code that was relying on the failure
+  was relying on a batch boundary that was never part of the contract. The
+  executor-level rule is unchanged — refs still do not resolve across two explicit
+  `apply()` calls, which `tests/executor_contract.py` pins.
+- **A failure part-way through a pass now rolls back more.** `DjangoExecutor`
+  wraps each `apply()` in a transaction, so a failing effect discards its whole
+  batch rather than just its own event's effects. Events dispatched before the
+  batch started are unaffected, and a malformed event still leaves everything
+  before it applied. If you were depending on per-event commit granularity within
+  a pass, you no longer have it.
+
+**If you never call `replay()` directly**, and reach it only through
+`django_rakaia.replay.replay_stream` or a rebuild, this needs no action.
 
 ## `poll` refuses a cursor from another store instead of reporting `rewound`
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 # PyPI by an unrelated placeholder. The import name is unaffected:
 #   pip install rakaia-streams   ->   import rakaia
 name = "rakaia-streams"
-version = "0.2.0"
+version = "0.3.0"
 description = "Python server implementation of the Durable Streams protocol"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_django_rakaia/test_replay_batching_cost.py
+++ b/tests/test_django_rakaia/test_replay_batching_cost.py
@@ -11,11 +11,12 @@ of one is never collapsed.
 from __future__ import annotations
 
 import pytest
+from django.core.exceptions import FieldError
 from django.db import connection
 from django.test.utils import CaptureQueriesContext
 
 from django_rakaia.effect_executor import DjangoExecutor
-from rakaia.effects import Update
+from rakaia.effects import Update, Upsert
 from rakaia.registry import HandlerRegistry
 from rakaia.replay import replay
 from rakaia.seed import seed_stream
@@ -99,3 +100,44 @@ def test_the_rows_are_the_same_without_the_collapse_enabled():
 
     assert len(_statements(ctx, "UPDATE")) == 9
     assert set(FinanceLine.objects.values_list("delta", flat=True)) == {7}
+
+
+def test_a_failure_part_way_through_a_pass_discards_the_whole_batch():
+    """The consumer-visible cost of batching, and the reason it is in UPGRADING.
+
+    `DjangoExecutor` wraps each `apply()` in a transaction. One call per event
+    meant an earlier event's write survived a later event's failure; one call per
+    pass means it does not. Nothing is *wrong* either way — the exception still
+    propagates and the replay still fails — but per-event commit granularity
+    within a pass is no longer on offer, and a consumer could have leaned on it.
+
+    Measured both ways rather than asserted: with `ctx.buffer` forced to None the
+    surviving rows are `['good']`, and with batching they are `[]`. That contrast
+    is the whole content of the upgrade note.
+    """
+    store = StreamStore()
+    seed_stream("s", [{"id": "good"}, {"id": "bad"}], store=store)
+
+    registry = HandlerRegistry()
+    registry.register(
+        name="h",
+        event_match=MATCH,
+        effective_from=0,
+        stage=0,
+        # The second event writes a column that does not exist, so its write
+        # fails inside the batch the first event's write is also in.
+        fn=lambda ev: Upsert(
+            MODEL,
+            {"submission_id": ev["id"]},
+            {"suku": "s", "delta": 1} if ev["id"] == "good" else {"nope": 1},
+        ),
+    )
+
+    with pytest.raises(FieldError):
+        replay(
+            store, "s", DjangoExecutor(), handler_registry=registry, event_match=MATCH
+        )
+
+    assert list(FinanceLine.objects.values_list("submission_id", flat=True)) == [], (
+        "the earlier event's write is rolled back with the batch it shared"
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -1215,7 +1215,7 @@ wheels = [
 
 [[package]]
 name = "rakaia-streams"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
Marks everything on main since 0.2.0 as a release: the version, the changelog
heading and the upgrade notes. This is a new minor rather than a patch because
several of the changes are breaking — constructing a replay result the old way is
refused, the dashboard views now turn away a position they did not issue, and
timestamps compare equal to the column they came from. Worth knowing before it
ships: partisipa pins the minor exactly, so it will not pick this up until that
pin is moved and validated.

It also adds the upgrade note that should have gone in with the replay batching
change, along with a test for the one part of it a consumer could be relying on.
Batching a whole pass into one transaction means an earlier event's write no
longer survives a later event's failure. That was measured both ways rather than
assumed.