### PR TITLE
Spike: one representation, instead of describing which values are allowed

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,6 +89,28 @@
 - Research notes live in `docs/research/` and are deliberately **not** in the
   nav. They are dated and are not decisions; decisions go in `docs/adr/`.
 
+## Writing it up
+
+- **Two plain paragraphs.** A commit message body, an issue body and a PR body are each
+  at most two paragraphs, written so someone who only reads the notification email gets
+  the whole point. Say what changed and what it means for whoever uses this. That is the
+  deliverable.
+- **Everything else goes in a comment.** Tables, measured counts, SHAs, query output,
+  repro steps, mutation records, per-file reasoning — post them below the body, on the PR.
+  They are evidence for whoever verifies the work, not the summary for whoever reads it. A
+  commit message has nowhere to put them, so they belong on its PR instead.
+- **No machinery in the body.** This library's own words — stream, event, consumer,
+  cursor, offset, replay, backend — are the vocabulary and are fine. Identifiers are not:
+  `DjangoExecutor.apply` is "the part that writes a batch", `_StageBuffer` is "batching a
+  pass together". Save the precise names for the comment, where precision is the job.
+- The test: read the body alone. If it needs the source open, or the point arrives after
+  the evidence, rewrite it.
+- **Docstrings too: two paragraphs**, with one difference — a docstring's reader is
+  looking at the code, so identifiers *are* their vocabulary. What does not belong is the
+  essay: the history of a bug, what an earlier cut did, or the same point twice. A
+  non-obvious constraint earns its own short paragraph; if it took a mutation to find,
+  write it down.
+
 ## Agent skills
 
 ### Issue tracker

--- a/docs/adr/0007-an-outcome-is-recorded-where-the-cursor-is-committed.md
+++ b/docs/adr/0007-an-outcome-is-recorded-where-the-cursor-is-committed.md
@@ -135,7 +135,8 @@ path serving two operations with opposite invariants is how a guard ends up corr
 one mode and silently wrong in the other.
 
 **6. An outcome carries reason codes and bounded parameters, never a message.**
-`reasons` is a tuple drawn from a closed vocabulary; `params` is a flat string map. An
+`reasons` is a tuple of codes; `params` is a flat string map whose values are *checked* to
+be strings rather than assumed to be. An
 interpolated message is where field values leak, and this library is used on submissions
 carrying personal and financial data. It also makes outcomes countable — "how many failed
 for this reason" is a query rather than a grep.
@@ -144,6 +145,14 @@ Plural, not singular, because one event can fail several rules at once and the c
 that motivated this already collects them as a tuple before flattening them with a
 `", ".join(...)` for display. Storing the join would re-lose exactly the structure this
 decision exists to keep.
+
+**The codes are opaque to rakaia, and are not a closed set anywhere yet.** An earlier draft
+said a consumer could borrow one it already had. Checked against that consumer: the field
+those codes come from is a bare 64-character text column with no constrained values, and one
+can be minted over HTTP by a reviewer resolving a flag. It is a vocabulary by convention and a
+static scan, not by construction. Borrowing it is still right — it is what people already say
+— but closing it is work the consumer has to do, and this decision should not be read as
+saying it is done.
 
 **6a. An outcome is immutable; nothing is resolved on it.** An earlier draft gave the
 record a `resolved_at`. That is wrong wherever the reason codes come from a consumer's own
@@ -159,6 +168,18 @@ Rakaia does not yet refuse an event whose sequence has an unresolved failure; th
 exists so that adding it later does not require re-deriving groupings a consumer has
 already decided. Named here because recording a key nothing reads is otherwise the sort
 of thing a later reader deletes as dead weight.
+
+**It is computed per refusal, not looked up per form.** The obvious source is a consumer's
+existing per-form refusal scope — group under the document where a partial write yields a
+wrong total, per row otherwise — and that is not sufficient on its own. Measured against the
+motivating consumer: an unclassified form silently falls back to per-row, and a blocked *root*
+row refuses the whole document whatever the form's scope says, because every child's typed
+record points at the root's. A key derived from the form alone is wrong in both cases.
+
+This is why `subject` is a separate field rather than the same one. The subject is the single
+thing an outcome is about; the sequence key is what that particular refusal actually parked.
+They coincide often enough to be mistaken for one field, and the cases where they do not are
+the ones that matter.
 
 ## Observations, refusals, and the record that one happened
 
@@ -202,7 +223,10 @@ live path, one refused repeater on a progress form does this:
    failure set is reported in one pass rather than one row per attempt.
 3. Policy for this form is *refuse the row, keep its siblings*. The refused row's event
    is dropped from the batch: **neither appended nor projected**, on the stated
-   principle that the log must not carry a row the consumer declined to accept.
+   principle that the log must not carry a row the consumer declined to accept. Its
+   siblings in the same call *are* appended and do get real offsets — "never appended"
+   is true of the refused row, not of the save. (Refuse the root instead and the whole
+   document is declined without the append being attempted at all.)
 4. An outcome is recorded against the refused row; the clean rows record success.
 5. The user sees a partial failure naming the offending row.
 
@@ -211,11 +235,13 @@ the third table row above, and the design handles it correctly. The siblings are
 genuinely independent, so parking the row and nothing else is the right answer.
 
 **Then a stage-2 reducer runs, and the containment stops.** It recomputes a field on a
-*different* form by reading the latest progress row per project **out of the projection**.
-The refused row was never written, so the reducer cannot see it, takes the previous
-period's figure instead, and *writes* the resulting value. Not stale by omission —
-actively written from an input with a hole in it, with nothing linking that write back to
-the refusal.
+*different* form by reading progress rows **out of the projection** and taking the one
+latest by *reporting period* — not by when it was filed, so a late correction for an earlier
+month cannot reset the answer. The refused row was never written, so the reducer cannot see
+it, takes the previous period's figure instead, and writes the resulting value. It updates
+rows that exist and never inserts one, so nothing is fabricated; what is wrong is the number.
+Not stale by omission — actively written from an input with a hole in it, with nothing
+linking that write back to the refusal.
 
 That is not a defect this decision introduces; the consumer measured it when it chose the
 policy, and chose it because refusing the row moves fewer of those derived values than
@@ -283,6 +309,19 @@ that is the point of it.
 - **Nothing enforces that the loop is used.** A consumer keeping its hand-written
   `poll`/`commit` records nothing, and its stream looks identical to a clean one. This
   decision adds a supported path; it does not close the unsupported one.
+- **A consumer that is not cursor-driven cannot adopt this.** Decision 3 makes absence of a
+  record mean success. The motivating consumer's existing surface means the exact opposite:
+  it writes a record on success *and* on failure precisely so that no record at all can be
+  read as "this never went through the pipeline", which is how it detects rows a bulk write
+  skipped. Both are coherent, and they are inverses — absence cannot mean both. The
+  reconciliation is the cursor: once a consumer polls and commits, "never processed" is
+  visible as the cursor not having reached it, and the extra row per success stops earning
+  its keep. Until then the two cannot be mixed, and a consumer part-way through the change
+  has one surface saying absence is fine and another saying it is a defect.
+- **A verdict over a group needs a denominator this does not supply.** "All rows failed"
+  versus "some did" needs to know how many there were, and `latest` returns only the ones
+  with an outcome. That count belongs to the consumer, which has it; worth saying because
+  the obvious reading of `latest` is that it is enough on its own, and it is not.
 - **Everything rests on the cursor meaning what it says.** A consumer that commits before
   applying — which `poll`'s docstring warns against and nothing prevents — silently
   converts "unapplied" into "succeeded", because success is the absence of a record. The

--- a/docs/adr/0007-an-outcome-is-recorded-where-the-cursor-is-committed.md
+++ b/docs/adr/0007-an-outcome-is-recorded-where-the-cursor-is-committed.md
@@ -135,8 +135,10 @@ path serving two operations with opposite invariants is how a guard ends up corr
 one mode and silently wrong in the other.
 
 **6. An outcome carries reason codes and bounded parameters, never a message.**
-`reasons` is a tuple of codes; `params` is a flat string map whose values are *checked* to
-be strings rather than assumed to be. An
+`reasons` is a tuple of codes; `params` is a flat map. Codes, keys and values are all
+*checked* to be strings rather than assumed to be, and both containers are copied on the way
+in — each of those was a separate round's finding, and each had let the backends disagree
+about what had been recorded. An
 interpolated message is where field values leak, and this library is used on submissions
 carrying personal and financial data. It also makes outcomes countable — "how many failed
 for this reason" is a query rather than a grep.
@@ -326,14 +328,20 @@ that is the point of it.
   versus "some did" needs to know how many there were, and `latest` returns only the ones
   with an outcome. That count belongs to the consumer, which has it; worth saying because
   the obvious reading of `latest` is that it is enough on its own, and it is not.
+- **The reason codes are available; the parameters beside them are not, on one path.** The
+  consumer's refusal object already carries a string-to-string map, so that path fits without
+  change. Its flag path does not: the structured detail is flattened into a sentence before
+  it is stored, so anything populating parameters from a flag has only prose to read back and
+  must re-derive them. Decision 6 asks for the opposite of what that path does today.
 - **Nothing here is exported.** `Outcome`, `OutcomeStore` and the two backends are absent
   from `rakaia.__all__`, so a consumer adopting this today is importing below the stable
   surface. Deliberate while the decision is Proposed — exporting is a stability promise, and
   making one for a design still under review is how a bad shape becomes permanent — but it
   means "usable" and "supported" are not yet the same thing here. Exporting is the last step
   before this is Accepted, not an oversight.
-- **`Outcome` is a name the motivating consumer already uses** for an unrelated pass/fail
-  enum, at roughly twenty sites. Nothing breaks, but `from rakaia import Outcome` would
+- **`Outcome` is a name the motivating consumer already uses** for an unrelated four-member
+  verdict enum — pass, fail, not-applicable, indeterminate — imported in twenty-odd modules
+  and referred to a few hundred times. Nothing breaks, but `from rakaia import Outcome` would
   shadow it there, so that consumer will want a qualified import.
 - **Everything rests on the cursor meaning what it says.** A consumer that commits before
   applying — which `poll`'s docstring warns against and nothing prevents — silently

--- a/docs/adr/0007-an-outcome-is-recorded-where-the-cursor-is-committed.md
+++ b/docs/adr/0007-an-outcome-is-recorded-where-the-cursor-is-committed.md
@@ -1,0 +1,202 @@
+# ADR 0007 — An outcome is recorded where the cursor is committed, not where the effect is applied
+
+- **Status:** Proposed
+- **Date:** 2026-09-05
+- **Deciders:** rakaia maintainers
+- **Related:** [ADR 0002](./0002-framework-vs-protocol-server-boundary.md) (the
+  framework/protocol tiers this splits across);
+  [ADR 0006](./0006-changing-backends-is-a-copy.md) (three stores behind one seam —
+  why an outcome record cannot be Django-shaped by default);
+  [ADR 0005](./0005-stream-positions-stay-a-counted-offset.md) (an offset is an
+  opaque token, which is why an outcome's is a string);
+  `src/rakaia/subscription.py`, `src/rakaia/protocols.py`,
+  `src/django_rakaia/effect_executor.py`, `src/rakaia/replay.py`.
+  Issues: #232 (a cursor should name its store — an outcome inherits this gap
+  unchanged), #34 (deletion retires offsets permanently).
+
+## Context
+
+A consumer applies an event and the apply fails. Rakaia has nowhere to say so.
+
+There is no dead-letter queue, no park, no attempt count, no per-event error record
+anywhere in the tree. `DriftLedger` is the closest thing, and it is per *rule*,
+deduplicated, in memory, and handed back on the result object rather than stored.
+`ApplyReport` carries `created`/`written`/`skipped` counts per batch, and only its
+`retire_flips` are read (`replay.py:521`, `:553`) — the counts go nowhere. What
+survives a restart is the cursor, and a cursor says only how far a consumer got — not
+whether it got there cleanly.
+
+That gap has a specific consequence, and it is not "we lack observability". It is
+that **absence of a record is read as success**. A consumer whose cursor is past
+offset 40 asserts nothing about offsets 1–39. If one of them was skipped by a bulk
+write path, or applied by a handler that raised and was swallowed upstream, nothing
+in rakaia distinguishes that from forty clean applies. The first consumer to hit this
+in production reported a form as imported when its row had been refused.
+
+Three things about this codebase decide the shape of the answer, and two of them rule
+out the obvious implementation.
+
+**The executor cannot record it.** `DjangoExecutor.apply` wraps its batch in
+`transaction.atomic` (`src/django_rakaia/effect_executor.py:204`). An outcome row
+written inside that block rolls back with the batch whose failure it exists to
+record. Worse, it could not name the event anyway: a stage-0 pass buffers many events
+into one `apply()` (`_StageBuffer`, `src/rakaia/replay.py:434`), and `RowEffect`
+carries `model_label` and `lookup` and nothing else (`src/rakaia/effects.py:176-189`).
+By the time effects reach an executor, which event produced which effect is not
+recoverable.
+
+**There is no loop to record it in.** `poll → apply → commit` is written by hand by
+each consumer. `django_rakaia.subscription` is 46 lines of free functions and holds no
+`try`. In `replay.py` the only `try` on the dispatch path is a bare `finally`
+(`:275-326`) whose comment explains it is there to flush buffered effects, not to
+catch anything; the four `except` clauses elsewhere in the file cover signature
+introspection, a non-hashable dedup key, merge-order comparability and JSON decoding,
+and each either returns a default or re-raises. None of them catches a handler
+exception, and neither does anything else — it propagates out of `replay()` uncaught.
+So there is no existing site
+where an outcome *would* be written; this decision introduces the site as well as the
+record.
+
+**A Django-only table would be the second mistake of a kind already regretted.**
+Migration 0008 says it plainly of the removed demo model: *"Because it was in
+`0001_initial`, **every** consumer got the table whether or not they ever used it."*
+Meanwhile `docs/framework-vs-protocol-server.md` lists cursors **twice** — *"Subscriber
+cursors … Python stdlib only"* (`:33`) and *"Durable subscriber cursors — persisted
+watermarks … Django (ORM)"* (`:39`). That split is the template. `poll` is stdlib
+because the decision is store-agnostic; only the place to keep the answer is Django.
+An outcome keyed by `(consumer, stream_path, offset)` is store-agnostic in exactly the
+same way, and there are now three stores.
+
+## Decision
+
+**1. An outcome is a core concept with pluggable storage.** `Outcome`,
+`OutcomeStatus`, `Stage` and an `OutcomeStore` protocol live in `rakaia`, dependency-free,
+with `OutcomeStore` in `src/rakaia/protocols.py` beside `CursorStore`. Django supplies a
+durable place to keep them and nothing else, mirroring `load_cursor`/`commit_cursor`.
+A shared contract suite at `tests/outcome_store_contract.py` is subclassed once per
+backend, so "does this work on JSONL?" is a red test rather than a question.
+
+**2. The record is written where the cursor is committed.** Rakaia gains the consume
+loop it has never had, next to `poll`. It applies, records any outcome in its own
+transaction — outside the executor's — and then commits the cursor. Nothing is
+recorded from inside an `Effect`, an executor, or a handler.
+
+**3. Only exceptions are recorded; the cursor is the success record.** Everything
+below the cursor succeeded unless an outcome says otherwise, and anything the cursor
+never reached is visibly unprocessed. A `gaps()` query over that difference is what
+turns "absence of a record" from an assumption into a question with an answer. The
+alternative — a row per applied event — is a durable write on the hot path for the
+case that is fine, and the append cost tests exist to catch exactly that.
+
+**4. A failed append and a failed projection are different records.** `stage="append"`
+means the event was never written: the fact is gone, its offset is null, and recovering
+it means re-producing from whatever the consumer derived it from. `stage="project"`
+means the event is safe in the log and merely unapplied, and replay recovers it. One
+field, because a re-drive built on the assumption that every row is replayable would
+be wrong for half of them.
+
+**5. The failure policy is a parameter with per-mode defaults, never inferred.**
+`on_error="skip"` when consuming continuously, `on_error="halt"` when rebuilding. The
+same shape as `on_drift` (`src/rakaia/drift.py:41`), and for the same reason: one code
+path serving two operations with opposite invariants is how a guard ends up correct in
+one mode and silently wrong in the other.
+
+**6. An outcome carries a reason code and bounded parameters, never a message.**
+`reason` is a closed vocabulary; `params` is a flat string map. An interpolated message
+is where field values leak, and this library is used on submissions carrying personal
+and financial data. It also makes outcomes countable — "how many failed for this
+reason" is a query rather than a grep.
+
+**7. Sequencing is recorded, not enforced.** An outcome carries a `sequence_key`.
+Rakaia does not yet refuse an event whose sequence has an unresolved failure; the field
+exists so that adding it later does not require re-deriving groupings a consumer has
+already decided. Named here because recording a key nothing reads is otherwise the sort
+of thing a later reader deletes as dead weight.
+
+## Alternatives considered
+
+**Thread event identity through `Effect` and record in the executor.** The version that
+first looks right, and it fails on its own terms: the outcome is written inside
+`transaction.atomic`, so a failing batch discards the record of its own failure. Making
+the record survive means a second connection or an autocommit escape hatch inside a
+class whose whole contract is that a batch is atomic. Rejected before the ergonomics of
+adding a field to `RowEffect` even matter.
+
+**Put the model in `django_rakaia` and be done.** Fastest, and consistent with
+`ConsumerCursor` as it stands. Rejected on the 0008 precedent: it lands a table on every
+consumer, on a branch whose recent history is almost entirely about removing Django
+coupling, and it would need undoing to reach the shape this ADR describes. `envelope.py`
+(`:21-23`) states the actual test — things live in `django_rakaia` when they are
+*intrinsically* Django-shaped, "the core package stays dependency-free" — and an outcome
+is not.
+
+**Record every applied event, not only the exceptions.** It answers the completeness
+question directly and needs no `gaps()` query. Rejected on cost and on precedent: it is
+one durable write per event on the success path, in a codebase that has a test file
+asserting the *set of SQL statements* an append issues
+(`tests/test_django_rakaia/test_append_query_cost.py`) because #202 found three
+duplicates. The consumer that motivated this work already writes a row per row per save
+and has neither a retention policy nor an index supporting the query its two hot paths
+run; that is the outcome to avoid reproducing, not to generalise.
+
+**Ship re-drive in the same change.** The obvious pairing — a dead letter is for
+re-driving — and deliberately deferred. Re-drive writes to the projection, so it needs
+the rebuild and parity gates extended to cover it, and the consumer that asked for this
+had precisely that feature cut in review after four attempts to guard it, each failing
+differently, because one path served both a scratch rebuild and a live database. The
+record is useful alone: it makes the manual repair path targeted instead of a sweep.
+
+**Reuse `DriftLedger`.** It already accumulates problems and reports them on the result
+object. Rejected because it is deliberately per-registration and memoised — it reports a
+rule once, not an event ever — and making it per-event would remove the deduplication
+that is the point of it.
+
+## Consequences
+
+### Positive
+
+- "Did we lose anything, and which ones?" becomes a query, and it survives a restart.
+- The consume loop lands as a first-class thing. Rakaia has documented at-least-once
+  semantics and, until now, no code expressing them; every consumer wrote the loop.
+- `stage` makes the difference between a lost fact and an unapplied one legible at the
+  point someone is deciding what to do about it.
+
+### Negative, and named rather than waved away
+
+- **Nothing enforces that the loop is used.** A consumer keeping its hand-written
+  `poll`/`commit` records nothing, and its gaps look identical to a clean run. This
+  decision adds a supported path; it does not close the unsupported one.
+- **`gaps()` is only as good as the cursor.** A consumer that commits before applying —
+  which `poll`'s docstring warns against but nothing prevents — reports no gap for an
+  event it never applied. The gap check inherits every weakness of the watermark.
+- **An outcome inherits #232 exactly.** `DjangoStreamStore` and `JsonlStreamStore` both
+  issue `PLAIN`, so an outcome's `(stream_path, offset)` cannot say which store's offset
+  it is any more than a cursor's can. Two backends at the same path produce outcomes that
+  collide silently.
+- **Sequencing is a field and a promise.** Decision 7 records a key nothing acts on. If
+  the enforcement never lands, this is a column carrying a consumer's private grouping
+  for no benefit rakaia delivers.
+- **The admin registration breaks a local pattern.** `ConsumerCursor`,
+  `StreamOffsetWatermark` and `StreamProducer` have no admin; operational bookkeeping is
+  not browsed. A dead-letter table is argued as the exception because looking at it *is*
+  the feature, but it is a deviation, not a precedent being followed.
+
+### Neutral
+
+- A consumer that never fails never writes a row, so the table is empty and the cost is
+  a migration.
+- Nothing about existing replay behaviour changes. `replay()` still raises out; the loop
+  is a new caller, not a change to what it calls.
+
+## What would reopen this
+
+- **#232 lands.** An outcome should name its issuing store at the same moment a cursor
+  does, and by the same mechanism. Amend rather than duplicate.
+- **Re-drive.** The deferred half. It needs a decision of its own about what a
+  re-drive may write and which gates must pass first, and Decision 4's `stage` split is
+  the part of this ADR it will lean on.
+- **Sequencing enforcement.** Refusing an event whose sequence has an unresolved failure
+  changes live behaviour and needs its own argument. If it is declined for good, Decision
+  7's field should go with it.
+- **A fourth store.** The contract suite is where that is absorbed; if a store cannot
+  implement `OutcomeStore` cheaply, the protocol is wrong rather than the store.

