### PR TITLE
A stream called .. no longer writes outside the store

### DIFF
--- a/src/rakaia/jsonl_outcomes.py
+++ b/src/rakaia/jsonl_outcomes.py
@@ -24,9 +24,10 @@ Layout, one file per consumer and stream::
 
     <root>/<quoted consumer>/<quoted stream path>.jsonl
 
-`quote(safe="")` on both components for the reason `JsonlStreamStore._dir` gives:
-a stream path contains slashes and must map to one name, not a tree, and
-percent-encoding is the mapping that is reversible.
+Both components go through `JsonlStreamStore`'s `_contained`, which maps a name
+to one child of a directory and then checks that it landed there — the same
+single rule the stream store uses, rather than each store carrying its own idea
+of which names are dangerous.
 
 Sharing the stream store's limits, and for the same reasons: `fcntl` only, so no
 Windows; `flock` is unreliable on NFS; readers do not take the lock. A torn
@@ -47,36 +48,14 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
-from urllib.parse import quote
 
-from .jsonl_store import _discard_torn_tail
+from .jsonl_store import _contained, _discard_torn_tail
 from .outcomes import Outcome, _order, decode, encode
 
 try:  # pragma: no cover - platform dependent
     import fcntl
 except ImportError:  # pragma: no cover - Windows
     fcntl = None  # type: ignore[assignment]
-
-
-def _safe_name(name: str) -> str:
-    """One path segment for `name`, guaranteed to stay under its parent.
-
-    `quote(safe="")` maps a slash to `%2F`, which is what keeps a stream path a
-    name rather than a tree, and it is reversible. What it does **not** touch is a
-    dot: `quote("..")` is `".."`, so a consumer or stream called `..` resolves
-    above the root and writes outside the store entirely. Only an all-dot name can
-    do that — anything else already carries an encoded character — so those are the
-    ones encoded here, and an empty name, which would otherwise collapse a
-    directory level.
-
-    Found by a containment test rather than by review, and that is the point worth
-    keeping: an unencoded name still *round-trips*, so reading back what was
-    written passes while the file sits somewhere it should never have been.
-    """
-    quoted = quote(name, safe="")
-    if not quoted or set(quoted) <= {"."}:
-        return quoted.replace(".", "%2E") or "%00"
-    return quoted
 
 
 class JsonlOutcomeStore:
@@ -101,7 +80,7 @@ class JsonlOutcomeStore:
         self.root.mkdir(parents=True, exist_ok=True)
 
     def _file(self, consumer: str, stream_path: str) -> Path:
-        return self.root / _safe_name(consumer) / f"{_safe_name(stream_path)}.jsonl"
+        return _contained(_contained(self.root, consumer), stream_path, ".jsonl")
 
     def record(self, outcome: Outcome) -> None:
         target = self._file(outcome.consumer, outcome.stream_path)

--- a/src/rakaia/jsonl_store.py
+++ b/src/rakaia/jsonl_store.py
@@ -121,6 +121,48 @@ def _discard_torn_tail(fh: Any) -> None:
     fh.truncate(cut)
 
 
