### PR TITLE
Give two shared rules one home each

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -23,7 +23,7 @@ page is the contract.
 |---|---|---|---|
 | `app` | `rakaia` | `(scope: 'Scope', receive: 'Receive', send: 'Send') -> 'None'` | — |
 | `create_app` | `rakaia` | `(store: 'StreamServerStore \| None' = None, options: 'ServerOptions \| None' = None) -> 'Any'` | Create a plain ASGI application implementing the Durable Streams protocol. |
-| `get_asgi_app` | `django_rakaia` | `(options: rakaia.handler.ServerOptions \| None = None, store: typing.Any \| None = None) -> object` | Get the Rakaia ASGI application configured with the store `RAKAIA_STORE` names. |
+| `get_asgi_app` | `django_rakaia` | `(options: rakaia.handler.ServerOptions \| None = None, store: rakaia.protocols.StreamServerStore \| None = None) -> object` | Get the Rakaia ASGI application configured with the store `RAKAIA_STORE` names. |
 | `ServerOptions` | `rakaia` | `(long_poll_timeout: 'float' = 3.0, cursor_options: 'CursorOptions' = <factory>, enable_fault_injection: 'bool' = <factory>) -> None` | Configuration for the ASGI handler. |
 | `get_store` | `django_rakaia` | `() -> Any` | Get the configured stream store. |
 | `reset_store_cache` | `django_rakaia` | `() -> None` | Drop every memoised store, so the next `get_store()` rebuilds. |

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -23,9 +23,10 @@ page is the contract.
 |---|---|---|---|
 | `app` | `rakaia` | `(scope: 'Scope', receive: 'Receive', send: 'Send') -> 'None'` | — |
 | `create_app` | `rakaia` | `(store: 'StreamServerStore \| None' = None, options: 'ServerOptions \| None' = None) -> 'Any'` | Create a plain ASGI application implementing the Durable Streams protocol. |
-| `get_asgi_app` | `django_rakaia` | `(options: rakaia.handler.ServerOptions \| None = None) -> object` | Get the Rakaia ASGI application configured with the store `RAKAIA_STORE` names. |
+| `get_asgi_app` | `django_rakaia` | `(options: rakaia.handler.ServerOptions \| None = None, store: typing.Any \| None = None) -> object` | Get the Rakaia ASGI application configured with the store `RAKAIA_STORE` names. |
 | `ServerOptions` | `rakaia` | `(long_poll_timeout: 'float' = 3.0, cursor_options: 'CursorOptions' = <factory>, enable_fault_injection: 'bool' = <factory>) -> None` | Configuration for the ASGI handler. |
 | `get_store` | `django_rakaia` | `() -> Any` | Get the configured stream store. |
+| `reset_store_cache` | `django_rakaia` | `() -> None` | Drop every memoised store, so the next `get_store()` rebuilds. |
 
 ## Reading and writing streams
 
@@ -229,6 +230,6 @@ page is the contract.
 
 ## Appendix — coverage
 
-138 exported names across 14 sections. 122 carry a docstring; 16 do not and show `—` above.
+139 exported names across 14 sections. 123 carry a docstring; 16 do not and show `—` above.
 
 Undocumented: `AnyEffect`, `DEFAULT_NORMALIZERS`, `ENVELOPE_TS`, `Effect`, `GREEN`, `HANDLERS_META_STREAM`, `Normalizer`, `PollStatus`, `ProducerValidationResult`, `RED`, `REDUCERS_META_STREAM`, `SCRATCH_PATH`, `UPCASTERS_META_STREAM`, `VACUOUS`, `__version__`, `app`.