--- a/docs/adr/0007-an-outcome-is-recorded-where-the-cursor-is-committed.md
+++ b/docs/adr/0007-an-outcome-is-recorded-where-the-cursor-is-committed.md
@@ -83,10 +83,30 @@ recorded from inside an `Effect`, an executor, or a handler.
 
 **3. Only exceptions are recorded; the cursor is the success record.** Everything
 below the cursor succeeded unless an outcome says otherwise, and anything the cursor
-never reached is visibly unprocessed. A `gaps()` query over that difference is what
-turns "absence of a record" from an assumption into a question with an answer. The
-alternative — a row per applied event — is a durable write on the hot path for the
-case that is fine, and the append cost tests exist to catch exactly that.
+never reached is visibly unprocessed. The alternative — a row per applied event — is a
+durable write on the hot path for the case that is fine, and the append cost tests exist
+to catch exactly that.
+
+There is deliberately **no gap query**, and an earlier draft of this decision was wrong to
+promise one. It proposed reporting "offsets below the cursor with no outcome recorded",
+which under this very decision is *every event that worked*: success writes nothing, so
+absence of a record is not a gap, it is the normal case. The two halves contradicted each
+other and the contradiction was only visible once a contract test had to state an expected
+value.
+
+What the model actually gives, and it is enough:
+
+- **Lag** is the head against the cursor. No outcomes required.
+- **Below the cursor**, an outcome means it failed, was refused or was skipped; no outcome
+  means it succeeded. By construction, with no third state.
+- An event below the cursor that neither succeeded nor recorded is a **defect in the loop**,
+  not a data condition. A test pins the loop; no runtime query can distinguish it, because
+  the design deliberately left no trace of success to look for.
+
+The class this was reaching for — a bulk write bypassing the pipeline, leaving derived rows
+missing and no record saying so — is answered structurally instead. A write that does not go
+through the loop does not advance the cursor, so the events are still pending and are still
+delivered. The bypass stops being a thing to detect.
 
 **4. Where the event is decides how it is recovered, and replay is only one of the
 answers.** `stage` says whether the event reached the log; `status` says what happened to
@@ -165,8 +185,8 @@ Two consequences worth stating before someone infers the opposite:
   `ConsumerCursor` holds an offset whose meaning is the store's.
 - **An outcome is not a verification result.** The parity commands that also get called
   gates — the ones that refuse to pass unless a replay matches live rows — are a different
-  thing again, and Decision 3's `gaps()` is deliberately a *report* rather than an input to
-  one. A consumer's own gate command warns about this directly, of its coverage counter:
+  thing again, and what this decision exposes — lag, and which events failed — is
+  deliberately a *report* rather than an input to one. A consumer's own gate command warns about this directly, of its coverage counter:
   it "belongs in a coverage verdict and would be wrong as a write blocker", and "a future
   apply must derive its own predicate from the report rather than reuse this verdict."
   Outcomes make such a residual explainable — *this row is missing and here is the record
@@ -201,8 +221,8 @@ That is not a defect this decision introduces; the consumer measured it when it 
 policy, and chose it because refusing the row moves fewer of those derived values than
 refusing the whole document would. What matters here is narrower and is a limit of *this*
 design: **a sequence key protects ordering within a sequence, and a reducer reads across
-sequences.** The gap check does not catch it either — there is no offset below the cursor
-carrying no outcome, because there is no offset at all.
+sequences.** Nothing else catches it either: the refused event has no offset, so it is
+absent from every view keyed on one.
 
 So the record says "this row was refused" and stays silent on "that derived value is now
 computed from an incomplete population". Recorded here as a known limit rather than