+def _contained(root: Path, name: str, suffix: str = "") -> Path:
+    """The path `name` maps to, *proven* to sit directly under `root`.
+
+    A caller-supplied name — a stream path, a consumer id — becomes exactly one
+    child of `root`. `quote(safe="")` does the mapping, because a stream path
+    contains slashes and a stream is one directory rather than a tree: `/a/b`
+    and `/a%2Fb` must not collide, and percent-encoding is the one mapping
+    `list_paths` can reverse.
+
+    What makes it safe is not the encoding, though. `quote` leaves a dot alone,
+    so a stream called `..` used to resolve *above* the root and write outside
+    the store entirely. The tempting repair is to extend the escaping until
+    every dangerous name is covered, and that is the losing move: the bad set is
+    open-ended, and the next encoding nobody thought of walks straight through.
+    So the rule here is the structural one instead — build the path,
+    canonicalise it, and check it really is a child of the root. Escaping the
+    dots is only the repair attempted when the check says no; the check, not a
+    list of known-bad names, is what decides. A name that still escapes after
+    the repair is refused rather than written.
+
+    Purely lexical, deliberately: the encoded name can never contain a
+    separator, so `normpath` collapsing `.` and `..` is the whole of the
+    canonicalisation, and no filesystem has to be touched on a path this hot.
+
+    Found by a containment test rather than by review, which is the part worth
+    remembering: an unencoded name still *round-trips*, so reading back what was
+    written passes while the file sits somewhere it should never have been.
+    """
+    base = Path(os.path.normpath(root))
+    encoded = quote(name, safe="")
+    candidate = Path(os.path.normpath(base / (encoded + suffix)))
+    if candidate.parent == base:
+        return candidate
+    # Outside, so re-encode and re-check. `%00` covers the empty name, which
+    # would otherwise collapse a level away rather than escape one.
+    encoded = encoded.replace(".", "%2E") or "%00"
+    candidate = Path(os.path.normpath(base / (encoded + suffix)))
+    if candidate.parent == base:
+        return candidate
+    raise ValueError(f"name {name!r} does not map to a path under {root}")
+
+
 #: Where retired offset high-marks live, as a sibling of the stream directories.
 #:
 #: The leading ``%`` is load-bearing. Stream directories are named
@@ -255,13 +297,8 @@ class JsonlStreamStore:
     # =========================================================================
 
     def _dir(self, path: str) -> Path:
-        """The directory for `path`.
-
-        `quote(safe="")` because a stream path contains slashes and a stream is
-        one directory, not a tree: `/a/b` and `/a%2Fb` must not collide, and
-        percent-encoding is the one mapping that is reversible for `list_paths`.
-        """
-        return self.root / quote(path, safe="")
+        """The directory for `path`, which `_contained` guarantees is under the root."""
+        return _contained(self.root, path)
 
     def _segment(self, path: str, entry_id: int) -> Path:
         start = (entry_id // self.segment_size) * self.segment_size
@@ -274,7 +311,7 @@ class JsonlStreamStore:
         return sorted(d.glob("*.jsonl"))
 
     def _retired_path(self, path: str) -> Path:
-        return self.root / _RETIRED_DIR / quote(path, safe="")
+        return _contained(self.root / _RETIRED_DIR, path)
 
     def _retired(self, path: str) -> int:
         f = self._retired_path(path)

--- a/src/rakaia/jsonl_store.py
+++ b/src/rakaia/jsonl_store.py
@@ -35,7 +35,10 @@ to be constructed rather than run unlocked), **NFS** (`flock` is not reliable
 across it), **readers do not take the lock**, and **appends are not broadcast**
 to live subscribers the way `DjangoStreamStore` broadcasts over channels, since
 this store cannot reach Django. `django_rakaia.checks` reports that last one as
-``rakaia.W002`` rather than leaving it to be discovered.
+``rakaia.W002`` rather than leaving it to be discovered. One more, added when
+it was found rather than left implied: a **symlink inside the root** still leads
+a write out of the store, because `_contained` checks containment lexically and
+a lexical check cannot see one. See its docstring for why that trade was taken.
 
 Two things this list used to name are now implemented, and the note is kept
 because their absence was a documented limitation: **fsync durability** is on by
@@ -141,9 +144,19 @@ def _contained(root: Path, name: str, suffix: str = "") -> Path:
     list of known-bad names, is what decides. A name that still escapes after
     the repair is refused rather than written.
 
