### PR TITLE
The translations demo keeps its log in files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,10 @@ htmlcov/
 django_rakaia_dev.db
 db.sqlite3
 
+# The polyglot sample's event log: a folder of JSON-lines files, written at
+# runtime the way db.sqlite3 above is.
+examples/polyglot/streams/
+
 # Collected static files (chat sample → WhiteNoise)
 examples/chat/staticfiles/
 
@@ -57,3 +61,4 @@ conformance-server.log
 
 # Agent worktrees — transient checkouts, never part of the tree
 .claude/worktrees/
+.gstack/

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -71,7 +71,7 @@ Real-time demos — run the server, open the URL, watch events stream in.
 | Example | Proves | Run |
 |---|---|---|
 | [`chat`](https://github.com/joshbrooks/rakaia/tree/main/examples/chat) | `@stream_model`, multi-stream events per save, live SSE fan-out | `just dev` → `http://localhost:8000` |
-| [`polyglot`](https://github.com/joshbrooks/rakaia/tree/main/examples/polyglot) | Language-scoped streams, live-editable translations over SSE | `just polyglot-dev` → `http://localhost:8001` |
+| [`polyglot`](https://github.com/joshbrooks/rakaia/tree/main/examples/polyglot) | Language-scoped streams, live-editable translations over SSE, served from the file-backed store with no database log and no channel layer | `just polyglot-dev` → `http://localhost:8001` |
 
 ### Headless event-sourcing (Django, scripted)
 
@@ -160,9 +160,10 @@ example exercises it yet (see [known gaps](#known-gaps)).
 
 | Concept | Demonstrated by |
 |---|---|
-| `@stream_model`, `create_stream_event`, multi-stream events | `chat`, `polyglot` |
-| Live SSE broadcast (Channels) | `chat`, `polyglot` |
+| `@stream_model`, `create_stream_event`, multi-stream events | `chat` |
+| Live SSE broadcast (Channels) | `chat` |
 | Durable `DjangoStreamStore` (log persisted in the DB) | `formkit_submissions` (stream) |
+| File-backed `JsonlStreamStore` under Django, with the protocol server mounted alongside it for live SSE | `polyglot` |
 
 ### Known gaps
 
@@ -181,7 +182,8 @@ No example exercises these yet — a good place to contribute a demo:
 Django project:
 
 - `<name>_project/settings.py` — `INSTALLED_APPS` includes `django_rakaia` and
-  the example app; `RAKAIA_STORE` selects the in-memory or durable store.
+  the example app; `RAKAIA_STORE` selects the in-memory, durable or
+  file-backed store.
 - `<app>/models.py` — the projection tables (the *derived* state).
 - `<app>/handlers.py` — the pure `event → Effect` handlers, registered with
   `@register_handler` / `@register_simple` / `@register_reducer`.

--- a/docs/translations.md
+++ b/docs/translations.md
@@ -24,10 +24,13 @@ icon: lucide/languages
 demonstration of the part rakaia actually provides: **one row changes, every
 connected browser sees it**, without polling.
 
-- A `post_save` receiver calls `create_stream_event` to fan the change out to a
-  per-language stream (`translations:tet`, `translations:pt`, …), so a client
-  subscribes to just the language it is showing.
-- The SSE endpoint delivers those events to the browser.
+- A `post_save` receiver appends the change to a per-language stream
+  (`/translations/tet`, `/translations/pt`, …), so a client subscribes to just
+  the language it is showing.
+- The log is a folder of files rather than database rows — the example runs on
+  the [file-backed store](store-streams-in-files.md) — and live delivery comes
+  from rakaia's protocol server, mounted alongside Django, tailing that folder.
+  No channel layer and no message broker are involved.
 - The model itself mirrors the `gettext` family (`gettext`, `ngettext`,
   `pgettext`, `npgettext`) with a database-backed manager, so a translation can
   be edited without a deploy.

--- a/examples/polyglot/README.md
+++ b/examples/polyglot/README.md
@@ -1,9 +1,13 @@
 # Polyglot — live-editable translations over SSE
 
 A marketing landing page where every visible string is a `Translatable`
-row. The right pane is a translation editor; saving a string broadcasts
-a StreamEvent over `translations:{langcode}` and every browser pinned to
+row. The right pane is a translation editor; saving a string appends a
+JSON record to `/translations/{langcode}` and every browser pinned to
 that language updates in place.
+
+The log is not in the database. It is a folder of ordinary JSON-lines
+files under `examples/polyglot/streams/`, which you can `tail -f` while
+the demo runs.
 
 ## Run
 
@@ -33,54 +37,48 @@ and pushes an event down every open EventSource. Leave a tab open at
 `/?lang=tet` and watch the left pane thrash. Originals are restored when
 the run ends (or on Ctrl-C) unless you pass `--no-restore`.
 
-The saves are POSTed to the running server, the same request the Save
-button makes — deliberately, because live delivery goes through the
-channel layer and `just polyglot-dev` uses `InMemoryChannelLayer`, which
-is in-memory to *one process*. `--direct` writes via the ORM with no
-server running; the events are still durable and replay on the next
-connect, but nothing arrives live under an in-memory layer.
+The saves are POSTed to the running server by default, the same request
+the Save button makes. `--direct` writes via the ORM instead, from a
+process of its own — and open browsers still update, because readers tail
+the log through the filesystem rather than waiting on a channel layer.
+That used to be the one thing `--direct` could not do.
 
 ### What limits it
 
 Numbers below are 400 `--direct` saves on one laptop — indicative, not a
-benchmark. Each save is ~10 queries: the row `UPDATE`, then an event, an
-offset allocation and a stream entry.
+benchmark. Each save is now two writes to two places: the `Translatable`
+row `UPDATE` in SQLite, and one line appended to a file.
 
-| | 1 writer | 12 writers, 1 stream | 12 writers, 3 streams |
-|---|---|---|---|
-| SQLite, stock pragmas | 41/s | *"database is locked"* | *"database is locked"* |
-| SQLite, WAL (what this app now uses) | 374/s | 220/s | 241/s |
-| Postgres 16 (container, loopback) | 85/s | 176/s | 363/s |
+| | 1 writer | 12 writers, 1 stream |
+|---|---|---|
+| log on disk, fsync on (the default) | 73/s | 84/s |
+| log on disk, fsync off | 195/s | — |
+| log on `/dev/shm`, fsync off | 242/s | 232/s |
 
-Three things that turned out to matter, in order:
+Two things about that shape:
 
-1. **SQLite's default `journal_mode=delete` + `synchronous=FULL`.** Two
-   fsyncs per save — the row `UPDATE` autocommits, then the event append
-   opens its own transaction — for ~24ms of the ~26ms. WAL plus
-   `synchronous=NORMAL` is a 9x win and is now set in `settings.py`.
-2. **Concurrent writers used to fail outright**, instantly, not after
-   `timeout`: a deferred transaction that reads before it writes cannot
-   upgrade to a write lock, and SQLite does not retry the upgrade. Fixed
-   with `transaction_mode: "IMMEDIATE"`.
-3. **Appends to one stream path serialize on that path's offset
-   high-water**, by design — offsets per path are a gapless ordered
-   sequence, so allocating one takes a row lock. On Postgres that is the
-   *only* thing serializing, which is why spreading the same 12 writers
-   across three langcodes doubles throughput. On SQLite it is moot: one
-   writer at a time for the whole file, so splitting streams buys nothing.
+1. **Concurrency buys almost nothing.** Writers to one stream take an
+   exclusive `flock` on that stream's directory for the whole
+   check-then-write, so appends to a path serialize — the same property
+   the database-backed store gets from `select_for_update()` on the
+   stream row. Spreading writers across langcodes would help; twelve
+   writers on one will not.
+2. **The default is slower than the database-backed store was**, which
+   managed 374/s here. That is not a like-for-like comparison: SQLite in
+   WAL with `synchronous=NORMAL` does not fsync on commit, so those
+   events survived a crashed process but not a power cut. This store
+   fsyncs every append by default and so survives both. Turn it off with
+   `POLYGLOT_STREAM_FSYNC=0` and the gap mostly closes.
 
-So Postgres is worse at one writer (85/s — ten network round trips beat
-ten in-process ones) and better the moment there is more than one, with
-the ceiling set by how many distinct stream paths you are writing to.
-To try it:
+To move the log somewhere else, or into memory:
 
 ```sh
-just pg-up
-export POLYGLOT_DB=postgres PGHOST=127.0.0.1 PGPORT=55432 \
-       PGUSER=postgres PGPASSWORD=postgres PGDATABASE=postgres
-uv run python manage.py migrate
-uv run python manage.py stress_translations --direct -c 8
+POLYGLOT_STREAM_ROOT=/dev/shm/polyglot POLYGLOT_STREAM_FSYNC=0 just polyglot-dev
 ```
+
+`POLYGLOT_DB=postgres` still switches the database (see `settings.py`),
+but it now only moves the `Translatable` row — the log stays in files
+wherever `POLYGLOT_STREAM_ROOT` points.
 
 The HTTP path (the default, no `--direct`) tops out around 137/s and is
 flat in `--concurrency`: `urllib` opens a fresh connection per request,
@@ -93,11 +91,23 @@ rather the point of running the stress command with a tab open.
 * `polyglot/strings.py` — the catalog of msgids the page renders, plus
   default translations per language. The view seeds rows on first hit.
 * `polyglot/signals.py` — `post_save` / `post_delete` on `Translatable`
-  call `create_stream_event(stream_paths=[f"translations:{langcode}"], …)`.
-  No decorator on the library model — the demo wires its own signal so
-  the library stays unopinionated.
-* `polyglot/templates/polyglot/landing.html` — split layout, EventSource
-  subscribed to the per-langcode stream, DOM updates by `data-msgid`.
+  append a JSON record to `/translations/{langcode}` through
+  `get_store()`, which `RAKAIA_STORE = "jsonl"` resolves to the
+  file-backed store. Not `create_stream_event`: that writes `StreamEvent`
+  rows directly and never consults the setting. No decorator on the
+  library model either — the demo wires its own signal so the library
+  stays unopinionated.
+* `polyglot_project/asgi.py` — Django, plus rakaia's protocol server
+  mounted on `/protocol/` over the same folder. This is what serves SSE.
+  Django's own SSE endpoint replays from `StreamEntry` rows and waits on
+  the channel layer, and neither exists here; the protocol server reads
+  through the store interface and blocks in `wait_for_messages`, which
+  the file-backed store answers by watching the directory.
+* `polyglot/templates/polyglot/landing.html` — split layout, an
+  `EventSource` on `/protocol/translations/{lang}?live=sse&offset=0`,
+  DOM updates by `data-msgid`. The frames are the protocol server's
+  named `data` / `control` pair, not the single unnamed frame Django's
+  endpoint sends.
 
 ## Production-style run
 
@@ -105,6 +115,14 @@ rather the point of running the stress command with a tab open.
 just polyglot-serve workers=4
 ```
 
-Uses `polyglot_project.settings_prod` (DEBUG=False, channels-redis,
-WhiteNoise CompressedManifest). Redis is started via podman by the
-`redis-up` recipe.
+Uses `polyglot_project.settings_prod` (DEBUG=False, WhiteNoise
+CompressedManifest). Four workers all serve live updates from one log
+with no message broker between them: writers coordinate with `flock` on
+the stream directory and readers tail the files. Redis is still started
+by the `redis-up` recipe and the channel layer is still configured, but
+nothing in this demo rides on it any more.
+
+That works because every worker is on one machine. `flock` is not
+dependable over NFS or another network filesystem, so this arrangement
+does not stretch across hosts — that is what the database-backed store
+is for.

--- a/examples/polyglot/polyglot/management/commands/stress_translations.py
+++ b/examples/polyglot/polyglot/management/commands/stress_translations.py
@@ -5,22 +5,19 @@ A human editing the right-hand pane produces one event every few seconds. That
 tells you the wiring is connected; it tells you nothing about what happens when
 events arrive faster than a browser can paint. This command is the other end of
 that range: N saves as fast as the stack will take them, every one of them a
-`StreamEvent` fanned out to `translations:{langcode}` and pushed down every open
+record appended to `/translations/{langcode}` and tailed down every open
 EventSource.
 
 By default the saves go through the running server's `update_translation` view
-over HTTP, exactly as the editor pane does. That matters more than it looks:
-live delivery happens through the channel layer, and under `just polyglot-dev`
-that layer is `InMemoryChannelLayer` — in-memory to *one process*. A management
-command that wrote to the database directly would append perfectly good events
-that no connected browser would ever see, because the runserver process never
-hears about them. Posting to the server puts the save inside the process the
-browsers are attached to, so the demo works under `polyglot-dev` (in-memory) and
-`polyglot-serve` (channels-redis) alike.
+over HTTP, exactly as the editor pane does.
 
-`--direct` is the escape hatch: save via the ORM, no server required. The events
-are still durable, so a browser that connects afterwards replays them from
-`Last-Event-ID` — but nothing arrives live under an in-memory channel layer.
+`--direct` skips the server and saves via the ORM. It used to be an escape hatch
+whose events no browser ever saw live: delivery went through the channel layer,
+and under `just polyglot-dev` that layer was `InMemoryChannelLayer` — in-memory
+to *one process*, so a save made anywhere but inside the runserver process was
+invisible until a reconnect. That is no longer true. The log is a folder of
+files and live readers tail it through the filesystem, so `--direct` reaches
+every open browser from a completely separate process.
 
 Usage:
 
@@ -176,8 +173,9 @@ class Command(BaseCommand):
             action="store_true",
             help=(
                 "Save via the ORM instead of posting to the server. No server "
-                "needed, but under an in-memory channel layer no connected "
-                "browser sees the events live."
+                "needed to write, and open browsers still see the events live: "
+                "readers tail the log through the filesystem, not the channel "
+                "layer."
             ),
         )
         parser.add_argument(
@@ -307,7 +305,7 @@ class Command(BaseCommand):
             self.style.SUCCESS(
                 f"{done} saves in {elapsed:.1f}s "
                 f"({done / max(elapsed, 1e-9):.0f}/s), "
-                f"{done} events appended to translations:{langcode}."
+                f"{done} events appended to /translations/{langcode}."
             )
         )
         if failures:

--- a/examples/polyglot/polyglot/signals.py
+++ b/examples/polyglot/polyglot/signals.py
@@ -1,26 +1,49 @@
-"""Emit per-langcode SSE events when Translatable rows change.
+"""Append a JSON record to the per-langcode stream when a Translatable changes.
 
-We don't decorate the library's `Translatable` model itself — that would
-push demo concerns into the library. Instead the polyglot app subscribes
-its own post_save / post_delete handlers and broadcasts to:
+We don't decorate the library's `Translatable` model itself — that would push
+demo concerns into the library. Instead the polyglot app subscribes its own
+post_save / post_delete handlers and appends to:
 
-    translations:{langcode}
+    /translations/{langcode}
 
-so a browser pinned to one language only receives updates for that
-language.
+so a browser pinned to one language only receives updates for that language.
+
+**Why this writes to the store rather than calling `create_stream_event`.**
+`create_stream_event` is the ORM door: it writes `StreamEvent` and `StreamEntry`
+rows directly and never consults `RAKAIA_STORE`, so with the file-backed store
+selected it would keep filling the database while the log this app now serves
+from stayed empty. Appending through `get_store()` is what makes the setting
+load-bearing. The cost is that this demo gives up the envelope the ORM door
+builds — provenance, and the fan-out of one event into several streams — for a
+plain JSON record, which is all the page renders anyway.
+
+The path is a protocol path (`/translations/tet`), not the old
+`translations:tet`, because the protocol server routes on the URL path verbatim:
+the stream id and the URL that reads it are the same string.
 """
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+import contextlib
+import json
+from dataclasses import asdict, dataclass
 from typing import cast
 
 from django.db import models
 from django.db.models.signals import post_delete, post_save
 from django.dispatch import receiver
 
-from django_rakaia import create_stream_event
+from django_rakaia.store import get_store
 from polyglot.models import Translatable
+from rakaia import AppendOptions, StreamConfigConflict
+
+#: JSON so the protocol server sends the record as text over SSE rather than
+#: base64, and so an append that is not valid JSON is refused at the door.
+CONTENT_TYPE = "application/json"
+
+
+def stream_path(langcode: str) -> str:
+    return f"/translations/{langcode}"
 
 
 @dataclass
@@ -30,9 +53,10 @@ class TranslationPayload:
     msgstr: str
     langcode: str
     msgctxt: str | None
+    action: str
 
 
-def _to_payload(obj: models.Model) -> TranslationPayload:
+def _to_payload(obj: models.Model, action: str) -> TranslationPayload:
     t = cast(Translatable, obj)
     return TranslationPayload(
         id=t.pk,
@@ -40,7 +64,28 @@ def _to_payload(obj: models.Model) -> TranslationPayload:
         msgstr=t.msgstr or "",
         langcode=t.langcode,
         msgctxt=t.msgctxt,
+        action=action,
     )
+
+
+def ensure_stream(path: str) -> None:
+    """Create `path` if it isn't there yet, tolerating a concurrent creator.
+
+    `create` is idempotent when the configuration matches, so the ordinary
+    second call is a cheap read of `meta.json`. A `StreamConfigConflict` here
+    can only mean a stream of this name already exists with different settings —
+    left over from an earlier run of the demo — which is not worth failing a
+    save over.
+    """
+    with contextlib.suppress(StreamConfigConflict):
+        get_store().create(path, content_type=CONTENT_TYPE)
+
+
+def _append(instance: Translatable, action: str) -> None:
+    path = stream_path(instance.langcode)
+    ensure_stream(path)
+    record = json.dumps(asdict(_to_payload(instance, action))).encode()
+    get_store().append(path, record, AppendOptions(label=action))
 
 
 @receiver(post_save, sender=Translatable)
@@ -55,12 +100,7 @@ def _translatable_saved(
     # this, every `loaddata` row appends a phantom event (issue #80).
     if kwargs.get("raw"):
         return
-    create_stream_event(
-        stream_paths=[f"translations:{instance.langcode}"],
-        to_dataclass=_to_payload,
-        instance=instance,
-        action="create" if created else "update",
-    )
+    _append(instance, "create" if created else "update")
 
 
 @receiver(post_delete, sender=Translatable)
@@ -69,9 +109,4 @@ def _translatable_deleted(
     instance: Translatable,
     **kwargs,  # noqa: ARG001
 ) -> None:
-    create_stream_event(
-        stream_paths=[f"translations:{instance.langcode}"],
-        to_dataclass=_to_payload,
-        instance=instance,
-        action="delete",
-    )
+    _append(instance, "delete")

--- a/examples/polyglot/polyglot/templates/polyglot/landing.html
+++ b/examples/polyglot/polyglot/templates/polyglot/landing.html
@@ -195,7 +195,7 @@
             </div>
         </header>
         <p style="color: var(--muted); font-size: 0.85em; font-family: system-ui, sans-serif;">
-            Stream: <code>{{ stream_id }}</code> — edits broadcast over SSE.
+            Stream: <code>{{ stream_id }}</code> — edits land in the log and are tailed over SSE.
         </p>
         <form id="editor-form" onsubmit="return false;">
             {% csrf_token %}
@@ -289,8 +289,18 @@
         // later refresh then logs "connection interrupted while page was
         // loading" because, as far as the browser is concerned, the page
         // never finished loading. Opening after `load` sidesteps that.
+        // The stream id IS the URL path the protocol server routes on, so it
+        // is appended to the mount point rather than encoded into a parameter.
+        // `live=sse` selects SSE, and `offset` is mandatory with it — there is
+        // no position to wait from otherwise, and the server answers a request
+        // without one with a 400. `offset=0` replays the whole log before
+        // blocking for more, which is what makes a reconnect converge: an
+        // EventSource reopens the same URL, and replaying every record in order
+        // leaves the preview holding the current value of each string.
+        // `offset=now` would be cheaper and would silently keep whatever the
+        // pane was showing when the connection dropped.
         const streamId = "{{ stream_id|escapejs }}";
-        const url = `/streams/api/streams/${encodeURIComponent(streamId)}/sse/`;
+        const url = `{{ protocol_prefix|escapejs }}${streamId}?live=sse&offset=0`;
         const liveEl = document.getElementById("live");
         const previewRoot = document.querySelector("section.preview");
         let es = null;
@@ -299,20 +309,27 @@
             es = new EventSource(url);
             es.onopen = () => liveEl.classList.remove("disconnected");
             es.onerror = () => liveEl.classList.add("disconnected");
-            es.onmessage = (msg) => {
-                let payload;
-                try { payload = JSON.parse(msg.data); } catch { return; }
-                const event = payload.event || payload;
-                const data = event.data || {};
-                const msgid = data.msgid;
-                if (!msgid) return;
-                // SSE only writes into the preview pane. Editor inputs are
-                // locally controlled — letting SSE replays touch them would
-                // resurrect stale values on every reconnect.
-                previewRoot
-                    .querySelectorAll(`[data-msgid="${CSS.escape(msgid)}"]`)
-                    .forEach(el => { el.textContent = data.msgstr || ""; });
-            };
+            // Named events, not `onmessage`. The protocol server emits an
+            // `event: data` frame per record and pairs each with an
+            // `event: control` frame carrying the offset and whether we are
+            // caught up; an unnamed `message` never arrives, so `onmessage`
+            // would sit silent forever.
+            es.addEventListener("data", (msg) => {
+                let records;
+                try { records = JSON.parse(msg.data); } catch { return; }
+                // The stream's content type is application/json, so the server
+                // frames a range as a JSON array — here always of one record.
+                for (const data of records) {
+                    const msgid = data.msgid;
+                    if (!msgid) continue;
+                    // SSE only writes into the preview pane. Editor inputs are
+                    // locally controlled — letting SSE replays touch them would
+                    // resurrect stale values on every reconnect.
+                    previewRoot
+                        .querySelectorAll(`[data-msgid="${CSS.escape(msgid)}"]`)
+                        .forEach(el => { el.textContent = data.msgstr || ""; });
+                }
+            });
         }
 
         function closeStream() {

--- a/examples/polyglot/polyglot/views.py
+++ b/examples/polyglot/polyglot/views.py
@@ -2,15 +2,16 @@
 
 Visiting `/?lang=<code>` renders the marketing page using Translatable rows.
 The right-hand pane is an editor — saving a row triggers a post_save
-signal (see signals.py) that emits a StreamEvent into
-`translations:{langcode}`. Browsers tuned to that langcode update in
-place.
+signal (see signals.py) that appends a JSON record to
+`/translations/{langcode}`. Browsers tuned to that langcode update in
+place, over SSE served by the protocol server mounted in asgi.py.
 
 First request seeds the catalog so the page is never blank.
 """
 
 from __future__ import annotations
 
+from django.conf import settings
 from django.http import HttpRequest, HttpResponse
 from django.shortcuts import redirect, render
 from django.urls import reverse
@@ -18,6 +19,7 @@ from django.views.decorators.http import require_http_methods
 
 from polyglot.models import Translatable
 
+from .signals import ensure_stream, stream_path
 from .strings import CATALOG, DEFAULT_LANG, LANGUAGES
 
 
@@ -50,6 +52,12 @@ def landing(request: HttpRequest) -> HttpResponse:
     if langcode not in {code for code, _ in LANGUAGES}:
         langcode = DEFAULT_LANG
 
+    # The seeding above appends, which creates the stream on a fresh checkout.
+    # This covers the other order: rows already in the database and the stream
+    # directory deleted, where the page would otherwise render against an
+    # endpoint that 404s until someone saves.
+    ensure_stream(stream_path(langcode))
+
     strings = _strings_for(langcode)
     ids = _ids_for(langcode)
     entries = [
@@ -66,7 +74,8 @@ def landing(request: HttpRequest) -> HttpResponse:
             "languages": LANGUAGES,
             "entries": entries,
             "t": by_msgid,
-            "stream_id": f"translations:{langcode}",
+            "stream_id": stream_path(langcode),
+            "protocol_prefix": settings.POLYGLOT_PROTOCOL_PREFIX,
         },
     )
 
@@ -77,7 +86,7 @@ def update_translation(request: HttpRequest, pk: int) -> HttpResponse:
     obj = Translatable.objects.filter(pk=pk).first()
     if obj is not None:
         obj.msgstr = msgstr
-        obj.save()  # post_save → SSE update event
+        obj.save()  # post_save → append to the log → SSE update event
     if request.headers.get("X-Requested-With") == "XMLHttpRequest":
         return HttpResponse(status=204)
     return redirect(

--- a/examples/polyglot/polyglot_project/asgi.py
+++ b/examples/polyglot/polyglot_project/asgi.py
@@ -1,4 +1,23 @@
-"""ASGI entry point for the polyglot sample."""
+"""ASGI entry point for the polyglot sample: Django, plus the protocol server.
+
+Two applications share one port. Anything under `/protocol/` is handled by
+rakaia's own ASGI app — the framework-independent Durable Streams server — and
+everything else is Django.
+
+That mount is what makes live updates work over the file-backed store. Django's
+own SSE endpoint (`django_rakaia.channels_views`) replays history from
+`StreamEntry` rows and waits on the channel layer, and neither exists when the
+log is a folder of files. The protocol server reads through the store interface
+instead and blocks in `store.wait_for_messages(...)`, which the file-backed
+store implements by watching the directory. So the page gets real SSE, over a
+log no database has seen, and it works across processes — the stress command's
+`--direct` mode now reaches open browsers, which it could not under an
+in-memory channel layer.
+
+The prefix is stripped by hand. `URLRouter` and `path()` do not strip it, so the
+handler would receive `/protocol/translations/tet` and look for a stream of that
+name; the streams are created as `/translations/tet`.
+"""
 
 import os
 
@@ -6,4 +25,19 @@ from django.core.asgi import get_asgi_application
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "polyglot_project.settings")
 
-application = get_asgi_application()
+django_app = get_asgi_application()
+
+# Imported after `get_asgi_application()`: both of these read settings.
+from django.conf import settings  # noqa: E402
+
+from django_rakaia.integration import get_asgi_app  # noqa: E402
+
+PROTOCOL_PREFIX = settings.POLYGLOT_PROTOCOL_PREFIX
+protocol_app = get_asgi_app()
+
+
+async def application(scope, receive, send):
+    if scope["type"] == "http" and scope["path"].startswith(PROTOCOL_PREFIX + "/"):
+        scope = {**scope, "path": scope["path"][len(PROTOCOL_PREFIX) :]}
+        return await protocol_app(scope, receive, send)
+    return await django_app(scope, receive, send)

--- a/examples/polyglot/polyglot_project/settings.py
+++ b/examples/polyglot/polyglot_project/settings.py
@@ -82,25 +82,61 @@ else:
             "ENGINE": "django.db.backends.sqlite3",
             "NAME": BASE_DIR / "db.sqlite3",
             # SQLite's defaults (`journal_mode=delete`, `synchronous=FULL`)
-            # fsync twice per save here — once for the row UPDATE, once for the
-            # event append — which capped this demo at ~40 events/s regardless
-            # of how fast anything else was. The same work measured ~370/s with
-            # the settings below.
+            # fsync on every commit, which capped this demo at ~40 saves/s
+            # regardless of how fast anything else was. The same work measured
+            # ~370/s with the settings below. The event append has since moved
+            # out of the database entirely (RAKAIA_STORE below), so only the
+            # `Translatable` row `UPDATE` is left here — but that is still one
+            # commit per save, and these settings are still what makes it cheap.
             "OPTIONS": {
                 "init_command": ("PRAGMA journal_mode=WAL; PRAGMA synchronous=NORMAL;"),
                 # Without this, a second concurrent writer fails *immediately*
                 # with "database is locked" rather than waiting out `timeout`: a
-                # deferred transaction that starts by reading (which every
-                # append does — it locks the offset high-water) cannot upgrade
-                # to a write lock while another writer holds one, and SQLite
-                # does not retry an upgrade. Taking the write lock up front
-                # makes the wait honour `timeout` instead of raising.
+                # deferred transaction that starts by reading cannot upgrade to
+                # a write lock while another writer holds one, and SQLite does
+                # not retry an upgrade. Taking the write lock up front makes the
+                # wait honour `timeout` instead of raising. The read that used
+                # to trigger this was the append locking the offset high-water;
+                # `stress_translations` still reads before it writes.
                 "transaction_mode": "IMMEDIATE",
                 "timeout": 15,
             },
         },
     }
 
+# The event log lives in a folder of ordinary JSON-lines files rather than in the
+# database. Nothing here needs a migration, and the whole log can be read with
+# `less` and diffed in git.
+#
+# The consequence is that live delivery no longer goes through the channel
+# layer: only the durable store broadcasts an append over channels, and the
+# file-backed one cannot — it lives in the framework-independent package and has
+# no way to reach Django. So SSE is served instead by rakaia's own protocol
+# server, mounted on /protocol/ in asgi.py over this same directory, which tails
+# the log through the filesystem. That works between processes on one machine,
+# which `InMemoryChannelLayer` never did.
+#
+# `rakaia.W002` is the check that warns about exactly this, and it is silenced
+# because the demo has answered it.
+RAKAIA_STORE = "jsonl"
+RAKAIA_JSONL_ROOT = os.environ.get("POLYGLOT_STREAM_ROOT", BASE_DIR / "streams")
+
+# Every append waits for the disk by default, which is what makes a returned
+# save mean the event survives a power cut. Set POLYGLOT_STREAM_FSYNC=0 to turn
+# that off — worth pairing with a memory-backed POLYGLOT_STREAM_ROOT such as
+# /dev/shm/polyglot, where there is no disk to wait for and the events still
+# outlive the process that wrote them.
+RAKAIA_JSONL_FSYNC = os.environ.get("POLYGLOT_STREAM_FSYNC", "1") != "0"
+SILENCED_SYSTEM_CHECKS = ["rakaia.W002"]
+
+# Where asgi.py mounts the protocol server, and what landing.html builds its
+# EventSource URL from. A setting rather than a constant in asgi.py, because
+# importing asgi.py from a view would run `get_asgi_application()` a second time
+# as a side effect of rendering a page.
+POLYGLOT_PROTOCOL_PREFIX = "/protocol"
+
+# Still an in-memory layer, and still only used by anything the demo wires to
+# channels itself — the translation stream no longer rides on it.
 CHANNEL_LAYERS = {
     "default": {
         "BACKEND": "channels.layers.InMemoryChannelLayer",

--- a/examples/polyglot/polyglot_project/urls.py
+++ b/examples/polyglot/polyglot_project/urls.py
@@ -6,5 +6,10 @@ from django.urls import include, path
 urlpatterns = [
     path("admin/", admin.site.urls),
     path("", include("polyglot.urls")),
-    path("streams/", include("django_rakaia.urls", namespace="django_rakaia")),
+    # `django_rakaia.urls` is deliberately not included. Every route in it —
+    # the dashboard, the read API, the SSE endpoint — reads `Stream` and
+    # `StreamEntry` rows, and this app's log is a folder of files that no row
+    # describes. Mounted, it would serve a permanently empty dashboard next to a
+    # page that is visibly streaming. The protocol server on /protocol/ (see
+    # asgi.py) is the read side here.
 ]


### PR DESCRIPTION
The translations demo used to keep its event log in the database. It now keeps
it in a folder of ordinary text files, one line per event, which you can read
with `less` and follow with `tail -f` while the demo runs.

Live updates still work, and one thing that never worked now does: a change made
from any process reaches every open browser. Previously only saves made inside
the web server itself showed up live, which is why the stress command had to
post over HTTP to be worth watching.
