### PR TITLE
Write down that changing a backend is a copy

### DIFF
--- a/docs/adr/0005-stream-positions-stay-a-counted-offset.md
+++ b/docs/adr/0005-stream-positions-stay-a-counted-offset.md
@@ -7,6 +7,8 @@
   vs protocol-server boundary); `docs/protocol.md` § *Strictly Increasing*;
   `src/rakaia/offsets.py`, `src/django_rakaia/offsets.py`,
   `src/django_rakaia/models.py`, `src/rakaia/types.py`.
+  [ADR 0006](./0006-changing-backends-is-a-copy.md) (changing a backend is a copy —
+  amends the format table below).
   Issues: [#138](https://github.com/joshbrooks/rakaia/issues/138) (this decision),
   #206 / #182 / #178 (one home for the five position rules — landed),
   #34 (global monotonicity — closed, and the reason the watermark exists),
@@ -21,7 +23,26 @@ declared in one place since #206 (`src/rakaia/offsets.py`):
 | Format | Shape | Store |
 |---|---|---|
 | `COMPOUND` | `{read_seq:016d}_{byte_offset:016d}` | in-memory `StreamStore` |
-| `PLAIN` | `{entry_id:020d}` | `DjangoStreamStore` |
+| `PLAIN` | `{entry_id:020d}` | `DjangoStreamStore` **and** `JsonlStreamStore` |
+
+> **Amended 2026-08-26 (#233).** The third row is the amendment. When this was
+> written there were two stores and two formats, one each, and the table read as a
+> one-to-one mapping. `JsonlStreamStore` (#229) reuses `PLAIN` — deliberately, since
+> it counts entries exactly as the durable store does, which is what lets a copy
+> between the two preserve offsets exactly.
+>
+> The consequence the two-row version could not state: **two backends now issue the
+> same format, so `offsets.after` can no longer tell a foreign cursor from a local
+> one.** Every cross-store cursor used to be refused by accident of shape; that now
+> holds for two of the three pairs. A `DjangoStreamStore` cursor is accepted by
+> `JsonlStreamStore` and vice versa — silently, and wrongly, when it sits at or below
+> the other store's head. [#232](https://github.com/joshbrooks/rakaia/issues/232)
+> proposes recording the issuing store beside the position;
+> [ADR 0006](./0006-changing-backends-is-a-copy.md) documents the rule that keeps a
+> deployment out of that state in the meantime.
+>
+> Nothing in the decision below changes. The widths, the lock and the ULID answer are
+> unaffected — this is the table catching up with a store that arrived after it.
 
 Both widths were chosen by hand — sixteen because the in-memory store's byte
 offset cannot exceed process memory, twenty because it covers a `BigAutoField`.

--- a/docs/adr/0005-stream-positions-stay-a-counted-offset.md
+++ b/docs/adr/0005-stream-positions-stay-a-counted-offset.md
@@ -25,15 +25,18 @@ declared in one place since #206 (`src/rakaia/offsets.py`):
 | `COMPOUND` | `{read_seq:016d}_{byte_offset:016d}` | in-memory `StreamStore` |
 | `PLAIN` | `{entry_id:020d}` | `DjangoStreamStore` **and** `JsonlStreamStore` |
 
-> **Amended 2026-08-26 (#233).** The third row is the amendment. When this was
-> written there were two stores and two formats, one each, and the table read as a
-> one-to-one mapping. `JsonlStreamStore` (#229) reuses `PLAIN` — deliberately, since
-> it counts entries exactly as the durable store does, which is what lets a copy
-> between the two preserve offsets exactly.
+> **Amended 2026-08-26 (#233).** The amendment is the second store on the `PLAIN`
+> row — not a new row, and that is the whole point. When this was written there were
+> two stores and two formats, one each, and the table read as a one-to-one mapping
+> between them. It is still two formats; it is no longer two stores.
+> `JsonlStreamStore` (#229) reuses `PLAIN` — deliberately, since it counts entries
+> exactly as the durable store does, which is what lets a copy between the two
+> preserve offsets exactly.
 >
-> The consequence the two-row version could not state: **two backends now issue the
-> same format, so `offsets.after` can no longer tell a foreign cursor from a local
-> one.** Every cross-store cursor used to be refused by accident of shape; that now
+> The consequence a one-store-per-format table could not state: **two backends now
+> issue the same format, so `offsets.after` can no longer tell a foreign cursor from
+> a local one.** Every cross-store cursor used to be refused by accident of shape;
+> that now
 > holds for two of the three pairs. A `DjangoStreamStore` cursor is accepted by
 > `JsonlStreamStore` and vice versa — silently, and wrongly, when it sits at or below
 > the other store's head. [#232](https://github.com/joshbrooks/rakaia/issues/232)

--- a/docs/adr/0006-changing-backends-is-a-copy.md
+++ b/docs/adr/0006-changing-backends-is-a-copy.md
@@ -1,0 +1,155 @@
+# ADR 0006 — Changing a stream's backend is a copy, never a setting change
+
+- **Status:** Proposed
+- **Date:** 2026-08-26
+- **Deciders:** rakaia maintainers
+- **Related:** [ADR 0005](./0005-stream-positions-stay-a-counted-offset.md) (positions
+  stay a counted offset — amended by this decision);
+  [ADR 0002](./0002-framework-vs-protocol-server-boundary.md) (the store seam this
+  relies on); `docs/store-streams-in-files.md`; `src/rakaia/migrate.py`,
+  `src/rakaia/offsets.py`.
+  Issues: [#233](https://github.com/joshbrooks/rakaia/issues/233) (this decision),
+  #229 (the third backend that raised it), #232 (a cursor should name its store —
+  the gap this decision documents rather than closes),
+  #34 (deletion retires offsets permanently — why a round trip cannot restore a log).
+
+## Context
+
+Rakaia now has three stores behind one seam: the in-memory `StreamStore`, the
+database-backed `DjangoStreamStore`, and the file-backed `JsonlStreamStore`. Which
+one a Django deployment uses is a single setting, `RAKAIA_STORE`.
+
+That setting looks like it names *where the log is*. It does not. It names which
+store the process constructs. Changing it and restarting does not move a single
+event: the application comes up against a different, empty log while every consumer
+still holds a saved position, and every one of those positions is still syntactically
+valid.
+
+What happens next depends on a detail nobody would think to check — whether the two
+stores issue the same offset *format*:
+
+| Old store → new store | What a resumed consumer gets |
+|---|---|
+| in-memory → either other | `ForeignOffset`. Loud, immediate, correct. |
+| `DjangoStreamStore` ↔ `JsonlStreamStore` | **Accepted.** Both issue `PLAIN`. |
+
+The second row is new. Until `JsonlStreamStore` existed, every pair of stores
+disagreed about format, so every cross-store cursor was refused by accident of
+shape. That protection is gone for one pair of three, and it was never a designed
+guarantee — `rakaia.offsets` refuses a cursor whose format it can see belongs to
+another store, and two stores sharing a format are indistinguishable to it.
+
+Measured on this tree, the accepted case splits in two:
+
+- **Cursor ahead of the new store's head** — reported as `rewound`, and the consumer
+  re-reads from the start. Over-cautious, but loud and safe.
+- **Cursor at or below the new store's head** — accepted silently. The consumer
+  resumes at that number in a log it has never seen, and the events before it are
+  skipped permanently. No error, no flag.
+
+The second is the failure this decision exists to rule out. It is not reachable by
+normal operation; it needs someone to change a backend, which is exactly the sort of
+once-per-deployment action that gets done from memory at an awkward hour.
+
+`rakaia.migrate.migrate_stream` already does the move properly and reports what
+survived. What was missing is the *rule*, written where someone looks before doing
+it rather than after.
+
+## Decision
+
+**1. Moving a stream between backends is a copy.** `migrate_stream` (or
+`migrate_all`) is the only supported way. Changing `RAKAIA_STORE` and restarting is
+not a migration and is not supported.
+
+**2. Consumer positions survive only when the copy says so.** `Migration.cursors_valid`
+is the answer, established by comparing the offsets the copy produced against the
+offsets it read — not by reasoning about the two backends beforehand. When it is
+`False`, consumers must be reset before they are started again, and reset
+*knowingly*.
+
+**3. A log cannot be round-tripped back into the store it was deleted from.**
+Deleting a stream retires its offsets permanently (#34), so a recreated stream
+resumes numbering *above* the mark it retired. "Export, delete, re-import" — the
+obvious way to try to rebuild a log in place — therefore cannot restore the original
+numbering. `migrate_stream` reports this as `offsets_preserved: False`, and it is
+named here because the technique looks safe and is not.
+
+**4. Two backends sharing an offset format is a known gap, recorded rather than
+fixed here.** `DjangoStreamStore` and `JsonlStreamStore` both issue `PLAIN`, so
+`offsets.after` cannot tell one's cursor from the other's. #232 proposes recording
+the issuing store alongside the position. This decision documents the rule that
+keeps deployments out of that state; it does not close the hole underneath it.
+
+## Alternatives considered
+
+**Make `RAKAIA_STORE` refuse to change under a populated log.** Tempting, and
+rejected: the store is constructed from a setting at process start, and nothing at
+that moment knows what the *previous* backend was. Detecting it would mean the new
+store carrying a record of a store it has never seen, which is a worse version of
+#232 with none of its benefit.
+
+**Give `JsonlStreamStore` its own offset format.** This looks like it would restore
+the accidental protection, and it is worth writing down why it would not — the
+obvious version of it does nothing at all.
+
+`OffsetFormat.owns` matches on **field count, not width** (`src/rakaia/offsets.py:89`,
+and the property's docstring says so deliberately; pinned by
+`test_offset_format.py::test_a_width_pads_output_without_filtering_input`). Widths
+are a padding and sort rule for offsets a store *issues*, not an input filter,
+because clients legitimately send unpadded positions — the dashboard's `?after=42` is
+one. So a "JSONL format" of eighteen digits instead of twenty is still one numeric
+field, still matched by `PLAIN`, and changes nothing: measured on this tree, minting
+18-digit offsets left `format_of` still reporting `durable` and every cross-store
+cursor still accepted.
+
+Separating them would mean a second numeric field, or a non-numeric shape — which
+either invents a component the file store does not have, or gives up the unpadded
+client offsets that work today.
+
+Rejected on its own merits as well: two entry-counting stores sharing a format is
+*why* a copy between them can preserve offsets exactly, which is the common and
+supported path. Making a rare mistake loud by making the common case impossible is
+the wrong trade. #232 gets both, because it records the issuing store rather than
+trying to infer it from the token's shape.
+
+**Document it only in `docs/store-streams-in-files.md`.** That page says it, and
+`migrate.py`'s own docstring says it. Both are read by someone who has already
+decided to use the file store. The tempting alternative — "just point it at the new
+one" — is what the rule exists to rule out, and it looks like it works right up until
+consumers resume, so it belongs where decisions are recorded.
+
+## Consequences
+
+### Positive
+
+- The unsupported path is named, so "just change the setting" is a documented
+  mistake rather than an undocumented one.
+- The one case that fails *silently* is written down next to the two that fail
+  loudly, which is the distinction an operator cannot derive from behaviour.
+
+### Negative, and named rather than waved away
+
+- The rule is documentation, not a guard. Nothing enforces it, and #232 is still
+  open. A deployment that ignores this ADR gets exactly the failure described above.
+- `migrate_stream` copies through the public store API, so what that API cannot
+  carry does not cross: producer fencing state has no public setter, and a sliding
+  TTL window restarts. Both are listed in `Migration.notes` rather than dropped
+  silently, but they are still not carried.
+
+### Neutral
+
+- Nothing about the single-backend case changes. A deployment that never switches
+  backends is unaffected by all of this.
+
+## What would reopen this
+
+- **#232 lands.** A cursor that names its issuing store makes the silent row of the
+  table above loud, at which point this decision is a convenience rather than the
+  only thing standing between an operator and skipped events. Amend, do not delete —
+  the copy is still the supported move.
+- **A fourth store.** Whether it shares `PLAIN` decides which row of the table it
+  joins, and that is a decision to take deliberately rather than by picking a
+  convenient format.
+- **A supported dual-run or rollback story.** Both backends live at once, heads
+  diverging, is the case most likely to put a consumer's cursor *below* the other
+  store's head. Nothing here makes that safe and this ADR does not attempt it.

--- a/docs/adr/0006-changing-backends-is-a-copy.md
+++ b/docs/adr/0006-changing-backends-is-a-copy.md
@@ -28,12 +28,15 @@ valid.
 What happens next depends on a detail nobody would think to check — whether the two
 stores issue the same offset *format*:
 
-| Old store → new store | What a resumed consumer gets |
+| Store pair | What a resumed consumer gets |
 |---|---|
-| in-memory → either other | `ForeignOffset`. Loud, immediate, correct. |
+| in-memory ↔ either other | `ForeignOffset`. Loud, immediate, correct. |
 | `DjangoStreamStore` ↔ `JsonlStreamStore` | **Accepted.** Both issue `PLAIN`. |
 
-The second row is new. Until `JsonlStreamStore` existed, every pair of stores
+Both are symmetric — a format is refused in whichever direction it is carried,
+and accepted in whichever direction too.
+
+The second entry is new. Until `JsonlStreamStore` existed, every pair of stores
 disagreed about format, so every cross-store cursor was refused by accident of
 shape. That protection is gone for one pair of three, and it was never a designed
 guarantee — `rakaia.offsets` refuses a cursor whose format it can see belongs to

--- a/src/rakaia/offsets.py
+++ b/src/rakaia/offsets.py
@@ -65,8 +65,8 @@ class ForeignOffset(InvalidOffset):
     """An offset was used where its format does not belong — passed to a store
     that did not issue it, or compared against one from another store.
 
-    Subclasses `InvalidOffset` on purpose: both stores already raised that for a
-    token they did not recognise, so every existing ``except InvalidOffset``
+    Subclasses `InvalidOffset` on purpose: every store already raised that for a
+    token it did not recognise, so every existing ``except InvalidOffset``
     still catches this.
     """
 
@@ -95,8 +95,14 @@ class OffsetFormat:
         filter. Clients send unpadded offsets — the dashboard's ``?after=42`` is
         one — and both regexes this replaced accepted them, so tightening to
         ``\\d{20}`` here would reject requests that work today. What the shape
-        does settle is the only question `owns` is asked: which of the two stores
-        a token belongs to, one field against two.
+        does settle is the only question `owns` is asked: which *format* a token
+        belongs to, one field against two.
+
+        A format, not a store — those stopped being the same thing when
+        `JsonlStreamStore` began issuing `PLAIN` alongside `DjangoStreamStore`.
+        Two stores sharing a format are indistinguishable here, and deliberately
+        so, since it is what lets a copy between them preserve every offset. See
+        `docs/adr/0006-changing-backends-is-a-copy.md`, which cites this rule.
         """
         return re.compile("^" + "_".join(r"\d+" for _ in self.widths) + "$")
 

--- a/tests/test_django_rakaia/test_offset_format_pin.py
+++ b/tests/test_django_rakaia/test_offset_format_pin.py
@@ -1,0 +1,59 @@
+"""`DjangoStreamStore` issues `PLAIN` — the fact ADR 0006's table turns on.
+
+`test_rakaia/test_cross_backend_cursors.py` pins what happens when two stores
+share an offset format, using two file-backed stores. This is the assertion that
+makes that pair the *real* one: the durable store and the file store issue the
+same format, so a cursor really does cross between them unchallenged in a
+deployment.
+
+Split out rather than folded in there because it needs a database, and the
+module it pins the behaviour in does not.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from django_rakaia.django_store import DjangoStreamStore
+from rakaia.offsets import PLAIN, format_of
+
+pytestmark = pytest.mark.django_db
+
+PATH = "s"
+
+
+def test_the_durable_store_issues_the_plain_format():
+    """Shared with `JsonlStreamStore` deliberately: both count entries, which is
+    what lets a copy between them preserve every offset exactly. The cost is
+    that `offsets.after` cannot tell one's cursor from the other's — ADR 0005's
+    amended table, and ADR 0006's silent row."""
+    store = DjangoStreamStore()
+    store.create(PATH)
+    store.append(PATH, b'{"n": 1}')
+
+    assert format_of(store.get_current_offset(PATH)) is PLAIN
+
+
+def test_a_durable_offset_is_accepted_by_the_file_store(tmp_path):
+    """The pair, end to end, with the real durable store on one side.
+
+    Not `ForeignOffset` — which is what every other pair of stores raises, and
+    what this one raised too until a third store reused `PLAIN`. Asserting the
+    acceptance keeps it a recorded decision rather than a surprise.
+    """
+    from rakaia.jsonl_store import JsonlStreamStore
+
+    durable = DjangoStreamStore()
+    durable.create(PATH)
+    for i in range(3):
+        durable.append(PATH, b'{"n": %d}' % i)
+    durable_offset = durable.get_current_offset(PATH)
+
+    files = JsonlStreamStore(tmp_path / "files", fsync=False)
+    files.create(PATH)
+    for i in range(10):
+        files.append(PATH, b'{"n": %d}' % i)
+
+    # No raise: the file store parses a position the durable store minted.
+    messages, _ = files.read(PATH, durable_offset)
+    assert len(messages) == 7

--- a/tests/test_rakaia/test_cross_backend_cursors.py
+++ b/tests/test_rakaia/test_cross_backend_cursors.py
@@ -1,9 +1,15 @@
 """What a saved position does when it meets the wrong store (ADR 0006, #233).
 
-ADR 0006 states a two-row table: which pairs of stores refuse each other's
-cursors, and which pair accepts them silently. That table is the whole reason
-the ADR exists — the rule it decides ("changing a backend is a copy") follows
-from the one row that fails without saying so.
+ADR 0006 states which pairs of stores refuse each other's cursors and which
+pair accepts them silently. That table is the whole reason the ADR exists — the
+rule it decides ("changing a backend is a copy") follows entirely from the pair
+that fails without saying so.
+
+Nothing below refers to a row by its position. Three successive drafts of these
+docstrings miscounted the table — a store added to a cell called a new row, two
+directions of one pair called two rows — so the numbering is simply not used.
+Each case is named by what it does instead, which cannot fall out of step with
+a table someone reorders.
 
 A table in a Markdown file rots. This pins it where it is decided, the way
 `test_producer_fencing_table.py` pins the fencing outcomes (#176). If someone
@@ -49,7 +55,8 @@ def files(tmp_path):
 
 
 class TestTheFormatsEachStoreIssues:
-    """Row one of the table: which store mints which format."""
+    """Which store mints which format — the fact the table is derived from,
+    rather than a row of it."""
 
     def test_the_in_memory_store_issues_compound(self, memory):
         assert format_of(memory.get_current_offset(PATH)) is COMPOUND
@@ -61,9 +68,9 @@ class TestTheFormatsEachStoreIssues:
 
 
 class TestAcrossFormatsACursorIsRefused:
-    """The loud row, both directions of it. Byte-compatible or not, a format
-    that belongs to another store is refused rather than resolved to a position
-    of its own."""
+    """Across two *different* formats, both directions. Byte-compatible or not,
+    a format that belongs to another store is refused rather than resolved to a
+    position of its own."""
 
     def test_a_file_cursor_is_refused_by_the_in_memory_store(self, memory, files):
         cursor = poll(files, PATH, None).cursor
@@ -77,7 +84,8 @@ class TestAcrossFormatsACursorIsRefused:
 
 
 class TestWithinOneFormatACursorIsAccepted:
-    """The silent row, and the reason ADR 0006 is a decision rather than a note.
+    """The case that fails silently, and the reason ADR 0006 is a decision
+    rather than a note.
 
     Two stores issuing the same format are indistinguishable to `offsets.after`,
     so a cursor crosses between them unchallenged. Both directions are pinned

--- a/tests/test_rakaia/test_cross_backend_cursors.py
+++ b/tests/test_rakaia/test_cross_backend_cursors.py
@@ -1,0 +1,117 @@
+"""What a saved position does when it meets the wrong store (ADR 0006, #233).
+
+ADR 0006 states a three-row table: which pairs of stores refuse each other's
+cursors, and which pair accepts them silently. That table is the whole reason
+the ADR exists — the rule it decides ("changing a backend is a copy") follows
+from the one row that fails without saying so.
+
+A table in a Markdown file rots. This pins it where it is decided, the way
+`test_producer_fencing_table.py` pins the fencing outcomes (#176). If someone
+gives `JsonlStreamStore` its own offset format, or lands #232, these go red and
+the ADR has to be amended rather than quietly left wrong.
+
+The two entry-counting stores are modelled here by two `JsonlStreamStore`s at
+different roots. That is not a stand-in for the durable store: the behaviour
+under test belongs to `rakaia.offsets`, which sees a *format*, not a class, and
+`test_django_rakaia/test_offset_format_pin.py` pins the fact that makes the pair
+real — that `DjangoStreamStore` issues the same format this one does.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from rakaia.jsonl_store import JsonlStreamStore
+from rakaia.offsets import COMPOUND, PLAIN, ForeignOffset, format_of
+from rakaia.store import StreamStore
+from rakaia.subscription import poll
+
+PATH = "s"
+
+
+def _seed(store, n, marker="e"):
+    store.create(PATH)
+    for i in range(n):
+        store.append(PATH, json.dumps({marker: i}).encode())
+    return store
+
+
+@pytest.fixture
+def memory():
+    return _seed(StreamStore(), 3)
+
+
+@pytest.fixture
+def files(tmp_path):
+    return _seed(JsonlStreamStore(tmp_path / "a", fsync=False), 3)
+
+
+class TestTheFormatsEachStoreIssues:
+    """Row one of the table: which store mints which format."""
+
+    def test_the_in_memory_store_issues_compound(self, memory):
+        assert format_of(memory.get_current_offset(PATH)) is COMPOUND
+
+    def test_the_file_store_issues_plain(self, files):
+        """`PLAIN` is named for the durable store and deliberately shared, so a
+        copy between the two entry-counting stores preserves offsets exactly."""
+        assert format_of(files.get_current_offset(PATH)) is PLAIN
+
+
+class TestAcrossFormatsACursorIsRefused:
+    """The two loud rows. Byte-compatible or not, a format that belongs to
+    another store is refused rather than resolved to a position of its own."""
+
+    def test_a_file_cursor_is_refused_by_the_in_memory_store(self, memory, files):
+        cursor = poll(files, PATH, None).cursor
+        with pytest.raises(ForeignOffset):
+            poll(memory, PATH, cursor)
+
+    def test_an_in_memory_cursor_is_refused_by_the_file_store(self, memory, files):
+        cursor = poll(memory, PATH, None).cursor
+        with pytest.raises(ForeignOffset):
+            poll(files, PATH, cursor)
+
+
+class TestWithinOneFormatACursorIsAccepted:
+    """The silent row, and the reason ADR 0006 is a decision rather than a note.
+
+    Two stores issuing the same format are indistinguishable to `offsets.after`,
+    so a cursor crosses between them unchallenged. Both directions are pinned
+    because they fail *differently*, and only one of them fails safely — an
+    operator cannot derive that difference from behaviour.
+    """
+
+    def test_a_cursor_ahead_of_the_new_head_is_reported_as_rewound(self, tmp_path):
+        """The safe direction: switching to an emptier log re-reads rather than
+        skipping. Over-cautious, and loud enough to notice."""
+        busy = _seed(JsonlStreamStore(tmp_path / "busy", fsync=False), 40, "OLD")
+        cursor = poll(busy, PATH, None).cursor
+
+        fresh = _seed(JsonlStreamStore(tmp_path / "fresh", fsync=False), 5, "NEW")
+        resumed = poll(fresh, PATH, cursor)
+
+        assert resumed.rewound is True
+        assert len(resumed.messages) == 5
+
+    def test_a_cursor_below_the_new_head_silently_skips_events(self, tmp_path):
+        """The failure ADR 0006 exists to rule out.
+
+        A position from one store, resumed against another that is already past
+        it, is accepted without a rewind and without an error — and every event
+        before it is skipped permanently. This asserts the *defect*, so that it
+        is a decision to leave it and not an oversight; #232 is what changes it,
+        and this test is where that change announces itself.
+        """
+        short = _seed(JsonlStreamStore(tmp_path / "short", fsync=False), 3, "OLD")
+        cursor = poll(short, PATH, None).cursor
+
+        longer = _seed(JsonlStreamStore(tmp_path / "long", fsync=False), 10, "NEW")
+        resumed = poll(longer, PATH, cursor)
+
+        assert resumed.rewound is False, "a rewind here would make this loud"
+        delivered = [json.loads(m.data)["NEW"] for m in resumed.messages]
+        assert delivered == [3, 4, 5, 6, 7, 8, 9]
+        assert 0 not in delivered, "events 0-2 are skipped, silently"

--- a/tests/test_rakaia/test_cross_backend_cursors.py
+++ b/tests/test_rakaia/test_cross_backend_cursors.py
@@ -1,6 +1,6 @@
 """What a saved position does when it meets the wrong store (ADR 0006, #233).
 
-ADR 0006 states a three-row table: which pairs of stores refuse each other's
+ADR 0006 states a two-row table: which pairs of stores refuse each other's
 cursors, and which pair accepts them silently. That table is the whole reason
 the ADR exists — the rule it decides ("changing a backend is a copy") follows
 from the one row that fails without saying so.
@@ -61,8 +61,9 @@ class TestTheFormatsEachStoreIssues:
 
 
 class TestAcrossFormatsACursorIsRefused:
-    """The two loud rows. Byte-compatible or not, a format that belongs to
-    another store is refused rather than resolved to a position of its own."""
+    """The loud row, both directions of it. Byte-compatible or not, a format
+    that belongs to another store is refused rather than resolved to a position
+    of its own."""
 
     def test_a_file_cursor_is_refused_by_the_in_memory_store(self, memory, files):
         cursor = poll(files, PATH, None).cursor

--- a/zensical.toml
+++ b/zensical.toml
@@ -58,6 +58,7 @@ nav = [
             { "ADR 0003 — Handler hermeticity" = "adr/0003-handler-hermeticity.md" },
             { "ADR 0004 — Handler types & fold order" = "adr/0004-handler-types-and-fold-order.md" },
             { "ADR 0005 — Stream positions stay a counted offset" = "adr/0005-stream-positions-stay-a-counted-offset.md" },
+            { "ADR 0006 — Changing a backend is a copy" = "adr/0006-changing-backends-is-a-copy.md" },
         ] },
     ] },
     { "Look it up" = [


### PR DESCRIPTION
There is a supported way to move a log between backends and an obvious way, and they are not the same one. Changing the setting and restarting moves nothing: the application comes up against a different, empty log while every saved reading position still looks valid. That rule now has a decision record, rather than living only in a page you read once you have already chosen the file store.

The record covering how positions work needed amending too, and the amendment is smaller and stranger than adding a backend usually is: no new kind of position was invented, because the new backend reuses the one the database-backed store already hands out. So the table gains a second store against an existing entry rather than a new entry, and what changes is what the table *means* — a position can no longer be told apart by its shape, which was never a guarantee anyone designed. It held by accident while the two kinds happened to differ.

Closes #233.