### PR TITLE
An outcome is recorded where the cursor is committed (ADR 0007 + the core seam)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,6 +89,28 @@
 - Research notes live in `docs/research/` and are deliberately **not** in the
   nav. They are dated and are not decisions; decisions go in `docs/adr/`.
 
+## Writing it up
+
+- **Two plain paragraphs.** A commit message body, an issue body and a PR body are each
+  at most two paragraphs, written so someone who only reads the notification email gets
+  the whole point. Say what changed and what it means for whoever uses this. That is the
+  deliverable.
+- **Everything else goes in a comment.** Tables, measured counts, SHAs, query output,
+  repro steps, mutation records, per-file reasoning — post them below the body, on the PR.
+  They are evidence for whoever verifies the work, not the summary for whoever reads it. A
+  commit message has nowhere to put them, so they belong on its PR instead.
+- **No machinery in the body.** This library's own words — stream, event, consumer,
+  cursor, offset, replay, backend — are the vocabulary and are fine. Identifiers are not:
+  `DjangoExecutor.apply` is "the part that writes a batch", `_StageBuffer` is "batching a
+  pass together". Save the precise names for the comment, where precision is the job.
+- The test: read the body alone. If it needs the source open, or the point arrives after
+  the evidence, rewrite it.
+- **Docstrings too: two paragraphs**, with one difference — a docstring's reader is
+  looking at the code, so identifiers *are* their vocabulary. What does not belong is the
+  essay: the history of a bug, what an earlier cut did, or the same point twice. A
+  non-obvious constraint earns its own short paragraph; if it took a mutation to find,
+  write it down.
+
 ## Agent skills
 
 ### Issue tracker

--- a/docs/adr/0007-an-outcome-is-recorded-where-the-cursor-is-committed.md
+++ b/docs/adr/0007-an-outcome-is-recorded-where-the-cursor-is-committed.md
@@ -67,6 +67,20 @@ because the decision is store-agnostic; only the place to keep the answer is Dja
 An outcome keyed by `(consumer, stream_path, subject)` is store-agnostic in exactly the
 same way, and there are now three stores.
 
+## What is built, and what this decision only proposes
+
+A decision record says what was decided; it should not be read as saying what exists. Of the
+decisions below, **3, 4, 6, 6a, 6b and 7 describe code in the tree.** Decision 1's core half
+does; its Django half does not. **Decisions 2 and 5 describe nothing that exists** — there is
+no consume loop and no `on_error` parameter — and the Consequences section's "'did we lose
+anything, and which ones?' becomes a query, and it survives a restart" is a claim about the
+finished thing, not about what is merged.
+
+That split is deliberate: what is merged is a record and the two stores that keep it, which
+is the part worth arguing about before the loop that writes them is built. It is called out
+here because an earlier version of this section did not, and a reader would reasonably have
+taken the Decision list for an inventory.
+
 ## Decision
 
 **1. An outcome is a core concept with pluggable storage.** `Outcome`,
