### PR TITLE
Route a stream by its real name, without needing the socket library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ All notable changes to Rakaia are documented here. The format is based on
 New here? The [guided tour](docs/whats-new.md) walks these capabilities with a
 runnable demo for each.
 
+## [Unreleased]
+
+### Fixed
+
+- **Polling no longer requires the live-updates library.** A consumer that only
+  reads a stream by polling still had to install `channels` — and on a production
+  tier a Redis channel layer with it — because `django_rakaia/urls.py` imported
+  the SSE view at module scope. `RAKAIA_ENABLE_SSE = False` could not help:
+  Django imports a URLconf while loading URLs, long before an `AppConfig` gets a
+  say, so following the `include("django_rakaia.urls")` instruction in that
+  file's own docstring raised `ModuleNotFoundError` on a tier that never opens a
+  socket. The route is now loaded through the same three-state gate `apps.py`
+  uses for its signal handlers, which has moved into `django_rakaia.sse_gate` so
+  the two cannot drift again. Opting *in* without the extra installed still
+  fails loudly. (#230)
+
+- **A stream whose name contains a slash can be addressed again.** Stream names
+  are the server's own business — the protocol says so, and rakaia puts no
+  restriction on them: `_scratch/fold` is one the library generates itself. The
+  shipped URL file routed them with Django's `str` converter, which matches
+  anything except a slash, so such a stream could be created, appended to and
+  read back through the store while the dashboard and the read API returned a
+  bare 404. The routes now use the `path` converter. (#231)
+
+  Note for anyone with their own copy of these routes: `path` is greedy where
+  `str` is not, so the catch-all stream-detail route has to be listed **last** or
+  it claims `api/streams/<name>/` as a stream called `api/streams/<name>` and the
+  read API starts returning HTML. Tests that reverse a URL name agree with that
+  mistake; the ones added here resolve real paths.
+
 ## [0.3.0] - 2026-08-23
 
 

--- a/docs/framework-vs-protocol-server.md
+++ b/docs/framework-vs-protocol-server.md
@@ -72,8 +72,9 @@ consumer can boot without `channels` installed:
 
 - **Framework tier** — handler/upcaster autodiscovery (`autodiscover()`) always
   runs and has no `channels` dependency.
-- **Protocol tier** — SSE signal wiring is gated by an optional
-  `RAKAIA_ENABLE_SSE` setting:
+- **Protocol tier** — SSE is gated by an optional `RAKAIA_ENABLE_SSE` setting.
+  The gate covers both places that reach for `channels`: the signal wiring in
+  `ready()`, and the SSE route in `django_rakaia/urls.py`.
 
 | `RAKAIA_ENABLE_SSE` | `channels` installed | Behaviour |
 |---|---|---|
@@ -82,9 +83,18 @@ consumer can boot without `channels` installed:
 | `True` | no | `ImportError` raised — you asked for SSE but didn't install the extra |
 | `False` | either | never wired |
 
-So framework-tier consumers get no `ModuleNotFoundError: channels` at app load,
-existing SSE consumers are unaffected, and a misconfiguration (opted into SSE
-without the dependency) still fails loudly.
+So framework-tier consumers get no `ModuleNotFoundError: channels`, existing SSE
+consumers are unaffected, and a misconfiguration (opted into SSE without the
+dependency) still fails loudly.
+
+The URL file used to be outside this gate, and that was a real hole rather than
+an oversight in the table: Django imports a URLconf as part of loading URLs, so
+`path("streams/", include("django_rakaia.urls"))` — the instruction in that
+file's own docstring — raised `ModuleNotFoundError` on a tier that never opens a
+socket, before any setting could be consulted. A polling-only consumer therefore
+had to install `channels`, and in production a Redis channel layer with it. Both
+callers now ask the same question through `django_rakaia.sse_gate.sse_import`,
+so the table above describes the whole package rather than only app startup.
 
 ## The store seams
 

--- a/src/django_rakaia/apps.py
+++ b/src/django_rakaia/apps.py
@@ -1,5 +1,4 @@
 from django.apps import AppConfig
-from django.conf import settings
 
 
 class DjangoRakaiaConfig(AppConfig):
@@ -29,20 +28,12 @@ class DjangoRakaiaConfig(AppConfig):
     def _wire_sse_signals(self) -> None:
         """Import the Channels SSE signal handlers unless opted out / absent.
 
-        Gate (issue #41 — keep `channels` optional for framework-tier use):
-
-        * ``RAKAIA_ENABLE_SSE = False`` — never wire.
-        * ``RAKAIA_ENABLE_SSE = True`` — wire; if `channels` is missing, let the
-          ``ImportError`` propagate (the consumer asked for SSE but didn't
-          install the extra — a real misconfiguration, surfaced loudly).
-        * unset — auto-detect: wire if `channels` imports, skip silently if not
-          (a framework-only consumer that never installed the extra).
+        The gate itself (issue #41 — keep `channels` optional for framework-tier
+        use) lives in `sse_gate.sse_import`, which is also what `urls.py` asks
+        before adding the SSE route. It was written out here and nowhere else,
+        which is how the URL file came to import the SSE view unconditionally
+        and make `channels` a hard dependency of the polling API (#230).
         """
-        enabled = getattr(settings, "RAKAIA_ENABLE_SSE", None)
-        if enabled is False:
-            return
-        try:
-            import django_rakaia.channels_signals  # noqa: F401
-        except ImportError:
-            if enabled:
-                raise
+        from .sse_gate import sse_import
+
+        sse_import("django_rakaia.channels_signals")

--- a/src/django_rakaia/sse_gate.py
+++ b/src/django_rakaia/sse_gate.py
@@ -1,0 +1,49 @@
+"""Whether this deployment wires its live-update surface — decided once.
+
+`channels` is an optional extra (#41), so every part of the package that touches
+it has to ask the same question first: does this deployment want SSE, and is the
+library there? The answer has three states and they are not obvious, which is
+why it belongs in one place rather than being re-derived per caller:
+
+* ``RAKAIA_ENABLE_SSE = False`` — never load. The consumer has said this tier
+  does not do live updates, and is entitled to not have the library installed.
+* ``RAKAIA_ENABLE_SSE = True`` — load, and let an `ImportError` propagate. The
+  consumer asked for SSE and did not install the extra; that is a real
+  misconfiguration and silently downgrading it to polling would hide it.
+* unset — auto-detect. Load if it imports, skip quietly if not, which is the
+  framework-only consumer who never wanted SSE and never said so.
+
+`apps.py` had this written out for its signal handlers and `urls.py` had nothing,
+which is #230: the URL file imported the SSE view at module scope, so a
+polling-only tier could not use the documented ``include()`` without installing
+`channels` and, in production, a Redis channel layer. The setting could not help
+because Django imports the URLconf before an `AppConfig` gets a say.
+"""
+
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Any
+
+from django.conf import settings
+
+__all__ = ["sse_import"]
+
+
+def sse_import(module: str, attr: str | None = None) -> Any | None:
+    """Import `module` (or `attr` from it) under the SSE gate, or return None.
+
+    Returns None when this deployment has opted out or has no `channels`, and
+    raises `ImportError` when it explicitly opted *in* without the library. See
+    the module docstring for why those are three cases and not two.
+    """
+    enabled = getattr(settings, "RAKAIA_ENABLE_SSE", None)
+    if enabled is False:
+        return None
+    try:
+        loaded = import_module(module)
+    except ImportError:
+        if enabled:
+            raise
+        return None
+    return loaded if attr is None else getattr(loaded, attr)

--- a/src/django_rakaia/urls.py
+++ b/src/django_rakaia/urls.py
@@ -9,24 +9,59 @@ Include these URLs in your project's main urls.py:
         # ...
         path("streams/", include("django_rakaia.urls")),
     ]
+
+Two things about this file are load-bearing and easy to undo by tidying it.
+
+**Stream ids use the `path` converter, not `str`.** A stream name is the
+server's business — the protocol says so, and offers ``/v1/stream/{path}`` as an
+example scheme — so names contain slashes in practice: rakaia's own
+``SCRATCH_PATH`` is ``_scratch/fold``, and the first production consumer names
+every one of its stream families that way. ``str`` refuses a slash, so those
+streams could be created, appended to and read back, but never addressed here
+(#231).
+
+**The route order is therefore load-bearing.** ``path`` is greedy where ``str``
+is not, so the catch-all dashboard route has to come *last*: listed first, as it
+used to be, it claims ``api/streams/orders/`` as a stream named
+``api/streams/orders`` and the read API quietly starts returning HTML. Tests that
+reverse a URL name agree with that mistake, which is why
+``tests/test_django_rakaia/test_urls.py`` resolves real paths instead.
+
+**The live-update route is conditional.** Importing it at module scope made
+`channels` a hard dependency of the polling API, because Django imports the
+URLconf before any setting is consulted (#230). It now loads through
+`sse_gate.sse_import`, the same gate `apps.py` uses for its signal handlers.
 """
 
 from django.urls import path
 
-from .channels_views import stream_events_sse
+from .sse_gate import sse_import
 from .views import stream_detail, stream_events_api, streams_api, streams_index
 
 app_name = "django_rakaia"
 
 urlpatterns = [
-    # Main dashboard pages
+    # Dashboard index and the API, before the catch-all below.
     path("", streams_index, name="streams_index"),
-    path("<str:stream_id>/", stream_detail, name="stream_detail"),
-    # API endpoints
     path("api/streams/", streams_api, name="streams_api"),
-    path("api/streams/<str:stream_id>/", stream_events_api, name="stream_events_api"),
-    # SSE endpoints (Django Channels)
-    path(
-        "api/streams/<str:stream_id>/sse/", stream_events_sse, name="stream_events_sse"
-    ),
+]
+
+# SSE endpoint (Django Channels), only where this deployment wants it. Ahead of
+# the read API's own route because both spell the same URL for a stream named
+# `<name>/sse`: the endpoint wins, since the alternative makes SSE unreachable
+# for every stream rather than making one unusual name unreachable here.
+_stream_events_sse = sse_import("django_rakaia.channels_views", "stream_events_sse")
+if _stream_events_sse is not None:
+    urlpatterns.append(
+        path(
+            "api/streams/<path:stream_id>/sse/",
+            _stream_events_sse,
+            name="stream_events_sse",
+        )
+    )
+
+urlpatterns += [
+    path("api/streams/<path:stream_id>/", stream_events_api, name="stream_events_api"),
+    # Last: `path` matches slashes, so this claims anything left over.
+    path("<path:stream_id>/", stream_detail, name="stream_detail"),
 ]

--- a/tests/test_django_rakaia/test_urls.py
+++ b/tests/test_django_rakaia/test_urls.py
@@ -1,0 +1,268 @@
+"""What the shipped URL file can address, and what it needs installed (#230, #231).
+
+Two defects in one thirty-line file, and they interact, so they are tested
+together.
+
+**#231 — slashes.** Stream names are the server's business; the protocol says so
+and offers `/v1/stream/{path}` as an example scheme. `StreamStore.create` takes a
+name as given, so `submissions/status` is created, appended to and read back
+without complaint — and then cannot be reached through the URL file, because
+Django's `str` converter refuses a slash. `SCRATCH_PATH` is `_scratch/fold`, so
+rakaia produces such a name itself.
+
+**#230 — the live-updates import.** A consumer that only polls still had to
+install `channels`, because this file imported the SSE view at module scope. The
+setting that is meant to say "this tier does not do live updates" could not help:
+Django imports the URLconf before any of it is consulted.
+
+**Why the ordering tests matter more than they look.** The fix for #231 swaps
+`str:` for `path:`, which is greedy where `str:` is not — so the *order* of the
+routes becomes load-bearing, and getting it wrong silently redirects the whole
+API to the dashboard view. Every test here resolves a real path rather than
+reversing a name, because reversing agrees with a wrong ordering.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from contextlib import contextmanager
+
+import pytest
+from django.urls import clear_url_caches, resolve
+
+from django_rakaia import urls as urls_module
+from django_rakaia.envelope import SCRATCH_PATH
+
+PREFIX = "/streams"
+
+
+def _names(module) -> list[str]:
+    return [pattern.name for pattern in module.urlpatterns]
+
+
+@contextmanager
+def _channels_missing():
+    """Make `import channels` fail, as it does on a polling-only tier.
+
+    `None` in `sys.modules` is the documented way to make an import raise
+    `ImportError` — the same failure a tier that never installed the extra gets,
+    without needing an environment that lacks it.
+    """
+    blocked = (
+        "channels",
+        "channels.layers",
+        "django_rakaia.channels_views",
+        "django_rakaia.channels_signals",
+    )
+    saved = {name: sys.modules.get(name, ...) for name in blocked}
+    for name in blocked:
+        sys.modules[name] = None  # type: ignore[assignment]
+    try:
+        yield
+    finally:
+        for name, module in saved.items():
+            if module is ...:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = module
+
+
+@pytest.fixture(autouse=True)
+def _restore_urls():
+    """Reloading the URL module is what these tests do; put it back afterwards
+    so a later test does not inherit a half-configured urlconf."""
+    yield
+    importlib.reload(urls_module)
+    clear_url_caches()
+
+
+class TestNamesWithSlashes:
+    """#231. A slash in a stream name must be addressable, not a 404."""
+
+    def test_the_read_api_reaches_a_slashed_name(self):
+        match = resolve(f"{PREFIX}/api/streams/submissions/status/")
+        assert match.url_name == "stream_events_api"
+        assert match.kwargs["stream_id"] == "submissions/status"
+
+    def test_the_dashboard_reaches_a_slashed_name(self):
+        match = resolve(f"{PREFIX}/submissions/status/")
+        assert match.url_name == "stream_detail"
+        assert match.kwargs["stream_id"] == "submissions/status"
+
+    def test_rakaias_own_scratch_stream_is_addressable(self):
+        """`SCRATCH_PATH` is `_scratch/fold`, so the library generates a name of
+        the shape its own URL file could not reach."""
+        match = resolve(f"{PREFIX}/api/streams/{SCRATCH_PATH}/")
+        assert match.kwargs["stream_id"] == SCRATCH_PATH
+
+    def test_a_deeply_nested_name_is_addressable(self):
+        match = resolve(f"{PREFIX}/api/streams/a/b/c/d/")
+        assert match.kwargs["stream_id"] == "a/b/c/d"
+
+    def test_a_plain_name_is_unaffected(self):
+        match = resolve(f"{PREFIX}/api/streams/orders/")
+        assert match.url_name == "stream_events_api"
+        assert match.kwargs["stream_id"] == "orders"
+
+
+class TestTheGreedyConverterDoesNotSwallowTheApi:
+    """The regression the #231 fix can introduce if the routes stay in order.
+
+    `path:` matches slashes, so a catch-all dashboard route listed first claims
+    `api/streams/foo/` as a stream named `api/streams/foo`. The read API would
+    then return an HTML page, and every test that *reverses* a URL name would
+    still pass.
+    """
+
+    def test_the_api_index_is_not_taken_for_a_stream(self):
+        assert resolve(f"{PREFIX}/api/streams/").url_name == "streams_api"
+
+    def test_a_read_api_url_is_not_taken_for_a_dashboard_page(self):
+        match = resolve(f"{PREFIX}/api/streams/orders/")
+        assert match.url_name == "stream_events_api", (
+            "the dashboard catch-all swallowed an API URL — the greedy "
+            "converter needs the API routes listed first"
+        )
+
+    def test_the_dashboard_index_still_resolves(self):
+        assert resolve(f"{PREFIX}/").url_name == "streams_index"
+
+
+class TestTheLiveUpdatesRoute:
+    def test_the_sse_route_resolves_when_channels_is_installed(self):
+        match = resolve(f"{PREFIX}/api/streams/orders/sse/")
+        assert match.url_name == "stream_events_sse"
+        assert match.kwargs["stream_id"] == "orders"
+
+    def test_the_sse_route_reaches_a_slashed_name(self):
+        match = resolve(f"{PREFIX}/api/streams/submissions/status/sse/")
+        assert match.url_name == "stream_events_sse"
+        assert match.kwargs["stream_id"] == "submissions/status"
+
+    def test_a_stream_named_like_the_sse_suffix_loses_to_the_endpoint(self):
+        """The one ambiguity `path:` cannot remove, pinned deliberately.
+
+        A stream genuinely named `orders/sse` spells the same URL as the SSE
+        endpoint of a stream named `orders`. The endpoint wins, because the
+        alternative makes SSE unreachable for *every* stream rather than making
+        one unusual name unreachable through this route.
+        """
+        match = resolve(f"{PREFIX}/api/streams/orders/sse/")
+        assert match.url_name == "stream_events_sse"
+        assert match.kwargs["stream_id"] == "orders"
+
+
+class TestPollingWithoutTheLiveUpdatesLibrary:
+    """#230. The setting that says "no live updates" has to mean it."""
+
+    def test_the_url_file_imports_without_channels(self):
+        with _channels_missing():
+            reloaded = importlib.reload(urls_module)
+        assert "streams_index" in _names(reloaded)
+
+    def test_the_polling_api_is_still_routed_without_channels(self):
+        with _channels_missing():
+            reloaded = importlib.reload(urls_module)
+        assert "stream_events_api" in _names(reloaded)
+        assert "streams_api" in _names(reloaded)
+
+    def test_the_sse_route_is_simply_absent_without_channels(self):
+        with _channels_missing():
+            reloaded = importlib.reload(urls_module)
+        assert "stream_events_sse" not in _names(reloaded)
+
+    def test_opting_out_drops_the_route_even_with_channels_installed(self, settings):
+        settings.RAKAIA_ENABLE_SSE = False
+        reloaded = importlib.reload(urls_module)
+        assert "stream_events_sse" not in _names(reloaded)
+        assert "stream_events_api" in _names(reloaded)
+
+    def test_asking_for_sse_without_the_library_still_fails_loudly(self, settings):
+        """The third state of the gate in `apps.py`: an explicit opt-*in* with
+        the extra missing is a real misconfiguration and must not be silently
+        downgraded to polling."""
+        settings.RAKAIA_ENABLE_SSE = True
+        with _channels_missing(), pytest.raises(ImportError):
+            importlib.reload(urls_module)
+
+    def test_the_default_still_wires_sse_when_channels_is_present(self, settings):
+        if hasattr(settings, "RAKAIA_ENABLE_SSE"):
+            del settings.RAKAIA_ENABLE_SSE
+        reloaded = importlib.reload(urls_module)
+        assert "stream_events_sse" in _names(reloaded)
+
+
+@pytest.mark.django_db
+class TestReachingASlashedStreamForReal:
+    """Routing is not the whole claim — the views have to serve the name too.
+
+    `resolve()` proves a URL reaches a view. It does not prove the view can find
+    a stream whose id contains a slash, which is what the issue is actually
+    about: the first production consumer names every stream family this way and
+    could not read any of them back through the dashboard or the API.
+    """
+
+    @pytest.fixture
+    def auth_client(self):
+        from django.contrib.auth import get_user_model
+        from django.test import Client
+
+        from django_rakaia.models import Stream, StreamEntry, StreamEvent
+
+        client = Client()
+        client.force_login(
+            get_user_model().objects.create_user(username="dash", password="pw")
+        )
+        # The test app emits a stream event on every `auth.User` save, so start
+        # from a clean slate rather than counting those incidental rows.
+        StreamEntry.objects.all().delete()
+        StreamEvent.objects.all().delete()
+        Stream.objects.all().delete()
+        return client
+
+    @pytest.fixture
+    def seeded(self, auth_client):  # noqa: ARG002 - ordering: it clears the DB
+        from django_rakaia.django_store import DjangoStreamStore
+
+        store = DjangoStreamStore()
+        store.create("submissions/status")
+        store.append("submissions/status", b'{"state": "approved"}')
+        return store
+
+    def test_the_read_api_returns_the_events(self, auth_client, seeded):  # noqa: ARG002
+        import json
+
+        response = auth_client.get(f"{PREFIX}/api/streams/submissions/status/")
+
+        assert response.status_code == 200
+        body = json.loads(response.content)
+        assert body["stream_id"] == "submissions/status"
+        assert body["count"] == 1
+        assert body["events"][0]["data"] == {"state": "approved"}
+
+    def test_the_dashboard_page_renders(self, auth_client, seeded):  # noqa: ARG002
+        response = auth_client.get(f"{PREFIX}/submissions/status/")
+        assert response.status_code == 200
+
+    def test_an_unknown_slashed_name_reads_as_empty_not_missing(
+        self,
+        auth_client,
+        seeded,  # noqa: ARG002 - the stream it seeds is not the one requested
+    ):
+        """The failure the issue names is a bare 404 that does not say what went
+        wrong. An unknown stream should read as empty, exactly as an unknown
+        plain name does — the route existing is what makes that possible."""
+        import json
+
+        response = auth_client.get(f"{PREFIX}/api/streams/nothing/here/")
+
+        assert response.status_code == 200
+        assert json.loads(response.content)["count"] == 0
+
+    def test_the_route_exists_even_for_an_anonymous_caller(self, client):
+        """A 302 to the login page proves the URL resolved. Before the fix this
+        was a 404, and the two are easy to confuse when debugging."""
+        response = client.get(f"{PREFIX}/api/streams/submissions/status/")
+        assert response.status_code == 302
+        assert "/accounts/login" in response["Location"]


### PR DESCRIPTION
Closes #230. Closes #231.

Two problems in the same thirty-line URL file, fixed together because they both edit the route list and the second one can break the first. A consumer that only polls a stream had to install the live-updates library anyway, because the file loaded the live-update view whether or not it was wanted — and the setting meant to turn that off could not help, since Django loads URLs before it reads any of it. And a stream whose name contains a slash could be created, written to and read back through the store, but answered a bare 404 through the dashboard and the read API, which is how the first production consumer's six stream families all became unreachable.

The second fix is smaller than its risk. Allowing slashes makes the last route greedy, so the order of the routes now matters: get it wrong and the dashboard quietly swallows the whole read API while every test that looks a URL up by name still passes. The tests added here ask the question the other way round, by resolving real addresses, and nine of them fail if the order is wrong.