--- a/scripts/gen_api_reference.py
+++ b/scripts/gen_api_reference.py
@@ -39,6 +39,7 @@ GROUPS: dict[str, tuple[str, ...]] = {
         "get_asgi_app",
         "ServerOptions",
         "get_store",
+        "reset_store_cache",
     ),
     "Reading and writing streams": (
         "Stream",

--- a/src/django_rakaia/__init__.py
+++ b/src/django_rakaia/__init__.py
@@ -65,6 +65,7 @@ _EXPORTS: dict[str, str] = {
     "SCRATCH_PATH": "django_rakaia.envelope",
     # -- stores -------------------------------------------------------------
     "get_store": "django_rakaia.store",
+    "reset_store_cache": "django_rakaia.store",
     "DjangoStreamStore": "django_rakaia.django_store",
     # -- replaying ----------------------------------------------------------
     "DjangoExecutor": "django_rakaia.effect_executor",

--- a/src/django_rakaia/integration.py
+++ b/src/django_rakaia/integration.py
@@ -1,11 +1,21 @@
+from typing import Any
+
 from rakaia import ServerOptions, create_app
 
 from .store import get_store
 
 
-def get_asgi_app(options: ServerOptions | None = None) -> object:
+def get_asgi_app(
+    options: ServerOptions | None = None, store: Any | None = None
+) -> object:
     """
     Get the Rakaia ASGI application configured with the store `RAKAIA_STORE` names.
+
+    Pass `store` to supply one directly and skip the setting entirely. This
+    exists so the function can be *driven*: resolving the store internally left
+    the only way to exercise this entry point being to reconfigure a
+    process-wide cache, which is why it previously had no test coverage at all.
+    `django_rakaia.replay` takes the same argument for the same reason.
 
     A raw ASGI app, not a Django view: mount it in `asgi.py` by dispatching on
     the path and stripping the prefix — `URLRouter`/`path("streams/", …)` does
@@ -26,4 +36,6 @@ def get_asgi_app(options: ServerOptions | None = None) -> object:
                 return await protocol_app(scope, receive, send)
             return await django_app(scope, receive, send)
     """
-    return create_app(store=get_store(), options=options)
+    return create_app(
+        store=store if store is not None else get_store(), options=options
+    )

--- a/src/django_rakaia/integration.py
+++ b/src/django_rakaia/integration.py
@@ -1,12 +1,11 @@
-from typing import Any
-
 from rakaia import ServerOptions, create_app
+from rakaia.protocols import StreamServerStore
 
 from .store import get_store
 
 
 def get_asgi_app(
-    options: ServerOptions | None = None, store: Any | None = None
+    options: ServerOptions | None = None, store: StreamServerStore | None = None
 ) -> object:
     """
     Get the Rakaia ASGI application configured with the store `RAKAIA_STORE` names.

--- a/src/django_rakaia/store.py
+++ b/src/django_rakaia/store.py
@@ -65,3 +65,21 @@ def get_store() -> Any:
             # behind: correcting the setting works without restarting.
             _stores[backend] = _build_store(backend)
     return _stores[backend]
+
+
+def reset_store_cache() -> None:
+    """Drop every memoised store, so the next `get_store()` rebuilds.
+
+    **For tests.** `get_store()` memoises per backend name, which is what makes
+    the in-memory store a process-wide singleton — correct in production, and
+    exactly what leaks between tests that vary ``RAKAIA_STORE``. Without this,
+    the only way to clear the cache was to reach in and mutate the private
+    ``_stores`` dict, which is the one place the suite reached past an interface
+    by design.
+
+    Not a way to *swap* the configured store: to drive a caller with a store of
+    your own, pass one to `get_asgi_app(store=...)` or
+    `django_rakaia.replay(store=...)` rather than reconfiguring a global.
+    """
+    with _store_lock:
+        _stores.clear()

--- a/src/django_rakaia/store.py
+++ b/src/django_rakaia/store.py
@@ -14,8 +14,14 @@ DEFAULT_BACKEND = "memory"
 
 # One cached store instance per backend name. Keeping the in-memory store a
 # process-wide singleton is essential — it holds all stream state in memory —
-# so we never rebuild or replace it. The durable store is stateless (state
-# lives in the DB) but is cached for symmetry.
+# so nothing on the serving path rebuilds or replaces it. The durable store is
+# stateless (state lives in the DB) but is cached for symmetry.
+#
+# `reset_store_cache` below is the one thing that drops an entry, and it exists
+# for tests. Calling it against a live in-memory store orphans every stream it
+# holds, and any app already built keeps the old object — so the process ends up
+# serving two stores. That is why the way to *drive* a caller with a store of
+# your own is to pass one (`get_asgi_app(store=...)`), not to reset the cache.
 _stores: dict[str, Any] = {}
 _store_lock = threading.Lock()
 

--- a/src/rakaia/effects.py
+++ b/src/rakaia/effects.py
@@ -27,7 +27,7 @@ it lives inside ``Transition``.
 from __future__ import annotations
 
 import json
-from collections.abc import Callable, Iterable
+from collections.abc import Callable, Iterable, Mapping
 from dataclasses import dataclass
 from dataclasses import field as dc_field
 from dataclasses import replace as dc_replace
@@ -136,6 +136,35 @@ class Transition:
                 "Transition has empty key_fields; it must name at least one "
                 "column identifying each flipped row."
             )
+
+
+#: The ``state`` every synthesised transition payload carries. A transition is
+#: emitted only for a row whose liveness sentinel actually flipped, so there is
+#: no other value it could take — there is no "still open" transition.
+TRANSITION_RESOLVED = "resolved"
+
+
+def transition_payload(
+    patch: Mapping[str, Any] | None, identity: Mapping[str, Any]
+) -> dict[str, Any]:
+    """Build the payload a :class:`Transition` notification carries.
+
+    This is the shape a *consumer* actually receives, so it belongs next to the
+    `Transition` that requests it rather than at the one call site that happens
+    to assemble it. It used to be built inline in the replay orchestrator with
+    ``"resolved"`` written as a bare literal, which put the request and the
+    thing delivered against it in two different modules.
+
+    ``patch`` is spread first so the orchestrator's own ``key`` and ``state``
+    always win: ``reconcile_by_key`` is a generic primitive, and a patch column
+    named ``key`` or ``state`` must not clobber the row identity or the
+    transition state.
+    """
+    return {
+        **(patch or {}),
+        "key": dict(identity),
+        "state": TRANSITION_RESOLVED,
+    }
 
 
 # =============================================================================

--- a/src/rakaia/replay.py
+++ b/src/rakaia/replay.py
@@ -87,6 +87,7 @@ from .effects import (
     Update,
     Upsert,
     _WrittenFields,
+    transition_payload,
 )
 from .protocols import ProjectionReader, ReadableStore
 from .registry import (
@@ -391,14 +392,9 @@ def _synth_transitions(report: ApplyReport | None) -> list[ExternalEffect]:
         # a generator body is a scope of its own.
         kind = eff.transition.kind
         out.extend(
-            ExternalEffect(
-                kind=kind,
-                # Spread patch first so the orchestrator's own `key`/`state`
-                # always win: reconcile_by_key is a generic primitive, and a
-                # patch column named `key` or `state` must not clobber the
-                # row identity or the transition state.
-                payload={**patch, "key": dict(identity), "state": "resolved"},
-            )
+            # The payload shape is defined beside `Transition`, which requests
+            # it — not here, which is only where it happens to be assembled.
+            ExternalEffect(kind=kind, payload=transition_payload(patch, identity))
             for identity in rows
         )
     return out

--- a/tests/test_django_rakaia/test_integration_entry_point.py
+++ b/tests/test_django_rakaia/test_integration_entry_point.py
@@ -1,0 +1,114 @@
+"""`get_asgi_app` — the mount point a Django project actually calls.
+
+This entry point had **no coverage at all**, and the reason was its shape: it
+resolved the store internally from `RAKAIA_STORE`, so the only way to drive it
+was to reconfigure a process-wide cache and hope nothing else in the run had
+already populated it. Taking an optional `store` makes it drivable, which is
+the whole of what these tests need.
+
+What is checked here is *wiring*, not protocol rules — the protocol itself is
+covered against both stores in `test_protocol_server.py` and the contract
+suites. The questions are narrower: does the app reach the store it was given,
+does an explicit store take precedence over the setting, and are `options`
+threaded through rather than dropped.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncIterator
+
+import httpx
+import pytest
+import pytest_asyncio
+
+from django_rakaia.integration import get_asgi_app
+from django_rakaia.store import reset_store_cache
+from rakaia import ServerOptions, StreamStore
+
+JSON = {"content-type": "application/json"}
+
+
+@pytest.fixture(autouse=True)
+def _clear_store_cache():
+    reset_store_cache()
+    yield
+    reset_store_cache()
+
+
+def _client(app: object) -> httpx.AsyncClient:
+    return httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app),  # type: ignore[arg-type]
+        base_url="http://test",
+    )
+
+
+@pytest_asyncio.fixture
+async def given_store() -> AsyncIterator[StreamStore]:
+    yield StreamStore()
+
+
+class TestItServesTheStoreItIsGiven:
+    async def test_an_append_lands_in_the_supplied_store(
+        self, given_store: StreamStore
+    ) -> None:
+        """The round trip is the point: a store passed in is the one written to."""
+        async with _client(get_asgi_app(store=given_store)) as client:
+            assert (await client.put("/s", headers=JSON)).status_code in (200, 201, 204)
+            posted = await client.post("/s", content=b'{"id": 1}', headers=JSON)
+            assert posted.status_code in (200, 204)
+
+            assert (await client.get("/s")).json() == [{"id": 1}]
+
+        # ...and observably in *that* object, not some other store the app
+        # resolved for itself. Streams key on the full request path.
+        messages, _ = given_store.read("/s")
+        assert [json.loads(m.data) for m in messages] == [{"id": 1}]
+
+    async def test_two_apps_with_two_stores_do_not_share(self) -> None:
+        """The failure this guards is the old shape: both apps resolving the
+        same process-wide singleton, so one test's appends leak into the next."""
+        a, b = StreamStore(), StreamStore()
+
+        async with _client(get_asgi_app(store=a)) as client:
+            await client.put("/s", headers=JSON)
+            await client.post("/s", content=b'{"from": "a"}', headers=JSON)
+
+        async with _client(get_asgi_app(store=b)) as client:
+            await client.put("/s", headers=JSON)
+            assert (await client.get("/s")).json() == []
+
+
+class TestAnExplicitStoreBeatsTheSetting:
+    def test_the_setting_is_not_consulted_at_all(self, settings) -> None:
+        """`RAKAIA_STORE` here is a value `get_store()` refuses outright, so if
+        the setting were still read this would raise instead of returning."""
+        settings.RAKAIA_STORE = "durrable"
+
+        assert get_asgi_app(store=StreamStore()) is not None
+
+    def test_without_a_store_the_setting_still_decides(self, settings) -> None:
+        from django.core.exceptions import ImproperlyConfigured
+
+        settings.RAKAIA_STORE = "durrable"
+
+        with pytest.raises(ImproperlyConfigured):
+            get_asgi_app()
+
+
+class TestOptionsAreThreadedThrough:
+    async def test_a_supplied_option_reaches_the_app(
+        self, given_store: StreamStore
+    ) -> None:
+        """A long poll at the tail waits out the server's window, so a short one
+        is observable: on the 3.0s default this would exceed the timeout below.
+        """
+        options = ServerOptions()
+        options.long_poll_timeout = 0.05
+
+        app = get_asgi_app(options=options, store=given_store)
+        async with _client(app) as client:
+            await client.put("/s", headers=JSON)
+            read = await client.get("/s?offset=now&live=long-poll", timeout=1.0)
+
+        assert read.status_code in (200, 204)