-    Purely lexical, deliberately: the encoded name can never contain a
-    separator, so `normpath` collapsing `.` and `..` is the whole of the
-    canonicalisation, and no filesystem has to be touched on a path this hot.
+    The containment is *lexical*, and that is a real limit rather than a
+    detail. The encoded name can never contain a separator, so `normpath`
+    collapsing `.` and `..` covers every spelling a caller can put in a name —
+    but it cannot see a symlink, and a symlink planted inside the root still
+    leads a write out of the store. `Path.resolve()` would catch it — the name
+    would be refused rather than misplaced — at the cost of a filesystem walk on
+    a path taken on every single append. The trade
+    was taken because the two sides are not comparable threats: a name is
+    supplied by whoever calls the store, while the contents of the root are the
+    deployer's, and anyone who can create a directory entry inside the root can
+    write outside it whatever this function does. Named rather than glossed
+    over, and pinned by a strict `xfail` in `test_jsonl_containment.py` so the
+    limit is found deliberately instead of discovered.
 
     Found by a containment test rather than by review, which is the part worth
     remembering: an unencoded name still *round-trips*, so reading back what was

--- a/tests/test_rakaia/test_jsonl_containment.py
+++ b/tests/test_rakaia/test_jsonl_containment.py
@@ -8,10 +8,15 @@ hostile name in, then look at where the bytes actually went.
 
 Both stores are asked, because the rule they share (`_contained`) is the thing
 under test, not either store's copy of it.
