### PR TITLE
Stop deciding what another store's positions look like

### DIFF
--- a/docs/adr/0005-stream-positions-stay-a-counted-offset.md
+++ b/docs/adr/0005-stream-positions-stay-a-counted-offset.md
@@ -98,11 +98,15 @@ backwards would violate the protocol's own MUST.
 
 Three further costs are concrete, and two of them were not in the issue:
 
-1. **Our own server would reject a ULID.** `VALID_OFFSET_PATTERN`
-   (`src/rakaia/types.py:66`) is `^(-1|now|\d+(_\d+)?)$` — digits only — and
-   `read_decision.py:183` guards every client-supplied offset with it. It is also
-   the one position rule #206 did not move into `rakaia.offsets`, so it is the
-   first thing any ULID work has to relocate and widen.
+1. **Our own server would reject a ULID.** `VALID_OFFSET_PATTERN` (then in
+   `rakaia.types`) was `^(-1|now|\d+(_\d+)?)$` — digits only — and guarded every
+   client-supplied offset. It was also the one position rule #206 did not move
+   into `rakaia.offsets`, so it was named here as the first thing any ULID work
+   would have to relocate and widen. **Done, 2026-08-26 (#226):** it is
+   `offsets.is_syntactically_valid`, and it now implements §6's actual rule — no
+   forbidden characters, no whitespace, under 256 — rather than enumerating
+   rakaia's own formats. This cost is retired, and it was worth paying whether or
+   not we ever mint a ULID, which is decision 3 below.
 2. **Block allocation is a genuine density dependence.** The bulk-append path
    reserves one contiguous integer block and assigns `start + i`
    (`src/django_rakaia/django_store.py:975-978`). Nothing depends on offsets being
@@ -158,6 +162,13 @@ It is a position rule living outside `rakaia.offsets`, and it is digits-only, so
 would reject a conforming third-party offset a client legitimately holds. Moving
 and widening it is worth doing on its own merits and does not commit us to minting
 ULIDs. Tracked separately rather than folded in here.
+
+> **Done 2026-08-26 (#226).** `offsets.is_syntactically_valid` replaces it and
+> implements §6 rather than an enumeration of our two formats. The guard now
+> refuses only what a URL cannot carry; a token that is merely not *this* store's
+> is refused by the store, with the same 400. Both parts of the claim above held:
+> it did belong in `rakaia.offsets`, and widening it committed us to nothing —
+> the decision to keep counted offsets is unchanged.
 
 ## Alternatives considered
 

--- a/src/rakaia/handler.py
+++ b/src/rakaia/handler.py
@@ -211,10 +211,10 @@ async def _send_producer_response(
 
 # The response header names live in `.read_decision`, the module that decides
 # what a read's headers are; they are imported above and used by the write paths
-# here too. `VALID_OFFSET_PATTERN` lives in `.types` (the single source of truth,
-# #41) and is now read only by `read_decision.read_param_error`. It is a
-# syntactic guard only — an offset's meaning belongs to the store that issued it,
-# and the two stores use different formats.
+# here too. Offset validity lives in `.offsets` with the rest of a position's
+# rules (#206, #226) and is read only by `read_decision.read_param_error`. It is
+# a syntactic guard only — it refuses what a URL cannot carry, and nothing about
+# shape, because an offset's meaning belongs to the store that issued it.
 
 # Strict integer pattern for producer headers
 STRICT_INTEGER_PATTERN = re.compile(r"^\d+$")

--- a/src/rakaia/offsets.py
+++ b/src/rakaia/offsets.py
@@ -53,12 +53,60 @@ from .types import InvalidOffset
 __all__ = [
     "COMPOUND",
     "FORMATS",
+    "MAX_OFFSET_LENGTH",
     "PLAIN",
     "ForeignOffset",
     "OffsetFormat",
     "after",
     "format_of",
+    "is_syntactically_valid",
 ]
+
+#: The longest offset a URL should carry, from `docs/protocol.md` §6 ("Servers
+#: **SHOULD** keep offsets reasonably short (under 256 characters) since they
+#: appear in every request URL").
+MAX_OFFSET_LENGTH = 256
+
+#: The characters §6 forbids outright, because they collide with query-string
+#: syntax and would split one offset into several parameters.
+_FORBIDDEN_IN_OFFSET = frozenset(",&=?/")
+
+
+def is_syntactically_valid(token: str) -> bool:
+    """Whether `token` could be *any* store's offset — not whether it is ours.
+
+    This is the guard a protocol server puts in front of a client-supplied
+    offset, and the whole of what it may check. `docs/protocol.md` §6 gives the
+    rule verbatim: offsets are opaque, case-sensitive single tokens; they **MUST
+    NOT** contain ``,`` ``&`` ``=`` ``?`` ``/``; they **SHOULD** be URL-safe and
+    under 256 characters. Everything past that is the issuing store's business.
+
+    It used to enumerate rakaia's own two formats — a *format* check wearing a
+    *syntax* check's docstring — and that had already failed once. The pattern
+    accepted only the compound form, which was invisible while the server could
+    only be handed the in-memory store; the moment the durable store could back
+    it, every resume 400'd on an offset the server had just issued. Widening it
+    by one format fixed the instance and left the rule. A third-party store
+    minting ULIDs is a supported deployment (`StreamServerStore` is a documented
+    seam with its own conformance suite) and would have hit the same wall.
+
+    **Nothing is let through that was not already refused one layer down.** A
+    token this accepts is handed to the store, and a store rejects one it did
+    not issue — `OffsetFormat.require` raises `ForeignOffset`, which is an
+    `InvalidOffset`, which the handler maps to the same 400. What changes is
+    which layer decides, and the store is the layer the design already names as
+    the authority. What that costs is a store call instead of a regex match for
+    junk, which is real and negligible.
+
+    Whitespace is refused even though §6 does not name it: the spec asks for
+    URL-safe characters, and a token with a space in it is far more likely to be
+    a mangled request than a store's considered choice of format.
+    """
+    if not token or len(token) >= MAX_OFFSET_LENGTH:
+        return False
+    if any(c in _FORBIDDEN_IN_OFFSET for c in token):
+        return False
+    return not any(c.isspace() for c in token)
 
 
 class ForeignOffset(InvalidOffset):
@@ -110,11 +158,12 @@ class OffsetFormat:
         """Whether `token` is one this format issues.
 
         Only a format can answer this, which is why the check cannot be shared
-        across stores as a single syntactic guard. `types.VALID_OFFSET_PATTERN`
-        deliberately accepts **both** shapes — it is the protocol server's guard
-        on what a client may send — so it cannot tell a durable offset from an
-        in-memory one. Nor can `int()`: it reads ``_`` as a digit separator, so
-        the in-memory ``{seq}_{byte}`` parses cleanly into an unrelated number.
+        across stores as a single syntactic guard. `is_syntactically_valid` in
+        this module accepts **any** shape a store might issue — it is the
+        protocol server's guard on what a client may send — so it cannot tell a
+        durable offset from an in-memory one, and does not try. Nor can `int()`:
+        it reads ``_`` as a digit separator, so the in-memory ``{seq}_{byte}``
+        parses cleanly into an unrelated number.
         """
         return bool(self.pattern.match(token))
 

--- a/src/rakaia/offsets.py
+++ b/src/rakaia/offsets.py
@@ -1,9 +1,9 @@
-"""What a stream position is, per store — all five rules in one place each.
+"""What a stream position is — the per-store rules, and the one that is not.
 
-An offset has about five rules: what the first one is, how wide it is, how to
-make the next one, how to tell a valid one, and how to compare two. Both stores
-implement the same idea in different bytes, so there is a real shared shape here;
-it had simply never been written down. Before this module:
+An offset has about five rules *per format*: what the first one is, how wide it
+is, how to make the next one, how to tell one of its own, and how to compare two.
+Every store implements the same idea in different bytes, so there is a real
+shared shape here; it had simply never been written down. Before this module:
 
 * the durable store kept four of its five in `django_rakaia/offsets.py`;
 * the in-memory store had them spread across `types.py` and `store.py`, with the
@@ -41,6 +41,15 @@ that builds a cursor with the wrong store, and a saved cursor that has been
 corrupted or hand-edited. Refusing turns both into an error naming the offset
 instead of a `rewound` result, which claims the log was rebuilt and tells the
 consumer to discard its derived state.
+
+**The sixth rule belongs to no format, and lives here anyway.**
+`is_syntactically_valid` is the protocol server's guard on what a *client* may
+send, and it deliberately knows nothing about shape — it refuses only what a URL
+cannot carry, because §6 makes offsets opaque and a third-party store's format is
+as valid as ours. It is here rather than in `types.py`, where it used to sit
+enumerating our own two formats, because this is where a position's rules live
+(#226); it is not a sixth member of `OffsetFormat`, because it is the one
+question that must be answerable *without* knowing which store issued the token.
 """
 
 from __future__ import annotations

--- a/src/rakaia/read_decision.py
+++ b/src/rakaia/read_decision.py
@@ -48,12 +48,12 @@ import base64
 from dataclasses import dataclass, field
 
 from .json_mode import is_json_content_type
+from .offsets import is_syntactically_valid
 from .types import (
     SSE_CLOSED_FIELD,
     SSE_CURSOR_FIELD,
     SSE_OFFSET_FIELD,
     SSE_UP_TO_DATE_FIELD,
-    VALID_OFFSET_PATTERN,
 )
 
 # Response header names, title-cased by HTTP convention. `rakaia.types` holds
@@ -180,8 +180,8 @@ def read_param_error(
             return 400, b"Empty offset parameter"
         if offset_count > 1:
             return 400, b"Multiple offset parameters not allowed"
-        if not VALID_OFFSET_PATTERN.match(offset):
-            return 400, b"Invalid offset format"
+        if not is_syntactically_valid(offset):
+            return 400, b"Invalid offset"
 
     # Long-poll and SSE both require an explicit offset: without one there is no
     # position to wait from.

--- a/src/rakaia/store.py
+++ b/src/rakaia/store.py
@@ -37,9 +37,9 @@ from .types import (
 )
 
 # This module neither renders nor validates the offset format itself: both are
-# `COMPOUND`'s job (`rakaia.offsets`). It still does not import
-# `VALID_OFFSET_PATTERN` — that is the protocol server's syntactic guard on what
-# a *client* may send, and it accepts both stores' shapes by design (#41), so it
+# `COMPOUND`'s job (`rakaia.offsets`). It still does not use
+# `offsets.is_syntactically_valid` — that is the protocol server's guard on what
+# a *client* may send, and it refuses only what no store could have issued, so it
 # cannot tell a foreign offset from one of ours.
 
 _log = logging.getLogger("rakaia.store")
@@ -705,7 +705,7 @@ class StreamStore:
         store emits, so a resume read returns nothing and the client is told it
         is up to date, having skipped the whole stream. The protocol makes
         offsets opaque rather than uniform (§6), so only the issuing store can
-        judge — `VALID_OFFSET_PATTERN` accepts both formats by design.
+        judge — the server's guard refuses only what no store could have issued.
         """
         COMPOUND.require(offset)
 

--- a/src/rakaia/types.py
+++ b/src/rakaia/types.py
@@ -7,7 +7,6 @@ and protocol constants.
 
 from __future__ import annotations
 
-import re
 from dataclasses import dataclass, field
 from typing import Literal
 
@@ -46,24 +45,11 @@ SSE_CLOSED_FIELD = "streamClosed"
 # Offset format: zero-padded 16-digit numbers separated by underscore
 INITIAL_OFFSET = "0000000000000000_0000000000000000"
 
-# Canonical offset-validation pattern: an opaque digit token — `{digits}` or
-# `{digits}_{digits}` — or the sentinels `-1` (stream start) / `now` (current
-# tail).
-#
-# Both documented offset formats must pass: the in-memory `StreamStore` emits
-# the compound `{seq}_{byte}` form, the durable `DjangoStreamStore` a
-# zero-padded integer. The pattern previously accepted only the compound form,
-# which was invisible while the server could only ever be handed the in-memory
-# store — the moment the durable store backed it, every resume read (`GET
-# ?offset=…`) 400'd on an offset the server itself had just issued.
-#
-# This is a syntactic guard against junk in a URL, nothing more. The protocol
-# mandates that offsets are opaque, not that they share one format (§6), so
-# meaning belongs to the store that issued it (#49, #41). Accepting both formats
-# therefore means a store *will* be handed the other's: each rejects one it did
-# not issue with `InvalidOffset`, rather than reading from whichever position it
-# happens to parse to.
-VALID_OFFSET_PATTERN = re.compile(r"^(-1|now|\d+(_\d+)?)$")
+# `VALID_OFFSET_PATTERN` used to live here. It enumerated rakaia's own two
+# formats, which made it a *format* check wearing a *syntax* check's docstring,
+# and it is now `rakaia.offsets.is_syntactically_valid` — the last of a stream
+# position's rules to move there (#206, #226). Nothing in this module decides
+# what an offset may look like any more.
 
 # Default port for standalone servers
 DEFAULT_PORT = 4437
@@ -119,11 +105,12 @@ class EmptyJsonArray(StreamError, ValueError):
 class InvalidOffset(StreamError, ValueError):
     """An offset is syntactically valid but not one this store can read.
 
-    `VALID_OFFSET_PATTERN` is a syntactic guard shared by every server; it
+    `offsets.is_syntactically_valid` is the guard shared by every server; it
     cannot tell whether a given token is an offset *this* store issued, because
-    the protocol makes offsets opaque rather than uniform (§6). A store that
-    cannot interpret the token must say so, rather than parse it into some
-    other position and read the wrong window.
+    the protocol makes offsets opaque rather than uniform (§6) — it only refuses
+    what no store could have issued. A store that cannot interpret the token
+    must say so, rather than parse it into some other position and read the
+    wrong window.
     """
 
 

--- a/tests/server_store_contract.py
+++ b/tests/server_store_contract.py
@@ -1065,8 +1065,7 @@ class ServerStoreContract:
         """An offset this store did not issue must fail, not resolve to some
         other position.
 
-        `VALID_OFFSET_PATTERN` is a shared *syntactic* guard and cannot tell
-        whose offset a token is — the protocol makes them opaque, not uniform
+        The server's syntactic guard cannot tell whose offset a token is — the protocol makes them opaque, not uniform
         (§6). A store that parses one leniently silently returns the wrong
         window: `int("0_5")` is 5 in Python, so the in-memory store's compound
         offset reads as an unrelated position rather than an error.

--- a/tests/server_store_contract.py
+++ b/tests/server_store_contract.py
@@ -1065,10 +1065,11 @@ class ServerStoreContract:
         """An offset this store did not issue must fail, not resolve to some
         other position.
 
-        The server's syntactic guard cannot tell whose offset a token is — the protocol makes them opaque, not uniform
-        (§6). A store that parses one leniently silently returns the wrong
-        window: `int("0_5")` is 5 in Python, so the in-memory store's compound
-        offset reads as an unrelated position rather than an error.
+        The server's syntactic guard cannot tell whose offset a token is — the
+        protocol makes them opaque, not uniform (§6). A store that parses one
+        leniently silently returns the wrong window: `int("0_5")` is 5 in
+        Python, so the in-memory store's compound offset reads as an unrelated
+        position rather than an error.
         """
         from rakaia.types import InvalidOffset
 

--- a/tests/test_django_rakaia/test_protocol_server.py
+++ b/tests/test_django_rakaia/test_protocol_server.py
@@ -124,8 +124,8 @@ class TestBugsTheDeletedImplementationHad:
     ) -> None:
         """Not the wrong window, and not a 500.
 
-        `VALID_OFFSET_PATTERN` accepts both stores' formats — it has to, since
-        the protocol makes offsets opaque rather than uniform (§6) — so the
+        The server's guard accepts any shape a store might issue — it has to,
+        since the protocol makes offsets opaque rather than uniform (§6) — so the
         compound `{seq}_{byte}` form reaches a durable-backed server looking
         perfectly valid. Python's `int()` would even parse it, treating the
         underscore as a digit separator, and read from an unrelated position:

--- a/tests/test_rakaia/test_offset_patterns.py
+++ b/tests/test_rakaia/test_offset_patterns.py
@@ -1,52 +1,126 @@
-"""Tests for the shared offset/TTL/content-type validation patterns.
+"""Tests for the shared offset/TTL/content-type validation.
 
-``VALID_OFFSET_PATTERN`` is the single source of truth in ``rakaia.types`` and is
-imported by every protocol server (#41). ``VALID_TTL_PATTERN`` /
-``VALID_CONTENT_TYPE_PATTERN`` live in ``rakaia.handler``.
+Offset validity lives in ``rakaia.offsets.is_syntactically_valid`` (#226) — the
+last of a stream position's rules to move there, after #206 moved the other
+four. ``VALID_TTL_PATTERN`` / ``VALID_CONTENT_TYPE_PATTERN`` still live in
+``rakaia.handler``.
+
+**The offset cases assert the request's outcome, not which layer produced it.**
+The old version asserted a regex directly, and that pinned the wrong thing twice
+over: it made the *server's* guard the authority on what an offset may look
+like, and it recorded tokens as "malformed" when the only true statement was "no
+rakaia store issues this shape". A store refuses a token it did not issue with
+`ForeignOffset`, which is an `InvalidOffset`, which the handler maps to 400 — so
+junk that now reaches the store still 400s, one layer later, and the status is
+the contract.
 """
 
 from __future__ import annotations
 
 import pytest
 
+from rakaia import StreamStore
 from rakaia.handler import VALID_CONTENT_TYPE_PATTERN, VALID_TTL_PATTERN
-from rakaia.types import VALID_OFFSET_PATTERN
+from rakaia.offsets import MAX_OFFSET_LENGTH, is_syntactically_valid
+from tests.asgi_client import asgi_client
 
 
-class TestValidOffsetPattern:
-    @pytest.mark.parametrize("value", ["-1", "now", "0_0", "123_456", "999999_0"])
-    def test_accepts_canonical_and_sentinels(self, value: str) -> None:
-        assert VALID_OFFSET_PATTERN.match(value)
+async def _status_for_offset(offset: str) -> int:
+    """The status a real GET carrying this raw offset returns, end to end."""
+    store = StreamStore()
+    store.create("/s")
+    store.append("/s", b'{"n": 1}')
+    async with asgi_client(store) as client:
+        return (await client.get(f"/s?offset={offset}")).status_code
 
-    @pytest.mark.parametrize("value", ["1", "00000000000000000001", "42"])
-    def test_accepts_the_durable_stores_plain_integer_format(self, value: str) -> None:
-        """A bare integer is `DjangoStreamStore`'s offset format.
 
-        This used to be asserted as malformed, which was harmless only while
-        the server could not be handed that store. Once it could, every resume
-        read 400'd on an offset the server had just issued itself. The protocol
-        makes offsets opaque, not one format (§6).
-        """
-        assert VALID_OFFSET_PATTERN.match(value)
+class TestAnOffsetNoStoreCouldHaveIssuedIsRefused:
+    """The guard's whole remaining job: reject what a URL cannot carry."""
+
+    @pytest.mark.parametrize("char", [",", "&", "=", "?", "/"])
+    def test_the_five_characters_the_spec_forbids(self, char: str) -> None:
+        """`docs/protocol.md` §6 names these exactly, because each would split
+        one offset into several query parameters."""
+        assert not is_syntactically_valid(f"12{char}34")
+
+    @pytest.mark.parametrize("value", ["", " ", "0_0 ", " 0_0", "a\tb", "a\nb"])
+    def test_empty_and_whitespace(self, value: str) -> None:
+        """§6 does not name whitespace, but it asks for URL-safe characters, and
+        a token with a space in it is a mangled request rather than a store's
+        considered choice of format."""
+        assert not is_syntactically_valid(value)
+
+    def test_the_length_ceiling(self) -> None:
+        assert is_syntactically_valid("9" * (MAX_OFFSET_LENGTH - 1))
+        assert not is_syntactically_valid("9" * MAX_OFFSET_LENGTH)
+
+
+class TestAnOffsetSomeStoreMightHaveIssuedIsPassedOn:
+    """What #226 asked for: the guard stops enumerating rakaia's own formats.
+
+    Every value here was refused at the URL layer before, on the grounds that it
+    is neither of our two shapes — which made `StreamServerStore`, a documented
+    seam with its own conformance suite, a promise the server itself broke.
+    """
 
     @pytest.mark.parametrize(
         "value",
         [
-            "",
-            "1_",  # missing byte
-            "_1",  # missing seq
-            "1_2_3",  # too many components
-            "-2",  # only -1 is a valid sentinel
-            "NOW",  # case-sensitive
-            "1_-2",  # negative byte
+            "01ARZ3NDEKTSV4RRFFQ69G5FAV",  # a ULID; §6 names them as acceptable
             "abc",
             "1.2",
-            " 0_0",  # leading space
-            "0_0 ",  # trailing space
+            "-2",
+            "NOW",
+            "1_",
+            "_1",
+            "1_2_3",
+            "1_-2",
         ],
     )
-    def test_rejects_malformed(self, value: str) -> None:
-        assert VALID_OFFSET_PATTERN.match(value) is None
+    def test_an_unfamiliar_shape_reaches_the_store(self, value: str) -> None:
+        assert is_syntactically_valid(value)
+
+    @pytest.mark.parametrize(
+        "value", ["abc", "1.2", "-2", "01ARZ3NDEKTSV4RRFFQ69G5FAV"]
+    )
+    async def test_and_the_store_still_makes_it_a_400(self, value: str) -> None:
+        """Passing the guard is not passing the request. This is what makes
+        widening the guard safe rather than merely tidier."""
+        assert await _status_for_offset(value) == 400
+
+
+class TestWhatTheStoresActuallyIssueStillWorks:
+    @pytest.mark.parametrize("value", ["-1", "now", "0_0", "123_456", "999999_0"])
+    def test_the_in_memory_format_and_the_sentinels(self, value: str) -> None:
+        assert is_syntactically_valid(value)
+
+    @pytest.mark.parametrize("value", ["1", "00000000000000000001", "42"])
+    def test_the_plain_integer_format(self, value: str) -> None:
+        """Shared by `DjangoStreamStore` and `JsonlStreamStore`.
+
+        Asserted as malformed once, which was harmless only while the server
+        could not be handed either store. The moment it could, every resume read
+        400'd on an offset the server had just issued itself — this issue's own
+        precedent, and the reason the rule stopped enumerating formats.
+        """
+        assert is_syntactically_valid(value)
+
+    async def test_a_real_resume_round_trips(self) -> None:
+        """The control for the whole file: an offset the store *did* issue is
+        read back, so none of the above passes by refusing everything."""
+        store = StreamStore()
+        store.create("/s", content_type="application/json")
+        store.append("/s", b'{"n": 1}')
+        head = store.get_current_offset("/s")
+        store.append("/s", b'{"n": 2}')
+
+        async with asgi_client(store) as client:
+            response = await client.get(f"/s?offset={head}")
+
+        assert response.status_code == 200
+        # The second message only: the offset resolved to a real position rather
+        # than to the start of the stream.
+        assert response.json() == [{"n": 2}]
 
 
 class TestValidTtlPattern:

--- a/tests/test_rakaia/test_offset_patterns.py
+++ b/tests/test_rakaia/test_offset_patterns.py
@@ -50,6 +50,17 @@ class TestAnOffsetNoStoreCouldHaveIssuedIsRefused:
         considered choice of format."""
         assert not is_syntactically_valid(value)
 
+    def test_the_ceiling_is_the_one_the_spec_names(self) -> None:
+        """The literal, not the constant.
+
+        Asserting the guard against `MAX_OFFSET_LENGTH` only proves the two
+        agree; the constant could be moved to 40 or 1024 and every other case
+        here would still pass. 40 would refuse exactly the conforming
+        third-party offset this change exists to admit, so the number is the
+        thing worth pinning.
+        """
+        assert MAX_OFFSET_LENGTH == 256, "docs/protocol.md §6: 'under 256'"
+
     def test_the_length_ceiling(self) -> None:
         assert is_syntactically_valid("9" * (MAX_OFFSET_LENGTH - 1))
         assert not is_syntactically_valid("9" * MAX_OFFSET_LENGTH)

--- a/tests/test_rakaia/test_read_decision.py
+++ b/tests/test_rakaia/test_read_decision.py
@@ -189,10 +189,16 @@ class TestTheParameterRefusals:
             b"Multiple offset parameters not allowed",
         )
 
-    def test_an_unparseable_offset_is_400(self):
+    def test_an_offset_no_store_could_have_issued_is_400(self):
+        """The body says `Invalid offset`, not `Invalid offset format`.
+
+        The guard no longer knows anything about *format* — it refuses only what
+        a URL cannot carry (#226), here a space. A token that is merely not this
+        store's is refused by the store, with the same status.
+        """
         assert read_param_error(offset="not an offset!", live=None) == (
             400,
-            b"Invalid offset format",
+            b"Invalid offset",
         )
 
     @pytest.mark.parametrize(

--- a/tests/test_rakaia/test_store_failures.py
+++ b/tests/test_rakaia/test_store_failures.py
@@ -326,8 +326,9 @@ class TestFailureBecomesStatus:
         whose offsets are compound.
 
         The syntactic guard admits plain integers — it admits any shape a store
-        might issue (#226) — so it no longer rejects this before the store does — the store's `InvalidOffset` must come back as a 400,
-        not crash an already-started SSE response.
+        might issue (#226) — so it no longer rejects this before the store does.
+        The store's `InvalidOffset` must come back as a 400, not crash an
+        already-started SSE response.
         """
         await client.put("/s")
         r = await client.get("/s", params={"offset": "42", "live": "sse"})

--- a/tests/test_rakaia/test_store_failures.py
+++ b/tests/test_rakaia/test_store_failures.py
@@ -325,9 +325,8 @@ class TestFailureBecomesStatus:
         """The unpatched end-to-end case: `?offset=42&live=sse` on a store
         whose offsets are compound.
 
-        `VALID_OFFSET_PATTERN` now admits plain integers (they are the durable
-        store's format), so the syntactic guard no longer rejects this before
-        the store does — the store's `InvalidOffset` must come back as a 400,
+        The syntactic guard admits plain integers — it admits any shape a store
+        might issue (#226) — so it no longer rejects this before the store does — the store's `InvalidOffset` must come back as a 400,
         not crash an already-started SSE response.
         """
         await client.put("/s")


### PR DESCRIPTION
The check in front of our server was described as a guard against junk in a web address, and was really a list of our own two position formats. Rakaia invites people to plug their own storage in behind the same server — and now ships three examples of doing so — but any storage that numbers positions differently would have had its positions turned away before it was ever asked, on the grounds that they do not look like ours.

This has already happened in-house, which is the reason to fix the rule rather than the case. The list once held only the in-memory format; that was harmless right up to the moment the database-backed store could sit behind the server, at which point every resume failed on a position the server had itself just issued. It was fixed by adding a format to the list.

The rule now says what the specification says, and nothing about shape. Widening it is safe because a store still refuses a position it did not issue, with the same status — what changes is which layer decides, and the store is the layer the design already names as the authority.

Closes #226.