@@ -227,7 +247,8 @@ coupling, and it would need undoing to reach the shape this ADR describes. `enve
 is not.
 
 **Record every applied event, not only the exceptions.** It answers the completeness
-question directly and needs no `gaps()` query. Rejected on cost and on precedent: it is
+question directly, with no reliance on the cursor meaning what it says. Rejected on cost
+and on precedent: it is
 one durable write per event on the success path, in a codebase that has a test file
 asserting the *set of SQL statements* an append issues
 (`tests/test_django_rakaia/test_append_query_cost.py`) because #202 found three
@@ -260,11 +281,13 @@ that is the point of it.
 ### Negative, and named rather than waved away
 
 - **Nothing enforces that the loop is used.** A consumer keeping its hand-written
-  `poll`/`commit` records nothing, and its gaps look identical to a clean run. This
+  `poll`/`commit` records nothing, and its stream looks identical to a clean one. This
   decision adds a supported path; it does not close the unsupported one.
-- **`gaps()` is only as good as the cursor.** A consumer that commits before applying —
-  which `poll`'s docstring warns against but nothing prevents — reports no gap for an
-  event it never applied. The gap check inherits every weakness of the watermark.
+- **Everything rests on the cursor meaning what it says.** A consumer that commits before
+  applying — which `poll`'s docstring warns against and nothing prevents — silently
+  converts "unapplied" into "succeeded", because success is the absence of a record. The
+  alternative design, a row per applied event, does not have this weakness, and giving it
+  up is the price of not writing on the hot path.
 - **An outcome inherits #232 exactly.** `DjangoStreamStore` and `JsonlStreamStore` both
   issue `PLAIN`, so an outcome's `(stream_path, offset)` cannot say which store's offset
   it is any more than a cursor's can. Two backends at the same path produce outcomes that
@@ -275,8 +298,8 @@ that is the point of it.
 - **A sequence key does not reach a reducer.** The worked example above is the case: a
   stage-2 construct reads committed projections across sequences, so an event parked in
   one sequence silently changes a value derived in another, and no outcome says so.
-  Nothing in this decision detects it, and the gap check cannot — an event that was never
-  appended has no offset to be missing at. This is the largest thing the design leaves
+  Nothing in this decision detects it, and nothing keyed on an offset can — an event that
+  was never appended has no offset to be found at. This is the largest thing the design leaves
   open, and it is a property of reducers reading projections, not of the record.
 - **The admin registration breaks a local pattern.** `ConsumerCursor`,
   `StreamOffsetWatermark` and `StreamProducer` have no admin; operational bookkeeping is

--- a/docs/adr/0007-an-outcome-is-recorded-where-the-cursor-is-committed.md
+++ b/docs/adr/0007-an-outcome-is-recorded-where-the-cursor-is-committed.md
@@ -114,17 +114,63 @@ same shape as `on_drift` (`src/rakaia/drift.py:41`), and for the same reason: on
 path serving two operations with opposite invariants is how a guard ends up correct in
 one mode and silently wrong in the other.
 
-**6. An outcome carries a reason code and bounded parameters, never a message.**
-`reason` is a closed vocabulary; `params` is a flat string map. An interpolated message
-is where field values leak, and this library is used on submissions carrying personal
-and financial data. It also makes outcomes countable — "how many failed for this
-reason" is a query rather than a grep.
+**6. An outcome carries reason codes and bounded parameters, never a message.**
+`reasons` is a tuple drawn from a closed vocabulary; `params` is a flat string map. An
+interpolated message is where field values leak, and this library is used on submissions
+carrying personal and financial data. It also makes outcomes countable — "how many failed
+for this reason" is a query rather than a grep.
+
+Plural, not singular, because one event can fail several rules at once and the consumer
+that motivated this already collects them as a tuple before flattening them with a
+`", ".join(...)` for display. Storing the join would re-lose exactly the structure this
+decision exists to keep.
+
+**6a. An outcome is immutable; nothing is resolved on it.** An earlier draft gave the
+record a `resolved_at`. That is wrong wherever the reason codes come from a consumer's own
+observations, because those observations already carry a resolution lifecycle — the
+motivating consumer's flags have `resolved_at`, `resolved_by`, `assigned_to` and an
+auto-resolve sweep. A second place to mark the same fact fixed is a second answer that
+will eventually disagree with the first. So outcomes are append-only and attempt-numbered,
+and "is this still failing?" is the latest outcome for the key, not a column. `unresolved`
+is therefore a derived query, not stored state.
 
 **7. Sequencing is recorded, not enforced.** An outcome carries a `sequence_key`.
 Rakaia does not yet refuse an event whose sequence has an unresolved failure; the field
 exists so that adding it later does not require re-deriving groupings a consumer has
 already decided. Named here because recording a key nothing reads is otherwise the sort
 of thing a later reader deletes as dead weight.
+
+## Observations, refusals, and the record that one happened
+
+Consumers already separate two of these three carefully, and the motivating one says so in
+its own vocabulary file: *"a gate is a **refusal**; a flag is an *observation* — do not use
+the words interchangeably."* An outcome is the third, and it is neither.
+
+| | What it is | Who owns it | Lifecycle |
+|---|---|---|---|
+| **Observation** | A rule noticed something about the data | The consumer's rules layer | Raised, assigned, resolved |
+| **Refusal** | The pipeline declined to accept a row | The consumer's policy | Decided per save |
+| **Outcome** | The record that a refusal (or a failure) happened | This decision | **Immutable** |
+
+One refusal produces several observations and exactly one outcome. The outcome's `reasons`
+are a *snapshot of the observations that were open at the moment it was refused* — in the
+motivating consumer, literally read back from its unresolved flags — which is why the
+outcome does not carry a resolution of its own (Decision 6a): resolving the observation is
+what fixes the underlying problem, and the next attempt records the next outcome.
+
+Two consequences worth stating before someone infers the opposite:
+
+- **rakaia does not define the vocabulary.** `reasons` is opaque to it. Which codes exist,
+  what they mean, and when they are resolved are the consumer's, exactly as
+  `ConsumerCursor` holds an offset whose meaning is the store's.
+- **An outcome is not a verification result.** The parity commands that also get called
+  gates — the ones that refuse to pass unless a replay matches live rows — are a different
+  thing again, and Decision 3's `gaps()` is deliberately a *report* rather than an input to
+  one. A consumer's own gate command warns about this directly, of its coverage counter:
+  it "belongs in a coverage verdict and would be wrong as a write blocker", and "a future
+  apply must derive its own predicate from the report rather than reuse this verdict."
+  Outcomes make such a residual explainable — *this row is missing and here is the record
+  saying why* — and must not become the thing that decides whether it passes.
 
 ## A worked example, and the thing it exposes
 

--- a/docs/adr/0007-an-outcome-is-recorded-where-the-cursor-is-committed.md
+++ b/docs/adr/0007-an-outcome-is-recorded-where-the-cursor-is-committed.md
@@ -88,12 +88,25 @@ turns "absence of a record" from an assumption into a question with an answer. T
 alternative — a row per applied event — is a durable write on the hot path for the
 case that is fine, and the append cost tests exist to catch exactly that.
 
-**4. A failed append and a failed projection are different records.** `stage="append"`
-means the event was never written: the fact is gone, its offset is null, and recovering
-it means re-producing from whatever the consumer derived it from. `stage="project"`
-means the event is safe in the log and merely unapplied, and replay recovers it. One
-field, because a re-drive built on the assumption that every row is replayable would
-be wrong for half of them.
+**4. Where the event is decides how it is recovered, and replay is only one of the
+answers.** `stage` says whether the event reached the log; `status` says what happened to
+it. Together they name the recovery, and a re-drive that assumed every recorded outcome
+was replayable would take the wrong action on most of them.
+
+| `stage` | `status` | Where the fact is | Recovery |
+|---|---|---|---|
+| `project` | `failed` | Safe in the log, unapplied | Replay it |
+| `append` | `failed` | **Gone.** The append was attempted and lost | Re-produce from whatever the consumer derived it from |
+| `append` | `refused` | Safe upstream, deliberately not logged | Fix the data upstream and let it be produced again |
+| either | `skipped` | Wherever it was | None wanted — not applying it *was* the decision |
+
+The third row is the one worth spelling out, because it looks like the second and is not.
+A consumer that gates its events refuses some of them *on purpose* — the log is the
+system of record, so it must not carry a row the consumer declined to accept — and the
+fact is not lost at all, it is sitting in whatever the consumer produced the event from.
+Nothing is missing; something was rejected. Treating that as a lost append would send a
+re-drive hunting for a fact that is exactly where it should be, and treating it as an
+unapplied projection would send a replay looking for an event that was never written.
 
 **5. The failure policy is a parameter with per-mode defaults, never inferred.**
 `on_error="skip"` when consuming continuously, `on_error="halt"` when rebuilding. The
@@ -112,6 +125,43 @@ Rakaia does not yet refuse an event whose sequence has an unresolved failure; th
 exists so that adding it later does not require re-deriving groupings a consumer has
 already decided. Named here because recording a key nothing reads is otherwise the sort
 of thing a later reader deletes as dead weight.
+
+## A worked example, and the thing it exposes
+
+The consumer that motivated this decision gates its events per row. Traced through its
+live path, one refused repeater on a progress form does this:
+
+1. The document is split. Every row exists as a derived row, including the bad one.
+2. Every row is checked — the gate deliberately does not short-circuit, so the whole
+   failure set is reported in one pass rather than one row per attempt.
+3. Policy for this form is *refuse the row, keep its siblings*. The refused row's event
+   is dropped from the batch: **neither appended nor projected**, on the stated
+   principle that the log must not carry a row the consumer declined to accept.
+4. An outcome is recorded against the refused row; the clean rows record success.
+5. The user sees a partial failure naming the offending row.
+
+Under this ADR that is `stage="append"`, `status="refused"`, `sequence_key` = the row —
+the third table row above, and the design handles it correctly. The siblings are
+genuinely independent, so parking the row and nothing else is the right answer.
+
+**Then a stage-2 reducer runs, and the containment stops.** It recomputes a field on a
+*different* form by reading the latest progress row per project **out of the projection**.
+The refused row was never written, so the reducer cannot see it, takes the previous
+period's figure instead, and *writes* the resulting value. Not stale by omission —
+actively written from an input with a hole in it, with nothing linking that write back to
+the refusal.
+
+That is not a defect this decision introduces; the consumer measured it when it chose the
+policy, and chose it because refusing the row moves fewer of those derived values than
+refusing the whole document would. What matters here is narrower and is a limit of *this*
+design: **a sequence key protects ordering within a sequence, and a reducer reads across
+sequences.** The gap check does not catch it either — there is no offset below the cursor
+carrying no outcome, because there is no offset at all.
+
+So the record says "this row was refused" and stays silent on "that derived value is now
+computed from an incomplete population". Recorded here as a known limit rather than
+closed, because closing it is a decision about reducers, not about outcomes — see *What
+would reopen this*.
 
 ## Alternatives considered
 
@@ -176,6 +226,12 @@ that is the point of it.
 - **Sequencing is a field and a promise.** Decision 7 records a key nothing acts on. If
   the enforcement never lands, this is a column carrying a consumer's private grouping
   for no benefit rakaia delivers.
+- **A sequence key does not reach a reducer.** The worked example above is the case: a
+  stage-2 construct reads committed projections across sequences, so an event parked in
+  one sequence silently changes a value derived in another, and no outcome says so.
+  Nothing in this decision detects it, and the gap check cannot — an event that was never
+  appended has no offset to be missing at. This is the largest thing the design leaves
+  open, and it is a property of reducers reading projections, not of the record.
 - **The admin registration breaks a local pattern.** `ConsumerCursor`,
   `StreamOffsetWatermark` and `StreamProducer` have no admin; operational bookkeeping is
   not browsed. A dead-letter table is argued as the exception because looking at it *is*
@@ -198,5 +254,13 @@ that is the point of it.
 - **Sequencing enforcement.** Refusing an event whose sequence has an unresolved failure
   changes live behaviour and needs its own argument. If it is declined for good, Decision
   7's field should go with it.
+- **An answer to the reducer gap.** Three shapes, none obviously right, and the choice
+  between them is a decision about reducers rather than about outcomes:
+  *(a)* extend parking to reducers, so one refuses to run over a population with an
+  unresolved outcome — correct, changes live behaviour, needs the gates;
+  *(b)* record a derived outcome against the affected row when a reducer's input has a
+  hole — purely additive, but a second kind of outcome with different provenance;
+  *(c)* leave the behaviour alone and make the affected population queryable.
+  Whichever lands, `stage`/`status` from Decision 4 is what it will key off.
 - **A fourth store.** The contract suite is where that is absorbed; if a store cannot
   implement `OutcomeStore` cheaply, the protocol is wrong rather than the store.

--- a/docs/adr/0007-an-outcome-is-recorded-where-the-cursor-is-committed.md
+++ b/docs/adr/0007-an-outcome-is-recorded-where-the-cursor-is-committed.md
@@ -329,8 +329,10 @@ that is the point of it.
   with an outcome. That count belongs to the consumer, which has it; worth saying because
   the obvious reading of `latest` is that it is enough on its own, and it is not.
 - **The reason codes are available; the parameters beside them are not, on one path.** The
-  consumer's refusal object already carries a string-to-string map, so that path fits without
-  change. Its flag path does not: the structured detail is flattened into a sentence before
+  consumer's refusal object carries a string-to-string map — built in one place, by a helper
+  that renders every value on the way in — so that path fits without change. (The verdict it
+  is built *from* is typed as holding anything, and at least one caller puts a number there;
+  it is the rendering step that makes the refusal safe, not the source.) Its flag path does not: the structured detail is flattened into a sentence before
   it is stored, so anything populating parameters from a flag has only prose to read back and
   must re-derive them. Decision 6 asks for the opposite of what that path does today.
 - **Nothing here is exported.** `Outcome`, `OutcomeStore` and the two backends are absent

--- a/docs/adr/0007-an-outcome-is-recorded-where-the-cursor-is-committed.md
+++ b/docs/adr/0007-an-outcome-is-recorded-where-the-cursor-is-committed.md
@@ -365,6 +365,17 @@ that is the point of it.
   verdict enum — pass, fail, not-applicable, indeterminate — imported in twenty-odd modules
   and referred to a few hundred times. Nothing breaks, but `from rakaia import Outcome` would
   shadow it there, so that consumer will want a qualified import.
+- **The codec closes shape, not size, and cannot.** Reading each field's declared type
+  settles what a value *is*; it says nothing about how long it may be. A backend with a
+  bounded column accepts a name every other backend keeps and then refuses or truncates it —
+  the same divergence, out of reach of the same mechanism. Measured on a spike of a third
+  backend: a 300-character stream path is kept by both current stores and by a database
+  under SQLite, and refused only under Postgres.
+
+  Which exposes the sharper half. The suite's default database does not enforce lengths, so
+  that divergence is invisible where the tests usually run — the same fault this decision
+  fixed one level in, where the reference store was the permissive one. Whatever else is
+  done, the cross-backend comparison has to run somewhere the constraints are real.
 - **Everything rests on the cursor meaning what it says.** A consumer that commits before
   applying — which `poll`'s docstring warns against and nothing prevents — silently
   converts "unapplied" into "succeeded", because success is the absence of a record. The

--- a/docs/adr/0007-an-outcome-is-recorded-where-the-cursor-is-committed.md
+++ b/docs/adr/0007-an-outcome-is-recorded-where-the-cursor-is-committed.md
@@ -174,9 +174,11 @@ of thing a later reader deletes as dead weight.
 **It is computed per refusal, not looked up per form.** The obvious source is a consumer's
 existing per-form refusal scope — group under the document where a partial write yields a
 wrong total, per row otherwise — and that is not sufficient on its own. Measured against the
-motivating consumer: an unclassified form silently falls back to per-row, and a blocked *root*
-row refuses the whole document whatever the form's scope says, because every child's typed
-record points at the root's. A key derived from the form alone is wrong in both cases.
+motivating consumer: the lookup falls back to per-row for a form nobody classified — held
+total by a fitness test that forbids the omission rather than by the lookup itself, so the
+scope is complete only as long as that test is — and a blocked *root* row refuses the whole
+document whatever the form's scope says, because every child's typed record points at the
+root's. A key derived from the form alone is wrong in the second case regardless.
 
 This is why `subject` is a separate field rather than the same one. The subject is the single
 thing an outcome is about; the sequence key is what that particular refusal actually parked.

--- a/docs/adr/0007-an-outcome-is-recorded-where-the-cursor-is-committed.md
+++ b/docs/adr/0007-an-outcome-is-recorded-where-the-cursor-is-committed.md
@@ -167,6 +167,26 @@ will eventually disagree with the first. So outcomes are append-only and attempt
 and "is this still failing?" is the latest outcome for the key, not a column. `unresolved`
 is therefore a derived query, not stored state.
 
+**6b. One translation decides what a stored outcome looks like, and every backend uses it.**
+`encode`/`decode` is the only crossing between an outcome and its stored form, the in-memory
+reference included. That store previously kept the object as handed to it while the durable
+ones had to render it, so it accepted values they refused — a reference implementation more
+permissive than the real ones makes a passing test a weaker promise than production.
+
+The check **walks the declared fields rather than naming them**, and that is the part worth
+recording. Five review rounds each closed one field: a map's values, then its keys, then the
+list beside it, then the plain fields — each check written where the defect was found instead
+of where the rule belongs, so the list was never more complete than the last bug. Reading the
+declaration also brought two cases nobody had reported: a value outside a `Literal`'s domain,
+and `bool` arriving where an `int` was declared.
+
+Two consequences follow and are not obvious. A name may not be empty — a file-backed store
+maps a name to one path segment, and every escaping of the empty string collides with
+something. And a line this version cannot rebuild is dropped with a log rather than an
+exception, because one such line must not cost the whole report; it is only logged and not
+yet counted, which is a weaker answer than this decision would like given that unnoticed
+absence is the thing it exists to prevent.
+
 **7. Sequencing is recorded, not enforced.** An outcome carries a `sequence_key`.
 Rakaia does not yet refuse an event whose sequence has an unresolved failure; the field
 exists so that adding it later does not require re-deriving groupings a consumer has

--- a/docs/adr/0007-an-outcome-is-recorded-where-the-cursor-is-committed.md
+++ b/docs/adr/0007-an-outcome-is-recorded-where-the-cursor-is-committed.md
@@ -64,7 +64,7 @@ Meanwhile `docs/framework-vs-protocol-server.md` lists cursors **twice** — *"S
 cursors … Python stdlib only"* (`:33`) and *"Durable subscriber cursors — persisted
 watermarks … Django (ORM)"* (`:39`). That split is the template. `poll` is stdlib
 because the decision is store-agnostic; only the place to keep the answer is Django.
-An outcome keyed by `(consumer, stream_path, offset)` is store-agnostic in exactly the
+An outcome keyed by `(consumer, stream_path, subject)` is store-agnostic in exactly the
 same way, and there are now three stores.
 
 ## Decision
@@ -149,7 +149,9 @@ decision exists to keep.
 **The codes are opaque to rakaia, and are not a closed set anywhere yet.** An earlier draft
 said a consumer could borrow one it already had. Checked against that consumer: the field
 those codes come from is a bare 64-character text column with no constrained values, and one
-can be minted over HTTP by a reviewer resolving a flag. It is a vocabulary by convention and a
+can be minted over HTTP by creating or editing a flag, both of which bypass the internal
+guard that checks a code was declared. (Resolving one does not — it writes only the
+resolution.) It is a vocabulary by convention and a
 static scan, not by construction. Borrowing it is still right — it is what people already say
 — but closing it is work the consumer has to do, and this decision should not be read as
 saying it is done.
@@ -322,6 +324,15 @@ that is the point of it.
   versus "some did" needs to know how many there were, and `latest` returns only the ones
   with an outcome. That count belongs to the consumer, which has it; worth saying because
   the obvious reading of `latest` is that it is enough on its own, and it is not.
+- **Nothing here is exported.** `Outcome`, `OutcomeStore` and the two backends are absent
+  from `rakaia.__all__`, so a consumer adopting this today is importing below the stable
+  surface. Deliberate while the decision is Proposed — exporting is a stability promise, and
+  making one for a design still under review is how a bad shape becomes permanent — but it
+  means "usable" and "supported" are not yet the same thing here. Exporting is the last step
+  before this is Accepted, not an oversight.
+- **`Outcome` is a name the motivating consumer already uses** for an unrelated pass/fail
+  enum, at roughly twenty sites. Nothing breaks, but `from rakaia import Outcome` would
+  shadow it there, so that consumer will want a qualified import.
 - **Everything rests on the cursor meaning what it says.** A consumer that commits before
   applying — which `poll`'s docstring warns against and nothing prevents — silently
   converts "unapplied" into "succeeded", because success is the absence of a record. The

--- a/src/rakaia/jsonl_outcomes.py
+++ b/src/rakaia/jsonl_outcomes.py
@@ -28,7 +28,6 @@ because a partial outcome is not worth failing a whole report over.
 
 from __future__ import annotations
 
-import json
 import os
 from pathlib import Path
 from urllib.parse import quote
@@ -89,19 +88,7 @@ class JsonlOutcomeStore:
     def record(self, outcome: Outcome) -> None:
         target = self._file(outcome.consumer, outcome.stream_path)
         target.parent.mkdir(parents=True, exist_ok=True)
-        # No `sort_keys`: `encode` already settles the order, and a second sorter
-        # here would be a second answer to the same question — the shape of defect
-        # this codec exists to remove.
-        #
-        # Worth being straight about what that does and does not buy. On this side
-        # the codec is not load-bearing: `__post_init__` already refuses anything
-        # unstorable, so bypassing `encode` here and sorting some other way produces
-        # the same bytes, and a review confirmed the suite stays green if you do. It
-        # is here so there is one definition of the stored shape rather than two that
-        # can drift, which is a claim about maintenance, not one a test can make. The
-        # store where it *is* load-bearing is the in-memory one, which otherwise
-        # normalises nothing at all.
-        line = json.dumps(encode(outcome)) + "\n"
+        line = encode(outcome) + "\n"
         # Narrowing, not defence: `__init__` refuses to build a store on a platform
         # without `fcntl`, so by here it is always a module. Stated as an assert
         # rather than an ignore comment, the way `jsonl_store.py` states the same
@@ -137,16 +124,11 @@ class JsonlOutcomeStore:
         for line in target.read_text(encoding="utf-8").splitlines():
             if not line.strip():
                 continue
-            try:
-                payload = json.loads(line)
-            except ValueError:
-                # A torn trailing line from a crash mid-append. Skipping it
-                # loses one outcome; failing the read would lose the report.
-                continue
-            # `decode` answers "can this version build it", including both
-            # version-skew cases — a field added later, or one since removed. A
-            # line it cannot build costs that line, never the report.
-            outcome = decode(payload)
+            # `decode` takes the stored text directly — the same text `encode`
+            # produced and the same text the in-memory store keeps. A torn line
+            # from a crash mid-append, and a line this version cannot rebuild,
+            # are the same case to it: that line is lost, never the report.
+            outcome = decode(line)
             if outcome is not None:
                 out.append(outcome)
         return out

--- a/src/rakaia/jsonl_outcomes.py
+++ b/src/rakaia/jsonl_outcomes.py
@@ -1,0 +1,140 @@
+"""An `OutcomeStore` backed by plain JSONL files on disk.
+
+The second implementation, and the reason the seam exists. `InMemoryOutcomeStore`
+proves nothing on its own — the same commit wrote it and the protocol, so of
+course it fits. This one has no database under it and shares no code with the
+first, so `tests/outcome_store_contract.py` passing against both is the evidence
+that an outcome is as store-agnostic as ADR 0007 Decision 1 claims.
+
+Outcomes are **append-only by definition** (Decision 6a), which makes a log file
+the natural shape rather than a compromise: `record` is one line appended, and
+nothing ever rewrites a line. Where the stream store needs segments, sealing and
+a head cache, this needs none of them — there is no head to track, and the
+population is exceptions only.
+
+Layout, one file per consumer and stream::
+
+    <root>/<quoted consumer>/<quoted stream path>.jsonl
+
+`quote(safe="")` on both components for the reason `JsonlStreamStore._dir` gives:
+a stream path contains slashes and must map to one name, not a tree, and
+percent-encoding is the mapping that is reversible.
+
+Sharing the stream store's limits, and for the same reasons: `fcntl` only, so no
+Windows; `flock` is unreliable on NFS; readers do not take the lock. A torn
+trailing line — a crash mid-append — is skipped on read rather than parsed,
+because a partial outcome is not worth failing a whole report over.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import asdict
+from pathlib import Path
+from urllib.parse import quote
+
+from .outcomes import Outcome
+
+try:  # pragma: no cover - platform dependent
+    import fcntl
+except ImportError:  # pragma: no cover - Windows
+    fcntl = None  # type: ignore[assignment]
+
+
+def _safe_name(name: str) -> str:
+    """One path segment for `name`, guaranteed to stay under its parent.
+
+    `quote(safe="")` maps a slash to `%2F`, which is what keeps a stream path a
+    name rather than a tree, and it is reversible. What it does **not** touch is a
+    dot: `quote("..")` is `".."`, so a consumer or stream called `..` resolves
+    above the root and writes outside the store entirely. Only an all-dot name can
+    do that — anything else already carries an encoded character — so those are the
+    ones encoded here, and an empty name, which would otherwise collapse a
+    directory level.
+
+    Found by a containment test rather than by review, and that is the point worth
+    keeping: an unencoded name still *round-trips*, so reading back what was
+    written passes while the file sits somewhere it should never have been.
+    """
+    quoted = quote(name, safe="")
+    if not quoted or set(quoted) <= {"."}:
+        return quoted.replace(".", "%2E") or "%00"
+    return quoted
+
+
+class JsonlOutcomeStore:
+    """Outcomes kept as JSONL, one file per `(consumer, stream_path)`."""
+
+    def __init__(self, root: str | Path, *, fsync: bool = True):
+        """`fsync` on means a recorded outcome has reached the disk when `record` returns.
+
+        On by default for the reason `JsonlStreamStore` gives: the backend it is
+        measured against is a database, whose commit is durable, and returning
+        with the record only in the page cache would claim something weaker while
+        looking the same. Turn it off for tmpfs and fixtures.
+        """
+        if fcntl is None:  # pragma: no cover - Windows
+            raise RuntimeError(
+                "JsonlOutcomeStore needs fcntl.flock, which this platform does not "
+                "provide. Two writers appending unlocked can interleave a partial "
+                "line, so the store refuses to start rather than run unlocked."
+            )
+        self.root = Path(root)
+        self.fsync = fsync
+        self.root.mkdir(parents=True, exist_ok=True)
+
+    def _file(self, consumer: str, stream_path: str) -> Path:
+        return self.root / _safe_name(consumer) / f"{_safe_name(stream_path)}.jsonl"
+
+    def record(self, outcome: Outcome) -> None:
+        target = self._file(outcome.consumer, outcome.stream_path)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        line = json.dumps(asdict(outcome), sort_keys=True) + "\n"
+        # Narrowing, not defence: `__init__` refuses to build a store on a platform
+        # without `fcntl`, so by here it is always a module. Stated as an assert
+        # rather than an ignore comment, the way `jsonl_store.py` states the same
+        # guarantee.
+        assert fcntl is not None
+        # Append under an exclusive lock so two writers cannot interleave halves
+        # of a line. `a` mode means the write is positioned at the end at write
+        # time, not at open time, so the lock is what orders them rather than a
+        # seek this would otherwise have to do itself.
+        with target.open("a", encoding="utf-8") as fh:
+            fcntl.flock(fh.fileno(), fcntl.LOCK_EX)
+            try:
+                fh.write(line)
+                fh.flush()
+                if self.fsync:
+                    os.fsync(fh.fileno())
+            finally:
+                fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
+
+    def latest(self, consumer: str, stream_path: str) -> list[Outcome]:
+        best: dict[str | None, Outcome] = {}
+        for record in self._read(consumer, stream_path):
+            held = best.get(record.offset)
+            if held is None or record.attempt > held.attempt:
+                best[record.offset] = record
+        # Offsets are opaque tokens and sort as the strings they are; the
+        # append-stage entries have none and go last rather than being compared
+        # against one.
+        return sorted(best.values(), key=lambda o: (o.offset is None, o.offset or ""))
+
+    def _read(self, consumer: str, stream_path: str) -> list[Outcome]:
+        target = self._file(consumer, stream_path)
+        if not target.is_file():
+            return []
+        out: list[Outcome] = []
+        for line in target.read_text(encoding="utf-8").splitlines():
+            if not line.strip():
+                continue
+            try:
+                payload = json.loads(line)
+            except ValueError:
+                # A torn trailing line from a crash mid-append. Skipping it
+                # loses one outcome; failing the read would lose the report.
+                continue
+            payload["reasons"] = tuple(payload.get("reasons", ()))
+            out.append(Outcome(**payload))
+        return out

--- a/src/rakaia/jsonl_outcomes.py
+++ b/src/rakaia/jsonl_outcomes.py
@@ -91,8 +91,16 @@ class JsonlOutcomeStore:
         target.parent.mkdir(parents=True, exist_ok=True)
         # No `sort_keys`: `encode` already settles the order, and a second sorter
         # here would be a second answer to the same question — the shape of defect
-        # this codec exists to remove. It also made the codec unobservable from this
-        # side, so reverting it looked harmless.
+        # this codec exists to remove.
+        #
+        # Worth being straight about what that does and does not buy. On this side
+        # the codec is not load-bearing: `__post_init__` already refuses anything
+        # unstorable, so bypassing `encode` here and sorting some other way produces
+        # the same bytes, and a review confirmed the suite stays green if you do. It
+        # is here so there is one definition of the stored shape rather than two that
+        # can drift, which is a claim about maintenance, not one a test can make. The
+        # store where it *is* load-bearing is the in-memory one, which otherwise
+        # normalises nothing at all.
         line = json.dumps(encode(outcome)) + "\n"
         # Narrowing, not defence: `__init__` refuses to build a store on a platform
         # without `fcntl`, so by here it is always a module. Stated as an assert

--- a/src/rakaia/jsonl_outcomes.py
+++ b/src/rakaia/jsonl_outcomes.py
@@ -30,11 +30,13 @@ from __future__ import annotations
 
 import json
 import os
-from dataclasses import asdict
+from dataclasses import asdict, fields
 from pathlib import Path
 from urllib.parse import quote
 
-from .outcomes import Outcome
+from .outcomes import Outcome, _order
+
+_FIELDS = {f.name for f in fields(Outcome)}
 
 try:  # pragma: no cover - platform dependent
     import fcntl
@@ -111,15 +113,12 @@ class JsonlOutcomeStore:
                 fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
 
     def latest(self, consumer: str, stream_path: str) -> list[Outcome]:
-        best: dict[str | None, Outcome] = {}
+        best: dict[str, Outcome] = {}
         for record in self._read(consumer, stream_path):
-            held = best.get(record.offset)
-            if held is None or record.attempt > held.attempt:
-                best[record.offset] = record
-        # Offsets are opaque tokens and sort as the strings they are; the
-        # append-stage entries have none and go last rather than being compared
-        # against one.
-        return sorted(best.values(), key=lambda o: (o.offset is None, o.offset or ""))
+            held = best.get(record.subject)
+            if held is None or record.attempt >= held.attempt:
+                best[record.subject] = record
+        return sorted(best.values(), key=_order)
 
     def _read(self, consumer: str, stream_path: str) -> list[Outcome]:
         target = self._file(consumer, stream_path)
@@ -136,5 +135,16 @@ class JsonlOutcomeStore:
                 # loses one outcome; failing the read would lose the report.
                 continue
             payload["reasons"] = tuple(payload.get("reasons", ()))
-            out.append(Outcome(**payload))
+            try:
+                out.append(
+                    Outcome(**{k: v for k, v in payload.items() if k in _FIELDS})
+                )
+            except (TypeError, ValueError):
+                # A line this version cannot build: a field added by a later
+                # version, or one removed. Unknown keys are dropped rather than
+                # passed through, because `Outcome(**payload)` raises on an extra
+                # one — and a single such line would otherwise take the whole
+                # report down, which is exactly what the torn-line handling above
+                # exists to prevent.
+                continue
         return out

--- a/src/rakaia/jsonl_outcomes.py
+++ b/src/rakaia/jsonl_outcomes.py
@@ -89,7 +89,11 @@ class JsonlOutcomeStore:
     def record(self, outcome: Outcome) -> None:
         target = self._file(outcome.consumer, outcome.stream_path)
         target.parent.mkdir(parents=True, exist_ok=True)
-        line = json.dumps(encode(outcome), sort_keys=True) + "\n"
+        # No `sort_keys`: `encode` already settles the order, and a second sorter
+        # here would be a second answer to the same question — the shape of defect
+        # this codec exists to remove. It also made the codec unobservable from this
+        # side, so reverting it looked harmless.
+        line = json.dumps(encode(outcome)) + "\n"
         # Narrowing, not defence: `__init__` refuses to build a store on a platform
         # without `fcntl`, so by here it is always a module. Stated as an assert
         # rather than an ignore comment, the way `jsonl_store.py` states the same

--- a/src/rakaia/jsonl_outcomes.py
+++ b/src/rakaia/jsonl_outcomes.py
@@ -30,13 +30,10 @@ from __future__ import annotations
 
 import json
 import os
-from dataclasses import asdict, fields
 from pathlib import Path
 from urllib.parse import quote
 
-from .outcomes import Outcome, _order
-
-_FIELDS = {f.name for f in fields(Outcome)}
+from .outcomes import Outcome, _order, decode, encode
 
 try:  # pragma: no cover - platform dependent
     import fcntl
@@ -92,7 +89,7 @@ class JsonlOutcomeStore:
     def record(self, outcome: Outcome) -> None:
         target = self._file(outcome.consumer, outcome.stream_path)
         target.parent.mkdir(parents=True, exist_ok=True)
-        line = json.dumps(asdict(outcome), sort_keys=True) + "\n"
+        line = json.dumps(encode(outcome), sort_keys=True) + "\n"
         # Narrowing, not defence: `__init__` refuses to build a store on a platform
         # without `fcntl`, so by here it is always a module. Stated as an assert
         # rather than an ignore comment, the way `jsonl_store.py` states the same
@@ -134,17 +131,10 @@ class JsonlOutcomeStore:
                 # A torn trailing line from a crash mid-append. Skipping it
                 # loses one outcome; failing the read would lose the report.
                 continue
-            payload["reasons"] = tuple(payload.get("reasons", ()))
-            try:
-                out.append(
-                    Outcome(**{k: v for k, v in payload.items() if k in _FIELDS})
-                )
-            except (TypeError, ValueError):
-                # A line this version cannot build: a field added by a later
-                # version, or one removed. Unknown keys are dropped rather than
-                # passed through, because `Outcome(**payload)` raises on an extra
-                # one — and a single such line would otherwise take the whole
-                # report down, which is exactly what the torn-line handling above
-                # exists to prevent.
-                continue
+            # `decode` answers "can this version build it", including both
+            # version-skew cases — a field added later, or one since removed. A
+            # line it cannot build costs that line, never the report.
+            outcome = decode(payload)
+            if outcome is not None:
+                out.append(outcome)
         return out

--- a/src/rakaia/outcomes.py
+++ b/src/rakaia/outcomes.py
@@ -149,16 +149,25 @@ class Outcome:
         # some other input already uses. Refusing here is cheaper than making every
         # store's naming injective, and an outcome about nothing is meaningless
         # anyway.
-        names = ("consumer", "stream_path", "subject")
-        # These three become path segments and dictionary keys, so they carry a
-        # constraint the payload does not: they must be writable text. A number is
-        # stored happily by anything keeping JSON and raises in a file store's path
-        # escaping; a lone surrogate is text by every type check and no path can
-        # carry it. Both reach the store and fail there — inside the loop whose job
-        # is recording that something failed. One rule, because it is one reason.
+        # The fields a *store* reasons about, as opposed to merely carries. These
+        # four become path segments, dictionary keys and sort keys, so they have to
+        # be writable text — and for reasons the payload rule cannot see:
+        #
+        #   a number stored as a name raises in a file store's path escaping;
+        #   a lone surrogate is text by every type check and no path can carry it;
+        #   a number stored as an offset is kept identically by every store and then
+        #     makes `latest` raise the moment a text offset sits beside it, because
+        #     the two cannot be compared.
+        #
+        # Everything else an outcome holds is settled by `encode` actually storing
+        # it. This list is short because it is not a description of the type system;
+        # it is the set of values the machinery touches.
+        handled = ("consumer", "stream_path", "subject", "offset")
         unwritable = []
-        for name in names:
+        for name in handled:
             value = getattr(self, name)
+            if value is None and name == "offset":
+                continue  # an event that never reached the log has no position
             if type(value) is not str:
                 unwritable.append(name)
                 continue
@@ -168,8 +177,10 @@ class Outcome:
                 unwritable.append(name)
         if unwritable:
             raise ValueError(
-                f"A name has to be writable text, and {', '.join(sorted(unwritable))} cannot be encoded."
+                f"A store sorts and names by these, so they have to be writable text: "
+                f"{', '.join(sorted(unwritable))}."
             )
+        names = ("consumer", "stream_path", "subject")
         empty = sorted(n for n in names if not getattr(self, n))
         if empty:
             raise ValueError(

--- a/src/rakaia/outcomes.py
+++ b/src/rakaia/outcomes.py
@@ -3,7 +3,7 @@
 A cursor says how far a consumer got. It says nothing about whether it got there
 cleanly, so an event that was skipped, refused or lost is indistinguishable from
 one applied without incident: **absence of a record reads as success**. This
-module is the record that closes that gap, and The loop that writes it is not in
+module is the record that closes that gap. The loop that writes it is not part of
 this change; ADR 0007 Decision 2 describes where it goes.
 
 Two things follow from where it is written, and both are load-bearing.
@@ -144,6 +144,14 @@ class Outcome:
             raise ValueError(
                 "An outcome needs a subject — what it is about — and got an empty one."
             )
+        # Keys as well as values. Checking only the values left the same divergence
+        # one round later: an integer key survives in memory and comes back a string
+        # from anything that serialises, and a key that is hashable but not a
+        # primitive records in memory and raises on write. Both halves have to be
+        # strings for the two to agree.
+        bad_keys = sorted(repr(k) for k in self.params if not isinstance(k, str))
+        if bad_keys:
+            raise ValueError(f"params keys must be strings; {bad_keys} are not.")
         bad = sorted(k for k, v in self.params.items() if not isinstance(v, str))
         if bad:
             raise ValueError(

--- a/src/rakaia/outcomes.py
+++ b/src/rakaia/outcomes.py
@@ -151,9 +151,18 @@ class Outcome:
         # some other input already uses. Refusing here is cheaper than making every
         # store's naming injective, and an outcome about nothing is meaningless
         # anyway.
-        empty = sorted(
-            n for n in ("consumer", "stream_path", "subject") if not getattr(self, n)
-        )
+        names = ("consumer", "stream_path", "subject")
+        # A lone surrogate is a `str` and is not text anything can write: a
+        # file-backed store raises out of its path escaping before recording
+        # anything — inside the very loop whose job is recording that something
+        # failed. Refused for the same reason an empty name is: a store cannot turn
+        # it into a name, and the declared type cannot tell it apart.
+        unwritable = sorted(n for n in names if not _encodable(getattr(self, n)))
+        if unwritable:
+            raise ValueError(
+                f"A name has to be writable text, and {', '.join(unwritable)} cannot be encoded."
+            )
+        empty = sorted(n for n in names if not getattr(self, n))
         if empty:
             raise ValueError(
                 f"A name saying what this outcome belongs to cannot be empty: {', '.join(empty)}."
@@ -186,6 +195,21 @@ def _declared() -> dict[str, Any]:
     return get_type_hints(Outcome)
 
 
+def _encodable(value: Any) -> bool:
+    """Whether this text can actually be written out.
+
+    A lone surrogate satisfies every type check and still cannot be encoded, so it
+    passes construction and fails inside a store instead.
+    """
+    if type(value) is not str:
+        return True  # a wrong type is a different complaint, reported elsewhere
+    try:
+        value.encode("utf-8")
+    except UnicodeEncodeError:
+        return False
+    return True
+
+
 def _matches(value: Any, hint: Any) -> bool:
     """Whether `value` is what `hint` says it is, as JSON would keep it.
 
@@ -202,7 +226,11 @@ def _matches(value: Any, hint: Any) -> bool:
     """
     origin = get_origin(hint)
     if origin is Literal:
-        return value in get_args(hint)
+        # `in` is equality, and equality is exactly what a `str` subclass passes —
+        # so the two fields declared as a small set of strings were the only ones
+        # this function did not protect, which is the case its own docstring names.
+        # A member has to be the same type as the alternative it matches.
+        return any(value == a and type(value) is type(a) for a in get_args(hint))
     if origin in (UnionType, Union):
         return any(_matches(value, arg) for arg in get_args(hint))
     if hint is type(None):

--- a/src/rakaia/outcomes.py
+++ b/src/rakaia/outcomes.py
@@ -3,8 +3,8 @@
 A cursor says how far a consumer got. It says nothing about whether it got there
 cleanly, so an event that was skipped, refused or lost is indistinguishable from
 one applied without incident: **absence of a record reads as success**. This
-module is the record that closes that gap, and `subscription.consume` is where it
-is written.
+module is the record that closes that gap, and The loop that writes it is not in
+this change; ADR 0007 Decision 2 describes where it goes.
 
 Two things follow from where it is written, and both are load-bearing.
 
@@ -128,10 +128,18 @@ class Outcome:
 
     attempt: int = 1
     """Which try this was, from 1. The natural key is
-    ``(consumer, stream_path, offset, attempt)``, so history accumulates instead
-    of overwriting itself."""
+    ``(consumer, stream_path, subject, attempt)`` — subject rather than offset,
+    because a refused event has no offset — so history accumulates instead of
+    overwriting itself."""
 
     def __post_init__(self) -> None:
+        # `frozen=True` freezes the *binding*, not the dict behind it: a caller that
+        # keeps its own reference can add a key after recording and the stored
+        # outcome changes with it. Copying here is what makes immutability real, and
+        # it matters most for this field — the one whose entire purpose is that
+        # field values do not reach it. Backends that serialise (JSONL) escaped this
+        # by accident; the in-memory one did not, so the two disagreed.
+        object.__setattr__(self, "params", dict(self.params))
         if not self.subject:
             raise ValueError(
                 "An outcome needs a subject — what it is about — and got an empty one."

--- a/src/rakaia/outcomes.py
+++ b/src/rakaia/outcomes.py
@@ -146,6 +146,24 @@ class Outcome:
         # tuple of the same codes are the same outcome, and only one of them
         # survives being written out.
         object.__setattr__(self, "reasons", tuple(self.reasons))
+        # The same defect as the two container fields, one level out: these are
+        # declared `str` and nothing made them so. A UUID subject — which the
+        # "opaque here" wording positively invites — records in memory and raises
+        # on write, so the backends disagree about whether the record exists at all.
+        # Four rounds closed this one field at a time; checking them together is
+        # what stops a fifth.
+        wrong = sorted(
+            name
+            for name in ("consumer", "stream_path", "subject", "sequence_key")
+            if not isinstance(getattr(self, name), str)
+        )
+        if self.offset is not None and not isinstance(self.offset, str):
+            wrong.append("offset")
+        if wrong:
+            raise ValueError(
+                f"{', '.join(wrong)} must be strings — an offset is an opaque token and the "
+                f"rest are names, so anything else survives in memory and fails on write."
+            )
         if not self.subject:
             raise ValueError(
                 "An outcome needs a subject — what it is about — and got an empty one."

--- a/src/rakaia/outcomes.py
+++ b/src/rakaia/outcomes.py
@@ -31,8 +31,9 @@ observation about the data nor a verification result.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass, field
-from typing import Literal
+from typing import Any, Literal
 
 Stage = Literal["append", "project"]
 """How far the event got before something went wrong.
@@ -133,59 +134,16 @@ class Outcome:
     overwriting itself."""
 
     def __post_init__(self) -> None:
-        # `frozen=True` freezes the *binding*, not the dict behind it: a caller that
-        # keeps its own reference can add a key after recording and the stored
-        # outcome changes with it. Copying here is what makes immutability real, and
-        # it matters most for this field — the one whose entire purpose is that
-        # field values do not reach it. Backends that serialise (JSONL) escaped this
-        # by accident; the in-memory one did not, so the two disagreed.
+        # Copy the two containers so `frozen=True` means what it says: it freezes
+        # the binding, not the dict or list behind it, and a caller keeping its own
+        # reference could otherwise change what had already been recorded.
         object.__setattr__(self, "params", dict(self.params))
-        # `reasons` is the same shape of problem and was missed twice: it is
-        # declared a tuple but nothing made it one, so a caller passing a list kept
-        # a live handle on it. Coercing here also settles the type — a list and a
-        # tuple of the same codes are the same outcome, and only one of them
-        # survives being written out.
         object.__setattr__(self, "reasons", tuple(self.reasons))
-        # The same defect as the two container fields, one level out: these are
-        # declared `str` and nothing made them so. A UUID subject — which the
-        # "opaque here" wording positively invites — records in memory and raises
-        # on write, so the backends disagree about whether the record exists at all.
-        # Four rounds closed this one field at a time; checking them together is
-        # what stops a fifth.
-        wrong = sorted(
-            name
-            for name in ("consumer", "stream_path", "subject", "sequence_key")
-            if not isinstance(getattr(self, name), str)
-        )
-        if self.offset is not None and not isinstance(self.offset, str):
-            wrong.append("offset")
-        if wrong:
-            raise ValueError(
-                f"{', '.join(wrong)} must be strings — an offset is an opaque token and the "
-                f"rest are names, so anything else survives in memory and fails on write."
-            )
+
+        # Structural invariants — about what an outcome *means*, not how it is kept.
         if not self.subject:
             raise ValueError(
                 "An outcome needs a subject — what it is about — and got an empty one."
-            )
-        # Keys as well as values. Checking only the values left the same divergence
-        # one round later: an integer key survives in memory and comes back a string
-        # from anything that serialises, and a key that is hashable but not a
-        # primitive records in memory and raises on write. Both halves have to be
-        # strings for the two to agree.
-        bad_reasons = sorted(repr(r) for r in self.reasons if not isinstance(r, str))
-        if bad_reasons:
-            raise ValueError(
-                f"reasons must be codes, given as strings; {bad_reasons} are not."
-            )
-        bad_keys = sorted(repr(k) for k in self.params if not isinstance(k, str))
-        if bad_keys:
-            raise ValueError(f"params keys must be strings; {bad_keys} are not.")
-        bad = sorted(k for k, v in self.params.items() if not isinstance(v, str))
-        if bad:
-            raise ValueError(
-                f"params values must be strings so a payload cannot be put here by accident; "
-                f"{bad} are not. Render them, or leave them out."
             )
         if self.stage == "append" and self.offset is not None:
             raise ValueError(
@@ -198,6 +156,97 @@ class Outcome:
             )
         if self.attempt < 1:
             raise ValueError(f"attempt counts from 1, got {self.attempt}.")
+
+        # Storability is one rule and `encode` is where it lives, so this asks the
+        # same question a store will ask rather than keeping a second copy of the
+        # answer. Five rounds of review closed this one field at a time — values of
+        # one map, then its keys, then the list beside it, then the plain fields —
+        # because each check was written where the defect was found instead of where
+        # the rule belongs. Calling it here only moves *when* the caller hears about
+        # it; the rule itself has one home.
+        encode(self)
+
+
+#: The fields a stored outcome carries. Anything else in a payload came from a
+#: different version and is not this record's business.
+_FIELDS = (
+    "consumer",
+    "stream_path",
+    "subject",
+    "offset",
+    "sequence_key",
+    "stage",
+    "status",
+    "reasons",
+    "params",
+    "attempt",
+)
+
+
+def encode(outcome: Outcome) -> dict[str, Any]:
+    """The one translation from an outcome to the shape a store keeps.
+
+    Every backend goes through this, **including the in-memory one**. That is the
+    point of it rather than an implementation detail: the in-memory store used to
+    keep the object as handed to it while the durable ones had to render it, so it
+    accepted values they refused and the two disagreed about what had been
+    recorded. A reference implementation that is more permissive than the real ones
+    makes a passing test a weaker promise than production, which is the shape of
+    defect this module spent five review rounds on, one field at a time.
+
+    Refuses rather than coerces. Rendering a value here would make the store
+    disagree with the caller instead of with another store — quieter, and worse.
+    """
+    wrong = sorted(
+        f"{name}={getattr(outcome, name)!r}"
+        for name in ("consumer", "stream_path", "subject", "sequence_key")
+        if not isinstance(getattr(outcome, name), str)
+    )
+    if outcome.offset is not None and not isinstance(outcome.offset, str):
+        wrong.append(f"offset={outcome.offset!r}")
+    wrong += [
+        f"reasons[{i}]={r!r}"
+        for i, r in enumerate(outcome.reasons)
+        if not isinstance(r, str)
+    ]
+    wrong += [f"params key {k!r}" for k in outcome.params if not isinstance(k, str)]
+    wrong += [
+        f"params[{k!r}]={v!r}"
+        for k, v in outcome.params.items()
+        if not isinstance(v, str)
+    ]
+    if wrong:
+        raise ValueError(
+            "An outcome is kept as text, so every part of it has to be text already: "
+            + ", ".join(wrong)
+            + ". Render it, or leave it out."
+        )
+    return {
+        "consumer": outcome.consumer,
+        "stream_path": outcome.stream_path,
+        "subject": outcome.subject,
+        "offset": outcome.offset,
+        "sequence_key": outcome.sequence_key,
+        "stage": outcome.stage,
+        "status": outcome.status,
+        "reasons": list(outcome.reasons),
+        "params": dict(outcome.params),
+        "attempt": outcome.attempt,
+    }
+
+
+def decode(payload: Mapping[str, Any]) -> Outcome | None:
+    """The inverse of `encode`, or ``None`` if this version cannot build it.
+
+    ``None`` rather than an exception because the caller is usually reading a whole
+    file: a line written by a version that added a field, or predating one, must
+    cost that line and not the report. Unknown keys are dropped and a missing
+    required one gives ``None``.
+    """
+    try:
+        return Outcome(**{k: v for k, v in payload.items() if k in _FIELDS})
+    except (TypeError, ValueError):
+        return None
 
 
 def _order(outcome: Outcome) -> tuple[bool, str, str]:
@@ -218,15 +267,23 @@ class InMemoryOutcomeStore:
     """
 
     def __init__(self) -> None:
-        self._recorded: list[Outcome] = []
+        self._recorded: list[dict[str, Any]] = []
 
     def record(self, outcome: Outcome) -> None:
-        self._recorded.append(outcome)
+        # Through the codec, not straight into the list. Keeping the object was
+        # what made this store more permissive than every real one, so "passes in
+        # memory" stopped meaning "will store".
+        self._recorded.append(encode(outcome))
 
     def latest(self, consumer: str, stream_path: str) -> list[Outcome]:
         best: dict[str, Outcome] = {}
-        for outcome in self._recorded:
-            if outcome.consumer != consumer or outcome.stream_path != stream_path:
+        for payload in self._recorded:
+            outcome = decode(payload)
+            if (
+                outcome is None
+                or outcome.consumer != consumer
+                or outcome.stream_path != stream_path
+            ):
                 continue
             held = best.get(outcome.subject)
             # `>=` so re-recording an attempt replaces it. A tie is a caller

--- a/src/rakaia/outcomes.py
+++ b/src/rakaia/outcomes.py
@@ -74,6 +74,20 @@ class Outcome:
     """The stream the event belongs to. A plain string, not a reference, so an
     outcome outlives the stream it describes."""
 
+    subject: str
+    """What this outcome is *about*, as the consumer identifies it. Opaque here.
+
+    Required, and not defaulted to the offset, because an event that never reached
+    the log has no offset — and those are the ones a consumer most needs to tell
+    apart. Keying on the offset alone collapsed every refusal on a stream into a
+    single row and reported the first as though it spoke for the rest, which is
+    the same defect as one bad row making a whole form look fine.
+
+    Distinct from `sequence_key`: the subject is the one thing this outcome
+    concerns, the sequence key is what it is *ordered within*. They are often the
+    same value, and are not when one decision refuses several subjects together.
+    """
+
     offset: str | None
     """The event's position, opaque and store-issued — or ``None`` when
     ``stage="append"``, because an event that never reached the log has no
@@ -104,8 +118,13 @@ class Outcome:
     """
 
     params: dict[str, str] = field(default_factory=dict)
-    """Bounded context for the reasons: identifiers, counts, verdicts. Values are
-    strings by construction, so a payload cannot be put here by accident."""
+    """Bounded context for the reasons: identifiers, counts, verdicts.
+
+    Values must be strings, and that is checked rather than asserted — the
+    docstring used to claim "by construction" while a nested dict of personal data
+    went in and came back out unchanged. Not leaking field values is this field's
+    whole reason for existing instead of a rendered message, so it refuses.
+    """
 
     attempt: int = 1
     """Which try this was, from 1. The natural key is
@@ -113,6 +132,16 @@ class Outcome:
     of overwriting itself."""
 
     def __post_init__(self) -> None:
+        if not self.subject:
+            raise ValueError(
+                "An outcome needs a subject — what it is about — and got an empty one."
+            )
+        bad = sorted(k for k, v in self.params.items() if not isinstance(v, str))
+        if bad:
+            raise ValueError(
+                f"params values must be strings so a payload cannot be put here by accident; "
+                f"{bad} are not. Render them, or leave them out."
+            )
         if self.stage == "append" and self.offset is not None:
             raise ValueError(
                 f"An outcome at stage='append' has no offset — the event never reached the log — "
@@ -124,6 +153,11 @@ class Outcome:
             )
         if self.attempt < 1:
             raise ValueError(f"attempt counts from 1, got {self.attempt}.")
+
+
+def _order(outcome: Outcome) -> tuple[bool, str, str]:
+    """Sort key shared by every backend, so `latest` returns one order."""
+    return (outcome.offset is None, outcome.offset or "", outcome.subject)
 
 
 class InMemoryOutcomeStore:
@@ -145,16 +179,17 @@ class InMemoryOutcomeStore:
         self._recorded.append(outcome)
 
     def latest(self, consumer: str, stream_path: str) -> list[Outcome]:
-        best: dict[str | None, Outcome] = {}
+        best: dict[str, Outcome] = {}
         for outcome in self._recorded:
             if outcome.consumer != consumer or outcome.stream_path != stream_path:
                 continue
-            held = best.get(outcome.offset)
-            if held is None or outcome.attempt > held.attempt:
-                best[outcome.offset] = outcome
+            held = best.get(outcome.subject)
+            # `>=` so re-recording an attempt replaces it. A tie is a caller
+            # error either way, and last-write-wins is the less surprising of the
+            # two answers.
+            if held is None or outcome.attempt >= held.attempt:
+                best[outcome.subject] = outcome
         # Offsets sort as the opaque strings they are; the append-stage entries
-        # have none and go last rather than being compared against one.
-        return sorted(
-            best.values(),
-            key=lambda o: (o.offset is None, o.offset or ""),
-        )
+        # have none and go last rather than being compared against one. Subject
+        # breaks the remaining ties so the order does not depend on insertion.
+        return sorted(best.values(), key=_order)

--- a/src/rakaia/outcomes.py
+++ b/src/rakaia/outcomes.py
@@ -31,9 +31,14 @@ observation about the data nor a verification result.
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Mapping
-from dataclasses import dataclass, field
-from typing import Any, Literal
+from dataclasses import dataclass, field, fields
+from functools import lru_cache
+from types import UnionType
+from typing import Any, Literal, Union, get_args, get_origin, get_type_hints
+
+logger = logging.getLogger(__name__)
 
 Stage = Literal["append", "project"]
 """How far the event got before something went wrong.
@@ -141,9 +146,17 @@ class Outcome:
         object.__setattr__(self, "reasons", tuple(self.reasons))
 
         # Structural invariants — about what an outcome *means*, not how it is kept.
-        if not self.subject:
+        # An empty name is not merely odd, it collides: a file-backed store maps a
+        # name to one path segment, and every escaping of "" lands on the segment
+        # some other input already uses. Refusing here is cheaper than making every
+        # store's naming injective, and an outcome about nothing is meaningless
+        # anyway.
+        empty = sorted(
+            n for n in ("consumer", "stream_path", "subject") if not getattr(self, n)
+        )
+        if empty:
             raise ValueError(
-                "An outcome needs a subject — what it is about — and got an empty one."
+                f"A name saying what this outcome belongs to cannot be empty: {', '.join(empty)}."
             )
         if self.stage == "append" and self.offset is not None:
             raise ValueError(
@@ -167,20 +180,42 @@ class Outcome:
         encode(self)
 
 
-#: The fields a stored outcome carries. Anything else in a payload came from a
-#: different version and is not this record's business.
-_FIELDS = (
-    "consumer",
-    "stream_path",
-    "subject",
-    "offset",
-    "sequence_key",
-    "stage",
-    "status",
-    "reasons",
-    "params",
-    "attempt",
-)
+@lru_cache(maxsize=1)
+def _declared() -> dict[str, Any]:
+    """Each field's declared type, resolved once."""
+    return get_type_hints(Outcome)
+
+
+def _matches(value: Any, hint: Any) -> bool:
+    """Whether `value` is what `hint` says it is, as JSON would keep it.
+
+    `type(...) is` rather than `isinstance`, deliberately. A `str` subclass — a
+    `StrEnum` member is the one that turns up — passes `isinstance`, compares equal
+    to its own text, and comes back from storage as plain text with a different type
+    and repr. `bool` under `int` is the same trap the other way. Equality cannot see
+    either, which is why this asks about the type.
+
+    Reading the declaration rather than a list of fields is the whole point. Five
+    review rounds each added the field it had just been bitten by, and the list was
+    never more complete than the last bug; a field added tomorrow is covered by this
+    without anyone remembering it exists.
+    """
+    origin = get_origin(hint)
+    if origin is Literal:
+        return value in get_args(hint)
+    if origin in (UnionType, Union):
+        return any(_matches(value, arg) for arg in get_args(hint))
+    if hint is type(None):
+        return value is None
+    if origin in (tuple, list):
+        member = get_args(hint)[0]
+        return type(value) is list and all(_matches(v, member) for v in value)
+    if origin is dict:
+        key, val = get_args(hint)
+        return type(value) is dict and all(
+            _matches(k, key) and _matches(v, val) for k, v in value.items()
+        )
+    return type(value) is hint
 
 
 def encode(outcome: Outcome) -> dict[str, Any]:
@@ -190,49 +225,44 @@ def encode(outcome: Outcome) -> dict[str, Any]:
     point of it rather than an implementation detail: the in-memory store used to
     keep the object as handed to it while the durable ones had to render it, so it
     accepted values they refused and the two disagreed about what had been
-    recorded. A reference implementation that is more permissive than the real ones
-    makes a passing test a weaker promise than production, which is the shape of
-    defect this module spent five review rounds on, one field at a time.
+    recorded. A reference implementation more permissive than the real ones makes a
+    passing test a weaker promise than production, which is the defect this module
+    spent five review rounds on, one field at a time.
 
-    Refuses rather than coerces. Rendering a value here would make the store
-    disagree with the caller instead of with another store — quieter, and worse.
+    The check walks the fields rather than naming them. Naming them is how it took
+    five rounds: each round added the field it had just been bitten by, and the list
+    was only ever as complete as the last bug. A field added to `Outcome` tomorrow
+    is covered by this without anyone remembering to add it.
+
+    Refuses rather than renders. Rendering here would make a store disagree with its
+    caller instead of with another store — quieter, and worse.
     """
-    wrong = sorted(
-        f"{name}={getattr(outcome, name)!r}"
-        for name in ("consumer", "stream_path", "subject", "sequence_key")
-        if not isinstance(getattr(outcome, name), str)
+    payload: dict[str, Any] = {}
+    for f in fields(outcome):
+        value = getattr(outcome, f.name)
+        if type(value) is tuple:
+            value = list(value)
+        elif type(value) is dict:
+            # Sorted so the two stores cannot disagree about order: one of them
+            # writes JSON with sorted keys and the other kept insertion order, and
+            # `==` on dicts hides the difference while anything comparing their
+            # rendered form does not.
+            value = dict(sorted(value.items()))
+        payload[f.name] = value
+
+    declared = _declared()
+    unstorable = sorted(
+        f"{name}={value!r}"
+        for name, value in payload.items()
+        if not _matches(value, declared[name])
     )
-    if outcome.offset is not None and not isinstance(outcome.offset, str):
-        wrong.append(f"offset={outcome.offset!r}")
-    wrong += [
-        f"reasons[{i}]={r!r}"
-        for i, r in enumerate(outcome.reasons)
-        if not isinstance(r, str)
-    ]
-    wrong += [f"params key {k!r}" for k in outcome.params if not isinstance(k, str)]
-    wrong += [
-        f"params[{k!r}]={v!r}"
-        for k, v in outcome.params.items()
-        if not isinstance(v, str)
-    ]
-    if wrong:
+    if unstorable:
         raise ValueError(
             "An outcome is kept as text, so every part of it has to be text already: "
-            + ", ".join(wrong)
+            + ", ".join(unstorable)
             + ". Render it, or leave it out."
         )
-    return {
-        "consumer": outcome.consumer,
-        "stream_path": outcome.stream_path,
-        "subject": outcome.subject,
-        "offset": outcome.offset,
-        "sequence_key": outcome.sequence_key,
-        "stage": outcome.stage,
-        "status": outcome.status,
-        "reasons": list(outcome.reasons),
-        "params": dict(outcome.params),
-        "attempt": outcome.attempt,
-    }
+    return payload
 
 
 def decode(payload: Mapping[str, Any]) -> Outcome | None:
@@ -242,10 +272,18 @@ def decode(payload: Mapping[str, Any]) -> Outcome | None:
     file: a line written by a version that added a field, or predating one, must
     cost that line and not the report. Unknown keys are dropped and a missing
     required one gives ``None``.
+
+    Dropping is logged, because a silently discarded line is the failure this whole
+    module exists to close — a file entirely of skew would otherwise read back as
+    "nothing failed". See ADR 0007 for why this is a log and not yet a count.
     """
+    known = {f.name for f in fields(Outcome)}
     try:
-        return Outcome(**{k: v for k, v in payload.items() if k in _FIELDS})
-    except (TypeError, ValueError):
+        return Outcome(**{k: v for k, v in payload.items() if k in known})
+    except (TypeError, ValueError) as exc:
+        logger.warning(
+            "rakaia: dropping an outcome this version cannot build (%s)", exc
+        )
         return None
 
 

--- a/src/rakaia/outcomes.py
+++ b/src/rakaia/outcomes.py
@@ -140,6 +140,12 @@ class Outcome:
         # field values do not reach it. Backends that serialise (JSONL) escaped this
         # by accident; the in-memory one did not, so the two disagreed.
         object.__setattr__(self, "params", dict(self.params))
+        # `reasons` is the same shape of problem and was missed twice: it is
+        # declared a tuple but nothing made it one, so a caller passing a list kept
+        # a live handle on it. Coercing here also settles the type — a list and a
+        # tuple of the same codes are the same outcome, and only one of them
+        # survives being written out.
+        object.__setattr__(self, "reasons", tuple(self.reasons))
         if not self.subject:
             raise ValueError(
                 "An outcome needs a subject — what it is about — and got an empty one."
@@ -149,6 +155,11 @@ class Outcome:
         # from anything that serialises, and a key that is hashable but not a
         # primitive records in memory and raises on write. Both halves have to be
         # strings for the two to agree.
+        bad_reasons = sorted(repr(r) for r in self.reasons if not isinstance(r, str))
+        if bad_reasons:
+            raise ValueError(
+                f"reasons must be codes, given as strings; {bad_reasons} are not."
+            )
         bad_keys = sorted(repr(k) for k in self.params if not isinstance(k, str))
         if bad_keys:
             raise ValueError(f"params keys must be strings; {bad_keys} are not.")

--- a/src/rakaia/outcomes.py
+++ b/src/rakaia/outcomes.py
@@ -1,0 +1,160 @@
+"""What happened to an event a consumer tried to apply — the record a cursor cannot carry.
+
+A cursor says how far a consumer got. It says nothing about whether it got there
+cleanly, so an event that was skipped, refused or lost is indistinguishable from
+one applied without incident: **absence of a record reads as success**. This
+module is the record that closes that gap, and `subscription.consume` is where it
+is written.
+
+Two things follow from where it is written, and both are load-bearing.
+
+The record is **not** produced inside an executor. A Django executor wraps its
+batch in a transaction, so a row written there would roll back with the batch
+whose failure it exists to record; and a staged pass buffers many events into one
+`apply()`, after which which event produced which effect is no longer
+recoverable. The loop that owns the cursor is the only place that still knows
+both the event and whether applying it worked.
+
+And only **exceptions** are recorded. The cursor is the success record —
+everything below it succeeded unless an outcome says otherwise — so a clean run
+writes nothing at all. There is no gap query, and ADR 0007 Decision 3 explains
+why one cannot exist here: with success leaving no trace, "no record" *is* the
+success case, so lag comes from the head against the cursor and everything else
+comes from `latest`.
+
+The `OutcomeStore` seam itself lives in `rakaia.protocols`, with the other
+store-facing protocols.
+
+See ADR 0007 for the reasoning in full, including why an outcome is neither an
+observation about the data nor a verification result.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Literal
+
+Stage = Literal["append", "project"]
+"""How far the event got before something went wrong.
+
+* ``append`` — it never reached the log. ``offset`` is ``None``, and ``status``
+  says whether it was lost or declined.
+* ``project`` — it is safe in the log and was not applied. Replay recovers it.
+"""
+
+OutcomeStatus = Literal["failed", "refused", "skipped"]
+"""What happened, and therefore what recovery is wanted.
+
+* ``failed`` — something raised. A bug or a transient fault; worth an alert.
+* ``refused`` — a consumer's own rules declined it. Ordinary data quality, not an
+  incident, and *deliberate*: with ``stage="append"`` the fact is not lost, it is
+  sitting wherever the event was produced from, and fixing the data upstream is
+  what recovers it.
+* ``skipped`` — deliberately not applied and nothing is wanted. Recorded so that
+  a later reader can tell "we decided not to" from "we never saw it".
+"""
+
+
+@dataclass(frozen=True)
+class Outcome:
+    """One event's failure to be applied cleanly, as a value.
+
+    Immutable, and deliberately so. Nothing here is resolved or retried in place:
+    a further attempt is a further outcome with a higher ``attempt``, and "is this
+    still failing?" is the latest outcome for the key. A mutable ``resolved_at``
+    would be a second answer to a question a consumer's own records already
+    answer — its rules layer typically owns the resolution of the very
+    observations ``reasons`` names — and two answers eventually disagree.
+    """
+
+    consumer: str
+    """Which consumer this is about. Pairs with ``ConsumerCursor.consumer_id``."""
+
+    stream_path: str
+    """The stream the event belongs to. A plain string, not a reference, so an
+    outcome outlives the stream it describes."""
+
+    offset: str | None
+    """The event's position, opaque and store-issued — or ``None`` when
+    ``stage="append"``, because an event that never reached the log has no
+    position to name."""
+
+    sequence_key: str
+    """What this event is ordered *within*, as the consumer defines it.
+
+    Rakaia records it and does not yet act on it. Its purpose is a later one: a
+    failure parks a sequence, and events behind it must wait rather than apply to
+    a state that never saw the one in front. Recording it now costs a field;
+    deriving it afterwards means re-deciding groupings a consumer has already
+    decided. See ADR 0007, Decision 7.
+    """
+
+    stage: Stage
+    status: OutcomeStatus
+
+    reasons: tuple[str, ...] = ()
+    """Why, as codes rather than prose. **Opaque to rakaia** — which codes exist
+    and what they mean belong to the consumer, exactly as an offset's meaning
+    belongs to the store.
+
+    Plural because one event can breach several rules at once, and flattening
+    them into a sentence loses the only property that makes them countable. An
+    interpolated message is also where field values leak, which matters for the
+    consumers this library was built for.
+    """
+
+    params: dict[str, str] = field(default_factory=dict)
+    """Bounded context for the reasons: identifiers, counts, verdicts. Values are
+    strings by construction, so a payload cannot be put here by accident."""
+
+    attempt: int = 1
+    """Which try this was, from 1. The natural key is
+    ``(consumer, stream_path, offset, attempt)``, so history accumulates instead
+    of overwriting itself."""
+
+    def __post_init__(self) -> None:
+        if self.stage == "append" and self.offset is not None:
+            raise ValueError(
+                f"An outcome at stage='append' has no offset — the event never reached the log — "
+                f"but got offset={self.offset!r}."
+            )
+        if self.stage == "project" and self.offset is None:
+            raise ValueError(
+                "An outcome at stage='project' names an event in the log, so it needs an offset."
+            )
+        if self.attempt < 1:
+            raise ValueError(f"attempt counts from 1, got {self.attempt}.")
+
+
+class InMemoryOutcomeStore:
+    """An `OutcomeStore` held in a list. The reference implementation.
+
+    Every backend is measured against this one through
+    `tests/outcome_store_contract.py`, and it is what a test uses when the point
+    under test is a consumer's behaviour rather than its storage.
+
+    Not durable, deliberately: an outcome that has to survive a restart needs a
+    backend that survives one, and pretending otherwise here would make the
+    contract easier to pass than to satisfy.
+    """
+
+    def __init__(self) -> None:
+        self._recorded: list[Outcome] = []
+
+    def record(self, outcome: Outcome) -> None:
+        self._recorded.append(outcome)
+
+    def latest(self, consumer: str, stream_path: str) -> list[Outcome]:
+        best: dict[str | None, Outcome] = {}
+        for outcome in self._recorded:
+            if outcome.consumer != consumer or outcome.stream_path != stream_path:
+                continue
+            held = best.get(outcome.offset)
+            if held is None or outcome.attempt > held.attempt:
+                best[outcome.offset] = outcome
+        # Offsets sort as the opaque strings they are; the append-stage entries
+        # have none and go last rather than being compared against one.
+        return sorted(
+            best.values(),
+            key=lambda o: (o.offset is None, o.offset or ""),
+        )

--- a/src/rakaia/outcomes.py
+++ b/src/rakaia/outcomes.py
@@ -31,12 +31,10 @@ observation about the data nor a verification result.
 
 from __future__ import annotations
 
+import json
 import logging
-from collections.abc import Mapping
 from dataclasses import dataclass, field, fields
-from functools import lru_cache
-from types import UnionType
-from typing import Any, Literal, Union, get_args, get_origin, get_type_hints
+from typing import Literal
 
 logger = logging.getLogger(__name__)
 
@@ -152,15 +150,25 @@ class Outcome:
         # store's naming injective, and an outcome about nothing is meaningless
         # anyway.
         names = ("consumer", "stream_path", "subject")
-        # A lone surrogate is a `str` and is not text anything can write: a
-        # file-backed store raises out of its path escaping before recording
-        # anything — inside the very loop whose job is recording that something
-        # failed. Refused for the same reason an empty name is: a store cannot turn
-        # it into a name, and the declared type cannot tell it apart.
-        unwritable = sorted(n for n in names if not _encodable(getattr(self, n)))
+        # These three become path segments and dictionary keys, so they carry a
+        # constraint the payload does not: they must be writable text. A number is
+        # stored happily by anything keeping JSON and raises in a file store's path
+        # escaping; a lone surrogate is text by every type check and no path can
+        # carry it. Both reach the store and fail there — inside the loop whose job
+        # is recording that something failed. One rule, because it is one reason.
+        unwritable = []
+        for name in names:
+            value = getattr(self, name)
+            if type(value) is not str:
+                unwritable.append(name)
+                continue
+            try:
+                value.encode("utf-8")
+            except UnicodeEncodeError:
+                unwritable.append(name)
         if unwritable:
             raise ValueError(
-                f"A name has to be writable text, and {', '.join(unwritable)} cannot be encoded."
+                f"A name has to be writable text, and {', '.join(sorted(unwritable))} cannot be encoded."
             )
         empty = sorted(n for n in names if not getattr(self, n))
         if empty:
@@ -189,111 +197,36 @@ class Outcome:
         encode(self)
 
 
-@lru_cache(maxsize=1)
-def _declared() -> dict[str, Any]:
-    """Each field's declared type, resolved once."""
-    return get_type_hints(Outcome)
+def encode(outcome: Outcome) -> str:
+    """The one translation from an outcome to the text a store keeps.
 
+    Returns **text**, not a dict, and that is the whole design. Every store keeps
+    this exact string, so there is only one representation of a stored outcome and
+    nothing for two backends to disagree about. The in-memory store is then the
+    file-backed store without the file, rather than a second implementation that
+    happens to behave the same.
 
-def _encodable(value: Any) -> bool:
-    """Whether this text can actually be written out.
+    That matters because the previous approach did not work. It validated each
+    field against its declared type, and five review rounds plus two more found
+    values that satisfy a type and still do not survive storage: a `str` subclass
+    that flattens, a lone surrogate a path cannot carry, a string longer than a
+    column allows. The set is open-ended, so approximating "survives storage" with
+    type rules leaks by construction — the check has to *be* the storing.
 
-    A lone surrogate satisfies every type check and still cannot be encoded, so it
-    passes construction and fails inside a store instead.
+    Refuses by raising, because `json.dumps` already refuses everything it cannot
+    represent. Nothing here re-states which types those are.
     """
-    if type(value) is not str:
-        return True  # a wrong type is a different complaint, reported elsewhere
     try:
-        value.encode("utf-8")
-    except UnicodeEncodeError:
-        return False
-    return True
-
-
-def _matches(value: Any, hint: Any) -> bool:
-    """Whether `value` is what `hint` says it is, as JSON would keep it.
-
-    `type(...) is` rather than `isinstance`, deliberately. A `str` subclass — a
-    `StrEnum` member is the one that turns up — passes `isinstance`, compares equal
-    to its own text, and comes back from storage as plain text with a different type
-    and repr. `bool` under `int` is the same trap the other way. Equality cannot see
-    either, which is why this asks about the type.
-
-    Reading the declaration rather than a list of fields is the whole point. Five
-    review rounds each added the field it had just been bitten by, and the list was
-    never more complete than the last bug; a field added tomorrow is covered by this
-    without anyone remembering it exists.
-    """
-    origin = get_origin(hint)
-    if origin is Literal:
-        # `in` is equality, and equality is exactly what a `str` subclass passes —
-        # so the two fields declared as a small set of strings were the only ones
-        # this function did not protect, which is the case its own docstring names.
-        # A member has to be the same type as the alternative it matches.
-        return any(value == a and type(value) is type(a) for a in get_args(hint))
-    if origin in (UnionType, Union):
-        return any(_matches(value, arg) for arg in get_args(hint))
-    if hint is type(None):
-        return value is None
-    if origin in (tuple, list):
-        member = get_args(hint)[0]
-        return type(value) is list and all(_matches(v, member) for v in value)
-    if origin is dict:
-        key, val = get_args(hint)
-        return type(value) is dict and all(
-            _matches(k, key) and _matches(v, val) for k, v in value.items()
+        return json.dumps(
+            {f.name: getattr(outcome, f.name) for f in fields(outcome)}, sort_keys=True
         )
-    return type(value) is hint
-
-
-def encode(outcome: Outcome) -> dict[str, Any]:
-    """The one translation from an outcome to the shape a store keeps.
-
-    Every backend goes through this, **including the in-memory one**. That is the
-    point of it rather than an implementation detail: the in-memory store used to
-    keep the object as handed to it while the durable ones had to render it, so it
-    accepted values they refused and the two disagreed about what had been
-    recorded. A reference implementation more permissive than the real ones makes a
-    passing test a weaker promise than production, which is the defect this module
-    spent five review rounds on, one field at a time.
-
-    The check walks the fields rather than naming them. Naming them is how it took
-    five rounds: each round added the field it had just been bitten by, and the list
-    was only ever as complete as the last bug. A field added to `Outcome` tomorrow
-    is covered by this without anyone remembering to add it.
-
-    Refuses rather than renders. Rendering here would make a store disagree with its
-    caller instead of with another store — quieter, and worse.
-    """
-    payload: dict[str, Any] = {}
-    for f in fields(outcome):
-        value = getattr(outcome, f.name)
-        if type(value) is tuple:
-            value = list(value)
-        elif type(value) is dict:
-            # Sorted so the two stores cannot disagree about order: one of them
-            # writes JSON with sorted keys and the other kept insertion order, and
-            # `==` on dicts hides the difference while anything comparing their
-            # rendered form does not.
-            value = dict(sorted(value.items()))
-        payload[f.name] = value
-
-    declared = _declared()
-    unstorable = sorted(
-        f"{name}={value!r}"
-        for name, value in payload.items()
-        if not _matches(value, declared[name])
-    )
-    if unstorable:
+    except (TypeError, ValueError) as exc:
         raise ValueError(
-            "An outcome is kept as text, so every part of it has to be text already: "
-            + ", ".join(unstorable)
-            + ". Render it, or leave it out."
-        )
-    return payload
+            f"An outcome has to be storable as text and this one is not: {exc}. Render it, or leave it out."
+        ) from exc
 
 
-def decode(payload: Mapping[str, Any]) -> Outcome | None:
+def decode(stored: str) -> Outcome | None:
     """The inverse of `encode`, or ``None`` if this version cannot build it.
 
     ``None`` rather than an exception because the caller is usually reading a whole
@@ -307,6 +240,7 @@ def decode(payload: Mapping[str, Any]) -> Outcome | None:
     """
     known = {f.name for f in fields(Outcome)}
     try:
+        payload = json.loads(stored)
         return Outcome(**{k: v for k, v in payload.items() if k in known})
     except (TypeError, ValueError) as exc:
         logger.warning(
@@ -333,18 +267,18 @@ class InMemoryOutcomeStore:
     """
 
     def __init__(self) -> None:
-        self._recorded: list[dict[str, Any]] = []
+        self._recorded: list[str] = []
 
     def record(self, outcome: Outcome) -> None:
-        # Through the codec, not straight into the list. Keeping the object was
-        # what made this store more permissive than every real one, so "passes in
-        # memory" stopped meaning "will store".
+        # The encoded *text*, not the object and not a dict. This store is then the
+        # file-backed one without the file, so the two cannot disagree about what
+        # was stored — which is the disagreement seven review findings were about.
         self._recorded.append(encode(outcome))
 
     def latest(self, consumer: str, stream_path: str) -> list[Outcome]:
         best: dict[str, Outcome] = {}
-        for payload in self._recorded:
-            outcome = decode(payload)
+        for stored in self._recorded:
+            outcome = decode(stored)
             if (
                 outcome is None
                 or outcome.consumer != consumer

--- a/src/rakaia/protocols.py
+++ b/src/rakaia/protocols.py
@@ -12,7 +12,9 @@ Producers and the meta-stream registry additionally *write*, captured by
 
 All store-facing protocols live here so they read as one coherent seam:
 `ReadableStore` (read), `WritableStore` (+ create/append/has), `CursorStore`
-(+ get_current_offset).
+(+ get_current_offset). `OutcomeStore` keeps what a cursor cannot say — which
+events a consumer failed to apply (ADR 0007) — and is separate because a backend
+may hold outcomes somewhere other than its events.
 """
 
 from __future__ import annotations
@@ -20,6 +22,7 @@ from __future__ import annotations
 from collections.abc import Iterable
 from typing import Any, Protocol, runtime_checkable
 
+from .outcomes import Outcome
 from .types import Stream as StreamMetadata
 from .types import StreamMessage
 
@@ -266,6 +269,32 @@ class CursorStore(ReadableStore, Protocol):
 
     def get_current_offset(self, path: str) -> str | None:
         """The offset after the last message, or None if the stream is absent."""
+        ...
+
+
+@runtime_checkable
+class OutcomeStore(Protocol):
+    """Somewhere durable to keep outcomes.
+
+    Sits beside `CursorStore` for the same reason: the decision about what to
+    record is store-agnostic, and only the keeping of it is backend-shaped. A
+    backend may implement this on the same object as its stream store or on a
+    separate one; nothing here assumes either.
+    """
+
+    def record(self, outcome: Outcome) -> None:
+        """Append `outcome`. Never updates an existing row — a repeat is a new
+        `attempt`."""
+        ...
+
+    def latest(self, consumer: str, stream_path: str) -> list[Outcome]:
+        """The most recent outcome per offset, newest attempt winning.
+
+        This is how "what is still failing?" is asked. An offset whose latest
+        outcome is `skipped` is not failing; one with no outcome at all never
+        failed. Ordered by offset, with `stage="append"` entries (which have
+        none) last.
+        """
         ...
 
 

--- a/src/rakaia/protocols.py
+++ b/src/rakaia/protocols.py
@@ -288,12 +288,17 @@ class OutcomeStore(Protocol):
         ...
 
     def latest(self, consumer: str, stream_path: str) -> list[Outcome]:
-        """The most recent outcome per offset, newest attempt winning.
+        """The most recent outcome per **subject**, newest attempt winning.
 
-        This is how "what is still failing?" is asked. An offset whose latest
+        This is how "what is still failing?" is asked. A subject whose latest
         outcome is `skipped` is not failing; one with no outcome at all never
-        failed. Ordered by offset, with `stage="append"` entries (which have
-        none) last.
+        failed. Ordered by offset — `stage="append"` entries have none and come
+        last — then by subject, so the order is total rather than insertion-order.
+
+        Per subject and not per offset, because the outcomes that matter most are
+        exactly the ones with no offset to key on: a refused event never reached
+        the log. Keying on the offset made every refusal on a stream collapse into
+        one row.
         """
         ...
 

--- a/tests/outcome_store_contract.py
+++ b/tests/outcome_store_contract.py
@@ -131,6 +131,23 @@ class OutcomeStoreContract:
         [got] = outcomes.latest("c", "s")
         assert got.params == {"row": "3"}
 
+    def test_a_recorded_outcome_does_not_change_when_the_caller_mutates_its_reasons(
+        self, outcomes
+    ):
+        """The twin of the params test, missing for three rounds.
+
+        `reasons` is declared a tuple and nothing made it one, so a caller passing
+        a list kept a live handle on what had already been recorded — and the two
+        backends then disagreed, because one serialises and one does not. Both
+        container fields need the same guarantee or neither has it.
+        """
+        reasons = ["missing_total"]
+        outcomes.record(project("0000000001", reasons=reasons))
+        reasons.append("LEAKED_AFTER_RECORD")
+
+        [got] = outcomes.latest("c", "s")
+        assert got.reasons == ("missing_total",)
+
     def test_an_append_stage_outcome_has_no_offset(self, outcomes):
         outcomes.record(refused("row-1", reasons=("declined_upstream",)))
         [got] = outcomes.latest("c", "s")

--- a/tests/outcome_store_contract.py
+++ b/tests/outcome_store_contract.py
@@ -197,6 +197,28 @@ class OutcomeStoreContract:
 
     # --- what a clean run looks like ---------------------------------------
 
+    def test_the_order_does_not_depend_on_when_things_were_recorded(self, outcomes):
+        """Refusals share the "no offset" sort position, so without a further term
+        the order is whatever the storage happened to do. Mutation: drop `subject`
+        from the sort key — dicts preserve insertion order and a stable sort keeps
+        it, so this comes back reversed."""
+        for subject in ("row-3", "row-1", "row-2"):
+            outcomes.record(refused(subject))
+        assert [o.subject for o in outcomes.latest("c", "s")] == [
+            "row-1",
+            "row-2",
+            "row-3",
+        ]
+
+    def test_re_recording_an_attempt_replaces_it(self, outcomes):
+        """Two outcomes for one subject at the same attempt is a caller error either
+        way; last-write-wins is the less surprising of the two answers, and `>` versus
+        `>=` is otherwise invisible."""
+        outcomes.record(project("0000000001", reasons=("first",), attempt=2))
+        outcomes.record(project("0000000001", reasons=("corrected",), attempt=2))
+        [got] = outcomes.latest("c", "s")
+        assert got.reasons == ("corrected",)
+
     def test_a_clean_run_records_nothing(self, outcomes):
         """The property the exceptions-only design rests on.
 

--- a/tests/outcome_store_contract.py
+++ b/tests/outcome_store_contract.py
@@ -1,0 +1,181 @@
+"""Shared conformance contract for `OutcomeStore` (ADR 0007).
+
+An outcome is as store-agnostic as a cursor: the decision about what to record is
+made once, and only the keeping of it is backend-shaped. So every backend that
+keeps outcomes is held to the same behaviour here, and "does this work on the
+file store too?" is a red test rather than a question. Subclass
+`OutcomeStoreContract` in each backend's test package and provide an `outcomes`
+fixture returning a fresh, empty store. See ADR 0002 / #36 for the pattern.
+
+This module is intentionally not named `test_*`, so pytest does not collect it
+directly; only the backend subclasses run it.
+
+**Scope, and what is deliberately not pinned.** Offsets here are illustrative
+opaque strings, shorter than any real store issues, and the contract only ever
+compares them lexicographically — so a backend issuing a compound
+`{seq}_{byte}` token and one issuing a zero-padded integer both satisfy it.
+Offset *opacity* is not pinned here and cannot usefully be: both formats are
+zero-padded precisely so that lexicographic and numeric order agree, which means
+an ordering assertion cannot catch a store that parses one. That property lives
+in `test_cross_backend_cursors.py`, where a foreign format is refused rather than
+misread. Retention, admin surfaces and
+re-drive are out of scope: the first is a policy a consumer schedules, and the
+last is deliberately not in this version (ADR 0007, "Not in v1").
+
+What *is* contract: an outcome is never updated in place, and `latest` collapses
+attempts and nothing else. There is no gap query to pin — ADR 0007 Decision 3
+records why one cannot exist when success leaves no trace.
+"""
+
+from __future__ import annotations
+
+from rakaia.outcomes import Outcome
+
+
+def project(offset: str, *, consumer: str = "c", path: str = "s", **kw) -> Outcome:
+    """A projection-stage outcome, the common case in these tests."""
+    kw.setdefault("sequence_key", "seq")
+    kw.setdefault("status", "failed")
+    return Outcome(
+        consumer=consumer, stream_path=path, offset=offset, stage="project", **kw
+    )
+
+
+class OutcomeStoreContract:
+    """Contract every outcome store must uphold.
+
+    Subclasses provide::
+
+        @pytest.fixture
+        def outcomes(self):
+            return MyOutcomeStore()
+    """
+
+    # --- the seam itself ----------------------------------------------------
+
+    def test_satisfies_the_outcome_store_protocol(self, outcomes):
+        from rakaia.protocols import OutcomeStore
+
+        assert isinstance(outcomes, OutcomeStore)
+
+    def test_an_empty_store_reports_nothing(self, outcomes):
+        assert outcomes.latest("c", "s") == []
+
+    # --- recording ----------------------------------------------------------
+
+    def test_a_recorded_outcome_is_returned(self, outcomes):
+        outcomes.record(project("0000000001", reasons=("bad_total",)))
+        [got] = outcomes.latest("c", "s")
+        assert (got.offset, got.status, got.reasons) == (
+            "0000000001",
+            "failed",
+            ("bad_total",),
+        )
+
+    def test_outcomes_are_scoped_by_consumer_and_stream(self, outcomes):
+        """Distinct offsets per scope, deliberately.
+
+        Mutation watched: dropping the consumer/stream filter from `latest`. With
+        all three rows sharing one offset the answer collapses to a single entry
+        either way and the mutation survives — the same shape of false green as
+        asserting a count where the contents are what matter.
+        """
+        outcomes.record(project("0000000001", reasons=("mine",)))
+        outcomes.record(project("0000000002", consumer="other", reasons=("theirs",)))
+        outcomes.record(project("0000000003", path="other", reasons=("elsewhere",)))
+
+        assert [(o.offset, o.reasons) for o in outcomes.latest("c", "s")] == [
+            ("0000000001", ("mine",))
+        ]
+        assert [(o.offset, o.reasons) for o in outcomes.latest("other", "s")] == [
+            ("0000000002", ("theirs",))
+        ]
+        assert [(o.offset, o.reasons) for o in outcomes.latest("c", "other")] == [
+            ("0000000003", ("elsewhere",))
+        ]
+
+    def test_params_round_trip(self, outcomes):
+        outcomes.record(project("0000000001", params={"row": "3", "budget": "500"}))
+        [got] = outcomes.latest("c", "s")
+        assert got.params == {"row": "3", "budget": "500"}
+
+    def test_an_append_stage_outcome_has_no_offset(self, outcomes):
+        outcomes.record(
+            Outcome(
+                consumer="c",
+                stream_path="s",
+                offset=None,
+                sequence_key="seq",
+                stage="append",
+                status="refused",
+                reasons=("declined_upstream",),
+            )
+        )
+        [got] = outcomes.latest("c", "s")
+        assert got.offset is None and got.stage == "append"
+
+    # --- immutability and attempts ------------------------------------------
+
+    def test_a_second_attempt_does_not_overwrite_the_first(self, outcomes):
+        """The record is append-only: history accumulates rather than being edited.
+
+        `latest` collapses it for reading, so this is asserted on the store's own
+        terms — a second attempt must not *replace* the first row.
+        """
+        outcomes.record(project("0000000001", reasons=("first",), attempt=1))
+        outcomes.record(project("0000000001", reasons=("second",), attempt=2))
+        [got] = outcomes.latest("c", "s")
+        assert got.reasons == ("second",) and got.attempt == 2
+
+    def test_latest_takes_the_highest_attempt_not_the_last_written(self, outcomes):
+        """Out-of-order writes must not decide the answer.
+
+        Mutation watched: `latest` returning the most recently recorded row. A
+        re-drive that records attempt 2 before a slow attempt 1 lands would then
+        report the older verdict as current.
+        """
+        outcomes.record(project("0000000001", reasons=("second",), attempt=2))
+        outcomes.record(project("0000000001", reasons=("first",), attempt=1))
+        [got] = outcomes.latest("c", "s")
+        assert got.reasons == ("second",)
+
+    def test_latest_returns_one_row_per_offset(self, outcomes):
+        for offset in ("0000000001", "0000000002", "0000000003"):
+            outcomes.record(project(offset, attempt=1))
+            outcomes.record(project(offset, attempt=2))
+        assert [o.offset for o in outcomes.latest("c", "s")] == [
+            "0000000001",
+            "0000000002",
+            "0000000003",
+        ]
+
+    def test_latest_orders_by_offset_with_append_stage_last(self, outcomes):
+        outcomes.record(project("0000000002"))
+        outcomes.record(
+            Outcome(
+                consumer="c",
+                stream_path="s",
+                offset=None,
+                sequence_key="seq",
+                stage="append",
+                status="refused",
+            )
+        )
+        outcomes.record(project("0000000001"))
+        assert [o.offset for o in outcomes.latest("c", "s")] == [
+            "0000000001",
+            "0000000002",
+            None,
+        ]
+
+    # --- what a clean run looks like ---------------------------------------
+
+    def test_a_clean_run_records_nothing(self, outcomes):
+        """The property the exceptions-only design rests on.
+
+        Nothing failed, so nothing was written. Stated as a test because it is
+        the load-bearing half of "the cursor is the success record": if a store
+        ever synthesised a row per applied event, every count built on this table
+        would change meaning without anything failing.
+        """
+        assert outcomes.latest("c", "s") == []

--- a/tests/outcome_store_contract.py
+++ b/tests/outcome_store_contract.py
@@ -114,6 +114,23 @@ class OutcomeStoreContract:
         [got] = outcomes.latest("c", "s")
         assert got.params == {"row": "3", "budget": "500"}
 
+    def test_a_recorded_outcome_does_not_change_when_the_caller_mutates_its_params(
+        self, outcomes
+    ):
+        """`frozen=True` freezes the binding, not the dict behind it.
+
+        A contract rather than a per-backend test because the two disagreed: a
+        backend that serialises escaped this by accident and one that keeps the
+        object did not. This is the field whose whole purpose is that field values
+        never reach it, so a caller adding one afterwards must not land.
+        """
+        params = {"row": "3"}
+        outcomes.record(project("0000000001", params=params))
+        params["national_id"] = "1234-LEAK"
+
+        [got] = outcomes.latest("c", "s")
+        assert got.params == {"row": "3"}
+
     def test_an_append_stage_outcome_has_no_offset(self, outcomes):
         outcomes.record(refused("row-1", reasons=("declined_upstream",)))
         [got] = outcomes.latest("c", "s")
@@ -175,7 +192,7 @@ class OutcomeStoreContract:
         [got] = outcomes.latest("c", "s")
         assert got.reasons == ("second",)
 
-    def test_latest_returns_one_row_per_offset(self, outcomes):
+    def test_latest_returns_one_row_per_subject(self, outcomes):
         for offset in ("0000000001", "0000000002", "0000000003"):
             outcomes.record(project(offset, attempt=1))
             outcomes.record(project(offset, attempt=2))

--- a/tests/outcome_store_contract.py
+++ b/tests/outcome_store_contract.py
@@ -36,8 +36,23 @@ def project(offset: str, *, consumer: str = "c", path: str = "s", **kw) -> Outco
     """A projection-stage outcome, the common case in these tests."""
     kw.setdefault("sequence_key", "seq")
     kw.setdefault("status", "failed")
+    kw.setdefault("subject", offset)
     return Outcome(
         consumer=consumer, stream_path=path, offset=offset, stage="project", **kw
+    )
+
+
+def refused(subject: str, *, consumer: str = "c", path: str = "s", **kw) -> Outcome:
+    """An append-stage refusal — no offset, because it never reached the log."""
+    kw.setdefault("sequence_key", subject)
+    kw.setdefault("status", "refused")
+    return Outcome(
+        consumer=consumer,
+        stream_path=path,
+        offset=None,
+        subject=subject,
+        stage="append",
+        **kw,
     )
 
 
@@ -100,32 +115,53 @@ class OutcomeStoreContract:
         assert got.params == {"row": "3", "budget": "500"}
 
     def test_an_append_stage_outcome_has_no_offset(self, outcomes):
-        outcomes.record(
-            Outcome(
-                consumer="c",
-                stream_path="s",
-                offset=None,
-                sequence_key="seq",
-                stage="append",
-                status="refused",
-                reasons=("declined_upstream",),
-            )
-        )
+        outcomes.record(refused("row-1", reasons=("declined_upstream",)))
         [got] = outcomes.latest("c", "s")
         assert got.offset is None and got.stage == "append"
 
     # --- immutability and attempts ------------------------------------------
 
-    def test_a_second_attempt_does_not_overwrite_the_first(self, outcomes):
-        """The record is append-only: history accumulates rather than being edited.
+    def test_a_later_attempt_is_what_latest_reports(self, outcomes):
+        """Renamed from a claim it could not keep.
 
-        `latest` collapses it for reading, so this is asserted on the store's own
-        terms — a second attempt must not *replace* the first row.
+        It used to say it proved the store never *replaces* a row, while reading
+        only through `latest()` — which collapses attempts, so an in-place
+        overwrite is invisible to it. Mutation that proved it vacuous: make
+        `record` delete the matching row before appending; this test stayed green.
+        Append-only storage is not observable through this interface, so the name
+        now claims only what the assertion can see.
         """
         outcomes.record(project("0000000001", reasons=("first",), attempt=1))
         outcomes.record(project("0000000001", reasons=("second",), attempt=2))
         [got] = outcomes.latest("c", "s")
         assert got.reasons == ("second",) and got.attempt == 2
+
+    def test_every_refused_subject_is_reported_separately(self, outcomes):
+        """The case the design exists for, and the one it originally lost.
+
+        Refusals never reach the log, so they have no offset. Keyed on offset they
+        all collapsed to a single row and the first was reported as though it spoke
+        for the rest — one bad row making a whole form look accounted for, which is
+        the defect this record is meant to expose.
+        """
+        for i in (1, 2, 3):
+            outcomes.record(refused(f"row-{i}", reasons=(f"rule_{i}",)))
+
+        got = outcomes.latest("c", "s")
+        assert [(o.subject, o.reasons) for o in got] == [
+            ("row-1", ("rule_1",)),
+            ("row-2", ("rule_2",)),
+            ("row-3", ("rule_3",)),
+        ]
+
+    def test_a_refusal_and_a_projection_failure_coexist(self, outcomes):
+        """One with an offset, one without, both about different subjects."""
+        outcomes.record(project("0000000001"))
+        outcomes.record(refused("row-9"))
+        assert [(o.subject, o.offset) for o in outcomes.latest("c", "s")] == [
+            ("0000000001", "0000000001"),
+            ("row-9", None),
+        ]
 
     def test_latest_takes_the_highest_attempt_not_the_last_written(self, outcomes):
         """Out-of-order writes must not decide the answer.
@@ -151,16 +187,7 @@ class OutcomeStoreContract:
 
     def test_latest_orders_by_offset_with_append_stage_last(self, outcomes):
         outcomes.record(project("0000000002"))
-        outcomes.record(
-            Outcome(
-                consumer="c",
-                stream_path="s",
-                offset=None,
-                sequence_key="seq",
-                stage="append",
-                status="refused",
-            )
-        )
+        outcomes.record(refused("row-1"))
         outcomes.record(project("0000000001"))
         assert [o.offset for o in outcomes.latest("c", "s")] == [
             "0000000001",

--- a/tests/test_rakaia/test_jsonl_outcome_store_contract.py
+++ b/tests/test_rakaia/test_jsonl_outcome_store_contract.py
@@ -1,0 +1,110 @@
+"""The file-backed outcome store against the shared contract.
+
+The point of running the same suite twice. `InMemoryOutcomeStore` and this one
+share no code, and this one has no database under it, so the pair passing is what
+makes ADR 0007's claim — that an outcome is as store-agnostic as a cursor — a
+measurement rather than an assertion.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from rakaia.jsonl_outcomes import JsonlOutcomeStore
+from tests.outcome_store_contract import OutcomeStoreContract
+
+
+class TestJsonlOutcomeStoreContract(OutcomeStoreContract):
+    @pytest.fixture
+    def outcomes(self, tmp_path: Path) -> JsonlOutcomeStore:
+        # fsync off: tmp_path has no durability question to answer and the
+        # syscall is pure cost per recorded row.
+        return JsonlOutcomeStore(tmp_path / "outcomes", fsync=False)
+
+
+class TestJsonlOutcomeStoreDurability:
+    """What the shared contract cannot ask for, because the in-memory store
+    cannot satisfy it."""
+
+    def test_outcomes_survive_a_new_store_over_the_same_root(self, tmp_path: Path):
+        from rakaia.outcomes import Outcome
+
+        root = tmp_path / "outcomes"
+        JsonlOutcomeStore(root, fsync=False).record(
+            Outcome(
+                consumer="c",
+                stream_path="submission/tf611",
+                offset="0000000001",
+                sequence_key="seq",
+                stage="project",
+                status="failed",
+                reasons=("bad_total",),
+            )
+        )
+        [got] = JsonlOutcomeStore(root, fsync=False).latest("c", "submission/tf611")
+        assert got.reasons == ("bad_total",)
+
+    @pytest.mark.parametrize("hostile", ["a/b", "../escape", "..", "a%2Fb"])
+    @pytest.mark.parametrize("field", ["consumer", "stream_path"])
+    def test_every_file_stays_directly_under_the_root(
+        self, tmp_path: Path, field: str, hostile: str
+    ):
+        """A consumer id and a stream path are names, not paths.
+
+        Asserted as *containment*, not as a round trip. Leaving either component
+        unencoded still round-trips — `a/b` reads back from `root/a/b/…` exactly as
+        it was written — so a read-what-you-wrote test passes while `../escape`
+        writes outside the root entirely. The property worth holding is the layout:
+        one directory per consumer, one file per stream, nothing deeper and nothing
+        above.
+        """
+        from rakaia.outcomes import Outcome
+
+        root = tmp_path / "outcomes"
+        store = JsonlOutcomeStore(root, fsync=False)
+        fixed = {"consumer": "c", "stream_path": "s"}
+        store.record(
+            Outcome(
+                **{**fixed, field: hostile},
+                offset="0000000001",
+                sequence_key="seq",
+                stage="project",
+                status="failed",
+                reasons=(hostile,),
+            )
+        )
+
+        written = list(root.rglob("*.jsonl"))
+        assert len(written) == 1
+        assert written[0].parent.parent == root, "a name became a directory tree"
+        assert not list(tmp_path.glob("*.jsonl")), "a name escaped the root"
+
+        scope = {**fixed, field: hostile}
+        assert [
+            o.reasons for o in store.latest(scope["consumer"], scope["stream_path"])
+        ] == [(hostile,)]
+
+    def test_a_torn_trailing_line_is_skipped_not_fatal(self, tmp_path: Path):
+        """A crash mid-append leaves half a line. Skipping it loses one outcome;
+        failing the read would lose the whole report."""
+        from rakaia.outcomes import Outcome
+
+        root = tmp_path / "outcomes"
+        store = JsonlOutcomeStore(root, fsync=False)
+        store.record(
+            Outcome(
+                consumer="c",
+                stream_path="s",
+                offset="0000000001",
+                sequence_key="seq",
+                stage="project",
+                status="failed",
+            )
+        )
+        target = next(root.rglob("*.jsonl"))
+        with target.open("a", encoding="utf-8") as fh:
+            fh.write('{"consumer": "c", "stream_pa')
+
+        assert [o.offset for o in store.latest("c", "s")] == ["0000000001"]

--- a/tests/test_rakaia/test_jsonl_outcome_store_contract.py
+++ b/tests/test_rakaia/test_jsonl_outcome_store_contract.py
@@ -47,7 +47,7 @@ class TestJsonlOutcomeStoreDurability:
         [got] = JsonlOutcomeStore(root, fsync=False).latest("c", "submission/tf611")
         assert got.reasons == ("bad_total",)
 
-    @pytest.mark.parametrize("hostile", ["a/b", "../escape", "..", "a%2Fb"])
+    @pytest.mark.parametrize("hostile", ["a/b", "../escape", "..", "a%2Fb", ""])
     @pytest.mark.parametrize("field", ["consumer", "stream_path"])
     def test_every_file_stays_directly_under_the_root(
         self, tmp_path: Path, field: str, hostile: str

--- a/tests/test_rakaia/test_jsonl_outcome_store_contract.py
+++ b/tests/test_rakaia/test_jsonl_outcome_store_contract.py
@@ -47,7 +47,10 @@ class TestJsonlOutcomeStoreDurability:
         [got] = JsonlOutcomeStore(root, fsync=False).latest("c", "submission/tf611")
         assert got.reasons == ("bad_total",)
 
-    @pytest.mark.parametrize("hostile", ["a/b", "../escape", "..", "a%2Fb", ""])
+    # The empty string used to be here. It is now refused at construction — an empty
+    # name collides with whatever else escapes to the same path segment — so the case
+    # this file covered moved to `test_the_names_cannot_be_empty`.
+    @pytest.mark.parametrize("hostile", ["a/b", "../escape", "..", "a%2Fb"])
     @pytest.mark.parametrize("field", ["consumer", "stream_path"])
     def test_every_file_stays_directly_under_the_root(
         self, tmp_path: Path, field: str, hostile: str

--- a/tests/test_rakaia/test_jsonl_outcome_store_contract.py
+++ b/tests/test_rakaia/test_jsonl_outcome_store_contract.py
@@ -161,3 +161,51 @@ class TestJsonlOutcomeStoreDurability:
             )
 
         assert [o.subject for o in store.latest("c", "s")] == ["row-1", "row-2"]
+
+    def test_a_line_missing_a_required_field_is_skipped_not_fatal(self, tmp_path: Path):
+        """The other half of "a field added by a later version, or one removed".
+
+        The unknown-key half is held by the field filter, so narrowing the `except`
+        back to `ValueError` alone left the suite green and the `TypeError` arm
+        looked dead. It is not: a line written before a field existed is missing a
+        required argument, and building it raises `TypeError`, which without this
+        arm takes the whole report down.
+        """
+        import json
+
+        from rakaia.outcomes import Outcome
+
+        root = tmp_path / "outcomes"
+        store = JsonlOutcomeStore(root, fsync=False)
+        store.record(
+            Outcome(
+                consumer="c",
+                stream_path="s",
+                subject="row-1",
+                offset="0000000001",
+                sequence_key="seq",
+                stage="project",
+                status="failed",
+            )
+        )
+        target = next(root.rglob("*.jsonl"))
+        with target.open("a", encoding="utf-8") as fh:
+            # No `sequence_key` — written by a version predating the field.
+            fh.write(
+                json.dumps(
+                    {
+                        "consumer": "c",
+                        "stream_path": "s",
+                        "subject": "row-2",
+                        "offset": "0000000002",
+                        "stage": "project",
+                        "status": "failed",
+                        "reasons": [],
+                        "params": {},
+                        "attempt": 1,
+                    }
+                )
+                + "\n"
+            )
+
+        assert [o.subject for o in store.latest("c", "s")] == ["row-1"]

--- a/tests/test_rakaia/test_jsonl_outcome_store_contract.py
+++ b/tests/test_rakaia/test_jsonl_outcome_store_contract.py
@@ -36,6 +36,7 @@ class TestJsonlOutcomeStoreDurability:
             Outcome(
                 consumer="c",
                 stream_path="submission/tf611",
+                subject="row-1",
                 offset="0000000001",
                 sequence_key="seq",
                 stage="project",
@@ -68,6 +69,7 @@ class TestJsonlOutcomeStoreDurability:
         store.record(
             Outcome(
                 **{**fixed, field: hostile},
+                subject="row-1",
                 offset="0000000001",
                 sequence_key="seq",
                 stage="project",
@@ -97,6 +99,7 @@ class TestJsonlOutcomeStoreDurability:
             Outcome(
                 consumer="c",
                 stream_path="s",
+                subject="row-1",
                 offset="0000000001",
                 sequence_key="seq",
                 stage="project",
@@ -108,3 +111,53 @@ class TestJsonlOutcomeStoreDurability:
             fh.write('{"consumer": "c", "stream_pa')
 
         assert [o.offset for o in store.latest("c", "s")] == ["0000000001"]
+
+    def test_a_line_this_version_cannot_build_is_skipped_not_fatal(
+        self, tmp_path: Path
+    ):
+        """A field added by a later version must not take the report down.
+
+        `Outcome(**payload)` raises `TypeError` on an unknown key, and the read
+        caught only `ValueError` — so one line written by a newer version lost
+        every outcome in the file. The ADR forecasts exactly this key: "#232
+        lands… an outcome should name its issuing store".
+        """
+        import json
+
+        from rakaia.outcomes import Outcome
+
+        root = tmp_path / "outcomes"
+        store = JsonlOutcomeStore(root, fsync=False)
+        store.record(
+            Outcome(
+                consumer="c",
+                stream_path="s",
+                subject="row-1",
+                offset="0000000001",
+                sequence_key="seq",
+                stage="project",
+                status="failed",
+            )
+        )
+        target = next(root.rglob("*.jsonl"))
+        with target.open("a", encoding="utf-8") as fh:
+            fh.write(
+                json.dumps(
+                    {
+                        "consumer": "c",
+                        "stream_path": "s",
+                        "subject": "row-2",
+                        "offset": "0000000002",
+                        "sequence_key": "seq",
+                        "stage": "project",
+                        "status": "failed",
+                        "reasons": [],
+                        "params": {},
+                        "attempt": 1,
+                        "store": "from-a-later-version",
+                    }
+                )
+                + "\n"
+            )
+
+        assert [o.subject for o in store.latest("c", "s")] == ["row-1", "row-2"]

--- a/tests/test_rakaia/test_outcome_backends_agree.py
+++ b/tests/test_rakaia/test_outcome_backends_agree.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import uuid
 from collections.abc import Hashable
 from decimal import Decimal
+from enum import Enum
 from pathlib import Path
 
 import pytest
@@ -23,10 +24,32 @@ import pytest
 from rakaia.jsonl_outcomes import JsonlOutcomeStore
 from rakaia.outcomes import InMemoryOutcomeStore, Outcome
 
+
 #: Values that are *not* text. Each was a real finding, or the next one predicted:
 #: rounds fixed a map's values, then its keys, then the list beside it, then the
 #: plain fields. A store must refuse all of them, and refuse them identically.
-NOT_TEXT = [uuid.uuid4(), 42, None, ("a", "b"), Decimal("1.5"), b"bytes", {"k": "v"}]
+class _StrSubclass(str, Enum):
+    """A `str` subclass, which is the shape that defeats every equality check.
+
+    It compares equal to its own text and reads back from storage as plain text
+    with a different type — so `==` cannot see the difference and only a type check
+    can. A `StrEnum` is the one that turns up in real consumers.
+    """
+
+    APPEND = "append"
+
+
+NOT_TEXT = [
+    uuid.uuid4(),
+    42,
+    None,
+    ("a", "b"),
+    Decimal("1.5"),
+    b"bytes",
+    {"k": "v"},
+    _StrSubclass.APPEND,
+    "\ud800",  # a lone surrogate: a str that cannot be encoded
+]
 
 
 def backends(tmp_path: Path):
@@ -104,7 +127,12 @@ def test_the_backends_agree_on_ordering(tmp_path: Path):
 
 @pytest.mark.parametrize("value", NOT_TEXT, ids=lambda v: type(v).__name__)
 @pytest.mark.parametrize(
-    "field", ["subject", "sequence_key", "consumer", "stream_path"]
+    # `stage` and `status` are in the list deliberately. They are the two fields
+    # declared as a small set of strings, and a value-equality check lets a `str`
+    # subclass through where every other field's type check catches it — so they
+    # were the only two the codec did not protect.
+    "field",
+    ["subject", "sequence_key", "consumer", "stream_path", "stage", "status"],
 )
 def test_no_backend_accepts_what_another_would_refuse(
     tmp_path: Path, field: str, value

--- a/tests/test_rakaia/test_outcome_backends_agree.py
+++ b/tests/test_rakaia/test_outcome_backends_agree.py
@@ -1,0 +1,150 @@
+"""Every backend stores the same outcome the same way.
+
+The shared contract asks each backend, separately, whether it matches an
+expectation. That is not the question five review rounds kept answering wrong.
+Every one of those defects was two backends *disagreeing with each other* — a
+value the in-memory reference kept as handed to it and a durable store rendered,
+refused or altered — and no test compared them, so the class was invisible while
+each member of it was found one round at a time.
+
+This asks the question directly. A new backend joins by adding one line to
+`backends`, and inherits every case below rather than re-deriving them.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Hashable
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+
+from rakaia.jsonl_outcomes import JsonlOutcomeStore
+from rakaia.outcomes import InMemoryOutcomeStore, Outcome
+
+#: Values that are *not* text. Each was a real finding, or the next one predicted:
+#: rounds fixed a map's values, then its keys, then the list beside it, then the
+#: plain fields. A store must refuse all of them, and refuse them identically.
+NOT_TEXT = [uuid.uuid4(), 42, None, ("a", "b"), Decimal("1.5"), b"bytes", {"k": "v"}]
+
+
+def backends(tmp_path: Path):
+    """One of every backend, so a disagreement between any two is visible."""
+    return {
+        "memory": InMemoryOutcomeStore(),
+        "jsonl": JsonlOutcomeStore(tmp_path / "outcomes", fsync=False),
+    }
+
+
+def an_outcome(**kw) -> Outcome:
+    base = {
+        "consumer": "c",
+        "stream_path": "submission/tf611",
+        "subject": "row-1",
+        "offset": None,
+        "sequence_key": "seq",
+        "stage": "append",
+        "status": "refused",
+    }
+    return Outcome(**{**base, **kw})
+
+
+def test_a_recorded_outcome_reads_back_identically_everywhere(tmp_path: Path):
+    outcome = an_outcome(reasons=("missing_total", "wrong_period"), params={"row": "3"})
+    got = {}
+    for name, store in backends(tmp_path).items():
+        store.record(outcome)
+        got[name] = store.latest("c", "submission/tf611")
+    assert len(set(map(repr, got.values()))) == 1, got
+    assert got["memory"] == [outcome]
+
+
+def test_no_backend_keeps_a_handle_on_what_the_caller_passed(tmp_path: Path):
+    """Mutating the source after recording must change nothing, anywhere.
+
+    This is the half the type checks cannot reach: the values are all text and
+    every store accepts them. What differed was whether the store kept the
+    caller's container or rendered it, and only a store that renders was safe by
+    accident. Asked across backends because "they agree" is the property; asked
+    after `record` because that is when the caller still has the handle.
+    """
+    reasons = ["missing_total"]
+    params = {"row": "3"}
+    outcome = an_outcome(reasons=reasons, params=params)
+
+    got = {}
+    for name, store in backends(tmp_path).items():
+        store.record(outcome)
+        got[name] = store.latest("c", "submission/tf611")
+
+    reasons.append("LEAKED")
+    params["national_id"] = "1234-LEAK"
+
+    assert len(set(map(repr, got.values()))) == 1, got
+    assert got["memory"][0].reasons == ("missing_total",)
+    assert got["memory"][0].params == {"row": "3"}
+
+
+def test_the_backends_agree_on_ordering(tmp_path: Path):
+    outcomes = [
+        an_outcome(subject="row-3"),
+        an_outcome(subject="row-1"),
+        an_outcome(
+            subject="row-2", offset="0000000001", stage="project", status="failed"
+        ),
+    ]
+    got = {}
+    for name, store in backends(tmp_path).items():
+        for o in outcomes:
+            store.record(o)
+        got[name] = [o.subject for o in store.latest("c", "submission/tf611")]
+    assert len(set(map(tuple, got.values()))) == 1, got
+
+
+@pytest.mark.parametrize("value", NOT_TEXT, ids=lambda v: type(v).__name__)
+@pytest.mark.parametrize(
+    "field", ["subject", "sequence_key", "consumer", "stream_path"]
+)
+def test_no_backend_accepts_what_another_would_refuse(
+    tmp_path: Path, field: str, value
+):
+    """The class itself, as one assertion.
+
+    Each of these used to record in memory and raise on write, so the two stores
+    disagreed about whether the outcome existed at all. Refusing at construction is
+    what makes that impossible — but the property under test is *agreement*, not
+    where the refusal happens, so this stays true if the refusal ever moves.
+    """
+    outcomes = {}
+    for name, store in backends(tmp_path).items():
+        try:
+            store.record(an_outcome(**{field: value}))
+            outcomes[name] = store.latest("c", "submission/tf611")
+        except (ValueError, TypeError) as exc:
+            outcomes[name] = type(exc).__name__
+
+    assert len(set(map(repr, outcomes.values()))) == 1, (
+        f"backends disagree about {field}={value!r}: {outcomes}"
+    )
+
+
+@pytest.mark.parametrize("value", NOT_TEXT, ids=lambda v: type(v).__name__)
+def test_the_backends_agree_about_a_bad_reason_or_param(tmp_path: Path, value):
+    cases = [{"reasons": (value,)}, {"params": {"k": value}}]
+    # A key case only where the value can be one at all — an unhashable value fails
+    # in this test's own literal, before a store sees it, which is Python and not a
+    # disagreement between backends.
+    if isinstance(value, Hashable):
+        cases.append({"params": {value: "v"}})
+    for kw in cases:
+        outcomes = {}
+        for name, store in backends(tmp_path).items():
+            try:
+                store.record(an_outcome(**kw))
+                outcomes[name] = store.latest("c", "submission/tf611")
+            except (ValueError, TypeError) as exc:
+                outcomes[name] = type(exc).__name__
+        assert len(set(map(repr, outcomes.values()))) == 1, (
+            f"disagree on {kw}: {outcomes}"
+        )

--- a/tests/test_rakaia/test_outcome_backends_agree.py
+++ b/tests/test_rakaia/test_outcome_backends_agree.py
@@ -148,3 +148,39 @@ def test_the_backends_agree_about_a_bad_reason_or_param(tmp_path: Path, value):
         assert len(set(map(repr, outcomes.values()))) == 1, (
             f"disagree on {kw}: {outcomes}"
         )
+
+
+def test_every_store_keeps_the_encoded_form_not_the_object():
+    """The redesign's own change, pinned.
+
+    A review found that reverting the in-memory store to keeping the object left
+    the entire suite green: construction validates, so nothing downstream noticed
+    which shape the store held. That made the change this commit exists for
+    decorative. What the shape actually buys is below — ordering, and any future
+    store inheriting one definition instead of writing its own — but a property
+    nothing asserts is a property that will be undone.
+    """
+    store = InMemoryOutcomeStore()
+    store.record(an_outcome())
+    [held] = store._recorded
+    assert isinstance(held, dict), (
+        f"the store kept a {type(held).__name__}, not the encoded form"
+    )
+    assert held["subject"] == "row-1"
+
+
+def test_the_stores_agree_on_the_order_of_params(tmp_path: Path):
+    """The discriminator the codec is load-bearing for.
+
+    One store writes JSON with sorted keys and the other kept whatever order the
+    caller used, so the same outcome read back differently from each. `dict.__eq__`
+    hides it — this compares the rendered form, which is what anything printing,
+    logging or diffing an outcome will see.
+    """
+    outcome = an_outcome(params={"z": "1", "a": "2", "m": "3"})
+    got = {}
+    for name, store in backends(tmp_path).items():
+        store.record(outcome)
+        got[name] = [list(o.params) for o in store.latest("c", "submission/tf611")]
+    assert len(set(map(repr, got.values()))) == 1, got
+    assert got["memory"] == [["a", "m", "z"]]

--- a/tests/test_rakaia/test_outcome_backends_agree.py
+++ b/tests/test_rakaia/test_outcome_backends_agree.py
@@ -179,7 +179,7 @@ def test_the_backends_agree_about_a_bad_reason_or_param(tmp_path: Path, value):
 
 
 def test_every_store_keeps_the_encoded_form_not_the_object():
-    """The redesign's own change, pinned.
+    """The design's central claim, pinned.
 
     A review found that reverting the in-memory store to keeping the object left
     the entire suite green: construction validates, so nothing downstream noticed
@@ -191,10 +191,10 @@ def test_every_store_keeps_the_encoded_form_not_the_object():
     store = InMemoryOutcomeStore()
     store.record(an_outcome())
     [held] = store._recorded
-    assert isinstance(held, dict), (
-        f"the store kept a {type(held).__name__}, not the encoded form"
+    assert isinstance(held, str), (
+        f"the store kept a {type(held).__name__}, not the encoded text"
     )
-    assert held["subject"] == "row-1"
+    assert '"subject": "row-1"' in held
 
 
 def test_the_stores_agree_on_the_order_of_params(tmp_path: Path):

--- a/tests/test_rakaia/test_outcome_store_contract.py
+++ b/tests/test_rakaia/test_outcome_store_contract.py
@@ -1,0 +1,14 @@
+"""The in-memory outcome store against the shared contract."""
+
+from __future__ import annotations
+
+import pytest
+
+from rakaia.outcomes import InMemoryOutcomeStore
+from tests.outcome_store_contract import OutcomeStoreContract
+
+
+class TestInMemoryOutcomeStoreContract(OutcomeStoreContract):
+    @pytest.fixture
+    def outcomes(self) -> InMemoryOutcomeStore:
+        return InMemoryOutcomeStore()

--- a/tests/test_rakaia/test_outcome_validation.py
+++ b/tests/test_rakaia/test_outcome_validation.py
@@ -76,3 +76,22 @@ def test_params_names_the_offending_keys():
             status="refused",
             params={"a": "fine", "b": 1, "c": None},
         )
+
+
+@pytest.mark.parametrize("key", [1, None, True, ("a", "b")])
+def test_params_refuses_a_key_that_is_not_a_string(key):
+    """The hole the values check left, found one round later.
+
+    A non-string key does not fail loudly, it makes the backends disagree: an
+    integer key survives in memory and comes back as a string from anything that
+    serialises, and a key that is hashable but not a primitive records in memory
+    and raises on write. Both halves have to be strings for the two to agree.
+    """
+    with pytest.raises(ValueError, match="keys must be strings"):
+        Outcome(
+            **BASE,
+            offset=None,
+            stage="append",
+            status="refused",
+            params={key: "x"},
+        )

--- a/tests/test_rakaia/test_outcome_validation.py
+++ b/tests/test_rakaia/test_outcome_validation.py
@@ -30,13 +30,52 @@ def test_the_names_cannot_be_empty(field):
         Outcome(**{**BASE, field: ""}, offset=None, stage="append", status="refused")
 
 
+@pytest.mark.parametrize("field", ["consumer", "stream_path", "subject", "offset"])
+@pytest.mark.parametrize(
+    "value", [42, uuid.uuid4(), ("a", "b")], ids=lambda v: type(v).__name__
+)
+def test_what_a_store_sorts_and_names_by_has_to_be_text(field, value):
+    """Not a type rule for its own sake — a rule about four specific fields.
+
+    A number stored as a name raises in a file store's path escaping. A number
+    stored as an *offset* is kept identically by every store and then makes
+    `latest` raise the moment a text offset sits beside it, because the two cannot
+    be compared: consistent, and still broken. Everything an outcome merely carries
+    is settled by storing it instead.
+    """
+    kw = {**BASE, "offset": None, "stage": "append", "status": "refused"}
+    if field == "offset":
+        kw |= {"offset": value, "stage": "project", "status": "failed"}
+    else:
+        kw[field] = value
+    with pytest.raises(ValueError, match="writable text"):
+        Outcome(**kw)
+
+
+def test_a_text_offset_and_a_missing_one_sort_together():
+    """The failure the rule above prevents, as the read path sees it."""
+    from rakaia.outcomes import InMemoryOutcomeStore
+
+    store = InMemoryOutcomeStore()
+    store.record(Outcome(**BASE, offset="0000000001", stage="project", status="failed"))
+    store.record(
+        Outcome(
+            **{**BASE, "subject": "row-2"},
+            offset=None,
+            stage="append",
+            status="refused",
+        )
+    )
+    assert [o.offset for o in store.latest("c", "s")] == ["0000000001", None]
+
+
 @pytest.mark.parametrize("field", ["consumer", "stream_path", "subject"])
 def test_a_name_that_cannot_be_written_is_refused(field):
     """A lone surrogate is text by every type check and no path can carry it, so it
     passes construction and raises inside the store — in the loop whose job is
     recording that something failed. The one storage constraint the codec cannot
     reach, because it is about the name rather than the payload."""
-    with pytest.raises(ValueError, match="cannot be encoded"):
+    with pytest.raises(ValueError, match="writable text"):
         Outcome(
             **{**BASE, field: "x\ud800"}, offset=None, stage="append", status="refused"
         )

--- a/tests/test_rakaia/test_outcome_validation.py
+++ b/tests/test_rakaia/test_outcome_validation.py
@@ -20,13 +20,15 @@ BASE = {
 }
 
 
-def test_an_outcome_needs_a_subject():
-    """Without one there is nothing to key on, and every refusal on a stream
-    collapses into whichever was recorded first."""
-    with pytest.raises(ValueError, match="needs a subject"):
-        Outcome(
-            **{**BASE, "subject": ""}, offset=None, stage="append", status="refused"
-        )
+@pytest.mark.parametrize("field", ["consumer", "stream_path", "subject"])
+def test_the_names_cannot_be_empty(field):
+    """Without a subject there is nothing to key on, and every refusal on a stream
+    collapses into whichever was recorded first. The other two matter for a
+    different reason: a file-backed store maps a name to one path segment, and an
+    empty name shares a segment with whatever else escapes to the same thing.
+    """
+    with pytest.raises(ValueError, match="cannot be empty"):
+        Outcome(**{**BASE, field: ""}, offset=None, stage="append", status="refused")
 
 
 def test_an_appended_outcome_cannot_carry_an_offset():
@@ -68,9 +70,14 @@ def test_params_refuses_anything_that_is_not_a_string(value):
         )
 
 
-def test_params_names_the_offending_keys():
-    """A refusal that does not say which key is a refusal someone works around."""
-    with pytest.raises(ValueError, match=r"params\['b'\]"):
+def test_a_refusal_names_the_field_and_shows_its_contents():
+    """A refusal that does not say what was wrong is one someone works around.
+
+    The message names the field and prints it, rather than listing offending keys:
+    one rule that walks the declaration cannot report per-key without re-deriving
+    per-field knowledge, and the printed value is enough to see which entry is bad.
+    """
+    with pytest.raises(ValueError, match=r"params=\{"):
         Outcome(
             **BASE,
             offset=None,
@@ -130,7 +137,11 @@ def test_the_name_fields_must_be_strings(field, value):
     # is text, and that is the better message for it. The test pins that one of them
     # happens, not which — naming a single message would make it pass for the wrong
     # reason on that one case.
-    with pytest.raises(ValueError, match=r"has to be text|needs a subject"):
+    # Which refusal fires depends on the value: `None` is caught as an empty name
+    # before anything asks whether it is text, and both answers are correct. The
+    # test pins that one of them happens, not which — naming a single message would
+    # make it pass for the wrong reason on that case.
+    with pytest.raises(ValueError):
         Outcome(**{**BASE, field: value}, offset=None, stage="append", status="refused")
 
 

--- a/tests/test_rakaia/test_outcome_validation.py
+++ b/tests/test_rakaia/test_outcome_validation.py
@@ -6,6 +6,8 @@ These had no tests at all: every `raise` in `__post_init__` could be turned into
 
 from __future__ import annotations
 
+import uuid
+
 import pytest
 
 from rakaia.outcomes import Outcome
@@ -109,3 +111,27 @@ def test_reasons_must_be_codes_given_as_strings(reason):
         Outcome(
             **BASE, offset=None, stage="append", status="refused", reasons=(reason,)
         )
+
+
+@pytest.mark.parametrize(
+    "field", ["consumer", "stream_path", "subject", "sequence_key"]
+)
+@pytest.mark.parametrize("value", [uuid.uuid4(), 42, ("a", "b"), None])
+def test_the_name_fields_must_be_strings(field, value):
+    """The fifth instance of a defect four rounds closed one field at a time.
+
+    These are declared `str` and nothing made them so. A UUID subject is the case
+    that matters — the field is required, consumer-supplied, and documented as
+    opaque, which invites a model key — and it records in memory then raises on
+    write, so the two backends disagree about whether the record exists.
+    """
+    with pytest.raises(ValueError, match="must be strings"):
+        Outcome(**{**BASE, field: value}, offset=None, stage="append", status="refused")
+
+
+@pytest.mark.parametrize("value", [42, ("a", "b"), uuid.uuid4()])
+def test_an_offset_must_be_a_string_when_there_is_one(value):
+    """An offset is an opaque token, never a number — parsing one is already
+    forbidden, and storing a non-string is the same coupling from the other end."""
+    with pytest.raises(ValueError, match="must be strings"):
+        Outcome(**BASE, offset=value, stage="project", status="failed")

--- a/tests/test_rakaia/test_outcome_validation.py
+++ b/tests/test_rakaia/test_outcome_validation.py
@@ -58,7 +58,7 @@ def test_params_refuses_anything_that_is_not_a_string(value):
     values must not reach it. That was a docstring claim and nothing else: a
     nested dict of personal data went in and came back out of storage unchanged.
     """
-    with pytest.raises(ValueError, match="must be strings"):
+    with pytest.raises(ValueError, match="has to be text"):
         Outcome(
             **BASE,
             offset=None,
@@ -70,7 +70,7 @@ def test_params_refuses_anything_that_is_not_a_string(value):
 
 def test_params_names_the_offending_keys():
     """A refusal that does not say which key is a refusal someone works around."""
-    with pytest.raises(ValueError, match=r"\['b', 'c'\]"):
+    with pytest.raises(ValueError, match=r"params\['b'\]"):
         Outcome(
             **BASE,
             offset=None,
@@ -89,7 +89,7 @@ def test_params_refuses_a_key_that_is_not_a_string(key):
     serialises, and a key that is hashable but not a primitive records in memory
     and raises on write. Both halves have to be strings for the two to agree.
     """
-    with pytest.raises(ValueError, match="keys must be strings"):
+    with pytest.raises(ValueError, match="has to be text"):
         Outcome(
             **BASE,
             offset=None,
@@ -107,7 +107,7 @@ def test_reasons_must_be_codes_given_as_strings(reason):
     and neither check. A non-string element records in memory and raises on write,
     so the backends disagree about whether the outcome exists at all.
     """
-    with pytest.raises(ValueError, match="reasons must be codes"):
+    with pytest.raises(ValueError, match="has to be text"):
         Outcome(
             **BASE, offset=None, stage="append", status="refused", reasons=(reason,)
         )
@@ -125,7 +125,12 @@ def test_the_name_fields_must_be_strings(field, value):
     opaque, which invites a model key — and it records in memory then raises on
     write, so the two backends disagree about whether the record exists.
     """
-    with pytest.raises(ValueError, match="must be strings"):
+    # Two refusals are correct here and which one fires depends on the field:
+    # `subject=None` is caught as an *empty* subject before anything asks whether it
+    # is text, and that is the better message for it. The test pins that one of them
+    # happens, not which — naming a single message would make it pass for the wrong
+    # reason on that one case.
+    with pytest.raises(ValueError, match=r"has to be text|needs a subject"):
         Outcome(**{**BASE, field: value}, offset=None, stage="append", status="refused")
 
 
@@ -133,5 +138,32 @@ def test_the_name_fields_must_be_strings(field, value):
 def test_an_offset_must_be_a_string_when_there_is_one(value):
     """An offset is an opaque token, never a number — parsing one is already
     forbidden, and storing a non-string is the same coupling from the other end."""
-    with pytest.raises(ValueError, match="must be strings"):
+    with pytest.raises(ValueError, match="has to be text"):
         Outcome(**BASE, offset=value, stage="project", status="failed")
+
+
+def test_an_outcome_does_not_change_when_the_caller_mutates_what_it_was_built_from():
+    """`frozen=True` freezes the binding, not the containers behind it.
+
+    Asserted on the object with no store involved, deliberately. The codec copies
+    on the way into storage, so every store is safe whether or not this holds — and
+    that is exactly why it needs its own test: without one, the copy here is
+    unpinned and reads as redundant, while the promise `frozen=True` makes to
+    anyone holding an outcome quietly stops being true.
+    """
+    reasons = ["missing_total"]
+    params = {"row": "3"}
+    outcome = Outcome(
+        **BASE,
+        offset=None,
+        stage="append",
+        status="refused",
+        reasons=reasons,
+        params=params,
+    )
+
+    reasons.append("LEAKED")
+    params["national_id"] = "1234-LEAK"
+
+    assert outcome.reasons == ("missing_total",)
+    assert outcome.params == {"row": "3"}

--- a/tests/test_rakaia/test_outcome_validation.py
+++ b/tests/test_rakaia/test_outcome_validation.py
@@ -95,3 +95,17 @@ def test_params_refuses_a_key_that_is_not_a_string(key):
             status="refused",
             params={key: "x"},
         )
+
+
+@pytest.mark.parametrize("reason", [1, None, object(), ("nested",)])
+def test_reasons_must_be_codes_given_as_strings(reason):
+    """Same class as the params checks, and the field the pattern pointed at.
+
+    Rounds fixed `params` values, then `params` keys; `reasons` had both problems
+    and neither check. A non-string element records in memory and raises on write,
+    so the backends disagree about whether the outcome exists at all.
+    """
+    with pytest.raises(ValueError, match="reasons must be codes"):
+        Outcome(
+            **BASE, offset=None, stage="append", status="refused", reasons=(reason,)
+        )

--- a/tests/test_rakaia/test_outcome_validation.py
+++ b/tests/test_rakaia/test_outcome_validation.py
@@ -1,0 +1,78 @@
+"""What an `Outcome` refuses to be built as.
+
+These had no tests at all: every `raise` in `__post_init__` could be turned into
+`if False:` with the full suite green, which means the validation was decoration.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from rakaia.outcomes import Outcome
+
+BASE = {
+    "consumer": "c",
+    "stream_path": "s",
+    "subject": "row-1",
+    "sequence_key": "seq",
+}
+
+
+def test_an_outcome_needs_a_subject():
+    """Without one there is nothing to key on, and every refusal on a stream
+    collapses into whichever was recorded first."""
+    with pytest.raises(ValueError, match="needs a subject"):
+        Outcome(
+            **{**BASE, "subject": ""}, offset=None, stage="append", status="refused"
+        )
+
+
+def test_an_appended_outcome_cannot_carry_an_offset():
+    with pytest.raises(ValueError, match="no offset"):
+        Outcome(**BASE, offset="0000000001", stage="append", status="refused")
+
+
+def test_a_projected_outcome_needs_an_offset():
+    with pytest.raises(ValueError, match="needs an offset"):
+        Outcome(**BASE, offset=None, stage="project", status="failed")
+
+
+def test_attempts_count_from_one():
+    with pytest.raises(ValueError, match="counts from 1"):
+        Outcome(**BASE, offset=None, stage="append", status="refused", attempt=0)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        {"national_id": "1234", "bank_acct": "999"},
+        ["a", "b"],
+        42,
+        None,
+    ],
+)
+def test_params_refuses_anything_that_is_not_a_string(value):
+    """The reason this field exists instead of a rendered message is that field
+    values must not reach it. That was a docstring claim and nothing else: a
+    nested dict of personal data went in and came back out of storage unchanged.
+    """
+    with pytest.raises(ValueError, match="must be strings"):
+        Outcome(
+            **BASE,
+            offset=None,
+            stage="append",
+            status="refused",
+            params={"leak": value},
+        )
+
+
+def test_params_names_the_offending_keys():
+    """A refusal that does not say which key is a refusal someone works around."""
+    with pytest.raises(ValueError, match=r"\['b', 'c'\]"):
+        Outcome(
+            **BASE,
+            offset=None,
+            stage="append",
+            status="refused",
+            params={"a": "fine", "b": 1, "c": None},
+        )

--- a/tests/test_rakaia/test_outcome_validation.py
+++ b/tests/test_rakaia/test_outcome_validation.py
@@ -7,6 +7,7 @@ These had no tests at all: every `raise` in `__post_init__` could be turned into
 from __future__ import annotations
 
 import uuid
+from decimal import Decimal
 
 import pytest
 
@@ -22,13 +23,23 @@ BASE = {
 
 @pytest.mark.parametrize("field", ["consumer", "stream_path", "subject"])
 def test_the_names_cannot_be_empty(field):
-    """Without a subject there is nothing to key on, and every refusal on a stream
-    collapses into whichever was recorded first. The other two matter for a
-    different reason: a file-backed store maps a name to one path segment, and an
-    empty name shares a segment with whatever else escapes to the same thing.
-    """
+    """Without a subject there is nothing to key on. The other two matter because a
+    file-backed store maps a name to one path segment, and an empty name shares a
+    segment with whatever else escapes to the same thing."""
     with pytest.raises(ValueError, match="cannot be empty"):
         Outcome(**{**BASE, field: ""}, offset=None, stage="append", status="refused")
+
+
+@pytest.mark.parametrize("field", ["consumer", "stream_path", "subject"])
+def test_a_name_that_cannot_be_written_is_refused(field):
+    """A lone surrogate is text by every type check and no path can carry it, so it
+    passes construction and raises inside the store — in the loop whose job is
+    recording that something failed. The one storage constraint the codec cannot
+    reach, because it is about the name rather than the payload."""
+    with pytest.raises(ValueError, match="cannot be encoded"):
+        Outcome(
+            **{**BASE, field: "x\ud800"}, offset=None, stage="append", status="refused"
+        )
 
 
 def test_an_appended_outcome_cannot_carry_an_offset():
@@ -48,120 +59,26 @@ def test_attempts_count_from_one():
 
 @pytest.mark.parametrize(
     "value",
-    [
-        {"national_id": "1234", "bank_acct": "999"},
-        ["a", "b"],
-        42,
-        None,
-    ],
+    [uuid.uuid4(), Decimal("1.5"), b"bytes", object()],
+    ids=lambda v: type(v).__name__,
 )
-def test_params_refuses_anything_that_is_not_a_string(value):
-    """The reason this field exists instead of a rendered message is that field
-    values must not reach it. That was a docstring claim and nothing else: a
-    nested dict of personal data went in and came back out of storage unchanged.
+def test_anything_that_cannot_be_stored_as_text_is_refused(value):
+    """The whole storability rule, and the only one there is.
+
+    It refuses by *doing the storing* rather than by describing which types are
+    allowed. Seven review findings were values that satisfied a type rule and still
+    did not survive storage — a text subclass that flattens, a lone surrogate, a
+    string longer than a column. That set is open-ended, so a description of it
+    leaks by construction.
     """
-    with pytest.raises(ValueError, match="has to be text"):
+    with pytest.raises(ValueError, match="storable as text"):
         Outcome(
-            **BASE,
-            offset=None,
-            stage="append",
-            status="refused",
-            params={"leak": value},
+            **BASE, offset=None, stage="append", status="refused", params={"k": value}
         )
-
-
-def test_a_refusal_names_the_field_and_shows_its_contents():
-    """A refusal that does not say what was wrong is one someone works around.
-
-    The message names the field and prints it, rather than listing offending keys:
-    one rule that walks the declaration cannot report per-key without re-deriving
-    per-field knowledge, and the printed value is enough to see which entry is bad.
-    """
-    with pytest.raises(ValueError, match=r"params=\{"):
-        Outcome(
-            **BASE,
-            offset=None,
-            stage="append",
-            status="refused",
-            params={"a": "fine", "b": 1, "c": None},
-        )
-
-
-@pytest.mark.parametrize("key", [1, None, True, ("a", "b")])
-def test_params_refuses_a_key_that_is_not_a_string(key):
-    """The hole the values check left, found one round later.
-
-    A non-string key does not fail loudly, it makes the backends disagree: an
-    integer key survives in memory and comes back as a string from anything that
-    serialises, and a key that is hashable but not a primitive records in memory
-    and raises on write. Both halves have to be strings for the two to agree.
-    """
-    with pytest.raises(ValueError, match="has to be text"):
-        Outcome(
-            **BASE,
-            offset=None,
-            stage="append",
-            status="refused",
-            params={key: "x"},
-        )
-
-
-@pytest.mark.parametrize("reason", [1, None, object(), ("nested",)])
-def test_reasons_must_be_codes_given_as_strings(reason):
-    """Same class as the params checks, and the field the pattern pointed at.
-
-    Rounds fixed `params` values, then `params` keys; `reasons` had both problems
-    and neither check. A non-string element records in memory and raises on write,
-    so the backends disagree about whether the outcome exists at all.
-    """
-    with pytest.raises(ValueError, match="has to be text"):
-        Outcome(
-            **BASE, offset=None, stage="append", status="refused", reasons=(reason,)
-        )
-
-
-@pytest.mark.parametrize(
-    "field", ["consumer", "stream_path", "subject", "sequence_key"]
-)
-@pytest.mark.parametrize("value", [uuid.uuid4(), 42, ("a", "b"), None])
-def test_the_name_fields_must_be_strings(field, value):
-    """The fifth instance of a defect four rounds closed one field at a time.
-
-    These are declared `str` and nothing made them so. A UUID subject is the case
-    that matters — the field is required, consumer-supplied, and documented as
-    opaque, which invites a model key — and it records in memory then raises on
-    write, so the two backends disagree about whether the record exists.
-    """
-    # Two refusals are correct here and which one fires depends on the field:
-    # `subject=None` is caught as an *empty* subject before anything asks whether it
-    # is text, and that is the better message for it. The test pins that one of them
-    # happens, not which — naming a single message would make it pass for the wrong
-    # reason on that one case.
-    # Which refusal fires depends on the value: `None` is caught as an empty name
-    # before anything asks whether it is text, and both answers are correct. The
-    # test pins that one of them happens, not which — naming a single message would
-    # make it pass for the wrong reason on that case.
-    with pytest.raises(ValueError):
-        Outcome(**{**BASE, field: value}, offset=None, stage="append", status="refused")
-
-
-@pytest.mark.parametrize("value", [42, ("a", "b"), uuid.uuid4()])
-def test_an_offset_must_be_a_string_when_there_is_one(value):
-    """An offset is an opaque token, never a number — parsing one is already
-    forbidden, and storing a non-string is the same coupling from the other end."""
-    with pytest.raises(ValueError, match="has to be text"):
-        Outcome(**BASE, offset=value, stage="project", status="failed")
 
 
 def test_an_outcome_does_not_change_when_the_caller_mutates_what_it_was_built_from():
-    """`frozen=True` freezes the binding, not the containers behind it.
-
-    Asserted on the object with no store involved, deliberately. The codec copies
-    on the way into storage, so every store is safe whether or not this holds — and
-    that is exactly why it needs its own test: without one, the copy here is
-    unpinned and reads as redundant, while the promise `frozen=True` makes to
-    anyone holding an outcome quietly stops being true.
-    """
+    """`frozen=True` freezes the binding, not the containers behind it."""
     reasons = ["missing_total"]
     params = {"row": "3"}
     outcome = Outcome(
@@ -172,9 +89,7 @@ def test_an_outcome_does_not_change_when_the_caller_mutates_what_it_was_built_fr
         reasons=reasons,
         params=params,
     )
-
     reasons.append("LEAKED")
     params["national_id"] = "1234-LEAK"
-
     assert outcome.reasons == ("missing_total",)
     assert outcome.params == {"row": "3"}

--- a/tests/test_rakaia/test_tier_boundary.py
+++ b/tests/test_rakaia/test_tier_boundary.py
@@ -71,7 +71,7 @@ PROTOCOL_SERVER = {
 #: format rules (`json_mode`, `offsets`) both tiers must agree on. ADR 0002 calls
 #: these out as the reason the tiers "genuinely share types today" — they are the
 #: substance of the split question, so a change here is the thing to look at.
-SHARED = {"types", "protocols", "json_mode", "offsets"}
+SHARED = {"types", "protocols", "json_mode", "offsets", "outcomes"}
 
 #: Deliberate, documented crossings. Keep this empty if you can; every entry is a
 #: thing a package split would have to resolve, so the list is the running cost

--- a/tests/test_rakaia/test_tier_boundary.py
+++ b/tests/test_rakaia/test_tier_boundary.py
@@ -58,6 +58,7 @@ PROTOCOL_SERVER = {
     "append_decision",
     "cursor",
     "handler",
+    "jsonl_outcomes",
     "jsonl_store",
     "migrate",
     "producer",

--- a/zensical.toml
+++ b/zensical.toml
@@ -59,6 +59,7 @@ nav = [
             { "ADR 0004 — Handler types & fold order" = "adr/0004-handler-types-and-fold-order.md" },
             { "ADR 0005 — Stream positions stay a counted offset" = "adr/0005-stream-positions-stay-a-counted-offset.md" },
             { "ADR 0006 — Changing a backend is a copy" = "adr/0006-changing-backends-is-a-copy.md" },
+            { "ADR 0007 — Where an outcome is recorded" = "adr/0007-an-outcome-is-recorded-where-the-cursor-is-committed.md" },
         ] },
     ] },
     { "Look it up" = [


### PR DESCRIPTION
Seven review findings across #243 were the same thing: a value one store kept and another altered or refused. Each fix was a better description of which values are allowed, and each description leaked, because the set it describes is open-ended — text that is a subclass of text, text no path can carry, text longer than a column allows. The last round found a bug in the description itself, in the two fields its own comment said it existed to protect.

This stops describing the set. The record renders itself to text, every store keeps that exact text, and whether something survives storage is settled by trying rather than by predicting — so the in-memory store is the file-backed one without the file rather than a second implementation that behaves similarly. Eighty-four lines and three functions go, including a hand-written type checker. The trade is real and worth arguing about before this is preferred to #243: a value of the wrong type that stores consistently is now accepted where it used to be refused, moving that check from run time to the type checker.