### PR TITLE
Importing the framework no longer starts a server, and the split question is answered

### DIFF
--- a/docs/adr/0002-framework-vs-protocol-server-boundary.md
+++ b/docs/adr/0002-framework-vs-protocol-server-boundary.md
@@ -1,6 +1,7 @@
 # ADR 0002 — Name the framework ↔ protocol-server boundary; formalize the framework seams
 
-- **Status:** Accepted (items 2 and 5 landed; boundary enforced 2026-08-21 — see the update notes below)
+- **Status:** Accepted (items 2 and 5 landed; boundary enforced 2026-08-21; the
+  package split declined and #191 closed 2026-08-26 — see the update notes below)
 - **Date:** 2026-07-21
 - **Deciders:** rakaia maintainers
 - **Related:** [`django-integration.md`](../django-integration.md),
@@ -122,6 +123,71 @@ This does not reopen or close #191; it replaces the guesswork in it with a
 measurement, and makes the cost of *not* splitting visible as a list of
 crossings that is currently one entry long.
 
+## Update — 2026-08-26: the split question is answered, and #191 closes
+
+The previous update deliberately left #191 open. It is closed now, not because
+the question got less interesting but because it has been measured twice with
+the same answer and there is nothing left to learn by asking a third time. **The
+tiers stay in one distribution.** What changed is that the last argument *for*
+splitting has been removed without splitting.
+
+**The boundary held through the largest change since it was written.** #229 added
+`JsonlStreamStore` and `migrate` — 1,405 lines of protocol-server code, a third
+store, and a tool that reads one store and writes another. The crossing list is
+still one entry. That is not luck: `test_the_tier_map_covers_every_module` fails
+on an unclassified module, so both new modules had to be placed in a tier as they
+landed, and the one-way rule was checked against them from their first commit.
+
+**Separability is now demonstrated rather than inferred.** Deleting the entire
+protocol-server tier from a copy of the tree and importing each framework module
+in turn: **11 of 12 import cleanly.** The single failure is `seed`, which is
+exactly the documented `ALLOWED_CROSSINGS` entry. The claim "a split would be
+mechanical" is no longer an argument from the import graph; it is a thing that
+was run.
+
+**The largest consumer would not benefit.** `django_rakaia`'s imports of `rakaia`
+are **16 framework, 3 protocol-server, 14 shared** — it is overwhelmingly a
+framework consumer that happens to serve the protocol. A framework/server split
+would leave it depending on all three resulting packages, so the biggest
+downstream gains no isolation and pays a three-way version matrix for it.
+
+**The one measurable cost of not splitting is gone.** The honest argument for a
+split was never install weight — the core has no runtime dependencies, so a
+framework consumer already installs nothing extra. It was that `import rakaia`
+eagerly loaded all ten protocol-server modules and *constructed an in-memory
+store*, because `app = create_app()` ran at module scope. Measured at 80ms and
+one unwanted store per process. Resolving the root's exports lazily (PEP 562, as
+`django_rakaia` already did) drops a framework consumer to **3ms and zero
+protocol-server modules**. A consumer now pays for the tier it uses, which is the
+benefit a split was being considered for.
+
+`replay` is the one export that cannot be lazy, and it is worth recording as a
+property of *this* seam rather than an implementation note: it is both a public
+name and a submodule, so importing the submodule binds the module over the
+function and `__getattr__` is never consulted. Left lazy, `from rakaia import
+replay` would return a function or a module depending on what else the process
+had imported — order-dependent, and worse than the shadowing described in #161
+item 1. It stays bound eagerly.
+
+### What would reopen this
+
+The trigger is no longer "the durable store grows into a protocol server"; that
+fired and was answered. The new ones, each a thing that would make a split buy
+something it does not buy today:
+
+- **The crossing list grows past one**, or an entry appears that is not a default
+  value. That is the tiers actually fusing, and the allowlist is where it shows.
+- **The shared vocabulary stops being tier-independent.** Four modules — `types`,
+  `protocols`, `json_mode`, `offsets` — currently depend on neither tier. A
+  shared module that needs one of them is the point where a third package stops
+  being optional.
+- **A consumer wants one tier without the other badly enough to say so.** Not
+  hypothetically: an actual report that installing the framework brings something
+  unwanted. Import cost no longer counts, since it has been paid down.
+- **The two tiers need different release cadences.** A protocol-conformance fix
+  that cannot ship because the framework half is mid-change is the cost a shared
+  distribution actually imposes, and nothing so far has hit it.
+
 ## Decision
 
 **Name the boundary and bring the framework-tier seams up to the protocol tier's
@@ -156,14 +222,17 @@ standard — without (yet) splitting the package.**
 | Option | Effort | Boundary clarity | Fixes consumer traps | Verdict |
 |---|---|---|---|---|
 | **Explicit boundary + formalize framework seams in place (chosen)** | Medium | High | Yes | **Chosen** |