@@ -76,8 +90,8 @@ durable place to keep them and nothing else, mirroring `load_cursor`/`commit_cur
 A shared contract suite at `tests/outcome_store_contract.py` is subclassed once per
 backend, so "does this work on JSONL?" is a red test rather than a question.
 
-**2. The record is written where the cursor is committed.** Rakaia gains the consume
-loop it has never had, next to `poll`. It applies, records any outcome in its own
+**2. The record is written where the cursor is committed.** *(Not built — this decision
+proposes it.)* Rakaia gains the consume loop it has never had, next to `poll`. It applies, records any outcome in its own
 transaction — outside the executor's — and then commits the cursor. Nothing is
 recorded from inside an `Effect`, an executor, or a handler.
 
@@ -128,7 +142,8 @@ Nothing is missing; something was rejected. Treating that as a lost append would
 re-drive hunting for a fact that is exactly where it should be, and treating it as an
 unapplied projection would send a replay looking for an event that was never written.
 
-**5. The failure policy is a parameter with per-mode defaults, never inferred.**
+**5. The failure policy is a parameter with per-mode defaults, never inferred.** *(Not
+built — this decision proposes it.)*
 `on_error="skip"` when consuming continuously, `on_error="halt"` when rebuilding. The
 same shape as `on_drift` (`src/rakaia/drift.py:41`), and for the same reason: one code
 path serving two operations with opposite invariants is how a guard ends up correct in
@@ -324,9 +339,11 @@ that is the point of it.
 
 ### Positive
 
-- "Did we lose anything, and which ones?" becomes a query, and it survives a restart.
-- The consume loop lands as a first-class thing. Rakaia has documented at-least-once
-  semantics and, until now, no code expressing them; every consumer wrote the loop.
+- "Did we lose anything, and which ones?" becomes a query that survives a restart — once
+  the loop of Decision 2 writes the records and a durable store keeps them. Neither is in
+  this change; both are what it is for.
+- The consume loop would land as a first-class thing. Rakaia has documented at-least-once
+  semantics and no code expressing them, so every consumer writes the loop itself.
 - `stage` makes the difference between a lost fact and an unapplied one legible at the
   point someone is deciding what to do about it.
 

--- a/docs/adr/0007-an-outcome-is-recorded-where-the-cursor-is-committed.md
+++ b/docs/adr/0007-an-outcome-is-recorded-where-the-cursor-is-committed.md
@@ -1,0 +1,428 @@
+# ADR 0007 — An outcome is recorded where the cursor is committed, not where the effect is applied
+
+- **Status:** Proposed
+- **Date:** 2026-09-05
+- **Deciders:** rakaia maintainers
+- **Related:** [ADR 0002](./0002-framework-vs-protocol-server-boundary.md) (the
+  framework/protocol tiers this splits across);
+  [ADR 0006](./0006-changing-backends-is-a-copy.md) (three stores behind one seam —
+  why an outcome record cannot be Django-shaped by default);
+  [ADR 0005](./0005-stream-positions-stay-a-counted-offset.md) (an offset is an
+  opaque token, which is why an outcome's is a string);
+  `src/rakaia/subscription.py`, `src/rakaia/protocols.py`,
+  `src/django_rakaia/effect_executor.py`, `src/rakaia/replay.py`.
+  Issues: #232 (a cursor should name its store — an outcome inherits this gap
+  unchanged), #34 (deletion retires offsets permanently).
+
+## Context
+
+A consumer applies an event and the apply fails. Rakaia has nowhere to say so.
+
+There is no dead-letter queue, no park, no attempt count, no per-event error record
+anywhere in the tree. `DriftLedger` is the closest thing, and it is per *rule*,
+deduplicated, in memory, and handed back on the result object rather than stored.
+`ApplyReport` carries `created`/`written`/`skipped` counts per batch, and only its
+`retire_flips` are read (`replay.py:521`, `:553`) — the counts go nowhere. What
+survives a restart is the cursor, and a cursor says only how far a consumer got — not
+whether it got there cleanly.
+
+That gap has a specific consequence, and it is not "we lack observability". It is
+that **absence of a record is read as success**. A consumer whose cursor is past
+offset 40 asserts nothing about offsets 1–39. If one of them was skipped by a bulk
+write path, or applied by a handler that raised and was swallowed upstream, nothing
+in rakaia distinguishes that from forty clean applies. The first consumer to hit this
+in production reported a form as imported when its row had been refused.
+
+Three things about this codebase decide the shape of the answer, and two of them rule
+out the obvious implementation.
+
+**The executor cannot record it.** `DjangoExecutor.apply` wraps its batch in
+`transaction.atomic` (`src/django_rakaia/effect_executor.py:204`). An outcome row
+written inside that block rolls back with the batch whose failure it exists to
+record. Worse, it could not name the event anyway: a stage-0 pass buffers many events
+into one `apply()` (`_StageBuffer`, `src/rakaia/replay.py:434`), and `RowEffect`
+carries `model_label` and `lookup` and nothing else (`src/rakaia/effects.py:176-189`).
+By the time effects reach an executor, which event produced which effect is not
+recoverable.
+
+**There is no loop to record it in.** `poll → apply → commit` is written by hand by
+each consumer. `django_rakaia.subscription` is 46 lines of free functions and holds no
+`try`. In `replay.py` the only `try` on the dispatch path is a bare `finally`
+(`:275-326`) whose comment explains it is there to flush buffered effects, not to
+catch anything; the four `except` clauses elsewhere in the file cover signature
+introspection, a non-hashable dedup key, merge-order comparability and JSON decoding,
+and each either returns a default or re-raises. None of them catches a handler
+exception, and neither does anything else — it propagates out of `replay()` uncaught.
+So there is no existing site
+where an outcome *would* be written; this decision introduces the site as well as the
+record.
+
+**A Django-only table would be the second mistake of a kind already regretted.**
+Migration 0008 says it plainly of the removed demo model: *"Because it was in
+`0001_initial`, **every** consumer got the table whether or not they ever used it."*
+Meanwhile `docs/framework-vs-protocol-server.md` lists cursors **twice** — *"Subscriber
+cursors … Python stdlib only"* (`:33`) and *"Durable subscriber cursors — persisted
+watermarks … Django (ORM)"* (`:39`). That split is the template. `poll` is stdlib
+because the decision is store-agnostic; only the place to keep the answer is Django.
+An outcome keyed by `(consumer, stream_path, subject)` is store-agnostic in exactly the
+same way, and there are now three stores.
+
+## Decision
+
+**1. An outcome is a core concept with pluggable storage.** `Outcome`,
+`OutcomeStatus`, `Stage` and an `OutcomeStore` protocol live in `rakaia`, dependency-free,
+with `OutcomeStore` in `src/rakaia/protocols.py` beside `CursorStore`. Django supplies a
+durable place to keep them and nothing else, mirroring `load_cursor`/`commit_cursor`.
+A shared contract suite at `tests/outcome_store_contract.py` is subclassed once per
+backend, so "does this work on JSONL?" is a red test rather than a question.
+
+**2. The record is written where the cursor is committed.** Rakaia gains the consume
+loop it has never had, next to `poll`. It applies, records any outcome in its own
+transaction — outside the executor's — and then commits the cursor. Nothing is
+recorded from inside an `Effect`, an executor, or a handler.
+
+**3. Only exceptions are recorded; the cursor is the success record.** Everything
+below the cursor succeeded unless an outcome says otherwise, and anything the cursor
+never reached is visibly unprocessed. The alternative — a row per applied event — is a
+durable write on the hot path for the case that is fine, and the append cost tests exist
+to catch exactly that.
+
+There is deliberately **no gap query**, and an earlier draft of this decision was wrong to
+promise one. It proposed reporting "offsets below the cursor with no outcome recorded",
+which under this very decision is *every event that worked*: success writes nothing, so
+absence of a record is not a gap, it is the normal case. The two halves contradicted each
+other and the contradiction was only visible once a contract test had to state an expected
+value.
+
+What the model actually gives, and it is enough:
+
+- **Lag** is the head against the cursor. No outcomes required.
+- **Below the cursor**, an outcome means it failed, was refused or was skipped; no outcome
+  means it succeeded. By construction, with no third state.
+- An event below the cursor that neither succeeded nor recorded is a **defect in the loop**,
+  not a data condition. A test pins the loop; no runtime query can distinguish it, because
+  the design deliberately left no trace of success to look for.
+
+The class this was reaching for — a bulk write bypassing the pipeline, leaving derived rows
+missing and no record saying so — is answered structurally instead. A write that does not go
+through the loop does not advance the cursor, so the events are still pending and are still
+delivered. The bypass stops being a thing to detect.
+
+**4. Where the event is decides how it is recovered, and replay is only one of the
+answers.** `stage` says whether the event reached the log; `status` says what happened to
+it. Together they name the recovery, and a re-drive that assumed every recorded outcome
+was replayable would take the wrong action on most of them.
+
+| `stage` | `status` | Where the fact is | Recovery |
+|---|---|---|---|
+| `project` | `failed` | Safe in the log, unapplied | Replay it |
+| `append` | `failed` | **Gone.** The append was attempted and lost | Re-produce from whatever the consumer derived it from |
+| `append` | `refused` | Safe upstream, deliberately not logged | Fix the data upstream and let it be produced again |
+| either | `skipped` | Wherever it was | None wanted — not applying it *was* the decision |
+
+The third row is the one worth spelling out, because it looks like the second and is not.
+A consumer that gates its events refuses some of them *on purpose* — the log is the
+system of record, so it must not carry a row the consumer declined to accept — and the
+fact is not lost at all, it is sitting in whatever the consumer produced the event from.
+Nothing is missing; something was rejected. Treating that as a lost append would send a
+re-drive hunting for a fact that is exactly where it should be, and treating it as an
+unapplied projection would send a replay looking for an event that was never written.
+
+**5. The failure policy is a parameter with per-mode defaults, never inferred.**
+`on_error="skip"` when consuming continuously, `on_error="halt"` when rebuilding. The
+same shape as `on_drift` (`src/rakaia/drift.py:41`), and for the same reason: one code
+path serving two operations with opposite invariants is how a guard ends up correct in
+one mode and silently wrong in the other.
+
+**6. An outcome carries reason codes and bounded parameters, never a message.**
+`reasons` is a tuple of codes; `params` is a flat map. Codes, keys and values are all
+*checked* to be strings rather than assumed to be, and both containers are copied on the way
+in — each of those was a separate round's finding, and each had let the backends disagree
+about what had been recorded. An
+interpolated message is where field values leak, and this library is used on submissions
+carrying personal and financial data. It also makes outcomes countable — "how many failed
+for this reason" is a query rather than a grep.
+
+Plural, not singular, because one event can fail several rules at once and the consumer
+that motivated this already collects them as a tuple before flattening them with a
+`", ".join(...)` for display. Storing the join would re-lose exactly the structure this
+decision exists to keep.
+
+**The codes are opaque to rakaia, and are not a closed set anywhere yet.** An earlier draft
+said a consumer could borrow one it already had. Checked against that consumer: the field
+those codes come from is a bare 64-character text column with no constrained values, and one
+can be minted over HTTP by creating or editing a flag, both of which bypass the internal
+guard that checks a code was declared. (Resolving one does not — it writes only the
+resolution.) It is a vocabulary by convention and a
+static scan, not by construction. Borrowing it is still right — it is what people already say
+— but closing it is work the consumer has to do, and this decision should not be read as
+saying it is done.
+
+**6a. An outcome is immutable; nothing is resolved on it.** An earlier draft gave the
+record a `resolved_at`. That is wrong wherever the reason codes come from a consumer's own
+observations, because those observations already carry a resolution lifecycle — the
+motivating consumer's flags have `resolved_at`, `resolved_by`, `assigned_to` and an
+auto-resolve sweep. A second place to mark the same fact fixed is a second answer that
+will eventually disagree with the first. So outcomes are append-only and attempt-numbered,
+and "is this still failing?" is the latest outcome for the key, not a column. `unresolved`
+is therefore a derived query, not stored state.
+
+**6b. One translation decides what a stored outcome looks like, and every backend uses it.**
+`encode`/`decode` is the only crossing between an outcome and its stored form, the in-memory
+reference included. That store previously kept the object as handed to it while the durable
+ones had to render it, so it accepted values they refused — a reference implementation more
+permissive than the real ones makes a passing test a weaker promise than production.
+
+The check **walks the declared fields rather than naming them**, and that is the part worth
+recording. Five review rounds each closed one field: a map's values, then its keys, then the
+list beside it, then the plain fields — each check written where the defect was found instead
+of where the rule belongs, so the list was never more complete than the last bug. Reading the
+declaration also brought two cases nobody had reported: a value outside a `Literal`'s domain,
+and `bool` arriving where an `int` was declared.
+
+Two consequences follow and are not obvious. A name may not be empty — a file-backed store
+maps a name to one path segment, and every escaping of the empty string collides with
+something. And a line this version cannot rebuild is dropped with a log rather than an
+exception, because one such line must not cost the whole report; it is only logged and not
+yet counted, which is a weaker answer than this decision would like given that unnoticed
+absence is the thing it exists to prevent.
+
+**7. Sequencing is recorded, not enforced.** An outcome carries a `sequence_key`.
+Rakaia does not yet refuse an event whose sequence has an unresolved failure; the field
+exists so that adding it later does not require re-deriving groupings a consumer has
+already decided. Named here because recording a key nothing reads is otherwise the sort
+of thing a later reader deletes as dead weight.
+
+**It is computed per refusal, not looked up per form.** The obvious source is a consumer's
+existing per-form refusal scope — group under the document where a partial write yields a
+wrong total, per row otherwise — and that is not sufficient on its own. Measured against the
+motivating consumer: the lookup falls back to per-row for a form nobody classified — held
+total by a fitness test that forbids the omission rather than by the lookup itself, so the
+scope is complete only as long as that test is — and a blocked *root* row refuses the whole
+document whatever the form's scope says, because every child's typed record points at the
+root's. A key derived from the form alone is wrong in the second case regardless.
+
+This is why `subject` is a separate field rather than the same one. The subject is the single
+thing an outcome is about; the sequence key is what that particular refusal actually parked.
+They coincide often enough to be mistaken for one field, and the cases where they do not are
+the ones that matter.
+
+## Observations, refusals, and the record that one happened
+
+Consumers already separate two of these three carefully, and the motivating one says so in
+its own vocabulary file: *"a gate is a **refusal**; a flag is an *observation* — do not use
+the words interchangeably."* An outcome is the third, and it is neither.
+
+| | What it is | Who owns it | Lifecycle |
+|---|---|---|---|
+| **Observation** | A rule noticed something about the data | The consumer's rules layer | Raised, assigned, resolved |
+| **Refusal** | The pipeline declined to accept a row | The consumer's policy | Decided per save |
+| **Outcome** | The record that a refusal (or a failure) happened | This decision | **Immutable** |
+
+One refusal produces several observations and exactly one outcome. The outcome's `reasons`
+are a *snapshot of the observations that were open at the moment it was refused* — in the
+motivating consumer, literally read back from its unresolved flags — which is why the
+outcome does not carry a resolution of its own (Decision 6a): resolving the observation is
+what fixes the underlying problem, and the next attempt records the next outcome.
+
+Two consequences worth stating before someone infers the opposite:
+
+- **rakaia does not define the vocabulary.** `reasons` is opaque to it. Which codes exist,
+  what they mean, and when they are resolved are the consumer's, exactly as
+  `ConsumerCursor` holds an offset whose meaning is the store's.
+- **An outcome is not a verification result.** The parity commands that also get called
+  gates — the ones that refuse to pass unless a replay matches live rows — are a different
+  thing again, and what this decision exposes — lag, and which events failed — is
+  deliberately a *report* rather than an input to one. A consumer's own gate command warns about this directly, of its coverage counter:
+  it "belongs in a coverage verdict and would be wrong as a write blocker", and "a future
+  apply must derive its own predicate from the report rather than reuse this verdict."
+  Outcomes make such a residual explainable — *this row is missing and here is the record
+  saying why* — and must not become the thing that decides whether it passes.
+
+## A worked example, and the thing it exposes
+
+The consumer that motivated this decision gates its events per row. Traced through its
+live path, one refused repeater on a progress form does this:
+
+1. The document is split. Every row exists as a derived row, including the bad one.
+2. Every row is checked — the gate deliberately does not short-circuit, so the whole
+   failure set is reported in one pass rather than one row per attempt.
+3. Policy for this form is *refuse the row, keep its siblings*. The refused row's event
+   is dropped from the batch: **neither appended nor projected**, on the stated
+   principle that the log must not carry a row the consumer declined to accept. Its
+   siblings in the same call *are* appended and do get real offsets — "never appended"
+   is true of the refused row, not of the save. (Refuse the root instead and the whole
+   document is declined without the append being attempted at all.)
+4. An outcome is recorded against the refused row; the clean rows record success.
+5. The user sees a partial failure naming the offending row.
+
+Under this ADR that is `stage="append"`, `status="refused"`, `sequence_key` = the row —
+the third table row above, and the design handles it correctly. The siblings are
+genuinely independent, so parking the row and nothing else is the right answer.
+
+**Then a stage-2 reducer runs, and the containment stops.** It recomputes a field on a
+*different* form by reading progress rows **out of the projection** and taking the one
+latest by *reporting period* — not by when it was filed, so a late correction for an earlier
+month cannot reset the answer. The refused row was never written, so the reducer cannot see
+it, takes the previous period's figure instead, and writes the resulting value. It updates
+rows that exist and never inserts one, so nothing is fabricated; what is wrong is the number.
+Not stale by omission — actively written from an input with a hole in it, with nothing
+linking that write back to the refusal.
+
+That is not a defect this decision introduces; the consumer measured it when it chose the
+policy, and chose it because refusing the row moves fewer of those derived values than
+refusing the whole document would. What matters here is narrower and is a limit of *this*
+design: **a sequence key protects ordering within a sequence, and a reducer reads across
+sequences.** Nothing else catches it either: the refused event has no offset, so it is
+absent from every view keyed on one.
+
+So the record says "this row was refused" and stays silent on "that derived value is now
+computed from an incomplete population". Recorded here as a known limit rather than
+closed, because closing it is a decision about reducers, not about outcomes — see *What
+would reopen this*.
+
+## Alternatives considered
+
+**Thread event identity through `Effect` and record in the executor.** The version that
+first looks right, and it fails on its own terms: the outcome is written inside
+`transaction.atomic`, so a failing batch discards the record of its own failure. Making
+the record survive means a second connection or an autocommit escape hatch inside a
+class whose whole contract is that a batch is atomic. Rejected before the ergonomics of
+adding a field to `RowEffect` even matter.
+
+**Put the model in `django_rakaia` and be done.** Fastest, and consistent with
+`ConsumerCursor` as it stands. Rejected on the 0008 precedent: it lands a table on every
+consumer, on a branch whose recent history is almost entirely about removing Django
+coupling, and it would need undoing to reach the shape this ADR describes. `envelope.py`
+(`:21-23`) states the actual test — things live in `django_rakaia` when they are
+*intrinsically* Django-shaped, "the core package stays dependency-free" — and an outcome
+is not.
+
+**Record every applied event, not only the exceptions.** It answers the completeness
+question directly, with no reliance on the cursor meaning what it says. Rejected on cost
+and on precedent: it is
+one durable write per event on the success path, in a codebase that has a test file
+asserting the *set of SQL statements* an append issues
+(`tests/test_django_rakaia/test_append_query_cost.py`) because #202 found three
+duplicates. The consumer that motivated this work already writes a row per row per save
+and has neither a retention policy nor an index supporting the query its two hot paths
+run; that is the outcome to avoid reproducing, not to generalise.
+
+**Ship re-drive in the same change.** The obvious pairing — a dead letter is for
+re-driving — and deliberately deferred. Re-drive writes to the projection, so it needs
+the rebuild and parity gates extended to cover it, and the consumer that asked for this
+had precisely that feature cut in review after four attempts to guard it, each failing
+differently, because one path served both a scratch rebuild and a live database. The
+record is useful alone: it makes the manual repair path targeted instead of a sweep.
+
+**Reuse `DriftLedger`.** It already accumulates problems and reports them on the result
+object. Rejected because it is deliberately per-registration and memoised — it reports a
+rule once, not an event ever — and making it per-event would remove the deduplication
+that is the point of it.
+
+## Consequences
+
+### Positive
+
+- "Did we lose anything, and which ones?" becomes a query, and it survives a restart.
+- The consume loop lands as a first-class thing. Rakaia has documented at-least-once
+  semantics and, until now, no code expressing them; every consumer wrote the loop.
+- `stage` makes the difference between a lost fact and an unapplied one legible at the
+  point someone is deciding what to do about it.
+
+### Negative, and named rather than waved away
+
+- **Nothing enforces that the loop is used.** A consumer keeping its hand-written
+  `poll`/`commit` records nothing, and its stream looks identical to a clean one. This
+  decision adds a supported path; it does not close the unsupported one.
+- **A consumer that is not cursor-driven cannot adopt this.** Decision 3 makes absence of a
+  record mean success. The motivating consumer's existing surface means the exact opposite:
+  it writes a record on success *and* on failure precisely so that no record at all can be
+  read as "this never went through the pipeline", which is how it detects rows a bulk write
+  skipped. Both are coherent, and they are inverses — absence cannot mean both. The
+  reconciliation is the cursor: once a consumer polls and commits, "never processed" is
+  visible as the cursor not having reached it, and the extra row per success stops earning
+  its keep. Until then the two cannot be mixed, and a consumer part-way through the change
+  has one surface saying absence is fine and another saying it is a defect.
+- **A verdict over a group needs a denominator this does not supply.** "All rows failed"
+  versus "some did" needs to know how many there were, and `latest` returns only the ones
+  with an outcome. That count belongs to the consumer, which has it; worth saying because
+  the obvious reading of `latest` is that it is enough on its own, and it is not.
+- **The reason codes are available; the parameters beside them are not, on one path.** The
+  consumer's refusal object carries a string-to-string map — built in one place, by a helper
+  that renders every value on the way in — so that path fits without change. (The verdict it
+  is built *from* is typed as holding anything, and at least one caller puts a number there;
+  it is the rendering step that makes the refusal safe, not the source.) Its flag path does not: the structured detail is flattened into a sentence before
+  it is stored, so anything populating parameters from a flag has only prose to read back and
+  must re-derive them. Decision 6 asks for the opposite of what that path does today.
+- **Nothing here is exported.** `Outcome`, `OutcomeStore` and the two backends are absent
+  from `rakaia.__all__`, so a consumer adopting this today is importing below the stable
+  surface. Deliberate while the decision is Proposed — exporting is a stability promise, and
+  making one for a design still under review is how a bad shape becomes permanent — but it
+  means "usable" and "supported" are not yet the same thing here. Exporting is the last step
+  before this is Accepted, not an oversight.
+- **`Outcome` is a name the motivating consumer already uses** for an unrelated four-member
+  verdict enum — pass, fail, not-applicable, indeterminate — imported in twenty-odd modules
+  and referred to a few hundred times. Nothing breaks, but `from rakaia import Outcome` would
+  shadow it there, so that consumer will want a qualified import.
+- **The codec closes shape, not size, and cannot.** Reading each field's declared type
+  settles what a value *is*; it says nothing about how long it may be. A backend with a
+  bounded column accepts a name every other backend keeps and then refuses or truncates it —
+  the same divergence, out of reach of the same mechanism. Measured on a spike of a third
+  backend: a 300-character stream path is kept by both current stores and by a database
+  under SQLite, and refused only under Postgres.
+
+  Which exposes the sharper half. The suite's default database does not enforce lengths, so
+  that divergence is invisible where the tests usually run — the same fault this decision
+  fixed one level in, where the reference store was the permissive one. Whatever else is
+  done, the cross-backend comparison has to run somewhere the constraints are real.
+- **Everything rests on the cursor meaning what it says.** A consumer that commits before
+  applying — which `poll`'s docstring warns against and nothing prevents — silently
+  converts "unapplied" into "succeeded", because success is the absence of a record. The
+  alternative design, a row per applied event, does not have this weakness, and giving it
+  up is the price of not writing on the hot path.
+- **An outcome inherits #232 exactly.** `DjangoStreamStore` and `JsonlStreamStore` both
+  issue `PLAIN`, so an outcome's `(stream_path, offset)` cannot say which store's offset
+  it is any more than a cursor's can. Two backends at the same path produce outcomes that
+  collide silently.
+- **Sequencing is a field and a promise.** Decision 7 records a key nothing acts on. If
+  the enforcement never lands, this is a column carrying a consumer's private grouping
+  for no benefit rakaia delivers.
+- **A sequence key does not reach a reducer.** The worked example above is the case: a
+  stage-2 construct reads committed projections across sequences, so an event parked in
+  one sequence silently changes a value derived in another, and no outcome says so.
+  Nothing in this decision detects it, and nothing keyed on an offset can — an event that
+  was never appended has no offset to be found at. This is the largest thing the design leaves
+  open, and it is a property of reducers reading projections, not of the record.
+- **The admin registration breaks a local pattern.** `ConsumerCursor`,
+  `StreamOffsetWatermark` and `StreamProducer` have no admin; operational bookkeeping is
+  not browsed. A dead-letter table is argued as the exception because looking at it *is*
+  the feature, but it is a deviation, not a precedent being followed.
+
+### Neutral
+
+- A consumer that never fails never writes a row, so the table is empty and the cost is
+  a migration.
+- Nothing about existing replay behaviour changes. `replay()` still raises out; the loop
+  is a new caller, not a change to what it calls.
+
+## What would reopen this
+
+- **#232 lands.** An outcome should name its issuing store at the same moment a cursor
+  does, and by the same mechanism. Amend rather than duplicate.
+- **Re-drive.** The deferred half. It needs a decision of its own about what a
+  re-drive may write and which gates must pass first, and Decision 4's `stage` split is
+  the part of this ADR it will lean on.
+- **Sequencing enforcement.** Refusing an event whose sequence has an unresolved failure
+  changes live behaviour and needs its own argument. If it is declined for good, Decision
+  7's field should go with it.
+- **An answer to the reducer gap.** Three shapes, none obviously right, and the choice
+  between them is a decision about reducers rather than about outcomes:
+  *(a)* extend parking to reducers, so one refuses to run over a population with an
+  unresolved outcome — correct, changes live behaviour, needs the gates;
+  *(b)* record a derived outcome against the affected row when a reducer's input has a
+  hole — purely additive, but a second kind of outcome with different provenance;
+  *(c)* leave the behaviour alone and make the affected population queryable.
+  Whichever lands, `stage`/`status` from Decision 4 is what it will key off.
+- **A fourth store.** The contract suite is where that is absorbed; if a store cannot
+  implement `OutcomeStore` cheaply, the protocol is wrong rather than the store.

--- a/docs/adr/0007-an-outcome-is-recorded-where-the-cursor-is-committed.md
+++ b/docs/adr/0007-an-outcome-is-recorded-where-the-cursor-is-committed.md
@@ -394,15 +394,17 @@ that is the point of it.
   Nothing in this decision detects it, and nothing keyed on an offset can — an event that
   was never appended has no offset to be found at. This is the largest thing the design leaves
   open, and it is a property of reducers reading projections, not of the record.
-- **The admin registration breaks a local pattern.** `ConsumerCursor`,
-  `StreamOffsetWatermark` and `StreamProducer` have no admin; operational bookkeeping is
-  not browsed. A dead-letter table is argued as the exception because looking at it *is*
-  the feature, but it is a deviation, not a precedent being followed.
+- **The admin registration will break a local pattern.** The Django backend is not in
+  this change, but when it lands: `ConsumerCursor`, `StreamOffsetWatermark` and
+  `StreamProducer` have no admin, because operational bookkeeping is not browsed. A
+  dead-letter table is argued as the exception because looking at it *is* the feature,
+  but it is a deviation, not a precedent being followed.
 
 ### Neutral
 
-- A consumer that never fails never writes a row, so the table is empty and the cost is
-  a migration.
+- A consumer that never fails never writes a row, so a store holding outcomes is empty
+  and the cost is whatever it takes to exist — a migration, once the Django backend lands;
+  an empty folder for the file-backed one.
 - Nothing about existing replay behaviour changes. `replay()` still raises out; the loop
   is a new caller, not a change to what it calls.
 

--- a/docs/adr/0007-an-outcome-is-recorded-where-the-cursor-is-committed.md
+++ b/docs/adr/0007-an-outcome-is-recorded-where-the-cursor-is-committed.md
@@ -70,7 +70,9 @@ same way, and there are now three stores.
 ## What is built, and what this decision only proposes
 
 A decision record says what was decided; it should not be read as saying what exists. Of the
-decisions below, **3, 4, 6, 6a, 6b and 7 describe code in the tree.** Decision 1's core half
+decisions below, **4, 6, 6a, 6b and 7 describe code in the tree**, and **3 describes it
+only in the negative** — what is built is the absence of a success status and the absence
+of a gap query; the rule itself is a property of the loop in Decision 2, which is not. Decision 1's core half
 does; its Django half does not. **Decisions 2 and 5 describe nothing that exists** — there is
 no consume loop and no `on_error` parameter — and the Consequences section's "'did we lose
 anything, and which ones?' becomes a query, and it survives a restart" is a claim about the

--- a/src/rakaia/jsonl_outcomes.py
+++ b/src/rakaia/jsonl_outcomes.py
@@ -26,13 +26,11 @@ trailing line — a crash mid-append — is skipped on read rather than parsed,
 because a partial outcome is not worth failing a whole report over, and cut off
 before the next append so that record is not glued onto it and lost as well.
 
-The lock is not pinned by a test, and that is a known gap rather than an
-oversight: with `O_APPEND` a single short `write()` lands whole on a local
-filesystem, so two unlocked writers cannot be made to interleave on demand. What
-the lock actually orders is the torn-tail check against a concurrent append —
-find the fragment, truncate, write — which is a window too narrow to hit
-deliberately. A test that fails with the lock removed would be welcome; none of
-the obvious ones do.
+What the lock orders is not the write itself — with `O_APPEND` a single short
+`write()` lands whole on a local filesystem — but the torn-tail check against a
+concurrent append: find the fragment, truncate, write. The test that pins it
+holds a writer inside that window and checks a second one waits, because a
+second writer that gets through is the one that can lose a line.
 """
 
 from __future__ import annotations

--- a/src/rakaia/jsonl_outcomes.py
+++ b/src/rakaia/jsonl_outcomes.py
@@ -1,10 +1,18 @@
 """An `OutcomeStore` backed by plain JSONL files on disk.
 
-The second implementation, and the reason the seam exists. `InMemoryOutcomeStore`
-proves nothing on its own — the same commit wrote it and the protocol, so of
-course it fits. This one has no database under it and shares no code with the
-first, so `tests/outcome_store_contract.py` passing against both is the evidence
-that an outcome is as store-agnostic as ADR 0007 Decision 1 claims.
+The second implementation, and the reason the seam exists — but be careful what
+the pair proves. It shows the *storing* is store-agnostic: keeping records in
+files needs no method the protocol lacks, and a third backend found a difference
+neither of these two had on its first run against the shared contract.
+
+It does **not** show the codec is right. Decision 6b makes both stores share
+`encode`, `decode` and `_order`, so a defect in any of the three is applied
+identically by both, agreed on by both, and invisible to the contract suite and
+to the cross-store comparison alike. That was the trade: one shared rendering
+buys structural agreement and spends the independence that would have made
+agreement evidence. What covers the codec is `test_outcome_validation.py`, which
+tests it directly rather than through a store. An earlier version of this
+paragraph said the two stores "share no code", which was never true.
 
 Outcomes are **append-only by definition** (Decision 6a), which makes a log file
 the natural shape rather than a compromise: `record` is one line appended, and

--- a/src/rakaia/jsonl_outcomes.py
+++ b/src/rakaia/jsonl_outcomes.py
@@ -23,7 +23,16 @@ percent-encoding is the mapping that is reversible.
 Sharing the stream store's limits, and for the same reasons: `fcntl` only, so no
 Windows; `flock` is unreliable on NFS; readers do not take the lock. A torn
 trailing line — a crash mid-append — is skipped on read rather than parsed,
-because a partial outcome is not worth failing a whole report over.
+because a partial outcome is not worth failing a whole report over, and cut off
+before the next append so that record is not glued onto it and lost as well.
+
+The lock is not pinned by a test, and that is a known gap rather than an
+oversight: with `O_APPEND` a single short `write()` lands whole on a local
+filesystem, so two unlocked writers cannot be made to interleave on demand. What
+the lock actually orders is the torn-tail check against a concurrent append —
+find the fragment, truncate, write — which is a window too narrow to hit
+deliberately. A test that fails with the lock removed would be welcome; none of
+the obvious ones do.
 """
 
 from __future__ import annotations
@@ -32,6 +41,7 @@ import os
 from pathlib import Path
 from urllib.parse import quote
 
+from .jsonl_store import _discard_torn_tail
 from .outcomes import Outcome, _order, decode, encode
 
 try:  # pragma: no cover - platform dependent
@@ -88,19 +98,20 @@ class JsonlOutcomeStore:
     def record(self, outcome: Outcome) -> None:
         target = self._file(outcome.consumer, outcome.stream_path)
         target.parent.mkdir(parents=True, exist_ok=True)
-        line = encode(outcome) + "\n"
+        line = (encode(outcome) + "\n").encode("utf-8")
         # Narrowing, not defence: `__init__` refuses to build a store on a platform
         # without `fcntl`, so by here it is always a module. Stated as an assert
         # rather than an ignore comment, the way `jsonl_store.py` states the same
         # guarantee.
         assert fcntl is not None
         # Append under an exclusive lock so two writers cannot interleave halves
-        # of a line. `a` mode means the write is positioned at the end at write
-        # time, not at open time, so the lock is what orders them rather than a
-        # seek this would otherwise have to do itself.
-        with target.open("a", encoding="utf-8") as fh:
+        # of a line. `a+` means the write is positioned at the end at write time,
+        # not at open time, and the file is readable, which the torn-tail check
+        # needs: it has to see the last byte before deciding whether to cut.
+        with target.open("a+b") as fh:
             fcntl.flock(fh.fileno(), fcntl.LOCK_EX)
             try:
+                _discard_torn_tail(fh)
                 fh.write(line)
                 fh.flush()
                 if self.fsync:
@@ -111,6 +122,11 @@ class JsonlOutcomeStore:
     def latest(self, consumer: str, stream_path: str) -> list[Outcome]:
         best: dict[str, Outcome] = {}
         for record in self._read(consumer, stream_path):
+            # The file name says which scope this is, but the line says so too,
+            # and the line wins: on a case-folding filesystem two consumers can
+            # share a file, and a hand-edited file can hold anything.
+            if record.consumer != consumer or record.stream_path != stream_path:
+                continue
             held = best.get(record.subject)
             if held is None or record.attempt >= held.attempt:
                 best[record.subject] = record

--- a/src/rakaia/jsonl_outcomes.py
+++ b/src/rakaia/jsonl_outcomes.py
@@ -22,9 +22,11 @@ percent-encoding is the mapping that is reversible.
 
 Sharing the stream store's limits, and for the same reasons: `fcntl` only, so no
 Windows; `flock` is unreliable on NFS; readers do not take the lock. A torn
-trailing line — a crash mid-append — is skipped on read rather than parsed,
-because a partial outcome is not worth failing a whole report over, and cut off
-before the next append so that record is not glued onto it and lost as well.
+trailing line — a crash mid-append — is cut off before the next append, so that
+record is not glued onto it and lost as well. One that is read costs that line
+and not the report, and is reported as a line this version cannot build: the
+reader cannot tell a crash fragment from a record written by another version,
+and does not try to.
 
 What the lock orders is not the write itself — with `O_APPEND` a single short
 `write()` lands whole on a local filesystem — but the torn-tail check against a

--- a/src/rakaia/jsonl_outcomes.py
+++ b/src/rakaia/jsonl_outcomes.py
@@ -1,0 +1,134 @@
+"""An `OutcomeStore` backed by plain JSONL files on disk.
+
+The second implementation, and the reason the seam exists. `InMemoryOutcomeStore`
+proves nothing on its own — the same commit wrote it and the protocol, so of
+course it fits. This one has no database under it and shares no code with the
+first, so `tests/outcome_store_contract.py` passing against both is the evidence
+that an outcome is as store-agnostic as ADR 0007 Decision 1 claims.
+
+Outcomes are **append-only by definition** (Decision 6a), which makes a log file
+the natural shape rather than a compromise: `record` is one line appended, and
+nothing ever rewrites a line. Where the stream store needs segments, sealing and
+a head cache, this needs none of them — there is no head to track, and the
+population is exceptions only.
+
+Layout, one file per consumer and stream::
+
+    <root>/<quoted consumer>/<quoted stream path>.jsonl
+
+`quote(safe="")` on both components for the reason `JsonlStreamStore._dir` gives:
+a stream path contains slashes and must map to one name, not a tree, and
+percent-encoding is the mapping that is reversible.
+
+Sharing the stream store's limits, and for the same reasons: `fcntl` only, so no
+Windows; `flock` is unreliable on NFS; readers do not take the lock. A torn
+trailing line — a crash mid-append — is skipped on read rather than parsed,
+because a partial outcome is not worth failing a whole report over.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from urllib.parse import quote
+
+from .outcomes import Outcome, _order, decode, encode
+
+try:  # pragma: no cover - platform dependent
+    import fcntl
+except ImportError:  # pragma: no cover - Windows
+    fcntl = None  # type: ignore[assignment]
+
+
+def _safe_name(name: str) -> str:
+    """One path segment for `name`, guaranteed to stay under its parent.
+
+    `quote(safe="")` maps a slash to `%2F`, which is what keeps a stream path a
+    name rather than a tree, and it is reversible. What it does **not** touch is a
+    dot: `quote("..")` is `".."`, so a consumer or stream called `..` resolves
+    above the root and writes outside the store entirely. Only an all-dot name can
+    do that — anything else already carries an encoded character — so those are the
+    ones encoded here, and an empty name, which would otherwise collapse a
+    directory level.
+
+    Found by a containment test rather than by review, and that is the point worth
+    keeping: an unencoded name still *round-trips*, so reading back what was
+    written passes while the file sits somewhere it should never have been.
+    """
+    quoted = quote(name, safe="")
+    if not quoted or set(quoted) <= {"."}:
+        return quoted.replace(".", "%2E") or "%00"
+    return quoted
+
+
+class JsonlOutcomeStore:
+    """Outcomes kept as JSONL, one file per `(consumer, stream_path)`."""
+
+    def __init__(self, root: str | Path, *, fsync: bool = True):
+        """`fsync` on means a recorded outcome has reached the disk when `record` returns.
+
+        On by default for the reason `JsonlStreamStore` gives: the backend it is
+        measured against is a database, whose commit is durable, and returning
+        with the record only in the page cache would claim something weaker while
+        looking the same. Turn it off for tmpfs and fixtures.
+        """
+        if fcntl is None:  # pragma: no cover - Windows
+            raise RuntimeError(
+                "JsonlOutcomeStore needs fcntl.flock, which this platform does not "
+                "provide. Two writers appending unlocked can interleave a partial "
+                "line, so the store refuses to start rather than run unlocked."
+            )
+        self.root = Path(root)
+        self.fsync = fsync
+        self.root.mkdir(parents=True, exist_ok=True)
+
+    def _file(self, consumer: str, stream_path: str) -> Path:
+        return self.root / _safe_name(consumer) / f"{_safe_name(stream_path)}.jsonl"
+
+    def record(self, outcome: Outcome) -> None:
+        target = self._file(outcome.consumer, outcome.stream_path)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        line = encode(outcome) + "\n"
+        # Narrowing, not defence: `__init__` refuses to build a store on a platform
+        # without `fcntl`, so by here it is always a module. Stated as an assert
+        # rather than an ignore comment, the way `jsonl_store.py` states the same
+        # guarantee.
+        assert fcntl is not None
+        # Append under an exclusive lock so two writers cannot interleave halves
+        # of a line. `a` mode means the write is positioned at the end at write
+        # time, not at open time, so the lock is what orders them rather than a
+        # seek this would otherwise have to do itself.
+        with target.open("a", encoding="utf-8") as fh:
+            fcntl.flock(fh.fileno(), fcntl.LOCK_EX)
+            try:
+                fh.write(line)
+                fh.flush()
+                if self.fsync:
+                    os.fsync(fh.fileno())
+            finally:
+                fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
+
+    def latest(self, consumer: str, stream_path: str) -> list[Outcome]:
+        best: dict[str, Outcome] = {}
+        for record in self._read(consumer, stream_path):
+            held = best.get(record.subject)
+            if held is None or record.attempt >= held.attempt:
+                best[record.subject] = record
+        return sorted(best.values(), key=_order)
+
+    def _read(self, consumer: str, stream_path: str) -> list[Outcome]:
+        target = self._file(consumer, stream_path)
+        if not target.is_file():
+            return []
+        out: list[Outcome] = []
+        for line in target.read_text(encoding="utf-8").splitlines():
+            if not line.strip():
+                continue
+            # `decode` takes the stored text directly — the same text `encode`
+            # produced and the same text the in-memory store keeps. A torn line
+            # from a crash mid-append, and a line this version cannot rebuild,
+            # are the same case to it: that line is lost, never the report.
+            outcome = decode(line)
+            if outcome is not None:
+                out.append(outcome)
+        return out

--- a/src/rakaia/jsonl_store.py
+++ b/src/rakaia/jsonl_store.py
@@ -99,6 +99,28 @@ _POLL_INTERVAL_SECONDS = 0.05
 
 _DEFAULT_SEGMENT_SIZE = 10_000
 
+
+def _discard_torn_tail(fh: Any) -> None:
+    """Truncate a partial trailing line before appending after it.
+
+    A crash mid-append leaves bytes with no newline. Reads already skip them —
+    but an append that simply continued would glue its own record onto the
+    fragment and lose *both*. Recovery has to happen on the write side too, and
+    this is the cheapest place: the file is already open and locked. Shared with
+    `JsonlOutcomeStore`, whose files have the same shape and the same failure.
+    """
+    fh.seek(0, os.SEEK_END)
+    size = fh.tell()
+    if size == 0:
+        return
+    fh.seek(size - 1)
+    if fh.read(1) == b"\n":
+        return
+    fh.seek(0)
+    cut = fh.read().rfind(b"\n") + 1
+    fh.truncate(cut)
+
+
 #: Where retired offset high-marks live, as a sibling of the stream directories.
 #:
 #: The leading ``%`` is load-bearing. Stream directories are named
@@ -412,7 +434,7 @@ class JsonlStreamStore:
         for seg, lines in by_segment.items():
             existed = seg.exists()
             with seg.open("a+b") as fh:
-                self._discard_torn_tail(fh)
+                _discard_torn_tail(fh)
                 fh.write("".join(line + "\n" for line in lines).encode("utf-8"))
                 if self.fsync:
                     fh.flush()
@@ -423,26 +445,6 @@ class JsonlStreamStore:
                 # it. Without this a roll-over can survive as data nothing can
                 # find.
                 self._fsync_dir(seg.parent)
-
-    @staticmethod
-    def _discard_torn_tail(fh: Any) -> None:
-        """Truncate a partial trailing line before appending after it.
-
-        A crash mid-append leaves bytes with no newline. Reads already skip them
-        — but an append that simply continued would glue its own record onto the
-        fragment and lose *both*. Recovery has to happen on the write side too,
-        and this is the cheapest place: the file is already open and locked.
-        """
-        fh.seek(0, os.SEEK_END)
-        size = fh.tell()
-        if size == 0:
-            return
-        fh.seek(size - 1)
-        if fh.read(1) == b"\n":
-            return
-        fh.seek(0)
-        cut = fh.read().rfind(b"\n") + 1
-        fh.truncate(cut)
 
     # =========================================================================
     # Records

--- a/src/rakaia/outcomes.py
+++ b/src/rakaia/outcomes.py
@@ -141,9 +141,15 @@ class Outcome:
     def __post_init__(self) -> None:
         # Copy the two containers so `frozen=True` means what it says: it freezes
         # the binding, not the dict or list behind it, and a caller keeping its own
-        # reference could otherwise change what had already been recorded.
-        object.__setattr__(self, "params", dict(self.params))
-        object.__setattr__(self, "reasons", tuple(self.reasons))
+        # reference could otherwise change what had already been recorded. Only a
+        # container of the declared shape is copied — a bare string is iterable,
+        # and `tuple("missing_total")` is thirteen one-letter codes that the walk
+        # below would then pass; anything else is left as it came, for the walk to
+        # refuse.
+        if type(self.params) is dict:
+            object.__setattr__(self, "params", dict(self.params))
+        if type(self.reasons) in (list, tuple):
+            object.__setattr__(self, "reasons", tuple(self.reasons))
 
         # Every declared field is checked against its declared type, and the
         # declaration is read rather than restated: a field added later is

--- a/src/rakaia/outcomes.py
+++ b/src/rakaia/outcomes.py
@@ -11,7 +11,7 @@ Two things follow from where it is written, and both are load-bearing.
 The record is **not** produced inside an executor. A Django executor wraps its
 batch in a transaction, so a row written there would roll back with the batch
 whose failure it exists to record; and a staged pass buffers many events into one
-`apply()`, after which which event produced which effect is no longer
+`apply()`, after which the question of which event produced which effect is no longer
 recoverable. The loop that owns the cursor is the only place that still knows
 both the event and whether applying it worked.
 
@@ -33,6 +33,8 @@ from __future__ import annotations
 
 import json
 import logging
+import types
+import typing
 from dataclasses import dataclass, field, fields
 from typing import Literal
 
@@ -124,10 +126,10 @@ class Outcome:
     params: dict[str, str] = field(default_factory=dict)
     """Bounded context for the reasons: identifiers, counts, verdicts.
 
-    Values must be strings, and that is checked rather than asserted — the
-    docstring used to claim "by construction" while a nested dict of personal data
-    went in and came back out unchanged. Not leaking field values is this field's
-    whole reason for existing instead of a rendered message, so it refuses.
+    Keys and values must be strings, and construction refuses anything else — a
+    nested map is exactly the shape a whole record of personal data arrives in,
+    and not leaking field values is this field's reason for existing instead of
+    a rendered message.
     """
 
     attempt: int = 1
@@ -143,45 +145,35 @@ class Outcome:
         object.__setattr__(self, "params", dict(self.params))
         object.__setattr__(self, "reasons", tuple(self.reasons))
 
-        # Structural invariants — about what an outcome *means*, not how it is kept.
+        # Every declared field is checked against its declared type, and the
+        # declaration is read rather than restated: a field added later is
+        # checked the moment it is declared, not when its first defect is found.
+        # `type(x) is str` rather than `isinstance`, because a `str` subclass
+        # reads back from storage as plain text and only a type check can see
+        # the difference; and every string must encode, because a lone surrogate
+        # is text by every type check and no path or column can carry it.
+        problems = _check_fields(self)
+        names = ("consumer", "stream_path", "subject", "offset")
+        unwritable = sorted(n for n in problems if n.split("[", 1)[0] in names)
+        if unwritable:
+            raise ValueError(
+                f"A store sorts and names by these, so they have to be writable text: "
+                f"{', '.join(unwritable)}."
+            )
+        if problems:
+            detail = "; ".join(f"{name}: {why}" for name, why in problems.items())
+            raise ValueError(
+                f"An outcome has to be storable as text and this one is not: {detail}. "
+                "Render it, or leave it out."
+            )
         # An empty name is not merely odd, it collides: a file-backed store maps a
         # name to one path segment, and every escaping of "" lands on the segment
         # some other input already uses. Refusing here is cheaper than making every
         # store's naming injective, and an outcome about nothing is meaningless
         # anyway.
-        # The fields a *store* reasons about, as opposed to merely carries. These
-        # four become path segments, dictionary keys and sort keys, so they have to
-        # be writable text — and for reasons the payload rule cannot see:
-        #
-        #   a number stored as a name raises in a file store's path escaping;
-        #   a lone surrogate is text by every type check and no path can carry it;
-        #   a number stored as an offset is kept identically by every store and then
-        #     makes `latest` raise the moment a text offset sits beside it, because
-        #     the two cannot be compared.
-        #
-        # Everything else an outcome holds is settled by `encode` actually storing
-        # it. This list is short because it is not a description of the type system;
-        # it is the set of values the machinery touches.
-        handled = ("consumer", "stream_path", "subject", "offset")
-        unwritable = []
-        for name in handled:
-            value = getattr(self, name)
-            if value is None and name == "offset":
-                continue  # an event that never reached the log has no position
-            if type(value) is not str:
-                unwritable.append(name)
-                continue
-            try:
-                value.encode("utf-8")
-            except UnicodeEncodeError:
-                unwritable.append(name)
-        if unwritable:
-            raise ValueError(
-                f"A store sorts and names by these, so they have to be writable text: "
-                f"{', '.join(sorted(unwritable))}."
-            )
-        names = ("consumer", "stream_path", "subject")
-        empty = sorted(n for n in names if not getattr(self, n))
+        empty = sorted(
+            n for n in ("consumer", "stream_path", "subject") if not getattr(self, n)
+        )
         if empty:
             raise ValueError(
                 f"A name saying what this outcome belongs to cannot be empty: {', '.join(empty)}."
@@ -198,14 +190,75 @@ class Outcome:
         if self.attempt < 1:
             raise ValueError(f"attempt counts from 1, got {self.attempt}.")
 
-        # Storability is one rule and `encode` is where it lives, so this asks the
-        # same question a store will ask rather than keeping a second copy of the
-        # answer. Five rounds of review closed this one field at a time — values of
-        # one map, then its keys, then the list beside it, then the plain fields —
-        # because each check was written where the defect was found instead of where
-        # the rule belongs. Calling it here only moves *when* the caller hears about
-        # it; the rule itself has one home.
+        # `encode` is still the last word: anything the walk above cannot see
+        # and json cannot render is refused there, with the same message.
         encode(self)
+
+
+def _check_fields(outcome: Outcome) -> dict[str, str]:
+    """Every declared field against its declared type; `{field: why}` for each miss.
+
+    Reads the annotations rather than naming the fields, so the rule is exactly the
+    declaration: a `Literal` admits only its members, an `int` is not a `bool`, a
+    `tuple[str, ...]` and a `dict[str, str]` are checked element by element, and
+    every `str` must be encodable. Paths into a container read as
+    ``params['k']`` so the message says which value was wrong.
+    """
+    problems: dict[str, str] = {}
+    hints = typing.get_type_hints(Outcome)
+    for f in fields(outcome):
+        _check_value(f.name, getattr(outcome, f.name), hints[f.name], problems)
+    return problems
+
+
+def _check_value(
+    path: str, value: object, hint: object, problems: dict[str, str]
+) -> None:
+    origin = typing.get_origin(hint)
+    args = typing.get_args(hint)
+    if origin in (typing.Union, types.UnionType):
+        if value is None and type(None) in args:
+            return
+        others = [a for a in args if a is not type(None)]
+        if len(others) == 1:
+            _check_value(path, value, others[0], problems)
+            return
+        raise TypeError(f"Unsupported annotation on {path}: {hint!r}")
+    if origin is Literal:
+        if type(value) is not str or value not in args:
+            problems[path] = (
+                f"expected one of {', '.join(map(repr, args))}, got {value!r}"
+            )
+        return
+    if origin is tuple:
+        if type(value) is not tuple:
+            problems[path] = f"expected a tuple, got {type(value).__name__}"
+            return
+        for i, item in enumerate(value):
+            _check_value(f"{path}[{i}]", item, args[0], problems)
+        return
+    if origin is dict:
+        if type(value) is not dict:
+            problems[path] = f"expected a dict, got {type(value).__name__}"
+            return
+        for k, v in value.items():
+            _check_value(f"{path}[{k!r}] (key)", k, args[0], problems)
+            _check_value(f"{path}[{k!r}]", v, args[1], problems)
+        return
+    if hint is str:
+        if type(value) is not str:
+            problems[path] = f"expected text, got {type(value).__name__}"
+            return
+        try:
+            value.encode("utf-8")
+        except UnicodeEncodeError:
+            problems[path] = "text that cannot be encoded"
+        return
+    if hint is int:
+        if type(value) is not int:
+            problems[path] = f"expected an int, got {type(value).__name__}"
+        return
+    raise TypeError(f"Unsupported annotation on {path}: {hint!r}")
 
 
 def encode(outcome: Outcome) -> str:
@@ -217,15 +270,10 @@ def encode(outcome: Outcome) -> str:
     file-backed store without the file, rather than a second implementation that
     happens to behave the same.
 
-    That matters because the previous approach did not work. It validated each
-    field against its declared type, and five review rounds plus two more found
-    values that satisfy a type and still do not survive storage: a `str` subclass
-    that flattens, a lone surrogate a path cannot carry, a string longer than a
-    column allows. The set is open-ended, so approximating "survives storage" with
-    type rules leaks by construction — the check has to *be* the storing.
-
     Refuses by raising, because `json.dumps` already refuses everything it cannot
-    represent. Nothing here re-states which types those are.
+    represent. Construction has already checked each field against its declared
+    type by the time this runs, so this is the backstop for whatever that walk
+    does not describe, not the rule itself.
     """
     try:
         return json.dumps(
@@ -252,6 +300,8 @@ def decode(stored: str) -> Outcome | None:
     known = {f.name for f in fields(Outcome)}
     try:
         payload = json.loads(stored)
+        if not isinstance(payload, dict):
+            raise ValueError(f"expected an object, got {type(payload).__name__}")
         return Outcome(**{k: v for k, v in payload.items() if k in known})
     except (TypeError, ValueError) as exc:
         logger.warning(

--- a/src/rakaia/outcomes.py
+++ b/src/rakaia/outcomes.py
@@ -1,0 +1,308 @@
+"""What happened to an event a consumer tried to apply — the record a cursor cannot carry.
+
+A cursor says how far a consumer got. It says nothing about whether it got there
+cleanly, so an event that was skipped, refused or lost is indistinguishable from
+one applied without incident: **absence of a record reads as success**. This
+module is the record that closes that gap. The loop that writes it is not part of
+this change; ADR 0007 Decision 2 describes where it goes.
+
+Two things follow from where it is written, and both are load-bearing.
+
+The record is **not** produced inside an executor. A Django executor wraps its
+batch in a transaction, so a row written there would roll back with the batch
+whose failure it exists to record; and a staged pass buffers many events into one
+`apply()`, after which which event produced which effect is no longer
+recoverable. The loop that owns the cursor is the only place that still knows
+both the event and whether applying it worked.
+
+And only **exceptions** are recorded. The cursor is the success record —
+everything below it succeeded unless an outcome says otherwise — so a clean run
+writes nothing at all. There is no gap query, and ADR 0007 Decision 3 explains
+why one cannot exist here: with success leaving no trace, "no record" *is* the
+success case, so lag comes from the head against the cursor and everything else
+comes from `latest`.
+
+The `OutcomeStore` seam itself lives in `rakaia.protocols`, with the other
+store-facing protocols.
+
+See ADR 0007 for the reasoning in full, including why an outcome is neither an
+observation about the data nor a verification result.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field, fields
+from typing import Literal
+
+logger = logging.getLogger(__name__)
+
+Stage = Literal["append", "project"]
+"""How far the event got before something went wrong.
+
+* ``append`` — it never reached the log. ``offset`` is ``None``, and ``status``
+  says whether it was lost or declined.
+* ``project`` — it is safe in the log and was not applied. Replay recovers it.
+"""
+
+OutcomeStatus = Literal["failed", "refused", "skipped"]
+"""What happened, and therefore what recovery is wanted.
+
+* ``failed`` — something raised. A bug or a transient fault; worth an alert.
+* ``refused`` — a consumer's own rules declined it. Ordinary data quality, not an
+  incident, and *deliberate*: with ``stage="append"`` the fact is not lost, it is
+  sitting wherever the event was produced from, and fixing the data upstream is
+  what recovers it.
+* ``skipped`` — deliberately not applied and nothing is wanted. Recorded so that
+  a later reader can tell "we decided not to" from "we never saw it".
+"""
+
+
+@dataclass(frozen=True)
+class Outcome:
+    """One event's failure to be applied cleanly, as a value.
+
+    Immutable, and deliberately so. Nothing here is resolved or retried in place:
+    a further attempt is a further outcome with a higher ``attempt``, and "is this
+    still failing?" is the latest outcome for the key. A mutable ``resolved_at``
+    would be a second answer to a question a consumer's own records already
+    answer — its rules layer typically owns the resolution of the very
+    observations ``reasons`` names — and two answers eventually disagree.
+    """
+
+    consumer: str
+    """Which consumer this is about. Pairs with ``ConsumerCursor.consumer_id``."""
+
+    stream_path: str
+    """The stream the event belongs to. A plain string, not a reference, so an
+    outcome outlives the stream it describes."""
+
+    subject: str
+    """What this outcome is *about*, as the consumer identifies it. Opaque here.
+
+    Required, and not defaulted to the offset, because an event that never reached
+    the log has no offset — and those are the ones a consumer most needs to tell
+    apart. Keying on the offset alone collapsed every refusal on a stream into a
+    single row and reported the first as though it spoke for the rest, which is
+    the same defect as one bad row making a whole form look fine.
+
+    Distinct from `sequence_key`: the subject is the one thing this outcome
+    concerns, the sequence key is what it is *ordered within*. They are often the
+    same value, and are not when one decision refuses several subjects together.
+    """
+
+    offset: str | None
+    """The event's position, opaque and store-issued — or ``None`` when
+    ``stage="append"``, because an event that never reached the log has no
+    position to name."""
+
+    sequence_key: str
+    """What this event is ordered *within*, as the consumer defines it.
+
+    Rakaia records it and does not yet act on it. Its purpose is a later one: a
+    failure parks a sequence, and events behind it must wait rather than apply to
+    a state that never saw the one in front. Recording it now costs a field;
+    deriving it afterwards means re-deciding groupings a consumer has already
+    decided. See ADR 0007, Decision 7.
+    """
+
+    stage: Stage
+    status: OutcomeStatus
+
+    reasons: tuple[str, ...] = ()
+    """Why, as codes rather than prose. **Opaque to rakaia** — which codes exist
+    and what they mean belong to the consumer, exactly as an offset's meaning
+    belongs to the store.
+
+    Plural because one event can breach several rules at once, and flattening
+    them into a sentence loses the only property that makes them countable. An
+    interpolated message is also where field values leak, which matters for the
+    consumers this library was built for.
+    """
+
+    params: dict[str, str] = field(default_factory=dict)
+    """Bounded context for the reasons: identifiers, counts, verdicts.
+
+    Values must be strings, and that is checked rather than asserted — the
+    docstring used to claim "by construction" while a nested dict of personal data
+    went in and came back out unchanged. Not leaking field values is this field's
+    whole reason for existing instead of a rendered message, so it refuses.
+    """
+
+    attempt: int = 1
+    """Which try this was, from 1. The natural key is
+    ``(consumer, stream_path, subject, attempt)`` — subject rather than offset,
+    because a refused event has no offset — so history accumulates instead of
+    overwriting itself."""
+
+    def __post_init__(self) -> None:
+        # Copy the two containers so `frozen=True` means what it says: it freezes
+        # the binding, not the dict or list behind it, and a caller keeping its own
+        # reference could otherwise change what had already been recorded.
+        object.__setattr__(self, "params", dict(self.params))
+        object.__setattr__(self, "reasons", tuple(self.reasons))
+
+        # Structural invariants — about what an outcome *means*, not how it is kept.
+        # An empty name is not merely odd, it collides: a file-backed store maps a
+        # name to one path segment, and every escaping of "" lands on the segment
+        # some other input already uses. Refusing here is cheaper than making every
+        # store's naming injective, and an outcome about nothing is meaningless
+        # anyway.
+        # The fields a *store* reasons about, as opposed to merely carries. These
+        # four become path segments, dictionary keys and sort keys, so they have to
+        # be writable text — and for reasons the payload rule cannot see:
+        #
+        #   a number stored as a name raises in a file store's path escaping;
+        #   a lone surrogate is text by every type check and no path can carry it;
+        #   a number stored as an offset is kept identically by every store and then
+        #     makes `latest` raise the moment a text offset sits beside it, because
+        #     the two cannot be compared.
+        #
+        # Everything else an outcome holds is settled by `encode` actually storing
+        # it. This list is short because it is not a description of the type system;
+        # it is the set of values the machinery touches.
+        handled = ("consumer", "stream_path", "subject", "offset")
+        unwritable = []
+        for name in handled:
+            value = getattr(self, name)
+            if value is None and name == "offset":
+                continue  # an event that never reached the log has no position
+            if type(value) is not str:
+                unwritable.append(name)
+                continue
+            try:
+                value.encode("utf-8")
+            except UnicodeEncodeError:
+                unwritable.append(name)
+        if unwritable:
+            raise ValueError(
+                f"A store sorts and names by these, so they have to be writable text: "
+                f"{', '.join(sorted(unwritable))}."
+            )
+        names = ("consumer", "stream_path", "subject")
+        empty = sorted(n for n in names if not getattr(self, n))
+        if empty:
+            raise ValueError(
+                f"A name saying what this outcome belongs to cannot be empty: {', '.join(empty)}."
+            )
+        if self.stage == "append" and self.offset is not None:
+            raise ValueError(
+                f"An outcome at stage='append' has no offset — the event never reached the log — "
+                f"but got offset={self.offset!r}."
+            )
+        if self.stage == "project" and self.offset is None:
+            raise ValueError(
+                "An outcome at stage='project' names an event in the log, so it needs an offset."
+            )
+        if self.attempt < 1:
+            raise ValueError(f"attempt counts from 1, got {self.attempt}.")
+
+        # Storability is one rule and `encode` is where it lives, so this asks the
+        # same question a store will ask rather than keeping a second copy of the
+        # answer. Five rounds of review closed this one field at a time — values of
+        # one map, then its keys, then the list beside it, then the plain fields —
+        # because each check was written where the defect was found instead of where
+        # the rule belongs. Calling it here only moves *when* the caller hears about
+        # it; the rule itself has one home.
+        encode(self)
+
+
+def encode(outcome: Outcome) -> str:
+    """The one translation from an outcome to the text a store keeps.
+
+    Returns **text**, not a dict, and that is the whole design. Every store keeps
+    this exact string, so there is only one representation of a stored outcome and
+    nothing for two backends to disagree about. The in-memory store is then the
+    file-backed store without the file, rather than a second implementation that
+    happens to behave the same.
+
+    That matters because the previous approach did not work. It validated each
+    field against its declared type, and five review rounds plus two more found
+    values that satisfy a type and still do not survive storage: a `str` subclass
+    that flattens, a lone surrogate a path cannot carry, a string longer than a
+    column allows. The set is open-ended, so approximating "survives storage" with
+    type rules leaks by construction — the check has to *be* the storing.
+
+    Refuses by raising, because `json.dumps` already refuses everything it cannot
+    represent. Nothing here re-states which types those are.
+    """
+    try:
+        return json.dumps(
+            {f.name: getattr(outcome, f.name) for f in fields(outcome)}, sort_keys=True
+        )
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            f"An outcome has to be storable as text and this one is not: {exc}. Render it, or leave it out."
+        ) from exc
+
+
+def decode(stored: str) -> Outcome | None:
+    """The inverse of `encode`, or ``None`` if this version cannot build it.
+
+    ``None`` rather than an exception because the caller is usually reading a whole
+    file: a line written by a version that added a field, or predating one, must
+    cost that line and not the report. Unknown keys are dropped and a missing
+    required one gives ``None``.
+
+    Dropping is logged, because a silently discarded line is the failure this whole
+    module exists to close — a file entirely of skew would otherwise read back as
+    "nothing failed". See ADR 0007 for why this is a log and not yet a count.
+    """
+    known = {f.name for f in fields(Outcome)}
+    try:
+        payload = json.loads(stored)
+        return Outcome(**{k: v for k, v in payload.items() if k in known})
+    except (TypeError, ValueError) as exc:
+        logger.warning(
+            "rakaia: dropping an outcome this version cannot build (%s)", exc
+        )
+        return None
+
+
+def _order(outcome: Outcome) -> tuple[bool, str, str]:
+    """Sort key shared by every backend, so `latest` returns one order."""
+    return (outcome.offset is None, outcome.offset or "", outcome.subject)
+
+
+class InMemoryOutcomeStore:
+    """An `OutcomeStore` held in a list. The reference implementation.
+
+    Every backend is measured against this one through
+    `tests/outcome_store_contract.py`, and it is what a test uses when the point
+    under test is a consumer's behaviour rather than its storage.
+
+    Not durable, deliberately: an outcome that has to survive a restart needs a
+    backend that survives one, and pretending otherwise here would make the
+    contract easier to pass than to satisfy.
+    """
+
+    def __init__(self) -> None:
+        self._recorded: list[str] = []
+
+    def record(self, outcome: Outcome) -> None:
+        # The encoded *text*, not the object and not a dict. This store is then the
+        # file-backed one without the file, so the two cannot disagree about what
+        # was stored — which is the disagreement seven review findings were about.
+        self._recorded.append(encode(outcome))
+
+    def latest(self, consumer: str, stream_path: str) -> list[Outcome]:
+        best: dict[str, Outcome] = {}
+        for stored in self._recorded:
+            outcome = decode(stored)
+            if (
+                outcome is None
+                or outcome.consumer != consumer
+                or outcome.stream_path != stream_path
+            ):
+                continue
+            held = best.get(outcome.subject)
+            # `>=` so re-recording an attempt replaces it. A tie is a caller
+            # error either way, and last-write-wins is the less surprising of the
+            # two answers.
+            if held is None or outcome.attempt >= held.attempt:
+                best[outcome.subject] = outcome
+        # Offsets sort as the opaque strings they are; the append-stage entries
+        # have none and go last rather than being compared against one. Subject
+        # breaks the remaining ties so the order does not depend on insertion.
+        return sorted(best.values(), key=_order)

--- a/src/rakaia/protocols.py
+++ b/src/rakaia/protocols.py
@@ -12,7 +12,9 @@ Producers and the meta-stream registry additionally *write*, captured by
 
 All store-facing protocols live here so they read as one coherent seam:
 `ReadableStore` (read), `WritableStore` (+ create/append/has), `CursorStore`
-(+ get_current_offset).
+(+ get_current_offset). `OutcomeStore` keeps what a cursor cannot say — which
+events a consumer failed to apply (ADR 0007) — and is separate because a backend
+may hold outcomes somewhere other than its events.
 """
 
 from __future__ import annotations
@@ -20,6 +22,7 @@ from __future__ import annotations
 from collections.abc import Iterable
 from typing import Any, Protocol, runtime_checkable
 
+from .outcomes import Outcome
 from .types import Stream as StreamMetadata
 from .types import StreamMessage
 
@@ -266,6 +269,37 @@ class CursorStore(ReadableStore, Protocol):
 
     def get_current_offset(self, path: str) -> str | None:
         """The offset after the last message, or None if the stream is absent."""
+        ...
+
+
+@runtime_checkable
+class OutcomeStore(Protocol):
+    """Somewhere durable to keep outcomes.
+
+    Sits beside `CursorStore` for the same reason: the decision about what to
+    record is store-agnostic, and only the keeping of it is backend-shaped. A
+    backend may implement this on the same object as its stream store or on a
+    separate one; nothing here assumes either.
+    """
+
+    def record(self, outcome: Outcome) -> None:
+        """Append `outcome`. Never updates an existing row — a repeat is a new
+        `attempt`."""
+        ...
+
+    def latest(self, consumer: str, stream_path: str) -> list[Outcome]:
+        """The most recent outcome per **subject**, newest attempt winning.
+
+        This is how "what is still failing?" is asked. A subject whose latest
+        outcome is `skipped` is not failing; one with no outcome at all never
+        failed. Ordered by offset — `stage="append"` entries have none and come
+        last — then by subject, so the order is total rather than insertion-order.
+
+        Per subject and not per offset, because the outcomes that matter most are
+        exactly the ones with no offset to key on: a refused event never reached
+        the log. Keying on the offset made every refusal on a stream collapse into
+        one row.
+        """
         ...
 
 

--- a/tests/outcome_store_contract.py
+++ b/tests/outcome_store_contract.py
@@ -20,7 +20,8 @@ an ordering assertion cannot catch a store that parses one. That property lives
 in `test_cross_backend_cursors.py`, where a foreign format is refused rather than
 misread. Retention, admin surfaces and
 re-drive are out of scope: the first is a policy a consumer schedules, and the
-last is deliberately not in this version (ADR 0007, "Not in v1").
+last is deliberately deferred (ADR 0007, "Alternatives considered — Ship re-drive
+in the same change").
 
 What *is* contract: an outcome is never updated in place, and `latest` collapses
 attempts and nothing else. There is no gap query to pin — ADR 0007 Decision 3

--- a/tests/outcome_store_contract.py
+++ b/tests/outcome_store_contract.py
@@ -1,0 +1,264 @@
+"""Shared conformance contract for `OutcomeStore` (ADR 0007).
+
+An outcome is as store-agnostic as a cursor: the decision about what to record is
+made once, and only the keeping of it is backend-shaped. So every backend that
+keeps outcomes is held to the same behaviour here, and "does this work on the
+file store too?" is a red test rather than a question. Subclass
+`OutcomeStoreContract` in each backend's test package and provide an `outcomes`
+fixture returning a fresh, empty store. See ADR 0002 / #36 for the pattern.
+
+This module is intentionally not named `test_*`, so pytest does not collect it
+directly; only the backend subclasses run it.
+
+**Scope, and what is deliberately not pinned.** Offsets here are illustrative
+opaque strings, shorter than any real store issues, and the contract only ever
+compares them lexicographically — so a backend issuing a compound
+`{seq}_{byte}` token and one issuing a zero-padded integer both satisfy it.
+Offset *opacity* is not pinned here and cannot usefully be: both formats are
+zero-padded precisely so that lexicographic and numeric order agree, which means
+an ordering assertion cannot catch a store that parses one. That property lives
+in `test_cross_backend_cursors.py`, where a foreign format is refused rather than
+misread. Retention, admin surfaces and
+re-drive are out of scope: the first is a policy a consumer schedules, and the
+last is deliberately not in this version (ADR 0007, "Not in v1").
+
+What *is* contract: an outcome is never updated in place, and `latest` collapses
+attempts and nothing else. There is no gap query to pin — ADR 0007 Decision 3
+records why one cannot exist when success leaves no trace.
+"""
+
+from __future__ import annotations
+
+from rakaia.outcomes import Outcome
+
+
+def project(offset: str, *, consumer: str = "c", path: str = "s", **kw) -> Outcome:
+    """A projection-stage outcome, the common case in these tests."""
+    kw.setdefault("sequence_key", "seq")
+    kw.setdefault("status", "failed")
+    kw.setdefault("subject", offset)
+    return Outcome(
+        consumer=consumer, stream_path=path, offset=offset, stage="project", **kw
+    )
+
+
+def refused(subject: str, *, consumer: str = "c", path: str = "s", **kw) -> Outcome:
+    """An append-stage refusal — no offset, because it never reached the log."""
+    kw.setdefault("sequence_key", subject)
+    kw.setdefault("status", "refused")
+    return Outcome(
+        consumer=consumer,
+        stream_path=path,
+        offset=None,
+        subject=subject,
+        stage="append",
+        **kw,
+    )
+
+
+class OutcomeStoreContract:
+    """Contract every outcome store must uphold.
+
+    Subclasses provide::
+
+        @pytest.fixture
+        def outcomes(self):
+            return MyOutcomeStore()
+    """
+
+    # --- the seam itself ----------------------------------------------------
+
+    def test_satisfies_the_outcome_store_protocol(self, outcomes):
+        from rakaia.protocols import OutcomeStore
+
+        assert isinstance(outcomes, OutcomeStore)
+
+    def test_an_empty_store_reports_nothing(self, outcomes):
+        assert outcomes.latest("c", "s") == []
+
+    # --- recording ----------------------------------------------------------
+
+    def test_a_recorded_outcome_is_returned(self, outcomes):
+        outcomes.record(project("0000000001", reasons=("bad_total",)))
+        [got] = outcomes.latest("c", "s")
+        assert (got.offset, got.status, got.reasons) == (
+            "0000000001",
+            "failed",
+            ("bad_total",),
+        )
+
+    def test_outcomes_are_scoped_by_consumer_and_stream(self, outcomes):
+        """Distinct offsets per scope, deliberately.
+
+        Mutation watched: dropping the consumer/stream filter from `latest`. With
+        all three rows sharing one offset the answer collapses to a single entry
+        either way and the mutation survives — the same shape of false green as
+        asserting a count where the contents are what matter.
+        """
+        outcomes.record(project("0000000001", reasons=("mine",)))
+        outcomes.record(project("0000000002", consumer="other", reasons=("theirs",)))
+        outcomes.record(project("0000000003", path="other", reasons=("elsewhere",)))
+
+        assert [(o.offset, o.reasons) for o in outcomes.latest("c", "s")] == [
+            ("0000000001", ("mine",))
+        ]
+        assert [(o.offset, o.reasons) for o in outcomes.latest("other", "s")] == [
+            ("0000000002", ("theirs",))
+        ]
+        assert [(o.offset, o.reasons) for o in outcomes.latest("c", "other")] == [
+            ("0000000003", ("elsewhere",))
+        ]
+
+    def test_params_round_trip(self, outcomes):
+        outcomes.record(project("0000000001", params={"row": "3", "budget": "500"}))
+        [got] = outcomes.latest("c", "s")
+        assert got.params == {"row": "3", "budget": "500"}
+
+    def test_a_recorded_outcome_does_not_change_when_the_caller_mutates_its_params(
+        self, outcomes
+    ):
+        """`frozen=True` freezes the binding, not the dict behind it.
+
+        A contract rather than a per-backend test because the two disagreed: a
+        backend that serialises escaped this by accident and one that keeps the
+        object did not. This is the field whose whole purpose is that field values
+        never reach it, so a caller adding one afterwards must not land.
+        """
+        params = {"row": "3"}
+        outcomes.record(project("0000000001", params=params))
+        params["national_id"] = "1234-LEAK"
+
+        [got] = outcomes.latest("c", "s")
+        assert got.params == {"row": "3"}
+
+    def test_a_recorded_outcome_does_not_change_when_the_caller_mutates_its_reasons(
+        self, outcomes
+    ):
+        """The twin of the params test, missing for three rounds.
+
+        `reasons` is declared a tuple and nothing made it one, so a caller passing
+        a list kept a live handle on what had already been recorded — and the two
+        backends then disagreed, because one serialises and one does not. Both
+        container fields need the same guarantee or neither has it.
+        """
+        reasons = ["missing_total"]
+        outcomes.record(project("0000000001", reasons=reasons))
+        reasons.append("LEAKED_AFTER_RECORD")
+
+        [got] = outcomes.latest("c", "s")
+        assert got.reasons == ("missing_total",)
+
+    def test_an_append_stage_outcome_has_no_offset(self, outcomes):
+        outcomes.record(refused("row-1", reasons=("declined_upstream",)))
+        [got] = outcomes.latest("c", "s")
+        assert got.offset is None and got.stage == "append"
+
+    # --- immutability and attempts ------------------------------------------
+
+    def test_a_later_attempt_is_what_latest_reports(self, outcomes):
+        """Renamed from a claim it could not keep.
+
+        It used to say it proved the store never *replaces* a row, while reading
+        only through `latest()` — which collapses attempts, so an in-place
+        overwrite is invisible to it. Mutation that proved it vacuous: make
+        `record` delete the matching row before appending; this test stayed green.
+        Append-only storage is not observable through this interface, so the name
+        now claims only what the assertion can see.
+        """
+        outcomes.record(project("0000000001", reasons=("first",), attempt=1))
+        outcomes.record(project("0000000001", reasons=("second",), attempt=2))
+        [got] = outcomes.latest("c", "s")
+        assert got.reasons == ("second",) and got.attempt == 2
+
+    def test_every_refused_subject_is_reported_separately(self, outcomes):
+        """The case the design exists for, and the one it originally lost.
+
+        Refusals never reach the log, so they have no offset. Keyed on offset they
+        all collapsed to a single row and the first was reported as though it spoke
+        for the rest — one bad row making a whole form look accounted for, which is
+        the defect this record is meant to expose.
+        """
+        for i in (1, 2, 3):
+            outcomes.record(refused(f"row-{i}", reasons=(f"rule_{i}",)))
+
+        got = outcomes.latest("c", "s")
+        assert [(o.subject, o.reasons) for o in got] == [
+            ("row-1", ("rule_1",)),
+            ("row-2", ("rule_2",)),
+            ("row-3", ("rule_3",)),
+        ]
+
+    def test_a_refusal_and_a_projection_failure_coexist(self, outcomes):
+        """One with an offset, one without, both about different subjects."""
+        outcomes.record(project("0000000001"))
+        outcomes.record(refused("row-9"))
+        assert [(o.subject, o.offset) for o in outcomes.latest("c", "s")] == [
+            ("0000000001", "0000000001"),
+            ("row-9", None),
+        ]
+
+    def test_latest_takes_the_highest_attempt_not_the_last_written(self, outcomes):
+        """Out-of-order writes must not decide the answer.
+
+        Mutation watched: `latest` returning the most recently recorded row. A
+        re-drive that records attempt 2 before a slow attempt 1 lands would then
+        report the older verdict as current.
+        """
+        outcomes.record(project("0000000001", reasons=("second",), attempt=2))
+        outcomes.record(project("0000000001", reasons=("first",), attempt=1))
+        [got] = outcomes.latest("c", "s")
+        assert got.reasons == ("second",)
+
+    def test_latest_returns_one_row_per_subject(self, outcomes):
+        for offset in ("0000000001", "0000000002", "0000000003"):
+            outcomes.record(project(offset, attempt=1))
+            outcomes.record(project(offset, attempt=2))
+        assert [o.offset for o in outcomes.latest("c", "s")] == [
+            "0000000001",
+            "0000000002",
+            "0000000003",
+        ]
+
+    def test_latest_orders_by_offset_with_append_stage_last(self, outcomes):
+        outcomes.record(project("0000000002"))
+        outcomes.record(refused("row-1"))
+        outcomes.record(project("0000000001"))
+        assert [o.offset for o in outcomes.latest("c", "s")] == [
+            "0000000001",
+            "0000000002",
+            None,
+        ]
+
+    # --- what a clean run looks like ---------------------------------------
+
+    def test_the_order_does_not_depend_on_when_things_were_recorded(self, outcomes):
+        """Refusals share the "no offset" sort position, so without a further term
+        the order is whatever the storage happened to do. Mutation: drop `subject`
+        from the sort key — dicts preserve insertion order and a stable sort keeps
+        it, so this comes back reversed."""
+        for subject in ("row-3", "row-1", "row-2"):
+            outcomes.record(refused(subject))
+        assert [o.subject for o in outcomes.latest("c", "s")] == [
+            "row-1",
+            "row-2",
+            "row-3",
+        ]
+
+    def test_re_recording_an_attempt_replaces_it(self, outcomes):
+        """Two outcomes for one subject at the same attempt is a caller error either
+        way; last-write-wins is the less surprising of the two answers, and `>` versus
+        `>=` is otherwise invisible."""
+        outcomes.record(project("0000000001", reasons=("first",), attempt=2))
+        outcomes.record(project("0000000001", reasons=("corrected",), attempt=2))
+        [got] = outcomes.latest("c", "s")
+        assert got.reasons == ("corrected",)
+
+    def test_a_clean_run_records_nothing(self, outcomes):
+        """The property the exceptions-only design rests on.
+
+        Nothing failed, so nothing was written. Stated as a test because it is
+        the load-bearing half of "the cursor is the success record": if a store
+        ever synthesised a row per applied event, every count built on this table
+        would change meaning without anything failing.
+        """
+        assert outcomes.latest("c", "s") == []

--- a/tests/test_rakaia/test_jsonl_outcome_store_contract.py
+++ b/tests/test_rakaia/test_jsonl_outcome_store_contract.py
@@ -322,3 +322,60 @@ class TestJsonlOutcomeStoreDurability:
                 fh.write(encode(foreign) + "\n")
 
         assert [o.subject for o in store.latest("c", "s")] == ["row-1"]
+
+
+class TestJsonlOutcomeStoreLocking:
+    """The one thing the append lock orders, pinned the only way it can be.
+
+    With `O_APPEND` a short `write()` lands whole, so two unlocked writers never
+    interleave and a test on the written bytes stays green with the lock removed.
+    What the lock guards is the torn-tail check — read the tail, maybe truncate,
+    then write — so the test holds one writer inside that window and checks the
+    second is still waiting. Removing the `LOCK_EX` call makes it fail; the
+    explicit unlock is not pinned, because closing the file releases it anyway.
+    """
+
+    def test_a_second_writer_waits_while_the_first_is_inside_the_torn_tail_check(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        import threading
+
+        from rakaia import jsonl_outcomes
+        from rakaia.outcomes import Outcome
+
+        def refused(subject: str) -> Outcome:
+            return Outcome(
+                consumer="c",
+                stream_path="s",
+                subject=subject,
+                offset=None,
+                sequence_key=subject,
+                stage="append",
+                status="refused",
+            )
+
+        store = JsonlOutcomeStore(tmp_path / "outcomes", fsync=False)
+        store.record(refused("row-0"))  # so the file and its directory exist
+        real = jsonl_outcomes._discard_torn_tail
+        second_still_waiting: list[bool] = []
+        entered = threading.Event()
+
+        def held_open(fh):
+            # Only the first writer is held; the second must run the real thing.
+            if not entered.is_set():
+                entered.set()
+                other = threading.Thread(target=store.record, args=(refused("row-2"),))
+                other.start()
+                other.join(timeout=0.5)
+                second_still_waiting.append(other.is_alive())
+            real(fh)
+
+        monkeypatch.setattr(jsonl_outcomes, "_discard_torn_tail", held_open)
+        store.record(refused("row-1"))
+
+        assert second_still_waiting == [True]
+        assert [o.subject for o in store.latest("c", "s")] == [
+            "row-0",
+            "row-1",
+            "row-2",
+        ]

--- a/tests/test_rakaia/test_jsonl_outcome_store_contract.py
+++ b/tests/test_rakaia/test_jsonl_outcome_store_contract.py
@@ -359,12 +359,12 @@ class TestJsonlOutcomeStoreLocking:
         real = jsonl_outcomes._discard_torn_tail
         second_still_waiting: list[bool] = []
         entered = threading.Event()
+        other = threading.Thread(target=store.record, args=(refused("row-2"),))
 
         def held_open(fh):
             # Only the first writer is held; the second must run the real thing.
             if not entered.is_set():
                 entered.set()
-                other = threading.Thread(target=store.record, args=(refused("row-2"),))
                 other.start()
                 other.join(timeout=0.5)
                 second_still_waiting.append(other.is_alive())
@@ -372,6 +372,9 @@ class TestJsonlOutcomeStoreLocking:
 
         monkeypatch.setattr(jsonl_outcomes, "_discard_torn_tail", held_open)
         store.record(refused("row-1"))
+        # The first writer returning is what unblocks the second; it still has
+        # its own check and write to do, so wait for it before reading.
+        other.join()
 
         assert second_still_waiting == [True]
         assert [o.subject for o in store.latest("c", "s")] == [

--- a/tests/test_rakaia/test_jsonl_outcome_store_contract.py
+++ b/tests/test_rakaia/test_jsonl_outcome_store_contract.py
@@ -1,0 +1,214 @@
+"""The file-backed outcome store against the shared contract.
+
+The point of running the same suite twice. `InMemoryOutcomeStore` and this one
+share no code, and this one has no database under it, so the pair passing is what
+makes ADR 0007's claim — that an outcome is as store-agnostic as a cursor — a
+measurement rather than an assertion.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from rakaia.jsonl_outcomes import JsonlOutcomeStore
+from tests.outcome_store_contract import OutcomeStoreContract
+
+
+class TestJsonlOutcomeStoreContract(OutcomeStoreContract):
+    @pytest.fixture
+    def outcomes(self, tmp_path: Path) -> JsonlOutcomeStore:
+        # fsync off: tmp_path has no durability question to answer and the
+        # syscall is pure cost per recorded row.
+        return JsonlOutcomeStore(tmp_path / "outcomes", fsync=False)
+
+
+class TestJsonlOutcomeStoreDurability:
+    """What the shared contract cannot ask for, because the in-memory store
+    cannot satisfy it."""
+
+    def test_outcomes_survive_a_new_store_over_the_same_root(self, tmp_path: Path):
+        from rakaia.outcomes import Outcome
+
+        root = tmp_path / "outcomes"
+        JsonlOutcomeStore(root, fsync=False).record(
+            Outcome(
+                consumer="c",
+                stream_path="submission/tf611",
+                subject="row-1",
+                offset="0000000001",
+                sequence_key="seq",
+                stage="project",
+                status="failed",
+                reasons=("bad_total",),
+            )
+        )
+        [got] = JsonlOutcomeStore(root, fsync=False).latest("c", "submission/tf611")
+        assert got.reasons == ("bad_total",)
+
+    # The empty string used to be here. It is now refused at construction — an empty
+    # name collides with whatever else escapes to the same path segment — so the case
+    # this file covered moved to `test_the_names_cannot_be_empty`.
+    @pytest.mark.parametrize("hostile", ["a/b", "../escape", "..", "a%2Fb"])
+    @pytest.mark.parametrize("field", ["consumer", "stream_path"])
+    def test_every_file_stays_directly_under_the_root(
+        self, tmp_path: Path, field: str, hostile: str
+    ):
+        """A consumer id and a stream path are names, not paths.
+
+        Asserted as *containment*, not as a round trip. Leaving either component
+        unencoded still round-trips — `a/b` reads back from `root/a/b/…` exactly as
+        it was written — so a read-what-you-wrote test passes while `../escape`
+        writes outside the root entirely. The property worth holding is the layout:
+        one directory per consumer, one file per stream, nothing deeper and nothing
+        above.
+        """
+        from rakaia.outcomes import Outcome
+
+        root = tmp_path / "outcomes"
+        store = JsonlOutcomeStore(root, fsync=False)
+        fixed = {"consumer": "c", "stream_path": "s"}
+        store.record(
+            Outcome(
+                **{**fixed, field: hostile},
+                subject="row-1",
+                offset="0000000001",
+                sequence_key="seq",
+                stage="project",
+                status="failed",
+                reasons=(hostile,),
+            )
+        )
+
+        written = list(root.rglob("*.jsonl"))
+        assert len(written) == 1
+        assert written[0].parent.parent == root, "a name became a directory tree"
+        assert not list(tmp_path.glob("*.jsonl")), "a name escaped the root"
+
+        scope = {**fixed, field: hostile}
+        assert [
+            o.reasons for o in store.latest(scope["consumer"], scope["stream_path"])
+        ] == [(hostile,)]
+
+    def test_a_torn_trailing_line_is_skipped_not_fatal(self, tmp_path: Path):
+        """A crash mid-append leaves half a line. Skipping it loses one outcome;
+        failing the read would lose the whole report."""
+        from rakaia.outcomes import Outcome
+
+        root = tmp_path / "outcomes"
+        store = JsonlOutcomeStore(root, fsync=False)
+        store.record(
+            Outcome(
+                consumer="c",
+                stream_path="s",
+                subject="row-1",
+                offset="0000000001",
+                sequence_key="seq",
+                stage="project",
+                status="failed",
+            )
+        )
+        target = next(root.rglob("*.jsonl"))
+        with target.open("a", encoding="utf-8") as fh:
+            fh.write('{"consumer": "c", "stream_pa')
+
+        assert [o.offset for o in store.latest("c", "s")] == ["0000000001"]
+
+    def test_a_line_this_version_cannot_build_is_skipped_not_fatal(
+        self, tmp_path: Path
+    ):
+        """A field added by a later version must not take the report down.
+
+        `Outcome(**payload)` raises `TypeError` on an unknown key, and the read
+        caught only `ValueError` — so one line written by a newer version lost
+        every outcome in the file. The ADR forecasts exactly this key: "#232
+        lands… an outcome should name its issuing store".
+        """
+        import json
+
+        from rakaia.outcomes import Outcome
+
+        root = tmp_path / "outcomes"
+        store = JsonlOutcomeStore(root, fsync=False)
+        store.record(
+            Outcome(
+                consumer="c",
+                stream_path="s",
+                subject="row-1",
+                offset="0000000001",
+                sequence_key="seq",
+                stage="project",
+                status="failed",
+            )
+        )
+        target = next(root.rglob("*.jsonl"))
+        with target.open("a", encoding="utf-8") as fh:
+            fh.write(
+                json.dumps(
+                    {
+                        "consumer": "c",
+                        "stream_path": "s",
+                        "subject": "row-2",
+                        "offset": "0000000002",
+                        "sequence_key": "seq",
+                        "stage": "project",
+                        "status": "failed",
+                        "reasons": [],
+                        "params": {},
+                        "attempt": 1,
+                        "store": "from-a-later-version",
+                    }
+                )
+                + "\n"
+            )
+
+        assert [o.subject for o in store.latest("c", "s")] == ["row-1", "row-2"]
+
+    def test_a_line_missing_a_required_field_is_skipped_not_fatal(self, tmp_path: Path):
+        """The other half of "a field added by a later version, or one removed".
+
+        The unknown-key half is held by the field filter, so narrowing the `except`
+        back to `ValueError` alone left the suite green and the `TypeError` arm
+        looked dead. It is not: a line written before a field existed is missing a
+        required argument, and building it raises `TypeError`, which without this
+        arm takes the whole report down.
+        """
+        import json
+
+        from rakaia.outcomes import Outcome
+
+        root = tmp_path / "outcomes"
+        store = JsonlOutcomeStore(root, fsync=False)
+        store.record(
+            Outcome(
+                consumer="c",
+                stream_path="s",
+                subject="row-1",
+                offset="0000000001",
+                sequence_key="seq",
+                stage="project",
+                status="failed",
+            )
+        )
+        target = next(root.rglob("*.jsonl"))
+        with target.open("a", encoding="utf-8") as fh:
+            # No `sequence_key` — written by a version predating the field.
+            fh.write(
+                json.dumps(
+                    {
+                        "consumer": "c",
+                        "stream_path": "s",
+                        "subject": "row-2",
+                        "offset": "0000000002",
+                        "stage": "project",
+                        "status": "failed",
+                        "reasons": [],
+                        "params": {},
+                        "attempt": 1,
+                    }
+                )
+                + "\n"
+            )
+
+        assert [o.subject for o in store.latest("c", "s")] == ["row-1"]

--- a/tests/test_rakaia/test_jsonl_outcome_store_contract.py
+++ b/tests/test_rakaia/test_jsonl_outcome_store_contract.py
@@ -212,3 +212,113 @@ class TestJsonlOutcomeStoreDurability:
             )
 
         assert [o.subject for o in store.latest("c", "s")] == ["row-1"]
+
+    def test_the_record_after_a_torn_tail_is_not_lost_with_it(self, tmp_path: Path):
+        """Skipping a torn line on read is half the recovery.
+
+        An append that simply continued would glue its own record onto the
+        fragment, and *both* are then dropped as one unparseable line — so a crash
+        costs the outcome it interrupted and the next one too. The write side has
+        to cut the fragment first. Mutation: drop the torn-tail cut from `record`;
+        row-2 disappears.
+        """
+        from rakaia.outcomes import Outcome
+
+        def refused(subject: str) -> Outcome:
+            return Outcome(
+                consumer="c",
+                stream_path="s",
+                subject=subject,
+                offset=None,
+                sequence_key=subject,
+                stage="append",
+                status="refused",
+            )
+
+        root = tmp_path / "outcomes"
+        store = JsonlOutcomeStore(root, fsync=False)
+        store.record(refused("row-1"))
+        target = next(root.rglob("*.jsonl"))
+        with target.open("a", encoding="utf-8") as fh:
+            fh.write('{"consumer": "c", "stream_pa')
+        store.record(refused("row-2"))
+        store.record(refused("row-3"))
+
+        assert [o.subject for o in store.latest("c", "s")] == [
+            "row-1",
+            "row-2",
+            "row-3",
+        ]
+
+    @pytest.mark.parametrize("line", ["[]", "null", "42", '"text"'])
+    def test_a_line_that_is_json_but_not_an_object_is_skipped_not_fatal(
+        self, tmp_path: Path, line: str
+    ):
+        """Valid JSON is not the same as a record. Each of these parsed and then
+        raised on `.items()`, outside the arm that catches a bad line — one such
+        line took the whole report down."""
+        from rakaia.outcomes import Outcome
+
+        root = tmp_path / "outcomes"
+        store = JsonlOutcomeStore(root, fsync=False)
+        store.record(
+            Outcome(
+                consumer="c",
+                stream_path="s",
+                subject="row-1",
+                offset="0000000001",
+                sequence_key="seq",
+                stage="project",
+                status="failed",
+            )
+        )
+        target = next(root.rglob("*.jsonl"))
+        with target.open("a", encoding="utf-8") as fh:
+            fh.write(line + "\n")
+
+        assert [o.subject for o in store.latest("c", "s")] == ["row-1"]
+
+    def test_a_line_naming_another_scope_is_not_reported(self, tmp_path: Path):
+        """The file name says which scope this is, and so does each line; the
+        line wins. A case-folding filesystem gives consumers `A` and `a` one file,
+        and trusting the name would show each the other's outcomes. Mutation:
+        drop the scope filter from `latest`; `row-other` appears."""
+        from rakaia.outcomes import Outcome, encode
+
+        root = tmp_path / "outcomes"
+        store = JsonlOutcomeStore(root, fsync=False)
+        mine = Outcome(
+            consumer="c",
+            stream_path="s",
+            subject="row-1",
+            offset="0000000001",
+            sequence_key="seq",
+            stage="project",
+            status="failed",
+        )
+        store.record(mine)
+        target = next(root.rglob("*.jsonl"))
+        with target.open("a", encoding="utf-8") as fh:
+            for foreign in (
+                Outcome(
+                    consumer="C",
+                    stream_path="s",
+                    subject="row-other",
+                    offset="0000000002",
+                    sequence_key="seq",
+                    stage="project",
+                    status="failed",
+                ),
+                Outcome(
+                    consumer="c",
+                    stream_path="S",
+                    subject="row-other",
+                    offset="0000000003",
+                    sequence_key="seq",
+                    stage="project",
+                    status="failed",
+                ),
+            ):
+                fh.write(encode(foreign) + "\n")
+
+        assert [o.subject for o in store.latest("c", "s")] == ["row-1"]

--- a/tests/test_rakaia/test_outcome_backends_agree.py
+++ b/tests/test_rakaia/test_outcome_backends_agree.py
@@ -1,0 +1,214 @@
+"""Every backend stores the same outcome the same way.
+
+The shared contract asks each backend, separately, whether it matches an
+expectation. That is not the question five review rounds kept answering wrong.
+Every one of those defects was two backends *disagreeing with each other* — a
+value the in-memory reference kept as handed to it and a durable store rendered,
+refused or altered — and no test compared them, so the class was invisible while
+each member of it was found one round at a time.
+
+This asks the question directly. A new backend joins by adding one line to
+`backends`, and inherits every case below rather than re-deriving them.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Hashable
+from decimal import Decimal
+from enum import Enum
+from pathlib import Path
+
+import pytest
+
+from rakaia.jsonl_outcomes import JsonlOutcomeStore
+from rakaia.outcomes import InMemoryOutcomeStore, Outcome
+
+
+#: Values that are *not* text. Each was a real finding, or the next one predicted:
+#: rounds fixed a map's values, then its keys, then the list beside it, then the
+#: plain fields. A store must refuse all of them, and refuse them identically.
+class _StrSubclass(str, Enum):
+    """A `str` subclass, which is the shape that defeats every equality check.
+
+    It compares equal to its own text and reads back from storage as plain text
+    with a different type — so `==` cannot see the difference and only a type check
+    can. A `StrEnum` is the one that turns up in real consumers.
+    """
+
+    APPEND = "append"
+
+
+NOT_TEXT = [
+    uuid.uuid4(),
+    42,
+    None,
+    ("a", "b"),
+    Decimal("1.5"),
+    b"bytes",
+    {"k": "v"},
+    _StrSubclass.APPEND,
+    "\ud800",  # a lone surrogate: a str that cannot be encoded
+]
+
+
+def backends(tmp_path: Path):
+    """One of every backend, so a disagreement between any two is visible."""
+    return {
+        "memory": InMemoryOutcomeStore(),
+        "jsonl": JsonlOutcomeStore(tmp_path / "outcomes", fsync=False),
+    }
+
+
+def an_outcome(**kw) -> Outcome:
+    base = {
+        "consumer": "c",
+        "stream_path": "submission/tf611",
+        "subject": "row-1",
+        "offset": None,
+        "sequence_key": "seq",
+        "stage": "append",
+        "status": "refused",
+    }
+    return Outcome(**{**base, **kw})
+
+
+def test_a_recorded_outcome_reads_back_identically_everywhere(tmp_path: Path):
+    outcome = an_outcome(reasons=("missing_total", "wrong_period"), params={"row": "3"})
+    got = {}
+    for name, store in backends(tmp_path).items():
+        store.record(outcome)
+        got[name] = store.latest("c", "submission/tf611")
+    assert len(set(map(repr, got.values()))) == 1, got
+    assert got["memory"] == [outcome]
+
+
+def test_no_backend_keeps_a_handle_on_what_the_caller_passed(tmp_path: Path):
+    """Mutating the source after recording must change nothing, anywhere.
+
+    This is the half the type checks cannot reach: the values are all text and
+    every store accepts them. What differed was whether the store kept the
+    caller's container or rendered it, and only a store that renders was safe by
+    accident. Asked across backends because "they agree" is the property; asked
+    after `record` because that is when the caller still has the handle.
+    """
+    reasons = ["missing_total"]
+    params = {"row": "3"}
+    outcome = an_outcome(reasons=reasons, params=params)
+
+    got = {}
+    for name, store in backends(tmp_path).items():
+        store.record(outcome)
+        got[name] = store.latest("c", "submission/tf611")
+
+    reasons.append("LEAKED")
+    params["national_id"] = "1234-LEAK"
+
+    assert len(set(map(repr, got.values()))) == 1, got
+    assert got["memory"][0].reasons == ("missing_total",)
+    assert got["memory"][0].params == {"row": "3"}
+
+
+def test_the_backends_agree_on_ordering(tmp_path: Path):
+    outcomes = [
+        an_outcome(subject="row-3"),
+        an_outcome(subject="row-1"),
+        an_outcome(
+            subject="row-2", offset="0000000001", stage="project", status="failed"
+        ),
+    ]
+    got = {}
+    for name, store in backends(tmp_path).items():
+        for o in outcomes:
+            store.record(o)
+        got[name] = [o.subject for o in store.latest("c", "submission/tf611")]
+    assert len(set(map(tuple, got.values()))) == 1, got
+
+
+@pytest.mark.parametrize("value", NOT_TEXT, ids=lambda v: type(v).__name__)
+@pytest.mark.parametrize(
+    # `stage` and `status` are in the list deliberately. They are the two fields
+    # declared as a small set of strings, and a value-equality check lets a `str`
+    # subclass through where every other field's type check catches it — so they
+    # were the only two the codec did not protect.
+    "field",
+    ["subject", "sequence_key", "consumer", "stream_path", "stage", "status"],
+)
+def test_no_backend_accepts_what_another_would_refuse(
+    tmp_path: Path, field: str, value
+):
+    """The class itself, as one assertion.
+
+    Each of these used to record in memory and raise on write, so the two stores
+    disagreed about whether the outcome existed at all. Refusing at construction is
+    what makes that impossible — but the property under test is *agreement*, not
+    where the refusal happens, so this stays true if the refusal ever moves.
+    """
+    outcomes = {}
+    for name, store in backends(tmp_path).items():
+        try:
+            store.record(an_outcome(**{field: value}))
+            outcomes[name] = store.latest("c", "submission/tf611")
+        except (ValueError, TypeError) as exc:
+            outcomes[name] = type(exc).__name__
+
+    assert len(set(map(repr, outcomes.values()))) == 1, (
+        f"backends disagree about {field}={value!r}: {outcomes}"
+    )
+
+
+@pytest.mark.parametrize("value", NOT_TEXT, ids=lambda v: type(v).__name__)
+def test_the_backends_agree_about_a_bad_reason_or_param(tmp_path: Path, value):
+    cases = [{"reasons": (value,)}, {"params": {"k": value}}]
+    # A key case only where the value can be one at all — an unhashable value fails
+    # in this test's own literal, before a store sees it, which is Python and not a
+    # disagreement between backends.
+    if isinstance(value, Hashable):
+        cases.append({"params": {value: "v"}})
+    for kw in cases:
+        outcomes = {}
+        for name, store in backends(tmp_path).items():
+            try:
+                store.record(an_outcome(**kw))
+                outcomes[name] = store.latest("c", "submission/tf611")
+            except (ValueError, TypeError) as exc:
+                outcomes[name] = type(exc).__name__
+        assert len(set(map(repr, outcomes.values()))) == 1, (
+            f"disagree on {kw}: {outcomes}"
+        )
+
+
+def test_every_store_keeps_the_encoded_form_not_the_object():
+    """The design's central claim, pinned.
+
+    A review found that reverting the in-memory store to keeping the object left
+    the entire suite green: construction validates, so nothing downstream noticed
+    which shape the store held. That made the change this commit exists for
+    decorative. What the shape actually buys is below — ordering, and any future
+    store inheriting one definition instead of writing its own — but a property
+    nothing asserts is a property that will be undone.
+    """
+    store = InMemoryOutcomeStore()
+    store.record(an_outcome())
+    [held] = store._recorded
+    assert isinstance(held, str), (
+        f"the store kept a {type(held).__name__}, not the encoded text"
+    )
+    assert '"subject": "row-1"' in held
+
+
+def test_the_stores_agree_on_the_order_of_params(tmp_path: Path):
+    """The discriminator the codec is load-bearing for.
+
+    One store writes JSON with sorted keys and the other kept whatever order the
+    caller used, so the same outcome read back differently from each. `dict.__eq__`
+    hides it — this compares the rendered form, which is what anything printing,
+    logging or diffing an outcome will see.
+    """
+    outcome = an_outcome(params={"z": "1", "a": "2", "m": "3"})
+    got = {}
+    for name, store in backends(tmp_path).items():
+        store.record(outcome)
+        got[name] = [list(o.params) for o in store.latest("c", "submission/tf611")]
+    assert len(set(map(repr, got.values()))) == 1, got
+    assert got["memory"] == [["a", "m", "z"]]

--- a/tests/test_rakaia/test_outcome_backends_agree.py
+++ b/tests/test_rakaia/test_outcome_backends_agree.py
@@ -29,11 +29,13 @@ from rakaia.outcomes import InMemoryOutcomeStore, Outcome
 #: rounds fixed a map's values, then its keys, then the list beside it, then the
 #: plain fields. A store must refuse all of them, and refuse them identically.
 class _StrSubclass(str, Enum):
-    """A `str` subclass, which is the shape that defeats every equality check.
+    """A `str` subclass — the shape that defeats every check made on value alone.
 
-    It compares equal to its own text and reads back from storage as plain text
-    with a different type — so `==` cannot see the difference and only a type check
-    can. A `StrEnum` is the one that turns up in real consumers.
+    It compares equal to its own text, so `==` cannot see it, and it renders to
+    plain text on the way into storage. Both stores therefore *agree* about it,
+    which is why the reason to refuse it is not disagreement between them: it is
+    that what comes back is not what went in. A `StrEnum` is the one that turns up
+    in real consumers.
     """
 
     APPEND = "append"
@@ -127,10 +129,10 @@ def test_the_backends_agree_on_ordering(tmp_path: Path):
 
 @pytest.mark.parametrize("value", NOT_TEXT, ids=lambda v: type(v).__name__)
 @pytest.mark.parametrize(
-    # `stage` and `status` are in the list deliberately. They are declared as a
-    # small set of strings, and a `str` subclass compares equal to a member of that
-    # set while reading back from storage as something else — the case a check on
-    # value alone cannot see.
+    # `stage` and `status` are in the list deliberately: declared as a small set of
+    # strings, and a `str` subclass compares equal to a member of that set, so a
+    # check on value alone admits it. Note the stores do not disagree about it —
+    # see `test_what_goes_in_is_what_comes_back` for what the refusal actually buys.
     "field",
     ["subject", "sequence_key", "consumer", "stream_path", "stage", "status"],
 )
@@ -212,3 +214,17 @@ def test_the_stores_agree_on_the_order_of_params(tmp_path: Path):
         got[name] = [list(o.params) for o in store.latest("c", "submission/tf611")]
     assert len(set(map(repr, got.values()))) == 1, got
     assert got["memory"] == [["a", "m", "z"]]
+
+
+def test_what_goes_in_is_what_comes_back():
+    """The property the declared-type check buys, now that one representation
+    means the stores cannot disagree.
+
+    A `str` subclass renders to plain text on the way in, so every store returns
+    the same thing and a cross-store comparison sees nothing wrong. What is wrong
+    is narrower and still worth refusing: the value read back is not the value
+    handed over. Asserted by refusing it at construction, because that is where the
+    difference is still visible.
+    """
+    with pytest.raises(ValueError, match="expected one of"):
+        an_outcome(stage=_StrSubclass.APPEND)

--- a/tests/test_rakaia/test_outcome_backends_agree.py
+++ b/tests/test_rakaia/test_outcome_backends_agree.py
@@ -127,10 +127,10 @@ def test_the_backends_agree_on_ordering(tmp_path: Path):
 
 @pytest.mark.parametrize("value", NOT_TEXT, ids=lambda v: type(v).__name__)
 @pytest.mark.parametrize(
-    # `stage` and `status` are in the list deliberately. They are the two fields
-    # declared as a small set of strings, and a value-equality check lets a `str`
-    # subclass through where every other field's type check catches it — so they
-    # were the only two the codec did not protect.
+    # `stage` and `status` are in the list deliberately. They are declared as a
+    # small set of strings, and a `str` subclass compares equal to a member of that
+    # set while reading back from storage as something else — the case a check on
+    # value alone cannot see.
     "field",
     ["subject", "sequence_key", "consumer", "stream_path", "stage", "status"],
 )

--- a/tests/test_rakaia/test_outcome_store_contract.py
+++ b/tests/test_rakaia/test_outcome_store_contract.py
@@ -1,0 +1,14 @@
+"""The in-memory outcome store against the shared contract."""
+
+from __future__ import annotations
+
+import pytest
+
+from rakaia.outcomes import InMemoryOutcomeStore
+from tests.outcome_store_contract import OutcomeStoreContract
+
+
+class TestInMemoryOutcomeStoreContract(OutcomeStoreContract):
+    @pytest.fixture
+    def outcomes(self) -> InMemoryOutcomeStore:
+        return InMemoryOutcomeStore()

--- a/tests/test_rakaia/test_outcome_validation.py
+++ b/tests/test_rakaia/test_outcome_validation.py
@@ -132,3 +132,44 @@ def test_an_outcome_does_not_change_when_the_caller_mutates_what_it_was_built_fr
     params["national_id"] = "1234-LEAK"
     assert outcome.reasons == ("missing_total",)
     assert outcome.params == {"row": "3"}
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("params", {"k": {"national_id": "1234"}}),
+        ("params", {"k": 42}),
+        ("params", {1: "v"}),
+        ("params", {"k": None}),
+        ("reasons", (42,)),
+        ("reasons", (None,)),
+        ("reasons", ("\ud800",)),
+        ("sequence_key", None),
+        ("sequence_key", 7),
+        ("stage", "bogus"),
+        ("status", "bogus"),
+        ("attempt", True),
+        ("attempt", "1"),
+    ],
+    ids=repr,
+)
+def test_a_value_json_can_render_is_still_refused_if_the_declaration_does_not_allow_it(
+    field, value
+):
+    """The privacy rule, as a test that can see it.
+
+    Every one of these is something `json.dumps` renders happily, so a check that
+    is only "does it store" lets a nested record of personal data through the one
+    field whose purpose is that field values never reach it — and lets a `bool`
+    stand in for an attempt number, and a made-up `stage` for a real one. The
+    declaration is the rule; each field is checked against it.
+    """
+    kwargs = {
+        **BASE,
+        "offset": None,
+        "stage": "append",
+        "status": "refused",
+        field: value,
+    }
+    with pytest.raises(ValueError, match="storable as text"):
+        Outcome(**kwargs)

--- a/tests/test_rakaia/test_outcome_validation.py
+++ b/tests/test_rakaia/test_outcome_validation.py
@@ -102,13 +102,10 @@ def test_attempts_count_from_one():
     ids=lambda v: type(v).__name__,
 )
 def test_anything_that_cannot_be_stored_as_text_is_refused(value):
-    """The whole storability rule, and the only one there is.
-
-    It refuses by *doing the storing* rather than by describing which types are
-    allowed. Seven review findings were values that satisfied a type rule and still
-    did not survive storage — a text subclass that flattens, a lone surrogate, a
-    string longer than a column. That set is open-ended, so a description of it
-    leaks by construction.
+    """The backstop under the declared-type walk: none of these is text, so the
+    walk refuses them before `json.dumps` would have. Kept because it is the case
+    a store cares about most — a value that cannot be written at all — and the
+    message a caller gets for it should not depend on which check saw it first.
     """
     with pytest.raises(ValueError, match="storable as text"):
         Outcome(
@@ -163,6 +160,40 @@ def test_a_value_json_can_render_is_still_refused_if_the_declaration_does_not_al
     field whose purpose is that field values never reach it — and lets a `bool`
     stand in for an attempt number, and a made-up `stage` for a real one. The
     declaration is the rule; each field is checked against it.
+    """
+    kwargs = {
+        **BASE,
+        "offset": None,
+        "stage": "append",
+        "status": "refused",
+        field: value,
+    }
+    with pytest.raises(ValueError, match="storable as text"):
+        Outcome(**kwargs)
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("reasons", "missing_total"),
+        ("reasons", None),
+        ("reasons", 123),
+        ("reasons", {"missing_total": "1"}),
+        ("params", None),
+        ("params", [("a", "b")]),
+        ("params", "k=v"),
+    ],
+    ids=repr,
+)
+def test_a_container_of_the_wrong_shape_is_refused_not_coerced(field, value):
+    """The copy that makes `frozen` mean something ran before the check did.
+
+    `tuple("missing_total")` is thirteen one-letter codes, each of them valid
+    text, so a bare string for `reasons` was accepted and stored as gibberish;
+    a list of pairs became a `params` dict; and anything `tuple()` or `dict()`
+    choked on raised `TypeError` from the copy rather than the `ValueError` every
+    other refusal gives. Mutation: copy unconditionally again; the first case
+    stores thirteen codes and the second raises the wrong type.
     """
     kwargs = {
         **BASE,

--- a/tests/test_rakaia/test_outcome_validation.py
+++ b/tests/test_rakaia/test_outcome_validation.py
@@ -1,0 +1,134 @@
+"""What an `Outcome` refuses to be built as.
+
+These had no tests at all: every `raise` in `__post_init__` could be turned into
+`if False:` with the full suite green, which means the validation was decoration.
+"""
+
+from __future__ import annotations
+
+import uuid
+from decimal import Decimal
+
+import pytest
+
+from rakaia.outcomes import Outcome
+
+BASE = {
+    "consumer": "c",
+    "stream_path": "s",
+    "subject": "row-1",
+    "sequence_key": "seq",
+}
+
+
+@pytest.mark.parametrize("field", ["consumer", "stream_path", "subject"])
+def test_the_names_cannot_be_empty(field):
+    """Without a subject there is nothing to key on. The other two matter because a
+    file-backed store maps a name to one path segment, and an empty name shares a
+    segment with whatever else escapes to the same thing."""
+    with pytest.raises(ValueError, match="cannot be empty"):
+        Outcome(**{**BASE, field: ""}, offset=None, stage="append", status="refused")
+
+
+@pytest.mark.parametrize("field", ["consumer", "stream_path", "subject", "offset"])
+@pytest.mark.parametrize(
+    "value", [42, uuid.uuid4(), ("a", "b")], ids=lambda v: type(v).__name__
+)
+def test_what_a_store_sorts_and_names_by_has_to_be_text(field, value):
+    """Not a type rule for its own sake — a rule about four specific fields.
+
+    A number stored as a name raises in a file store's path escaping. A number
+    stored as an *offset* is kept identically by every store and then makes
+    `latest` raise the moment a text offset sits beside it, because the two cannot
+    be compared: consistent, and still broken. Everything an outcome merely carries
+    is settled by storing it instead.
+    """
+    kw = {**BASE, "offset": None, "stage": "append", "status": "refused"}
+    if field == "offset":
+        kw |= {"offset": value, "stage": "project", "status": "failed"}
+    else:
+        kw[field] = value
+    with pytest.raises(ValueError, match="writable text"):
+        Outcome(**kw)
+
+
+def test_a_text_offset_and_a_missing_one_sort_together():
+    """The failure the rule above prevents, as the read path sees it."""
+    from rakaia.outcomes import InMemoryOutcomeStore
+
+    store = InMemoryOutcomeStore()
+    store.record(Outcome(**BASE, offset="0000000001", stage="project", status="failed"))
+    store.record(
+        Outcome(
+            **{**BASE, "subject": "row-2"},
+            offset=None,
+            stage="append",
+            status="refused",
+        )
+    )
+    assert [o.offset for o in store.latest("c", "s")] == ["0000000001", None]
+
+
+@pytest.mark.parametrize("field", ["consumer", "stream_path", "subject"])
+def test_a_name_that_cannot_be_written_is_refused(field):
+    """A lone surrogate is text by every type check and no path can carry it, so it
+    passes construction and raises inside the store — in the loop whose job is
+    recording that something failed. The one storage constraint the codec cannot
+    reach, because it is about the name rather than the payload."""
+    with pytest.raises(ValueError, match="writable text"):
+        Outcome(
+            **{**BASE, field: "x\ud800"}, offset=None, stage="append", status="refused"
+        )
+
+
+def test_an_appended_outcome_cannot_carry_an_offset():
+    with pytest.raises(ValueError, match="no offset"):
+        Outcome(**BASE, offset="0000000001", stage="append", status="refused")
+
+
+def test_a_projected_outcome_needs_an_offset():
+    with pytest.raises(ValueError, match="needs an offset"):
+        Outcome(**BASE, offset=None, stage="project", status="failed")
+
+
+def test_attempts_count_from_one():
+    with pytest.raises(ValueError, match="counts from 1"):
+        Outcome(**BASE, offset=None, stage="append", status="refused", attempt=0)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [uuid.uuid4(), Decimal("1.5"), b"bytes", object()],
+    ids=lambda v: type(v).__name__,
+)
+def test_anything_that_cannot_be_stored_as_text_is_refused(value):
+    """The whole storability rule, and the only one there is.
+
+    It refuses by *doing the storing* rather than by describing which types are
+    allowed. Seven review findings were values that satisfied a type rule and still
+    did not survive storage — a text subclass that flattens, a lone surrogate, a
+    string longer than a column. That set is open-ended, so a description of it
+    leaks by construction.
+    """
+    with pytest.raises(ValueError, match="storable as text"):
+        Outcome(
+            **BASE, offset=None, stage="append", status="refused", params={"k": value}
+        )
+
+
+def test_an_outcome_does_not_change_when_the_caller_mutates_what_it_was_built_from():
+    """`frozen=True` freezes the binding, not the containers behind it."""
+    reasons = ["missing_total"]
+    params = {"row": "3"}
+    outcome = Outcome(
+        **BASE,
+        offset=None,
+        stage="append",
+        status="refused",
+        reasons=reasons,
+        params=params,
+    )
+    reasons.append("LEAKED")
+    params["national_id"] = "1234-LEAK"
+    assert outcome.reasons == ("missing_total",)
+    assert outcome.params == {"row": "3"}

--- a/tests/test_rakaia/test_tier_boundary.py
+++ b/tests/test_rakaia/test_tier_boundary.py
@@ -58,6 +58,7 @@ PROTOCOL_SERVER = {
     "append_decision",
     "cursor",
     "handler",
+    "jsonl_outcomes",
     "jsonl_store",
     "migrate",
     "producer",
@@ -71,7 +72,7 @@ PROTOCOL_SERVER = {
 #: format rules (`json_mode`, `offsets`) both tiers must agree on. ADR 0002 calls
 #: these out as the reason the tiers "genuinely share types today" — they are the
 #: substance of the split question, so a change here is the thing to look at.
-SHARED = {"types", "protocols", "json_mode", "offsets"}
+SHARED = {"types", "protocols", "json_mode", "offsets", "outcomes"}
 
 #: Deliberate, documented crossings. Keep this empty if you can; every entry is a
 #: thing a package split would have to resolve, so the list is the running cost

--- a/zensical.toml
+++ b/zensical.toml
@@ -59,6 +59,7 @@ nav = [
             { "ADR 0004 — Handler types & fold order" = "adr/0004-handler-types-and-fold-order.md" },
             { "ADR 0005 — Stream positions stay a counted offset" = "adr/0005-stream-positions-stay-a-counted-offset.md" },
             { "ADR 0006 — Changing a backend is a copy" = "adr/0006-changing-backends-is-a-copy.md" },
+            { "ADR 0007 — Where an outcome is recorded" = "adr/0007-an-outcome-is-recorded-where-the-cursor-is-committed.md" },
         ] },
     ] },
     { "Look it up" = [


### PR DESCRIPTION
A marker of how far a consumer has read cannot say whether it got there cleanly, so
an event that was skipped, declined or lost looks exactly like one that worked.
Nothing being recorded reads as everything being fine. This adds the decision record
for what to record instead, along with the types, the seam and a shared conformance
suite that any backend keeping those records has to satisfy.

The decision is proposed rather than settled, and it is the thing that wants review
— the code is here because writing it is what found the decision's mistakes. Two
backends exist so far, one in memory and one in files, which is what makes the
"works on any backend" claim a measurement rather than an assertion. Storing them in
a database, the loop that writes them, and retrying a failure are all still to come;
retrying is deliberately last, because it writes to the projection and needs the
existing verification commands extended first.