--- a/tests/test_django_rakaia/test_integration_entry_point.py
+++ b/tests/test_django_rakaia/test_integration_entry_point.py
@@ -16,6 +16,7 @@ threaded through rather than dropped.
 from __future__ import annotations
 
 import json
+import time
 from collections.abc import AsyncIterator
 
 import httpx
@@ -100,8 +101,14 @@ class TestOptionsAreThreadedThrough:
     async def test_a_supplied_option_reaches_the_app(
         self, given_store: StreamStore
     ) -> None:
-        """A long poll at the tail waits out the server's window, so a short one
-        is observable: on the 3.0s default this would exceed the timeout below.
+        """A long poll at the tail waits out the server's own window, so a short
+        one is observable *as elapsed time* and only as that.
+
+        The obvious form of this test — pass `timeout=` to the client and assert
+        a status — proves nothing: `httpx.ASGITransport` calls the app in-process
+        with no network layer, so it never enforces a client timeout. Dropping
+        `options=options` from the call below leaves that version green, merely
+        60x slower. Hence the wall clock.
         """
         options = ServerOptions()
         options.long_poll_timeout = 0.05
@@ -109,6 +116,11 @@ class TestOptionsAreThreadedThrough:
         app = get_asgi_app(options=options, store=given_store)
         async with _client(app) as client:
             await client.put("/s", headers=JSON)
-            read = await client.get("/s?offset=now&live=long-poll", timeout=1.0)
+            started = time.monotonic()
+            read = await client.get("/s?offset=now&live=long-poll")
+            elapsed = time.monotonic() - started
 
         assert read.status_code in (200, 204)
+        # Generous against the 0.05s asked for, decisive against the 3.0s
+        # default a dropped `options` would fall back to.
+        assert elapsed < 1.0, f"long poll waited {elapsed:.2f}s; option not applied"

--- a/tests/test_django_rakaia/test_store_selection.py
+++ b/tests/test_django_rakaia/test_store_selection.py
@@ -18,19 +18,22 @@ import pytest
 from django.core.exceptions import ImproperlyConfigured
 
 from django_rakaia.django_store import DjangoStreamStore
-from django_rakaia.store import get_store
+from django_rakaia.store import get_store, reset_store_cache
 from rakaia import StreamStore
 
 
 @pytest.fixture(autouse=True)
 def _clear_store_cache():
     """`get_store()` memoises per backend name; drop the cache around each test
