### PR TITLE
Prepare 0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to Rakaia are documented here. The format is based on
 New here? The [guided tour](docs/whats-new.md) walks these capabilities with a
 runnable demo for each.
 
-## [Unreleased]
+## [0.3.1] - 2026-08-24
 
 ### Fixed
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 # PyPI by an unrelated placeholder. The import name is unaffected:
 #   pip install rakaia-streams   ->   import rakaia
 name = "rakaia-streams"
-version = "0.3.0"
+version = "0.3.1"
 description = "Python server implementation of the Durable Streams protocol"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -1215,7 +1215,7 @@ wheels = [
 
 [[package]]
 name = "rakaia-streams"
-version = "0.3.0"
+version = "0.3.1"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
Marks the two URL fixes already on main as a release. The version goes to 0.3.1 and the changelog entry gets its date; nothing else changes.

A patch rather than a minor because nothing in the public surface moved — both entries fix routing that was always meant to work, so a consumer pinned to the 0.3 range needs to do nothing on crossing it, and there is no upgrade note to write. The remark in the changelog about route ordering is for anyone maintaining their own copy of those routes, not an action for anyone using the shipped ones.