+
+The last test in the file is the other half of honesty about that rule: it names
+the case the rule does *not* cover — a symlink planted inside the root — as a
+strict `xfail`, so the limit is read here rather than found in production.
 """
 
 from __future__ import annotations
 
+import contextlib
 from pathlib import Path
 
 import pytest
@@ -147,3 +152,39 @@ def test_a_contained_name_still_says_which_stream_it_was(tmp_path: Path):
         store.create(name)
 
     assert sorted(store.list_paths()) == sorted(names)
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "Known limit, named rather than discovered (#246 review): `_contained` "
+        "checks containment lexically, and a lexical check cannot see a symlink. "
+        "A symlink planted inside the root therefore still leads a write out of "
+        "the store. `Path.resolve()` would catch it — refusing the name rather "
+        "than misplacing it — at the cost of a filesystem walk on every append, "
+        "while the root's contents are the deployer's rather than a caller's, so "
+        "the trade was taken deliberately. Strict, so the day someone resolves "
+        "instead this reports XPASS and the marker comes off."
+    ),
+)
+def test_a_symlink_inside_the_root_does_not_lead_a_write_out_of_it(tmp_path: Path):
+    """The strong reading of containment, which the lexical check does not hold.
+
+    Distinct from every case above: the hostile input there is the *name*, which
+    a caller supplies. Here the name is ordinary and the *root* has been prepared,
+    which takes an actor who can already write inside the store.
+    """
+    root = tmp_path / "streams"
+    root.mkdir()
+    outside = tmp_path / "elsewhere"
+    outside.mkdir()
+    (root / "link").symlink_to(outside)
+
+    store = JsonlStreamStore(root, fsync=False)
+    # Refusing the name is as good an answer as containing it, so a `ValueError`
+    # counts as holding the property rather than as failing to reach the check.
+    with contextlib.suppress(ValueError):
+        store.create("link")
+        store.append("link", b'{"n": 1}', AppendOptions())
+
+    assert not list(outside.iterdir()), "a symlink in the root led the write outside"

--- a/tests/test_rakaia/test_jsonl_containment.py
+++ b/tests/test_rakaia/test_jsonl_containment.py
@@ -1,0 +1,149 @@
+"""Every file a file-backed store writes lands under its own root (#246).
+
+The property, and the reason this file exists rather than another read-back
+test: a stream called `..` used to *round-trip* perfectly while its segments sat
+in the store root's parent directory, so a test that writes a name and reads it
+back passed and review saw nothing. Containment is what catches it — put a
+hostile name in, then look at where the bytes actually went.
+
+Both stores are asked, because the rule they share (`_contained`) is the thing
+under test, not either store's copy of it.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from rakaia.jsonl_outcomes import JsonlOutcomeStore
+from rakaia.jsonl_store import JsonlStreamStore
+from rakaia.outcomes import Outcome
+from rakaia.types import AppendOptions
+
+#: Names that have to stay inside. `..` and `../escape` traverse outright; `a/b`
+#: and `a%2Fb` are the pair that must not collide once slashes are encoded;
+#: `%2e%2e` and `%252e%252e` are the singly- and doubly-encoded spellings of
+#: `..` that defeat a filter which merely looks for dots; `.` and the empty name
+#: are the two that name a directory instead of a child of one.
+HOSTILE = [
+    "..",
+    "../escape",
+    "../../escape",
+    "a/b",
+    "a%2Fb",
+    "%2e%2e",
+    "%252e%252e",
+    ".",
+    "",
+]
+
+
+def _files_under(directory: Path) -> list[Path]:
+    return [p for p in directory.rglob("*") if p.is_file()]
+
+
+@pytest.mark.parametrize("name", HOSTILE)
+def test_a_stream_writes_only_under_the_store_root(tmp_path: Path, name: str):
+    """Nothing the stream store writes for `name` escapes the root.
+
+    `sandbox` is the parent, and it is checked as well as the root: the original
+    defect wrote a perfectly valid stream directory, just one level too high, so
+    "the root holds the right files" is only half the assertion. Nothing may
+    appear beside the root either.
+    """
+    sandbox = tmp_path / "sandbox"
+    root = sandbox / "streams"
+    store = JsonlStreamStore(root, fsync=False)
+
+    store.create(name)
+    store.append(name, b'{"n": 1}', AppendOptions())
+
+    written = _files_under(sandbox)
+    assert written, "the append wrote nothing at all"
+    for path in written:
+        assert root in path.parents, f"{path} escaped {root}"
+        # Directly under the root, one directory deep: a stream is one
+        # directory, never a tree.
+        assert path.parent.parent == root, f"{path} is not in a stream directory"
+
+
+#: The same names an outcome can carry. The empty one is missing because
+#: `Outcome` refuses it at construction (`test_outcome_validation.py`), so it
+#: never reaches a path — a stream path may still be empty, which is why the
+#: stream list above keeps it.
+HOSTILE_OUTCOME_NAMES = [n for n in HOSTILE if n != ""]
+
+
+@pytest.mark.parametrize("name", HOSTILE_OUTCOME_NAMES)
+@pytest.mark.parametrize("field", ["consumer", "stream_path"])
+def test_an_outcome_writes_only_under_the_store_root(
+    tmp_path: Path, field: str, name: str
+):
+    """The same for the outcome store, with the hostile name in either component.
+
+    A consumer id and a stream path are names, not paths: one directory per
+    consumer, one file per stream, nothing deeper and nothing above. The last
+    assertion is the read-back that is *not* the point — it is here only so a fix
+    cannot buy containment by losing the outcome.
+    """
+    sandbox = tmp_path / "sandbox"
+    root = sandbox / "outcomes"
+    store = JsonlOutcomeStore(root, fsync=False)
+    fixed = {"consumer": "c", "stream_path": "s"}
+    scope = {**fixed, field: name}
+
+    store.record(
+        Outcome(
+            **scope,
+            subject="row-1",
+            offset="0000000001",
+            sequence_key="seq",
+            stage="project",
+            status="failed",
+            reasons=(name,),
+        )
+    )
+
+    written = _files_under(sandbox)
+    assert written, "the record wrote nothing at all"
+    for path in written:
+        assert root in path.parents, f"{path} escaped {root}"
+        assert path.parent.parent == root, f"{path} is not in a consumer directory"
+
+    assert [
+        o.reasons for o in store.latest(scope["consumer"], scope["stream_path"])
+    ] == [(name,)]
+
+
+def test_hostile_names_do_not_collide_with_each_other(tmp_path: Path):
+    """Containment must not be bought by mapping several names onto one place.
+
+    Two streams sharing a directory would mix their logs, which is a worse bug
+    than the one being fixed.
+    """
+    root = tmp_path / "streams"
+    store = JsonlStreamStore(root, fsync=False)
+    distinct = [n for n in HOSTILE if n != ""]
+
+    for name in distinct:
+        store.create(name)
+
+    directories = {store._dir(name) for name in distinct}
+    assert len(directories) == len(distinct)
+
+
+def test_a_contained_name_still_says_which_stream_it_was(tmp_path: Path):
+    """Encoding stays reversible, so `list_paths` reports the names it was given.
+
+    Not the property that catches the bug — that is containment above — but the
+    one a fix could quietly break while the containment test went green.
+    """
+    root = tmp_path / "streams"
+    store = JsonlStreamStore(root, fsync=False)
+    names = [n for n in HOSTILE if n != ""]
+
+    for name in names:
+        store.create(name)
+
+    assert sorted(store.list_paths()) == sorted(names)

--- a/tests/test_rakaia/test_jsonl_outcome_store_contract.py
+++ b/tests/test_rakaia/test_jsonl_outcome_store_contract.py
@@ -47,49 +47,10 @@ class TestJsonlOutcomeStoreDurability:
         [got] = JsonlOutcomeStore(root, fsync=False).latest("c", "submission/tf611")
         assert got.reasons == ("bad_total",)
 
-    # The empty string used to be here. It is now refused at construction — an empty
-    # name collides with whatever else escapes to the same path segment — so the case
-    # this file covered moved to `test_the_names_cannot_be_empty`.
-    @pytest.mark.parametrize("hostile", ["a/b", "../escape", "..", "a%2Fb"])
-    @pytest.mark.parametrize("field", ["consumer", "stream_path"])
-    def test_every_file_stays_directly_under_the_root(
-        self, tmp_path: Path, field: str, hostile: str
-    ):
-        """A consumer id and a stream path are names, not paths.
-
-        Asserted as *containment*, not as a round trip. Leaving either component
-        unencoded still round-trips — `a/b` reads back from `root/a/b/…` exactly as
-        it was written — so a read-what-you-wrote test passes while `../escape`
-        writes outside the root entirely. The property worth holding is the layout:
-        one directory per consumer, one file per stream, nothing deeper and nothing
-        above.
-        """
-        from rakaia.outcomes import Outcome
-
-        root = tmp_path / "outcomes"
-        store = JsonlOutcomeStore(root, fsync=False)
-        fixed = {"consumer": "c", "stream_path": "s"}
-        store.record(
-            Outcome(
-                **{**fixed, field: hostile},
-                subject="row-1",
-                offset="0000000001",
-                sequence_key="seq",
-                stage="project",
-                status="failed",
-                reasons=(hostile,),
-            )
-        )
-
-        written = list(root.rglob("*.jsonl"))
-        assert len(written) == 1
-        assert written[0].parent.parent == root, "a name became a directory tree"
-        assert not list(tmp_path.glob("*.jsonl")), "a name escaped the root"
-
-        scope = {**fixed, field: hostile}
-        assert [
-            o.reasons for o in store.latest(scope["consumer"], scope["stream_path"])
-        ] == [(hostile,)]
+    # Containment — every file directly under the root, whatever the consumer id
+    # or stream path is called — lives in `test_jsonl_containment.py`, with the
+    # stream store beside it, because the two share one rule and it is the rule
+    # under test rather than either store's use of it (#246).
 
     def test_a_torn_trailing_line_is_skipped_not_fatal(self, tmp_path: Path):
         """A crash mid-append leaves half a line. Skipping it loses one outcome;


### PR DESCRIPTION
The file-backed stores turned a stream or consumer name into a folder name by escaping anything that looked like a path separator. A name made only of dots slipped through that, so a stream called `..` put its data in the folder above the store instead of inside it. It went unnoticed because the data still read back correctly — the only thing wrong was where it sat.

Both stores now work the other way round: build the intended location, then check it really is inside the store, and only fall back to further escaping when the check says otherwise. One rule in one place, instead of each store keeping its own list of names it thinks are dangerous. New tests put a range of hostile names through both stores and confirm every file lands where it should. Closes #246.