-    so one test's selection can't satisfy the next one's lookup."""
-    from django_rakaia import store as store_module
+    so one test's selection can't satisfy the next one's lookup.
 
-    store_module._stores.clear()
+    This goes through `reset_store_cache()` rather than mutating the private
+    `_stores` dict, which is what this file used to do — the one place in the
+    suite that reached past an interface by design.
+    """
+    reset_store_cache()
     yield
-    store_module._stores.clear()
+    reset_store_cache()
 
 
 class TestBackendSelection:
@@ -86,16 +89,43 @@ class TestUnknownBackendIsRefused:
 
     def test_a_refused_backend_is_not_cached(self, settings):
         """A failed selection must not poison the cache — fixing the setting
-        without restarting the process has to work."""
-        from django_rakaia import store as store_module
+        without restarting the process has to work.
 
+        Asserted through behaviour rather than by inspecting the cache dict: if
+        the refusal had left an entry behind, the second call would hand it back
+        instead of raising again.
+        """
         settings.RAKAIA_STORE = "durrable"
         with pytest.raises(ImproperlyConfigured):
             get_store()
-        assert "durrable" not in store_module._stores
+        with pytest.raises(ImproperlyConfigured):
+            get_store()
 
         settings.RAKAIA_STORE = "memory"
         assert isinstance(get_store(), StreamStore)