-| Full package split (`rakaia-streams` + `rakaia-projections`) | High | Highest | Yes | Deferred — high churn; the tiers still share `StreamMessage`/store; revisit if divergence grows |
+| Full package split (`rakaia-streams` + `rakaia-projections`) | High | Highest | Yes | **Declined 2026-08-26** (#191) — separability demonstrated, but a split buys nothing left to buy; see the update above for the new triggers |
 | Boundary as docs only (no protocol formalization) | Low | Medium | No | Insufficient — the store/executor/reader seams need real, exported, conformance-tested protocols, not prose |
 | Status quo (leave fused, undocumented) | None | None | No | Rejected — the fusion traps keep reaching consumers |
 
-- **Full split** is the "correct" end-state but premature: the tiers genuinely
-  share types and the store object today, so splitting now trades one set of seams
-  for a harder cross-package one. This ADR keeps it on the table (item revisited
-  when/if the durable store grows a real protocol-server implementation).
+- **Full split** was recorded here as the "correct" end-state, deferred as
+  premature. Revisited twice (2026-08-21, 2026-08-26) and now declined: the tiers
+  are separable — demonstrated by deleting one and importing the other — but the
+  reasons to split have been answered without splitting, and the largest
+  consumer, `django_rakaia`, depends mostly on the framework and so would gain no
+  isolation from it. "Correct end-state" overstated it; a shared distribution
+  with an asserted boundary is a fine end-state.
 - **Docs-only** was rejected because the highest-impact issue (#36) is a *missing
   protocol + conformance suite*, which prose cannot substitute for.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -189,6 +189,17 @@ ignore = [
 # A Django `TestCase` in this example uses `assertEqual`/`assertRaises`, which is
 # the framework's own idiom rather than pytest's.
 "examples/formkit_submissions/**" = ["PT009", "PT027"]
+# The package root resolves its exports lazily (PEP 562), so its `__all__` is
+# built from a dict rather than written as a literal. Ruff cannot see through
+# that, and reads the `TYPE_CHECKING` block — which exists only so pyright can
+# follow names `__getattr__` provides at runtime — as ~100 unused imports.
+#
+# The alternative ruff accepts is the redundant-alias form, `from .x import y as
+# y` on every line. That silences it and is unreadable at this size, which is
+# the whole reason the block is written as ordinary imports. The names are still
+# checked: `test_public_api.py` asserts the block and `_EXPORTS` agree, and that
+# every exported name resolves — a real unused import here fails there.
+"src/rakaia/__init__.py" = ["F401"]
 
 [tool.ruff.lint.isort]
 known-first-party = ["rakaia", "django_rakaia"]

--- a/src/rakaia/__init__.py
+++ b/src/rakaia/__init__.py
@@ -17,115 +17,282 @@ Usage:
     # Run with: uvicorn rakaia:app
 """
 
-from .append import append_if_changed, snapshots_equal
-from .context import get_provenance, provenance
-from .cursor import CursorOptions, calculate_cursor, generate_response_cursor
-from .drift import DriftLedger
-from .effects import (
-    AnyEffect,
-    Delete,
-    DuplicateProducesError,
-    Effect,
-    EffectCollisionError,
-    Exclude,
-    Executor,
-    ExternalEffect,
-    Ref,
-    RefResolver,
-    Retire,
-    RowEffect,
-    SpareKeys,
-    Transition,
-    UnresolvedRefError,
-    Update,
-    Upsert,
-    check_disjoint_defaults,
-)
-from .executors import CollectingExecutor, InMemoryProjections
-from .handler import ServerOptions, create_app
-from .history import (
-    envelope_actor,
-    history_effects,
-    label_marker,
-)
-from .jsonl_store import JsonlStreamStore
-from .migrate import Migration, migrate_all, migrate_stream
-from .offsets import ForeignOffset
-from .projections import (
-    project_latest,
-    reconcile_aggregate,
-    reconcile_by_key,
-    reconcile_children,
-    reconcile_tree,
-)
-from .protocols import (
-    CursorStore,
-    ProjectionReader,
-    ReadableStore,
-    StreamServerStore,
-    WritableStore,
-)
-from .registry import (
-    HANDLERS_META_STREAM,
-    REDUCERS_META_STREAM,
-    UPCASTERS_META_STREAM,
-    HandlerDriftError,
-    HandlerGapError,
-    HandlerOverlapError,
-    HandlerRegistry,
-    HandlerVersion,
-    ReducerVersion,
-    UpcasterChainError,
-    UpcasterConflictError,
-    UpcasterRegistry,
-    UpcasterVersion,
-    get_default_registry,
-    get_default_upcaster_registry,
-    register_handler,
-    register_reducer,
-    register_simple,
-    register_upcaster,
-    reset_default_registries,
-    upcast,
-)
-from .replay import ENVELOPE_TS, ReplayResult, TouchedSubject, merge_replay, replay
-from .seed import seed_stream
-from .store import StreamStore
-from .subscription import Poll, PollStatus, poll
-from .types import (
-    AppendOptions,
-    AppendResult,
-    ClosedBy,
-    CloseResult,
-    ContentTypeMismatch,
-    EmptyJsonArray,
-    InvalidJson,
-    InvalidOffset,
-    ProducerAccepted,
-    ProducerDuplicate,
-    ProducerInvalidEpochSeq,
-    ProducerSequenceGap,
-    ProducerStaleEpoch,
-    ProducerState,
-    ProducerStreamClosed,
-    ProducerValidationResult,
-    SequenceConflict,
-    Stream,
-    StreamConfigConflict,
-    StreamError,
-    StreamMessage,
-    StreamNotFound,
-)
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+# =============================================================================
+# Public API
+# =============================================================================
+#
+# Resolved lazily (PEP 562), the same way `django_rakaia` resolves its own — for
+# a different reason, and the reason is worth stating because it is not the
+# obvious one.
+#
+# This package is two tiers in one distribution (ADR 0002): the event-sourcing
+# framework, and the Durable Streams protocol server. Eager imports here meant
+# that importing the framework loaded the whole server — all ten of its modules
+# — and `app = create_app()` at module scope allocated an in-memory
+# `StreamStore` in every process that so much as touched `import rakaia`,
+# whether or not it ever served a request. Measured before this change: 80ms
+# against 37ms for the framework alone, and one store per process nobody asked
+# for.
+#
+# The tier boundary is asserted by `tests/test_rakaia/test_tier_boundary.py`;
+# this is what stops the package root quietly undoing it. Nothing is imported
+# until a name is touched, so a consumer pays for the tier it uses.
+#
+# See `docs/public-api.md` for what Tier 1 guarantees, and ADR 0002 for why the
+# two tiers still share a distribution.
+
+if TYPE_CHECKING:
+    # Re-exported for type checkers only: the runtime path is `__getattr__`
+    # below, which pyright cannot follow. Every name here is in `_EXPORTS`, and
+    # `test_public_api.py` fails if the two ever disagree.
+    from .append import append_if_changed, snapshots_equal
+    from .context import get_provenance, provenance
+    from .cursor import CursorOptions, calculate_cursor, generate_response_cursor
+    from .drift import DriftLedger
+    from .effects import (
+        AnyEffect,
+        Delete,
+        DuplicateProducesError,
+        Effect,
+        EffectCollisionError,
+        Exclude,
+        Executor,
+        ExternalEffect,
+        Ref,
+        RefResolver,
+        Retire,
+        RowEffect,
+        SpareKeys,
+        Transition,
+        UnresolvedRefError,
+        Update,
+        Upsert,
+        check_disjoint_defaults,
+    )
+    from .executors import CollectingExecutor, InMemoryProjections
+    from .handler import ServerOptions, create_app
+    from .history import (
+        envelope_actor,
+        history_effects,
+        label_marker,
+    )
+    from .jsonl_store import JsonlStreamStore
+    from .migrate import Migration, migrate_all, migrate_stream
+    from .offsets import ForeignOffset
+    from .projections import (
+        project_latest,
+        reconcile_aggregate,
+        reconcile_by_key,
+        reconcile_children,
+        reconcile_tree,
+    )
+    from .protocols import (
+        CursorStore,
+        ProjectionReader,
+        ReadableStore,
+        StreamServerStore,
+        WritableStore,
+    )
+    from .registry import (
+        HANDLERS_META_STREAM,
+        REDUCERS_META_STREAM,
+        UPCASTERS_META_STREAM,
+        HandlerDriftError,
+        HandlerGapError,
+        HandlerOverlapError,
+        HandlerRegistry,
+        HandlerVersion,
+        ReducerVersion,
+        UpcasterChainError,
+        UpcasterConflictError,
+        UpcasterRegistry,
+        UpcasterVersion,
+        get_default_registry,
+        get_default_upcaster_registry,
+        register_handler,
+        register_reducer,
+        register_simple,
+        register_upcaster,
+        reset_default_registries,
+        upcast,
+    )
+    from .replay import ENVELOPE_TS, ReplayResult, TouchedSubject, merge_replay
+    from .seed import seed_stream
+    from .store import StreamStore
+    from .subscription import Poll, PollStatus, poll
+    from .types import (
+        AppendOptions,
+        AppendResult,
+        ClosedBy,
+        CloseResult,
+        ContentTypeMismatch,
+        EmptyJsonArray,
+        InvalidJson,
+        InvalidOffset,
+        ProducerAccepted,
+        ProducerDuplicate,
+        ProducerInvalidEpochSeq,
+        ProducerSequenceGap,
+        ProducerStaleEpoch,
+        ProducerState,
+        ProducerStreamClosed,
+        ProducerValidationResult,
+        SequenceConflict,
+        Stream,
+        StreamConfigConflict,
+        StreamError,
+        StreamMessage,
+        StreamNotFound,
+    )
+
+# `replay` is bound eagerly, and is the one name that has to be.
+#
+# It is the only export whose name is also a submodule name (asserted by
+# `test_public_api.py`), and that collision cannot be resolved lazily. Importing
+# `rakaia.replay` makes the import system set `replay` on this package to the
+# *module*; once that attribute exists, `__getattr__` is never consulted, so
+# `from rakaia import replay` would hand back a module or a function depending
+# on whether anything else in the process had imported the submodule first.
+#
+# Binding here reproduces exactly what the eager version did — the submodule
+# loads, then this rebinds the name to the function, and nothing rebinds it
+# afterwards. The function wins deterministically, which is the documented
+# sharp edge of #161 item 1 and the status quo this change must not alter.
+# The cost is that `rakaia.replay` (framework tier) always loads; measured at
+# well under a millisecond, and it pulls no protocol-server module.
+from .replay import replay
+
+#: name -> the module that defines it.
+_EXPORTS: dict[str, str] = {
+    # App factory
+    "create_app": "rakaia.handler",
+    # "app" is computed, not imported — see __getattr__.
+    # Store
+    "StreamStore": "rakaia.store",
+    "JsonlStreamStore": "rakaia.jsonl_store",
+    "seed_stream": "rakaia.seed",
+    # Moving a log between backends
+    "migrate_stream": "rakaia.migrate",
+    "migrate_all": "rakaia.migrate",
+    "Migration": "rakaia.migrate",
+    # Extension protocols (storage / projection seams)
+    "ReadableStore": "rakaia.protocols",
+    "WritableStore": "rakaia.protocols",
+    "StreamServerStore": "rakaia.protocols",
+    "CursorStore": "rakaia.protocols",
+    "ProjectionReader": "rakaia.protocols",
+    "provenance": "rakaia.context",
+    "get_provenance": "rakaia.context",
+    "append_if_changed": "rakaia.append",
+    "snapshots_equal": "rakaia.append",
+    "history_effects": "rakaia.history",
+    "label_marker": "rakaia.history",
+    "envelope_actor": "rakaia.history",
+    # Options
+    "ServerOptions": "rakaia.handler",
+    "CursorOptions": "rakaia.cursor",
+    # Types
+    "Stream": "rakaia.types",
+    "StreamMessage": "rakaia.types",
+    "ProducerState": "rakaia.types",
+    "ClosedBy": "rakaia.types",
+    "AppendOptions": "rakaia.types",
+    "AppendResult": "rakaia.types",
+    "CloseResult": "rakaia.types",
+    # Producer validation
+    "ProducerValidationResult": "rakaia.types",
+    "ProducerAccepted": "rakaia.types",
+    "ProducerDuplicate": "rakaia.types",
+    "ProducerStaleEpoch": "rakaia.types",
+    "ProducerInvalidEpochSeq": "rakaia.types",
+    "ProducerSequenceGap": "rakaia.types",
+    "ProducerStreamClosed": "rakaia.types",
+    # Store failures (each subclasses the builtin it replaced)
+    "StreamError": "rakaia.types",
+    "StreamNotFound": "rakaia.types",
+    "StreamConfigConflict": "rakaia.types",
+    "SequenceConflict": "rakaia.types",
+    "ContentTypeMismatch": "rakaia.types",
+    "InvalidJson": "rakaia.types",
+    "EmptyJsonArray": "rakaia.types",
+    "ForeignOffset": "rakaia.offsets",
+    "InvalidOffset": "rakaia.types",
+    # Cursor
+    "calculate_cursor": "rakaia.cursor",
+    "generate_response_cursor": "rakaia.cursor",
+    # Versioned handlers — effects
+    "Effect": "rakaia.effects",
+    "AnyEffect": "rakaia.effects",
+    "RowEffect": "rakaia.effects",
+    "Upsert": "rakaia.effects",
+    "Update": "rakaia.effects",
+    "Delete": "rakaia.effects",
+    "Retire": "rakaia.effects",
+    "ExternalEffect": "rakaia.effects",
+    "Exclude": "rakaia.effects",
+    "SpareKeys": "rakaia.effects",
+    "Transition": "rakaia.effects",
+    "Executor": "rakaia.effects",
+    "EffectCollisionError": "rakaia.effects",
+    "DuplicateProducesError": "rakaia.effects",
+    "Ref": "rakaia.effects",
+    "RefResolver": "rakaia.effects",
+    "UnresolvedRefError": "rakaia.effects",
+    "check_disjoint_defaults": "rakaia.effects",
+    "CollectingExecutor": "rakaia.executors",
+    "InMemoryProjections": "rakaia.executors",
+    # Versioned handlers — projections
+    "reconcile_by_key": "rakaia.projections",
+    "reconcile_children": "rakaia.projections",
+    "reconcile_tree": "rakaia.projections",
+    "reconcile_aggregate": "rakaia.projections",
+    "project_latest": "rakaia.projections",
+    # Versioned handlers — registry
+    "register_handler": "rakaia.registry",
+    "register_simple": "rakaia.registry",
+    "register_reducer": "rakaia.registry",
+    "register_upcaster": "rakaia.registry",
+    "HandlerRegistry": "rakaia.registry",
+    "UpcasterRegistry": "rakaia.registry",
+    "HandlerVersion": "rakaia.registry",
+    "ReducerVersion": "rakaia.registry",
+    "REDUCERS_META_STREAM": "rakaia.registry",
+    "UpcasterVersion": "rakaia.registry",
+    "HandlerOverlapError": "rakaia.registry",
+    "HandlerGapError": "rakaia.registry",
+    "HandlerDriftError": "rakaia.registry",
+    "UpcasterConflictError": "rakaia.registry",
+    "UpcasterChainError": "rakaia.registry",
+    "get_default_registry": "rakaia.registry",
+    "get_default_upcaster_registry": "rakaia.registry",
+    "reset_default_registries": "rakaia.registry",
+    "upcast": "rakaia.registry",
+    "HANDLERS_META_STREAM": "rakaia.registry",
+    "UPCASTERS_META_STREAM": "rakaia.registry",
+    # Versioned handlers — replay
+    "replay": "rakaia.replay",
+    "merge_replay": "rakaia.replay",
+    "ENVELOPE_TS": "rakaia.replay",
+    "ReplayResult": "rakaia.replay",
+    "TouchedSubject": "rakaia.replay",
+    "DriftLedger": "rakaia.drift",
+    # Subscriber cursors
+    "poll": "rakaia.subscription",
+    "Poll": "rakaia.subscription",
+    "PollStatus": "rakaia.subscription",
+    # Version
+    # "__version__" is computed, not imported — see __getattr__.
+}
+
+__all__ = [*sorted(_EXPORTS), "app", "__version__"]
 
 
 def _installed_version() -> str:
-    """The version of the installed distribution.
-
-    Read from package metadata rather than declared here, so there is exactly one
-    place the version lives (`pyproject.toml`) instead of two that must be kept in
-    step by hand. They drifted: this literal stayed `"0.1.0"` across 23 commits
-    and several breaking changes, so `rakaia.__version__` reported a number that
-    no longer described the code — to a consumer, confidently.
+    """The installed distribution's version.
 
     The distribution is `rakaia-streams`; the import name is `rakaia` (plain
     `rakaia` was taken on PyPI), so the lookup cannot use `__name__`.
@@ -142,128 +309,35 @@ def _installed_version() -> str:
         return "0.0.0+unknown"
 
 
-__version__ = _installed_version()
+def __getattr__(name: str) -> Any:
+    """Resolve a public name on first use (PEP 562).
 
-# Default ASGI app for uvicorn: `uvicorn rakaia:app`
-app = create_app()
+    The resolved value is cached in `globals()`, so this runs once per name and
+    every later access is an ordinary module attribute. That matters most for
+    `app`: `uvicorn rakaia:app` must get the *same* object every time, and a
+    factory called per access would hand out a new store to each caller.
+    """
+    if name == "app":
+        # The default ASGI app, for `uvicorn rakaia:app`. Built here rather than
+        # at module scope so that importing the framework does not allocate a
+        # server's worth of state — this is the singleton the eager version
+        # created in every process.
+        from .handler import create_app
 
-__all__ = [
-    # App factory
-    "create_app",
-    "app",
-    # Store
-    "StreamStore",
-    "JsonlStreamStore",
-    "seed_stream",
-    # Moving a log between backends
-    "migrate_stream",
-    "migrate_all",
-    "Migration",
-    # Extension protocols (storage / projection seams)
-    "ReadableStore",
-    "WritableStore",
-    "StreamServerStore",
-    "CursorStore",
-    "ProjectionReader",
-    "provenance",
-    "get_provenance",
-    "append_if_changed",
-    "snapshots_equal",
-    "history_effects",
-    "label_marker",
-    "envelope_actor",
-    # Options
-    "ServerOptions",
-    "CursorOptions",
-    # Types
-    "Stream",
-    "StreamMessage",
-    "ProducerState",
-    "ClosedBy",
-    "AppendOptions",
-    "AppendResult",
-    "CloseResult",
-    # Producer validation
-    "ProducerValidationResult",
-    "ProducerAccepted",
-    "ProducerDuplicate",
-    "ProducerStaleEpoch",
-    "ProducerInvalidEpochSeq",
-    "ProducerSequenceGap",
-    "ProducerStreamClosed",
-    # Store failures (each subclasses the builtin it replaced)
-    "StreamError",
-    "StreamNotFound",
-    "StreamConfigConflict",
-    "SequenceConflict",
-    "ContentTypeMismatch",
-    "InvalidJson",
-    "EmptyJsonArray",
-    "ForeignOffset",
-    "InvalidOffset",
-    # Cursor
-    "calculate_cursor",
-    "generate_response_cursor",
-    # Versioned handlers — effects
-    "Effect",
-    "AnyEffect",
-    "RowEffect",
-    "Upsert",
-    "Update",
-    "Delete",
-    "Retire",
-    "ExternalEffect",
-    "Exclude",
-    "SpareKeys",
-    "Transition",
-    "Executor",
-    "EffectCollisionError",
-    "DuplicateProducesError",
-    "Ref",
-    "RefResolver",
-    "UnresolvedRefError",
-    "check_disjoint_defaults",
-    "CollectingExecutor",
-    "InMemoryProjections",
-    # Versioned handlers — projections
-    "reconcile_by_key",
-    "reconcile_children",
-    "reconcile_tree",
-    "reconcile_aggregate",
-    "project_latest",
-    # Versioned handlers — registry
-    "register_handler",
-    "register_simple",
-    "register_reducer",
-    "register_upcaster",
-    "HandlerRegistry",
-    "UpcasterRegistry",
-    "HandlerVersion",
-    "ReducerVersion",
-    "REDUCERS_META_STREAM",
-    "UpcasterVersion",
-    "HandlerOverlapError",
-    "HandlerGapError",
-    "HandlerDriftError",
-    "UpcasterConflictError",
-    "UpcasterChainError",
-    "get_default_registry",
-    "get_default_upcaster_registry",
-    "reset_default_registries",
-    "upcast",
-    "HANDLERS_META_STREAM",
-    "UPCASTERS_META_STREAM",
-    # Versioned handlers — replay
-    "replay",
-    "merge_replay",
-    "ENVELOPE_TS",
-    "ReplayResult",
-    "TouchedSubject",
-    "DriftLedger",
-    # Subscriber cursors
-    "poll",
-    "Poll",
-    "PollStatus",
-    # Version
-    "__version__",
-]
+        value: Any = create_app()
+    elif name == "__version__":
+        value = _installed_version()
+    else:
+        module = _EXPORTS.get(name)
+        if module is None:
+            raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+        import importlib
+
+        value = getattr(importlib.import_module(module), name)
+
+    globals()[name] = value
+    return value
+
+
+def __dir__() -> list[str]:
+    return sorted(__all__)

--- a/src/rakaia/__init__.py
+++ b/src/rakaia/__init__.py
@@ -19,6 +19,7 @@ Usage:
 
 from __future__ import annotations
 
+import threading
 from typing import TYPE_CHECKING, Any
 
 # =============================================================================
@@ -49,6 +50,14 @@ if TYPE_CHECKING:
     # Re-exported for type checkers only: the runtime path is `__getattr__`
     # below, which pyright cannot follow. Every name here is in `_EXPORTS`, and
     # `test_public_api.py` fails if the two ever disagree.
+
+    # The two names `__getattr__` computes rather than imports. Declared as bare
+    # annotations — the standard way to tell a checker that a PEP 562 module
+    # provides a name — because `__all__` listing something with no binding is
+    # `reportUnsupportedDunderAll` otherwise.
+    app: Any
+    __version__: str
+
     from .append import append_if_changed, snapshots_equal
     from .context import get_provenance, provenance
     from .cursor import CursorOptions, calculate_cursor, generate_response_cursor
@@ -309,24 +318,44 @@ def _installed_version() -> str:
         return "0.0.0+unknown"
 
 
+#: Guards the one-time construction of `app`. See `__getattr__`.
+_app_lock = threading.Lock()
+
+
 def __getattr__(name: str) -> Any:
     """Resolve a public name on first use (PEP 562).
 
     The resolved value is cached in `globals()`, so this runs once per name and
-    every later access is an ordinary module attribute. That matters most for
-    `app`: `uvicorn rakaia:app` must get the *same* object every time, and a
-    factory called per access would hand out a new store to each caller.
+    every later access is an ordinary module attribute.
+
+    Only `app` needs the lock. A mapped name resolves through
+    `importlib.import_module`, which is itself serialised and idempotent, so two
+    threads racing for one get the same object either way; the worst case is a
+    duplicated `getattr`. `app` is *constructed* here, and construction is not
+    idempotent — it allocates a `StreamStore`. Without the lock, every thread
+    that got past the cache check built its own, and all but the last were
+    orphaned: live, holding their own log, and unreachable through
+    `rakaia.app`. Measured at 16 threads: 16 stores, 15 of them lost. The eager
+    `app = create_app()` this replaced was serialised by the import lock, so the
+    lock is restoring a property that used to come for free rather than adding
+    one.
     """
     if name == "app":
         # The default ASGI app, for `uvicorn rakaia:app`. Built here rather than
         # at module scope so that importing the framework does not allocate a
         # server's worth of state — this is the singleton the eager version
         # created in every process.
-        from .handler import create_app
+        with _app_lock:
+            # Re-checked inside the lock: a thread that waited here while
+            # another built it must take that one, not build a second.
+            if "app" not in globals():
+                from .handler import create_app
 
-        value: Any = create_app()
-    elif name == "__version__":
-        value = _installed_version()
+                globals()["app"] = create_app()
+            return globals()["app"]
+
+    if name == "__version__":
+        value: Any = _installed_version()
     else:
         module = _EXPORTS.get(name)
         if module is None:

--- a/tests/test_rakaia/test_public_api.py
+++ b/tests/test_rakaia/test_public_api.py
@@ -202,6 +202,129 @@ class TestRakaiaSurface:
         assert [n for n in rakaia.__all__ if n.startswith("_")] == ["__version__"]
 
 
+class TestTheLazyRootResolvesOnce:
+    """`__getattr__` caches into `globals()`, and that caching is the contract.
+
+    Deleting the cache line left the whole suite green while making every
+    `rakaia.app` access mint a fresh app and a fresh `StreamStore` — so the
+    property the module root is *for* had no test at all. These are those tests.
+    """
+
+    def test_a_resolved_name_becomes_a_real_module_attribute(self):
+        """The cache is what makes the *second* access free, and identity alone
+        cannot see it.
+
+        `rakaia.StreamStore is rakaia.StreamStore` passes with the caching line
+        deleted — re-resolving imports an already-imported module and returns
+        the same class object, so the assertion is satisfied by `importlib`
+        being idempotent rather than by anything this module does. What the
+        cache actually promises is that the name stops going through
+        `__getattr__` at all, which is visible in the module dict and nowhere
+        else.
+
+        A subprocess because the check is about the transition from absent to
+        present, and any earlier test in the session may already have resolved
+        the name.
+        """
+        import subprocess
+        import sys
+        import textwrap
+
+        program = textwrap.dedent("""
+            import rakaia
+            print("before" if "StreamStore" not in vars(rakaia) else "PRESENT")
+            rakaia.StreamStore
+            print("after" if "StreamStore" in vars(rakaia) else "MISSING")
+        """)
+        result = subprocess.run(
+            [sys.executable, "-c", program], capture_output=True, text=True, timeout=60
+        )
+
+        assert result.returncode == 0, result.stderr
+        assert result.stdout.split() == ["before", "after"], result.stdout
+
+    def test_a_resolved_name_is_the_submodule_s_own_object(self):
+        """Lazy resolution must hand back the real thing, not a copy or proxy."""
+        from rakaia import store
+
+        assert rakaia.StreamStore is store.StreamStore
+
+    def test_the_app_is_built_once(self):
+        assert rakaia.app is rakaia.app
+
+    def test_the_app_is_built_once_under_concurrent_first_touch(self):
+        """The regression this guards is invisible after the first access.
+
+        `app` is *constructed*, not imported, so before the lock every thread
+        that raced past the cache check built its own — 16 threads gave 16
+        stores, 15 of them orphaned and holding their own log. The eager
+        `app = create_app()` this replaced was serialised by the import lock, so
+        this asserts a property that used to come for free.
+
+        A fresh interpreter per run, because `app` is cached after first touch
+        and the race exists only on the way in.
+        """
+        import subprocess
+        import sys
+        import textwrap
+
+        program = textwrap.dedent("""
+            import threading
+            import rakaia
+
+            start = threading.Barrier(16)
+            seen = []
+
+            def touch():
+                start.wait()
+                seen.append(id(rakaia.app))
+
+            threads = [threading.Thread(target=touch) for _ in range(16)]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join()
+            print(len(set(seen)))
+        """)
+        result = subprocess.run(
+            [sys.executable, "-c", program], capture_output=True, text=True, timeout=60
+        )
+
+        assert result.returncode == 0, result.stderr
+        assert result.stdout.strip() == "1", (
+            f"16 threads saw {result.stdout.strip()} distinct apps; each extra "
+            "one is an orphaned StreamStore holding its own log"
+        )
+
+
+class TestTheLazyRootRefusesWhatItDoesNotExport:
+    """A module `__getattr__` that returns instead of raising makes `hasattr`
+    unconditionally true, which is worse than a missing name — it turns a typo
+    into `None` at the call site rather than an error at the import."""
+
+    def test_an_unknown_name_raises(self):
+        with pytest.raises(AttributeError):
+            rakaia.not_a_real_export  # noqa: B018
+
+    def test_the_error_names_the_module_and_the_attribute(self):
+        with pytest.raises(AttributeError) as exc:
+            rakaia.not_a_real_export  # noqa: B018
+
+        assert "rakaia" in str(exc.value)
+        assert "not_a_real_export" in str(exc.value)
+
+    def test_hasattr_is_false_for_a_name_that_is_not_exported(self):
+        assert not hasattr(rakaia, "not_a_real_export")
+
+    # Deliberately not asserted: that an unexported *submodule* — `read_decision`
+    # and friends — is unreachable as `rakaia.<name>`. It is reachable, once
+    # anything in the process has imported it, because the import system binds a
+    # submodule onto its parent package. That is ordinary Python and is true of
+    # the eager version too (checked on both), so an assertion here would pin
+    # import order rather than this module's surface, and would pass or fail
+    # depending on what else the test session had touched.
+
+
 class TestTheLazyRootAndItsTypeCheckingBlockAgree:
     """The package root resolves exports lazily, so it carries the same list
     twice: `_EXPORTS`, which the runtime uses, and a `TYPE_CHECKING` block, which

--- a/tests/test_rakaia/test_public_api.py
+++ b/tests/test_rakaia/test_public_api.py
@@ -202,6 +202,70 @@ class TestRakaiaSurface:
         assert [n for n in rakaia.__all__ if n.startswith("_")] == ["__version__"]
 
 
+class TestTheLazyRootAndItsTypeCheckingBlockAgree:
+    """The package root resolves exports lazily, so it carries the same list
+    twice: `_EXPORTS`, which the runtime uses, and a `TYPE_CHECKING` block, which
+    is the only thing pyright can follow. Two lists drift.
+
+    Drift here is silent in the worst way. A name missing from the block still
+    *works* — `__getattr__` returns it — but pyright types it as `Any`, so every
+    annotation checked against it stops being checked and nothing goes red. That
+    is also what `pyproject.toml`'s `F401` exemption for this file leans on: ruff
+    can no longer see the block's imports as used, so this is what keeps them
+    honest instead.
+    """
+
+    @staticmethod
+    def _type_checking_imports() -> set[str]:
+        import ast
+        import pathlib
+
+        source = pathlib.Path(rakaia.__file__).read_text()
+        for node in ast.walk(ast.parse(source)):
+            is_guard = (
+                isinstance(node, ast.If)
+                and isinstance(node.test, ast.Name)
+                and node.test.id == "TYPE_CHECKING"
+            )
+            if not is_guard:
+                continue
+            return {
+                alias.asname or alias.name
+                for child in ast.walk(node)
+                if isinstance(child, ast.ImportFrom)
+                for alias in child.names
+            }
+        raise AssertionError("no `if TYPE_CHECKING:` block in rakaia/__init__.py")
+
+    def test_the_block_covers_every_lazily_resolved_name(self):
+        lazily_resolved = set(rakaia._EXPORTS) - {"replay"}
+
+        missing = lazily_resolved - self._type_checking_imports()
+
+        assert not missing, (
+            f"in `_EXPORTS` but not the TYPE_CHECKING block: {sorted(missing)}. "
+            "These still import at runtime, and pyright silently types them "
+            "`Any` — add them to the block."
+        )
+
+    def test_the_block_imports_nothing_that_is_not_exported(self):
+        """The other direction, which ruff used to catch and no longer can."""
+        extra = self._type_checking_imports() - set(rakaia._EXPORTS)
+
+        assert not extra, (
+            f"imported for type checkers but not exported: {sorted(extra)}. "
+            "An unused import in that block is invisible to ruff now that the "
+            "file is F401-exempt."
+        )
+
+    def test_replay_is_bound_eagerly_rather_than_listed_in_the_block(self):
+        """`replay` is the one name that cannot be lazy, so it must not be in
+        the block: it is imported unconditionally, and a second import under
+        `TYPE_CHECKING` would be a redefinition that hides which one wins."""
+        assert "replay" not in self._type_checking_imports()
+        assert "replay" in rakaia._EXPORTS
+
+
 class TestDjangoRakaiaSurface:
     def test_all_is_exactly_the_pinned_set(self):
         import django_rakaia


### PR DESCRIPTION
Reaching for the event-sourcing half of this library used to drag the whole protocol server in with it, and build a stream store in every process that imported it, whether or not anything ever served a request. That was about eighty milliseconds and one unwanted store, for people who wanted neither. Names now resolve when something asks for them, so a consumer loads the half it uses and nothing else.

The other half is a decision. A record from July said the two halves ought to eventually become separate packages, and set a condition for revisiting that; the condition fired a while ago and the question has since been measured twice with the same answer. It is closed rather than deferred a third time — they stay together, and the reasons for splitting have been answered without splitting. New conditions for reopening are written down in place of the spent one.

Closes #191.