+
+
+class TestTheCacheAndItsReset:
+    """`reset_store_cache()` replaces the private-dict poke this file used to do.
+
+    Both halves are asserted, because a no-op reset would pass a test that only
+    checked the second: memoisation has to be real for dropping it to mean
+    anything.
+    """
+
+    def test_the_same_backend_is_memoised(self, settings):
+        settings.RAKAIA_STORE = "memory"
+        assert get_store() is get_store()
+
+    def test_reset_forces_a_rebuild(self, settings):
+        settings.RAKAIA_STORE = "memory"
+        first = get_store()
+        reset_store_cache()
+        assert get_store() is not first
+
+    def test_reset_is_safe_on_an_empty_cache(self):
+        reset_store_cache()
+        reset_store_cache()
 
 
 class TestInMemoryInProductionIsFlagged:

--- a/tests/test_rakaia/test_effects.py
+++ b/tests/test_rakaia/test_effects.py
@@ -7,6 +7,7 @@ from dataclasses import FrozenInstanceError
 import pytest
 
 from rakaia.effects import (
+    TRANSITION_RESOLVED,
     Delete,
     EffectCollisionError,
     Exclude,
@@ -18,6 +19,7 @@ from rakaia.effects import (
     Update,
     Upsert,
     check_disjoint_defaults,
+    transition_payload,
 )
 
 
@@ -142,6 +144,45 @@ class TestTransition:
         t = Transition(kind="k", key_fields=("a",))
         with pytest.raises(FrozenInstanceError):
             t.kind = "other"  # type: ignore[misc]
+
+
+class TestTransitionPayload:
+    """The payload a consumer receives, defined beside the request for it.
+
+    This used to be assembled inline in `replay._synth_transitions` with
+    ``"resolved"`` as a bare literal, so the `Transition` that *requests* a
+    notification and the shape actually *delivered* against it lived in two
+    modules. These pin the shape here; `test_replay.py` pins that the
+    orchestrator is what calls this.
+    """
+
+    def test_carries_identity_and_resolved_state(self):
+        payload = transition_payload({"note": "n"}, {"alert_type": "a", "id": 1})
+        assert payload == {
+            "note": "n",
+            "key": {"alert_type": "a", "id": 1},
+            "state": TRANSITION_RESOLVED,
+        }
+
+    def test_state_is_resolved(self):
+        assert TRANSITION_RESOLVED == "resolved"
+        assert transition_payload(None, {"id": 1})["state"] == "resolved"
+
+    def test_a_missing_patch_is_the_same_as_an_empty_one(self):
+        assert transition_payload(None, {"id": 1}) == transition_payload({}, {"id": 1})
+
+    @pytest.mark.parametrize("clobber", ["key", "state"])
+    def test_a_patch_cannot_clobber_key_or_state(self, clobber):
+        """`reconcile_by_key` is generic, so a patch column may genuinely be
+        named `key` or `state`. Row identity and transition state still win."""
+        payload = transition_payload({clobber: "from-patch"}, {"id": 1})
+        assert payload[clobber] != "from-patch"
+
+    def test_the_identity_is_copied_not_aliased(self):
+        identity = {"id": 1}
+        payload = transition_payload({}, identity)
+        identity["id"] = 2
+        assert payload["key"] == {"id": 1}
 
 
 class TestCheckDisjointDefaults:

--- a/tests/test_rakaia/test_public_api.py
+++ b/tests/test_rakaia/test_public_api.py
@@ -176,6 +176,7 @@ DJANGO_RAKAIA_PUBLIC = {
     "materialize_history",
     "poll_consumer",
     "rebuild_and_verify",
+    "reset_store_cache",
     "register_stream_event_admin",
     "replay_stream",
     "stream_model",

--- a/tests/test_rakaia/test_replay.py
+++ b/tests/test_rakaia/test_replay.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import sys
 
 import pytest
 
@@ -1422,3 +1423,30 @@ class TestSynthTransitions:
 
     def test_none_report_yields_nothing(self):
         assert _synth_transitions(None) == []
+
+    def test_the_payload_is_the_one_defined_beside_transition(self, monkeypatch):
+        """The shape is *owned* by `effects.transition_payload`, not re-invented
+        here.
+
+        Asserting the value cannot show this — an inline
+        ``{**patch, "key": …, "state": "resolved"}`` builds an equal dict, so
+        every other assertion in this class passes either way. Substituting the
+        shared definition is what distinguishes them: if the orchestrator went
+        back to assembling its own, the substitution would have no effect.
+
+        The patch goes through `sys.modules`, not the dotted string form.
+        ``monkeypatch.setattr("rakaia.replay.transition_payload", …)`` would
+        resolve `rakaia.replay` to the *function* — see this module's docstring
+        and item 1 of #161 — and silently patch nothing, which is the exact trap
+        that once produced a wrong measurement.
+        """
+        replay_module = sys.modules["rakaia.replay"]
+        monkeypatch.setattr(
+            replay_module, "transition_payload", lambda *_: {"sentinel": 1}
+        )
+
+        rows = [{"stream_key": "s", "alert_type": "a"}]
+        (t,) = _synth_transitions(
+            ApplyReport(retire_flips=[(self._retire({"resolved_at": "t2"}), rows)])
+        )
+        assert t.payload == {"sentinel": 1}


### PR DESCRIPTION
Closes the last two items of the smaller-findings list from the architecture review, so #161 and the epic above it can close.

The payload a resolved-item notification carries was invented in the replay orchestrator, with its state written as a bare literal, while the request for one is defined elsewhere. It now has a single definition beside that request. The ASGI entry point resolved its store from a setting internally, so the only way to drive it was to reconfigure a process-wide cache — which is why it had no tests at all. It now accepts a store, as the replay entry point already did.

Closes #161.