### PR TITLE
Keep a consumer's outcomes in the database

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -39,6 +39,13 @@ else an outcome carries is unbounded. If your names can run longer than that,
 they will not fit, and you will see the refusal when the outcome is recorded
 rather than when it is read back.
 
+One more thing to know if you wrap your own consuming in a transaction. By
+default the store writes on whichever connection is already open, so a record
+written inside a block that later rolls back is rolled back with it — the record
+of the failure goes down with the failure. Pass `using=` a database alias your
+own transaction does not cover if you need the record to survive that; there is a
+test stating both numbers.
+
 ---
 
 # 0.3.0

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -15,6 +15,32 @@ ones you are crossing.
 
 ---
 
+# Unreleased
+
+## A new table for the outcomes a consumer records
+
+There is a new migration, `django_rakaia` `0010`, adding one table:
+`rakaia_consumeroutcome`. Run `manage.py migrate django_rakaia` when you upgrade.
+
+Nothing existing changes and nothing writes to the table on its own. It is where
+`django_rakaia.outcomes.DjangoOutcomeStore` keeps a record of an event a consumer
+could not apply — the third place outcomes can be kept, after the in-memory
+reference and the JSONL files — and only a consumer that asks for that store ever
+puts a row in it. A consumer that never fails, or never uses the store, carries an
+empty table and nothing else; outcomes record exceptions only, so there is no row
+per applied event.
+
+One thing to know before you point a consumer at it. Four of the values are kept
+in bounded columns, at the same widths `ConsumerCursor` already uses — the
+consumer name at 128 characters, the stream path and the subject at 255, the
+offset at 64 — and the store refuses an outcome whose name is longer rather than
+shortening it, because a shortened subject is a different subject. Everything
+else an outcome carries is unbounded. If your names can run longer than that,
+they will not fit, and you will see the refusal when the outcome is recorded
+rather than when it is read back.
+
+---
+
 # 0.3.0
 
 ## A replay applies a whole pass of effects at once, not one event at a time

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -37,10 +37,12 @@ wrong.
 
 The one thing to know if you plan to read the table directly rather than through
 the store. The `payload` column is the record: it holds the whole outcome as text,
-and `rakaia.outcomes.decode` turns it back into one. The columns ending in `_key`
-are an index over that text, not a copy of it — each holds a percent-encoded,
-possibly shortened form of the value, so `stream_path_key` for `submission/tf611`
-reads `submission%2Ftf611`. Query them to find rows; read the payload for values.
+and `rakaia.outcomes.decode` turns it back into one. The two columns ending in
+`_key` are the scope index over that text, not a copy of it — each holds a
+percent-encoded, possibly shortened form of the value, so `stream_path_key` for
+`submission/tf611` reads `submission%2Ftf611`. Use them to find the rows for a
+consumer and a stream; read everything else, the subject and offset included, out
+of the payload.
 
 One more thing to know if you wrap your own consuming in a transaction. By
 default the store writes on whichever connection is already open, so a record

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -30,14 +30,17 @@ puts a row in it. A consumer that never fails, or never uses the store, carries 
 empty table and nothing else; outcomes record exceptions only, so there is no row
 per applied event.
 
-One thing to know before you point a consumer at it. Four of the values are kept
-in bounded columns, at the same widths `ConsumerCursor` already uses — the
-consumer name at 128 characters, the stream path and the subject at 255, the
-offset at 64 — and the store refuses an outcome whose name is longer rather than
-shortening it, because a shortened subject is a different subject. Everything
-else an outcome carries is unbounded. If your names can run longer than that,
-they will not fit, and you will see the refusal when the outcome is recorded
-rather than when it is read back.
+Recording never refuses. Whatever your consumer names its streams and subjects —
+any length, any character — the record is kept whole, so a bad name cannot turn
+into a failed write on the path whose job is to record that something already went
+wrong.
+
+The one thing to know if you plan to read the table directly rather than through
+the store. The `payload` column is the record: it holds the whole outcome as text,
+and `rakaia.outcomes.decode` turns it back into one. The columns ending in `_key`
+are an index over that text, not a copy of it — each holds a percent-encoded,
+possibly shortened form of the value, so `stream_path_key` for `submission/tf611`
+reads `submission%2Ftf611`. Query them to find rows; read the payload for values.
 
 One more thing to know if you wrap your own consuming in a transaction. By
 default the store writes on whichever connection is already open, so a record

--- a/docs/public-api.md
+++ b/docs/public-api.md
@@ -45,8 +45,8 @@ is why the package exported nothing for so long.
 ### Tier 2 — Provisional: the ORM models and the database schema
 
 `django_rakaia.models` — `Stream`, `StreamEvent`, `StreamEntry`,
-`StreamProducer`, `StreamOffsetWatermark`, `ConsumerCursor` — plus the table
-shape behind them.
+`StreamProducer`, `StreamOffsetWatermark`, `ConsumerCursor`, `ConsumerOutcome`
+— plus the table shape behind them.
 
 **These are usable, and deliberately not in `__all__`.** Importing them from
 `django_rakaia.models` keeps the weaker guarantee visible at the import site

--- a/src/django_rakaia/migrations/0010_consumeroutcome.py
+++ b/src/django_rakaia/migrations/0010_consumeroutcome.py
@@ -7,6 +7,10 @@ class Migration(migrations.Migration):
     A record of what happened to an event a consumer could not apply, kept beside
     the cursor that says how far it got. Empty for a consumer that never fails —
     only exceptions are recorded — so the cost of having it is the table itself.
+
+    ``payload`` is the record. The ``_key`` columns are a percent-encoded index
+    over it, cut to the width, so no consumer-supplied name can be a value the
+    column refuses; see the model for why a cut key is still a correct index.
     """
 
     dependencies = [
@@ -26,11 +30,10 @@ class Migration(migrations.Migration):
                         verbose_name="ID",
                     ),
                 ),
-                ("consumer", models.CharField(max_length=128)),
-                ("stream_path", models.CharField(max_length=255)),
-                ("subject", models.CharField(max_length=255)),
-                ("offset", models.CharField(blank=True, max_length=64, null=True)),
-                ("attempt", models.PositiveIntegerField()),
+                ("consumer_key", models.CharField(max_length=128)),
+                ("stream_path_key", models.CharField(max_length=255)),
+                ("subject_key", models.CharField(max_length=255)),
+                ("offset_key", models.CharField(blank=True, max_length=64, null=True)),
                 ("payload", models.TextField()),
                 ("recorded_at", models.DateTimeField(auto_now_add=True)),
             ],
@@ -38,7 +41,7 @@ class Migration(migrations.Migration):
                 "db_table": "rakaia_consumeroutcome",
                 "indexes": [
                     models.Index(
-                        fields=["consumer", "stream_path"],
+                        fields=["consumer_key", "stream_path_key"],
                         name="rakaia_outcome_scope_idx",
                     )
                 ],

--- a/src/django_rakaia/migrations/0010_consumeroutcome.py
+++ b/src/django_rakaia/migrations/0010_consumeroutcome.py
@@ -8,9 +8,11 @@ class Migration(migrations.Migration):
     the cursor that says how far it got. Empty for a consumer that never fails —
     only exceptions are recorded — so the cost of having it is the table itself.
 
-    ``payload`` is the record. The ``_key`` columns are a percent-encoded index
-    over it, cut to the width, so no consumer-supplied name can be a value the
-    column refuses; see the model for why a cut key is still a correct index.
+    ``payload`` is the record. The two ``_key`` columns are a percent-encoded
+    index over it, cut to the width, so no consumer-supplied name can be a value
+    the column refuses; they are the scope `latest` queries by, and everything
+    else an outcome carries lives in the payload. See the model for why a cut key
+    is still a correct index.
     """
 
     dependencies = [
@@ -32,8 +34,6 @@ class Migration(migrations.Migration):
                 ),
                 ("consumer_key", models.CharField(max_length=128)),
                 ("stream_path_key", models.CharField(max_length=255)),
-                ("subject_key", models.CharField(max_length=255)),
-                ("offset_key", models.CharField(blank=True, max_length=64, null=True)),
                 ("payload", models.TextField()),
                 ("recorded_at", models.DateTimeField(auto_now_add=True)),
             ],

--- a/src/django_rakaia/migrations/0010_consumeroutcome.py
+++ b/src/django_rakaia/migrations/0010_consumeroutcome.py
@@ -1,0 +1,47 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    """The table behind `django_rakaia.outcomes.DjangoOutcomeStore`.
+
+    A record of what happened to an event a consumer could not apply, kept beside
+    the cursor that says how far it got. Empty for a consumer that never fails —
+    only exceptions are recorded — so the cost of having it is the table itself.
+    """
+
+    dependencies = [
+        ("django_rakaia", "0009_alter_stream_last_seq"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="ConsumerOutcome",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("consumer", models.CharField(max_length=128)),
+                ("stream_path", models.CharField(max_length=255)),
+                ("subject", models.CharField(max_length=255)),
+                ("offset", models.CharField(blank=True, max_length=64, null=True)),
+                ("attempt", models.PositiveIntegerField()),
+                ("payload", models.TextField()),
+                ("recorded_at", models.DateTimeField(auto_now_add=True)),
+            ],
+            options={
+                "db_table": "rakaia_consumeroutcome",
+                "indexes": [
+                    models.Index(
+                        fields=["consumer", "stream_path"],
+                        name="rakaia_outcome_scope_idx",
+                    )
+                ],
+            },
+        ),
+    ]

--- a/src/django_rakaia/models.py
+++ b/src/django_rakaia/models.py
@@ -412,3 +412,64 @@ class ConsumerCursor(models.Model):
 
     def __str__(self) -> str:
         return f"{self.consumer_id}@{self.stream_path}={self.offset}"
+
+
+class ConsumerOutcome(models.Model):
+    """A durable record of one event a consumer could not apply cleanly.
+
+    The table behind `django_rakaia.outcomes.DjangoOutcomeStore`, and the third
+    place an outcome can be kept after the in-memory reference and the JSONL
+    files. It sits beside `ConsumerCursor` and is scoped the same way: a cursor
+    says how far a consumer got, a row here says what went wrong on the way, and
+    ``(consumer, stream_path)`` addresses both.
+
+    ``payload`` holds the whole outcome as `rakaia.outcomes.encode` rendered it,
+    which is the same text the other two stores keep — ADR 0007 Decision 6b. The
+    columns beside it are not a second copy of the record; they are the four
+    values `latest` has to filter, group and order by, lifted out so that work
+    happens in the database rather than over every decoded row. Everything else
+    an outcome carries — the reasons, the parameters, the sequence key, the stage
+    and the status — is in the payload only, so a field added to `Outcome` needs
+    no migration here.
+
+    There is no unique constraint, deliberately. Outcomes are append-only
+    (Decision 6a): a second attempt is a new row, and even a repeat of an attempt
+    already recorded is appended rather than overwritten, with `latest` taking the
+    last one written. A constraint would turn an append into an error on the one
+    path whose whole job is to record that something already went wrong.
+    """
+
+    consumer = models.CharField(max_length=128)
+    """Who this is about. Pairs with ``ConsumerCursor.consumer_id`` and is the
+    same width, so a consumer that can hold a cursor can hold an outcome."""
+
+    stream_path = models.CharField(max_length=255)
+    """The stream the event belongs to, at ``ConsumerCursor.stream_path``'s width."""
+
+    subject = models.CharField(max_length=255)
+    """What the outcome is about, as the consumer names it. A name of the same
+    order as a stream path, so it gets the same width."""
+
+    offset = models.CharField(max_length=64, null=True, blank=True)
+    """The event's position, or NULL for an append-stage outcome — an event that
+    never reached the log has none. ``ConsumerCursor.offset``'s width."""
+
+    attempt = models.PositiveIntegerField()
+    """Which try this was, from 1. Highest wins in `latest`."""
+
+    payload = models.TextField()
+    """The whole outcome, as `rakaia.outcomes.encode` wrote it."""
+
+    recorded_at = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        db_table = "rakaia_consumeroutcome"
+        indexes = [
+            models.Index(
+                fields=["consumer", "stream_path"],
+                name="rakaia_outcome_scope_idx",
+            )
+        ]
+
+    def __str__(self) -> str:
+        return f"{self.consumer}@{self.stream_path}/{self.subject}#{self.attempt}"

--- a/src/django_rakaia/models.py
+++ b/src/django_rakaia/models.py
@@ -420,45 +420,62 @@ class ConsumerOutcome(models.Model):
     The table behind `django_rakaia.outcomes.DjangoOutcomeStore`, and the third
     place an outcome can be kept after the in-memory reference and the JSONL
     files. It sits beside `ConsumerCursor` and is scoped the same way: a cursor
-    says how far a consumer got, a row here says what went wrong on the way, and
-    ``(consumer, stream_path)`` addresses both.
+    says how far a consumer got, a row here says what went wrong on the way.
 
-    ``payload`` holds the whole outcome as `rakaia.outcomes.encode` rendered it,
-    which is the same text the other two stores keep — ADR 0007 Decision 6b. The
-    columns beside it are not a second copy of the record; they are the four
-    values `latest` has to filter, group and order by, lifted out so that work
-    happens in the database rather than over every decoded row. Everything else
-    an outcome carries — the reasons, the parameters, the sequence key, the stage
-    and the status — is in the payload only, so a field added to `Outcome` needs
-    no migration here.
+    ``payload`` is the record. It holds the whole outcome as
+    `rakaia.outcomes.encode` rendered it, which is the same text the other two
+    stores keep — ADR 0007 Decision 6b — and `decode` is the only way back out of
+    it.
+
+    **The ``_key`` columns are an index over the payload, not a second copy of
+    it.** Each holds `urllib.parse.quote(value, safe="")`, cut to the column
+    width. That is the JSONL store's answer to the same question, borrowed: it
+    already had to turn an arbitrary consumer-supplied string into something a
+    filesystem would accept as one path segment, and making a string acceptable
+    to a filesystem and making it acceptable to a ``varchar`` are the same
+    problem. Percent-encoded ASCII is the total answer to both — no NUL, no
+    control bytes, no encoding a database can refuse, and injective, so two
+    different names never collide.
+
+    They are named ``_key`` rather than ``consumer``/``subject`` because reading
+    one and expecting the value the consumer passed is the mistake the shape
+    invites. ``stream_path_key`` for ``submission/tf611`` is
+    ``submission%2Ftf611``. The value is in the payload.
+
+    Cutting to the width is safe for the same reason: a prefix of an index is
+    still an index. Two names sharing a prefix land on one key and the query
+    returns both, and the payload comparison in `latest` drops the one that does
+    not belong. It costs selectivity and never correctness — which is why the
+    widths below are a prefix length, not a capacity, and why nothing here can
+    refuse a name for being too long.
 
     There is no unique constraint, deliberately. Outcomes are append-only
     (Decision 6a): a second attempt is a new row, and even a repeat of an attempt
     already recorded is appended rather than overwritten, with `latest` taking the
     last one written. A constraint would turn an append into an error on the one
     path whose whole job is to record that something already went wrong.
+
+    ``attempt`` is not a column at all. It is a counter rather than a name,
+    nothing queries it — `latest` reads it from the payload — and as an
+    ``int4`` it was the one field a database could still refuse.
     """
 
-    consumer = models.CharField(max_length=128)
-    """Who this is about. Pairs with ``ConsumerCursor.consumer_id`` and is the
-    same width, so a consumer that can hold a cursor can hold an outcome."""
+    consumer_key = models.CharField(max_length=128)
+    """Quoted `Outcome.consumer`, cut to `ConsumerCursor.consumer_id`'s width."""
 
-    stream_path = models.CharField(max_length=255)
-    """The stream the event belongs to, at ``ConsumerCursor.stream_path``'s width."""
+    stream_path_key = models.CharField(max_length=255)
+    """Quoted `Outcome.stream_path`, at `ConsumerCursor.stream_path`'s width."""
 
-    subject = models.CharField(max_length=255)
-    """What the outcome is about, as the consumer names it. A name of the same
-    order as a stream path, so it gets the same width."""
+    subject_key = models.CharField(max_length=255)
+    """Quoted `Outcome.subject`. A name of the same order as a stream path, so it
+    gets the same prefix length."""
 
-    offset = models.CharField(max_length=64, null=True, blank=True)
-    """The event's position, or NULL for an append-stage outcome — an event that
-    never reached the log has none. ``ConsumerCursor.offset``'s width."""
-
-    attempt = models.PositiveIntegerField()
-    """Which try this was, from 1. Highest wins in `latest`."""
+    offset_key = models.CharField(max_length=64, null=True, blank=True)
+    """Quoted `Outcome.offset`, or NULL for an append-stage outcome — an event
+    that never reached the log has no position. `ConsumerCursor.offset`'s width."""
 
     payload = models.TextField()
-    """The whole outcome, as `rakaia.outcomes.encode` wrote it."""
+    """The whole outcome, as `rakaia.outcomes.encode` wrote it. The record."""
 
     recorded_at = models.DateTimeField(auto_now_add=True)
 
@@ -466,10 +483,10 @@ class ConsumerOutcome(models.Model):
         db_table = "rakaia_consumeroutcome"
         indexes = [
             models.Index(
-                fields=["consumer", "stream_path"],
+                fields=["consumer_key", "stream_path_key"],
                 name="rakaia_outcome_scope_idx",
             )
         ]
 
     def __str__(self) -> str:
-        return f"{self.consumer}@{self.stream_path}/{self.subject}#{self.attempt}"
+        return f"{self.consumer_key}@{self.stream_path_key}/{self.subject_key}"

--- a/src/django_rakaia/models.py
+++ b/src/django_rakaia/models.py
@@ -427,8 +427,8 @@ class ConsumerOutcome(models.Model):
     stores keep — ADR 0007 Decision 6b — and `decode` is the only way back out of
     it.
 
-    **The ``_key`` columns are an index over the payload, not a second copy of
-    it.** Each holds `urllib.parse.quote(value, safe="")`, cut to the column
+    **The two ``_key`` columns are the scope index, and nothing else is a
+    column.** Each holds `urllib.parse.quote(value, safe="")`, cut to the column
     width. That is the JSONL store's answer to the same question, borrowed: it
     already had to turn an arbitrary consumer-supplied string into something a
     filesystem would accept as one path segment, and making a string acceptable
@@ -437,27 +437,40 @@ class ConsumerOutcome(models.Model):
     control bytes, no encoding a database can refuse, and injective, so two
     different names never collide.
 
-    They are named ``_key`` rather than ``consumer``/``subject`` because reading
-    one and expecting the value the consumer passed is the mistake the shape
-    invites. ``stream_path_key`` for ``submission/tf611`` is
+    They are named ``_key`` rather than ``consumer``/``stream_path`` because
+    reading one and expecting the value the consumer passed is the mistake the
+    shape invites. ``stream_path_key`` for ``submission/tf611`` is
     ``submission%2Ftf611``. The value is in the payload.
 
     Cutting to the width is safe for the same reason: a prefix of an index is
-    still an index. Two names sharing a prefix land on one key and the query
-    returns both, and the payload comparison in `latest` drops the one that does
-    not belong. It costs selectivity and never correctness — which is why the
-    widths below are a prefix length, not a capacity, and why nothing here can
-    refuse a name for being too long.
+    still an index. Two names sharing a prefix land on one key, `latest` fetches
+    both — there is no ``LIMIT``, so a cut key can only over-fetch — and the
+    payload comparison drops the one that does not belong. It costs selectivity
+    and never correctness, which is why the widths below are a prefix length, not
+    a capacity, and why nothing here can refuse a name for being too long.
+
+    **There are exactly two because `latest(consumer, stream_path)` is the only
+    query.** `subject` and `offset` were columns for one round and were written
+    and never read: `latest` groups by subject and orders by offset in Python,
+    from the payload. An index nothing queries is not free — it is two derived
+    writes per record, and a ``subject_key`` holding a cut, percent-encoded
+    string is a trap for the next reader, who will take it for the subject and
+    get a value that is neither the subject nor reliably distinct from another
+    one. When the operator worklist ADR 0007 sketches arrives it can add the
+    column the query actually wants; the ADR's own complaint about the motivating
+    consumer is that it has "neither a retention policy nor an index supporting
+    the query its two hot paths run", which is an argument for indexes that match
+    real queries and against carrying ones that match imagined queries.
+
+    ``attempt`` is not a column either, for the same reason plus one more. It is
+    a counter rather than a name, `latest` reads it from the payload, and as an
+    ``int4`` it was the one field a database could still refuse.
 
     There is no unique constraint, deliberately. Outcomes are append-only
     (Decision 6a): a second attempt is a new row, and even a repeat of an attempt
     already recorded is appended rather than overwritten, with `latest` taking the
     last one written. A constraint would turn an append into an error on the one
     path whose whole job is to record that something already went wrong.
-
-    ``attempt`` is not a column at all. It is a counter rather than a name,
-    nothing queries it — `latest` reads it from the payload — and as an
-    ``int4`` it was the one field a database could still refuse.
     """
 
     consumer_key = models.CharField(max_length=128)
@@ -465,14 +478,6 @@ class ConsumerOutcome(models.Model):
 
     stream_path_key = models.CharField(max_length=255)
     """Quoted `Outcome.stream_path`, at `ConsumerCursor.stream_path`'s width."""
-
-    subject_key = models.CharField(max_length=255)
-    """Quoted `Outcome.subject`. A name of the same order as a stream path, so it
-    gets the same prefix length."""
-
-    offset_key = models.CharField(max_length=64, null=True, blank=True)
-    """Quoted `Outcome.offset`, or NULL for an append-stage outcome — an event
-    that never reached the log has no position. `ConsumerCursor.offset`'s width."""
 
     payload = models.TextField()
     """The whole outcome, as `rakaia.outcomes.encode` wrote it. The record."""
@@ -489,4 +494,6 @@ class ConsumerOutcome(models.Model):
         ]
 
     def __str__(self) -> str:
-        return f"{self.consumer_key}@{self.stream_path_key}/{self.subject_key}"
+        # The scope plus the row id: a scope holds many outcomes and nothing here
+        # is unique on its own, so naming a subject would suggest otherwise.
+        return f"{self.consumer_key}@{self.stream_path_key}#{self.pk}"

--- a/src/django_rakaia/outcomes.py
+++ b/src/django_rakaia/outcomes.py
@@ -1,0 +1,111 @@
+"""Durable outcomes backed by the ``ConsumerOutcome`` model.
+
+The third `OutcomeStore` after the in-memory reference and the JSONL files, and
+the thin persistence layer `django_rakaia.subscription` is for cursors: the
+decision about what to record is store-agnostic and lives in `rakaia.outcomes`,
+and only the keeping of it is Django-shaped.
+
+What is kept is the **encoded text**, exactly as the other two stores keep it —
+ADR 0007 Decision 6b. The columns beside it exist so `latest` can filter and
+order in SQL, not so a reader can reconstruct an outcome from them; the payload
+is the record, and `decode` is the only way back out of it. That is what stops
+three backends developing three opinions about what was stored.
+
+**Lengths are checked here, not left to the database, and that is the one place
+this store deliberately does more than pass a value through.** The columns are
+bounded — the widths `ConsumerCursor` already uses — and the two databases this
+suite runs on disagree about what a bounded column means: Postgres refuses an
+over-long value, SQLite keeps it. ADR 0007 predicted exactly that ("a backend
+with a bounded column accepts a name every other backend keeps and then refuses
+or truncates it"), and a store whose behaviour depends on which database is under
+it is the same defect the shared codec exists to prevent, one level down. So the
+check runs in Python, before the insert, against the model's own declared widths
+— read from the field, so the rule cannot drift from the column — and both
+databases then refuse the same value with the same error.
+
+Refusing rather than truncating, because a truncated subject is a *different*
+subject: it would collapse two rows into one and report the first as speaking for
+the rest, which is the defect the `subject` field was introduced to fix.
+"""
+
+from __future__ import annotations
+
+from rakaia.outcomes import Outcome, _order, decode, encode
+
+from .models import ConsumerOutcome
+
+#: The bounded columns, in the order a caller most likely got one wrong.
+_BOUNDED = ("consumer", "stream_path", "subject", "offset")
+
+
+def _check_widths(outcome: Outcome) -> None:
+    """Refuse anything a bounded column cannot hold, identically on any database.
+
+    Widths come from the model rather than from constants here, so widening a
+    column widens the check with it and there is no second declaration to forget.
+    """
+    too_long = []
+    for name in _BOUNDED:
+        value = getattr(outcome, name)
+        if value is None:
+            continue
+        limit = ConsumerOutcome._meta.get_field(name).max_length
+        assert limit is not None  # every name in `_BOUNDED` is a CharField
+        if len(value) > limit:
+            too_long.append(
+                f"{name} is {len(value)} characters, the column holds {limit}"
+            )
+    if too_long:
+        raise ValueError(
+            "This store keeps the names in bounded columns and one of them does not "
+            f"fit: {'; '.join(too_long)}. Shorten it — truncating here would file the "
+            "outcome under a subject that is not the one it is about."
+        )
+
+
+class DjangoOutcomeStore:
+    """Outcomes kept as rows in ``rakaia_consumeroutcome``.
+
+    Holds no state, so one instance is as good as another and a caller may build
+    it wherever it needs one.
+    """
+
+    def record(self, outcome: Outcome) -> None:
+        _check_widths(outcome)
+        # `encode` first and store what it returns: the same text the in-memory
+        # store holds in a list and the file-backed one writes as a line. Nothing
+        # here renders an outcome its own way, so there is nothing for the three
+        # backends to disagree about.
+        ConsumerOutcome.objects.create(
+            consumer=outcome.consumer,
+            stream_path=outcome.stream_path,
+            subject=outcome.subject,
+            offset=outcome.offset,
+            attempt=outcome.attempt,
+            payload=encode(outcome),
+        )
+
+    def latest(self, consumer: str, stream_path: str) -> list[Outcome]:
+        best: dict[str, Outcome] = {}
+        rows = ConsumerOutcome.objects.filter(
+            consumer=consumer, stream_path=stream_path
+        ).order_by("pk")
+        for row in rows:
+            # The columns say which scope this is and so does the payload; the
+            # payload wins, for the reason the file-backed store gives — the
+            # record is what was stored, the columns are an index over it, and a
+            # row hand-edited or written by something else must not be reported
+            # to a consumer it does not belong to.
+            record = decode(row.payload)
+            if (
+                record is None
+                or record.consumer != consumer
+                or record.stream_path != stream_path
+            ):
+                continue
+            held = best.get(record.subject)
+            # `>=`, and rows in primary-key order, so re-recording an attempt
+            # replaces it: last write wins, as it does in the other two stores.
+            if held is None or record.attempt >= held.attempt:
+                best[record.subject] = record
+        return sorted(best.values(), key=_order)

--- a/src/django_rakaia/outcomes.py
+++ b/src/django_rakaia/outcomes.py
@@ -6,38 +6,53 @@ decision about what to record is store-agnostic and lives in `rakaia.outcomes`,
 and only the keeping of it is Django-shaped.
 
 What is kept is the **encoded text**, exactly as the other two stores keep it —
-ADR 0007 Decision 6b. The columns beside it exist so `latest` can filter and
-order in SQL, not so a reader can reconstruct an outcome from them; the payload
-is the record, and `decode` is the only way back out of it. That is what stops
-three backends developing three opinions about what was stored.
+ADR 0007 Decision 6b. The payload is the record; the columns beside it are an
+index over it, so `latest` can narrow in SQL rather than decode the table.
 
-**Lengths are checked here, not left to the database, and that is the one place
-this store deliberately does more than pass a value through.** The columns are
-bounded — the widths `ConsumerCursor` already uses — and the two databases this
-suite runs on disagree about what a bounded column means: Postgres refuses an
-over-long value, SQLite keeps it. ADR 0007 predicted exactly that ("a backend
-with a bounded column accepts a name every other backend keeps and then refuses
-or truncates it"), and a store whose behaviour depends on which database is under
-it is the same defect the shared codec exists to prevent, one level down. So the
-check runs in Python, before the insert, against the model's own declared widths
-— read from the field, so the rule cannot drift from the column — and both
-databases then refuse the same value with the same error.
+**The index is derived, never the raw value.** Each key column holds
+``quote(value, safe="")`` cut to the column width, and that is not a new idea
+here — it is `JsonlOutcomeStore._safe_name`, borrowed. That store already had to
+turn an arbitrary consumer-supplied string into something a filesystem accepts as
+one path segment; a ``varchar`` asks the same question with different edges, and
+percent-encoded ASCII answers both at once. It is total (every string has one),
+injective (two names never collide), free of NUL and every other byte a text
+column can refuse, and identical on every backend.
 
-Refusing rather than truncating, because a truncated subject is a *different*
-subject: it would collapse two rows into one and report the first as speaking for
-the rest, which is the defect the `subject` field was introduced to fix.
+That matters because the alternative was a list. An earlier version of this
+module put raw values in the columns and checked their *length* before writing,
+because SQLite keeps an over-long value and Postgres refuses it. The check was
+correct and the approach was not: review immediately found NUL — kept by SQLite,
+refused by Postgres — and then ``attempt`` overflowing ``int4``, and the next
+round would have found something else. Enumerating the properties a column
+objects to is the same mistake as enumerating the fields a codec must check, and
+`rakaia.outcomes` had already paid five review rounds to learn it. Encoding
+removes the enumeration instead of extending it.
+
+**Cutting to the width is safe here, and was not before.** When a column held the
+value, truncating meant filing a record under a name that is not its own — two
+subjects collapsing into one, which is the defect `Outcome.subject` exists to
+fix. When the column is an index, a prefix is still an index: two names sharing
+one cut key both come back from the query, and the payload comparison in `latest`
+drops the one that does not belong. So the widths are a prefix length rather than
+a capacity, and **`record` cannot refuse an outcome** — no length, no byte, and no
+value a consumer can supply makes it raise. That totality is not a nicety: every
+other `OutcomeStore` is total, and the consume loop being built alongside this
+(#248) records from inside its own error handler, so a store that raised there
+would turn one poisoned event into a stopped stream — the opposite of what
+skipping a bad event is for. Being the one partial backend would make that
+loop grow a guard for this store; staying total is the cheaper half.
 
 **What this store cannot promise on its own.** ADR 0007 keeps the record out of
 the executor's transaction so a failure cannot discard the record of itself. One
-level further out the same hole reopens, and this store cannot see it: a caller
-that wraps the whole consume in `transaction.atomic()` and then rolls back takes
-the outcome with it, because by default the write joins whatever transaction is
-already open. Measured, and stated as a number in
+level further out the same hole reopens, and the core loop cannot see it: a
+caller that wraps the whole consume in `transaction.atomic()` and then rolls back
+takes the outcome with it, because by default the write joins whatever
+transaction is already open. Measured, and stated as a number in
 `tests/test_django_rakaia/test_outcome_store_contract.py`.
 
-`using=` is the way out that exists today. A store pointed at a database alias
-the caller's transaction does not cover commits independently of it, so the
-record survives the rollback — the same seam `DjangoStreamStore(using=…)` and
+`using=` is the way out. A store pointed at a database alias the caller's
+transaction does not cover commits independently of it, so the record survives
+the rollback — the same seam `DjangoStreamStore(using=…)` and
 `DjangoExecutor(using=…)` already use. It is opt-in rather than the default
 because a store that always opened its own connection would sit outside the test
 harness's rollback as well, leaving rows behind between tests, and because every
@@ -48,37 +63,23 @@ not settled here.
 
 from __future__ import annotations
 
+from urllib.parse import quote
+
 from rakaia.outcomes import Outcome, _order, decode, encode
 
 from .models import ConsumerOutcome
 
-#: The bounded columns, in the order a caller most likely got one wrong.
-_BOUNDED = ("consumer", "stream_path", "subject", "offset")
 
+def _key(column: str, value: str) -> str:
+    """The indexed form of `value` for `column`: quoted, then cut to the width.
 
-def _check_widths(outcome: Outcome) -> None:
-    """Refuse anything a bounded column cannot hold, identically on any database.
-
-    Widths come from the model rather than from constants here, so widening a
-    column widens the check with it and there is no second declaration to forget.
+    The width is read from the model field rather than restated here, so widening
+    a column widens the key with it and there is no second declaration to forget.
+    Writes and reads both go through this, so a cut key still matches itself.
     """
-    too_long = []
-    for name in _BOUNDED:
-        value = getattr(outcome, name)
-        if value is None:
-            continue
-        limit = ConsumerOutcome._meta.get_field(name).max_length
-        assert limit is not None  # every name in `_BOUNDED` is a CharField
-        if len(value) > limit:
-            too_long.append(
-                f"{name} is {len(value)} characters, the column holds {limit}"
-            )
-    if too_long:
-        raise ValueError(
-            "This store keeps the names in bounded columns and one of them does not "
-            f"fit: {'; '.join(too_long)}. Shorten it — truncating here would file the "
-            "outcome under a subject that is not the one it is about."
-        )
+    limit = ConsumerOutcome._meta.get_field(column).max_length
+    assert limit is not None  # every key column is a CharField
+    return quote(value, safe="")[:limit]
 
 
 class DjangoOutcomeStore:
@@ -95,33 +96,37 @@ class DjangoOutcomeStore:
         self._using = using
 
     def record(self, outcome: Outcome) -> None:
-        _check_widths(outcome)
+        """Append `outcome`. Total: nothing a caller can put in one makes this raise."""
         # `encode` first and store what it returns: the same text the in-memory
         # store holds in a list and the file-backed one writes as a line. Nothing
         # here renders an outcome its own way, so there is nothing for the three
-        # backends to disagree about.
+        # backends to disagree about. The key columns beside it are derived from
+        # the same outcome and are only ever read back through `_key`.
         ConsumerOutcome.objects.using(self._using).create(
-            consumer=outcome.consumer,
-            stream_path=outcome.stream_path,
-            subject=outcome.subject,
-            offset=outcome.offset,
-            attempt=outcome.attempt,
+            consumer_key=_key("consumer_key", outcome.consumer),
+            stream_path_key=_key("stream_path_key", outcome.stream_path),
+            subject_key=_key("subject_key", outcome.subject),
+            offset_key=(
+                None if outcome.offset is None else _key("offset_key", outcome.offset)
+            ),
             payload=encode(outcome),
         )
 
     def latest(self, consumer: str, stream_path: str) -> list[Outcome]:
-        best: dict[str, Outcome] = {}
+        # The key columns narrow; the payload decides. A cut key can admit a row
+        # belonging to a name that merely shares a prefix, so the comparison below
+        # is not a belt-and-braces check on the query — it is what makes the query
+        # safe to cut in the first place.
         rows = (
             ConsumerOutcome.objects.using(self._using)
-            .filter(consumer=consumer, stream_path=stream_path)
+            .filter(
+                consumer_key=_key("consumer_key", consumer),
+                stream_path_key=_key("stream_path_key", stream_path),
+            )
             .order_by("pk")
         )
+        best: dict[str, Outcome] = {}
         for row in rows:
-            # The columns say which scope this is and so does the payload; the
-            # payload wins, for the reason the file-backed store gives — the
-            # record is what was stored, the columns are an index over it, and a
-            # row hand-edited or written by something else must not be reported
-            # to a consumer it does not belong to.
             record = decode(row.payload)
             if (
                 record is None

--- a/src/django_rakaia/outcomes.py
+++ b/src/django_rakaia/outcomes.py
@@ -6,8 +6,11 @@ decision about what to record is store-agnostic and lives in `rakaia.outcomes`,
 and only the keeping of it is Django-shaped.
 
 What is kept is the **encoded text**, exactly as the other two stores keep it —
-ADR 0007 Decision 6b. The payload is the record; the columns beside it are an
-index over it, so `latest` can narrow in SQL rather than decode the table.
+ADR 0007 Decision 6b. The payload is the record; the two columns beside it are the
+scope index, so `latest` can narrow in SQL rather than decode the table. There are
+two because `latest(consumer, stream_path)` is the only query — subject and offset
+were columns for one round, written and never read, and the model says why they are
+not columns now.
 
 **The index is derived, never the raw value.** Each key column holds
 ``quote(value, safe="")`` cut to the column width, and that is not a new idea
@@ -32,8 +35,9 @@ removes the enumeration instead of extending it.
 value, truncating meant filing a record under a name that is not its own — two
 subjects collapsing into one, which is the defect `Outcome.subject` exists to
 fix. When the column is an index, a prefix is still an index: two names sharing
-one cut key both come back from the query, and the payload comparison in `latest`
-drops the one that does not belong. So the widths are a prefix length rather than
+one cut key both come back from the query — `latest` applies no ``LIMIT``, so a
+cut key can only over-fetch and never under-fetch — and the payload comparison in
+`latest` drops the one that does not belong. So the widths are a prefix length rather than
 a capacity, and **`record` cannot refuse an outcome** — no length, no byte, and no
 value a consumer can supply makes it raise. That totality is not a nicety: every
 other `OutcomeStore` is total, and the consume loop being built alongside this
@@ -100,15 +104,12 @@ class DjangoOutcomeStore:
         # `encode` first and store what it returns: the same text the in-memory
         # store holds in a list and the file-backed one writes as a line. Nothing
         # here renders an outcome its own way, so there is nothing for the three
-        # backends to disagree about. The key columns beside it are derived from
-        # the same outcome and are only ever read back through `_key`.
+        # backends to disagree about. The two key columns beside it are derived
+        # from the same outcome and are only ever read back through `_key`. Every
+        # other field of the outcome is in the payload and nowhere else.
         ConsumerOutcome.objects.using(self._using).create(
             consumer_key=_key("consumer_key", outcome.consumer),
             stream_path_key=_key("stream_path_key", outcome.stream_path),
-            subject_key=_key("subject_key", outcome.subject),
-            offset_key=(
-                None if outcome.offset is None else _key("offset_key", outcome.offset)
-            ),
             payload=encode(outcome),
         )
 

--- a/src/django_rakaia/outcomes.py
+++ b/src/django_rakaia/outcomes.py
@@ -26,6 +26,24 @@ databases then refuse the same value with the same error.
 Refusing rather than truncating, because a truncated subject is a *different*
 subject: it would collapse two rows into one and report the first as speaking for
 the rest, which is the defect the `subject` field was introduced to fix.
+
+**What this store cannot promise on its own.** ADR 0007 keeps the record out of
+the executor's transaction so a failure cannot discard the record of itself. One
+level further out the same hole reopens, and this store cannot see it: a caller
+that wraps the whole consume in `transaction.atomic()` and then rolls back takes
+the outcome with it, because by default the write joins whatever transaction is
+already open. Measured, and stated as a number in
+`tests/test_django_rakaia/test_outcome_store_contract.py`.
+
+`using=` is the way out that exists today. A store pointed at a database alias
+the caller's transaction does not cover commits independently of it, so the
+record survives the rollback — the same seam `DjangoStreamStore(using=…)` and
+`DjangoExecutor(using=…)` already use. It is opt-in rather than the default
+because a store that always opened its own connection would sit outside the test
+harness's rollback as well, leaving rows behind between tests, and because every
+other Django store here writes on the ambient connection. Making independence the
+default is a decision about connection management, not about outcomes, and it is
+not settled here.
 """
 
 from __future__ import annotations
@@ -66,9 +84,15 @@ def _check_widths(outcome: Outcome) -> None:
 class DjangoOutcomeStore:
     """Outcomes kept as rows in ``rakaia_consumeroutcome``.
 
-    Holds no state, so one instance is as good as another and a caller may build
-    it wherever it needs one.
+    Pass ``using`` to write and read on a named database alias instead of the
+    default one, exactly as `DjangoStreamStore` does. ``using=None`` is the
+    ambient connection, which means the write joins any transaction the caller
+    already has open — see the module docstring for what that costs and when to
+    reach for an alias instead.
     """
+
+    def __init__(self, *, using: str | None = None) -> None:
+        self._using = using
 
     def record(self, outcome: Outcome) -> None:
         _check_widths(outcome)
@@ -76,7 +100,7 @@ class DjangoOutcomeStore:
         # store holds in a list and the file-backed one writes as a line. Nothing
         # here renders an outcome its own way, so there is nothing for the three
         # backends to disagree about.
-        ConsumerOutcome.objects.create(
+        ConsumerOutcome.objects.using(self._using).create(
             consumer=outcome.consumer,
             stream_path=outcome.stream_path,
             subject=outcome.subject,
@@ -87,9 +111,11 @@ class DjangoOutcomeStore:
 
     def latest(self, consumer: str, stream_path: str) -> list[Outcome]:
         best: dict[str, Outcome] = {}
-        rows = ConsumerOutcome.objects.filter(
-            consumer=consumer, stream_path=stream_path
-        ).order_by("pk")
+        rows = (
+            ConsumerOutcome.objects.using(self._using)
+            .filter(consumer=consumer, stream_path=stream_path)
+            .order_by("pk")
+        )
         for row in rows:
             # The columns say which scope this is and so does the payload; the
             # payload wins, for the reason the file-backed store gives — the

--- a/tests/test_django_rakaia/test_outcome_store_contract.py
+++ b/tests/test_django_rakaia/test_outcome_store_contract.py
@@ -2,11 +2,11 @@
 
 The third run of the same suite, and the first one where the storage has
 constraints of its own. ADR 0007 records why that matters: the codec settles what
-a value *is* and says nothing about how long it may be, so a bounded column is
-the one divergence the shared rendering cannot reach. Run this under
+a value *is* and says nothing about what a column will accept, so a bounded
+column is the one divergence the shared rendering cannot reach. Run this under
 ``RAKAIA_TEST_DB=postgres`` (`just test-pg`) as well as on the default SQLite —
-SQLite does not enforce ``max_length``, so a run there cannot tell a store that
-refuses an over-long name from one that quietly keeps it.
+SQLite enforces almost nothing about column contents, so a run there cannot tell
+a store that keeps a hostile name from one the database would have refused.
 """
 
 from __future__ import annotations
@@ -15,11 +15,11 @@ import pytest
 
 from django_rakaia.outcomes import DjangoOutcomeStore
 from rakaia.outcomes import Outcome
-from tests.outcome_store_contract import OutcomeStoreContract, project, refused
+from tests.outcome_store_contract import OutcomeStoreContract, project
 
 
 def an_outcome(**kw) -> Outcome:
-    """A projection-stage outcome with every bounded name overridable."""
+    """A projection-stage outcome with every name overridable."""
     base = {
         "consumer": "c",
         "stream_path": "s",
@@ -49,25 +49,24 @@ class TestDjangoOutcomeStoreDurability:
         [got] = DjangoOutcomeStore().latest("c", "s")
         assert got.reasons == ("bad_total",)
 
-    def test_the_row_keeps_the_encoded_text_not_a_column_per_field(self):
-        """Decision 6b, pinned where it can actually be undone.
+    def test_the_row_holds_the_bytes_encode_produced(self):
+        """Decision 6b, pinned as byte-identity rather than round-trippability.
 
-        The columns are an index over the record, not the record. A future change
-        that spread `reasons` and `params` across columns of their own would give
-        this backend a second opinion about what a stored outcome looks like —
-        which is the disagreement the shared codec exists to prevent — and every
-        contract case would stay green, because they all read back through
-        `latest`.
+        This used to assert `decode(row.payload) == outcome`, which is a weaker
+        claim than it reads as: a hand-rolled `json.dumps` of the same ten fields
+        decodes to the same outcome, so replacing `encode(outcome)` with one left
+        the whole suite green. Decision 6b is not "the store can rebuild an
+        equal outcome", it is "every store keeps the *same text*" — and only an
+        equality on the text says so.
         """
         from django_rakaia.models import ConsumerOutcome
-        from rakaia.outcomes import decode
+        from rakaia.outcomes import encode
 
         outcome = project("0000000001", reasons=("bad_total",), params={"row": "3"})
         DjangoOutcomeStore().record(outcome)
 
         [row] = ConsumerOutcome.objects.all()
-        assert isinstance(row.payload, str)
-        assert decode(row.payload) == outcome
+        assert row.payload == encode(outcome)
 
     def test_a_second_attempt_is_a_new_row_not_an_update(self):
         """Append-only (Decision 6a), pinned below `latest`.
@@ -85,24 +84,154 @@ class TestDjangoOutcomeStoreDurability:
 
         assert ConsumerOutcome.objects.count() == 2
 
-    def test_a_row_whose_columns_disagree_with_its_payload_is_not_reported(self):
-        """The payload is the record; the columns are an index over it.
 
-        The file-backed store holds the same rule for the same reason — there,
-        two consumers can share a file on a case-folding filesystem. Here the
-        columns can be written by anything with SQL access, and a row filed under
-        the wrong consumer must not be handed to one it is not about.
+@pytest.mark.django_db
+class TestTheKeyColumnsAreADerivedIndex:
+    """The columns are `quote(value)` cut to the width, not the value.
+
+    Every case here fails on Postgres, and several pass on SQLite, if the columns
+    ever go back to holding raw values — which is exactly why they are here rather
+    than left to a review round.
+    """
+
+    def test_a_key_column_holds_the_quoted_form_not_the_value(self):
+        """The whole design in one assertion.
+
+        Without this, reverting to raw columns leaves every behavioural test green
+        on SQLite: the values round-trip through the payload either way, and the
+        difference only shows up on a database that objects to a byte.
         """
+        from django_rakaia.models import ConsumerOutcome
+
+        DjangoOutcomeStore().record(
+            an_outcome(consumer="a/b", stream_path="submission/tf611")
+        )
+        [row] = ConsumerOutcome.objects.all()
+        assert (row.consumer_key, row.stream_path_key) == (
+            "a%2Fb",
+            "submission%2Ftf611",
+        )
+
+    @pytest.mark.parametrize("field", ["consumer", "stream_path", "subject", "offset"])
+    def test_a_nul_byte_in_any_name_round_trips(self, field: str):
+        """Postgres refuses NUL in a text column outright; SQLite keeps it.
+
+        The divergence that reopened one character wide after the length check
+        closed it 256 characters long. `quote` maps NUL to `%00`, so neither
+        database ever sees the byte and both backends agree — the same reason the
+        file-backed store is safe.
+        """
+        hostile = "row\x001"
+        outcome = an_outcome(**{field: hostile})
+        store = DjangoOutcomeStore()
+        store.record(outcome)
+
+        [got] = store.latest(outcome.consumer, outcome.stream_path)
+        assert getattr(got, field) == hostile
+
+    def test_an_attempt_too_large_for_an_integer_column_round_trips(self):
+        """`attempt` was a `PositiveIntegerField`, which is `int4`.
+
+        `2**31` was kept by SQLite and refused by Postgres with "integer out of
+        range" — the same class as NUL, arriving through a different property.
+        It is not a column any more; `latest` reads it from the payload, so
+        there is no range for it to leave.
+        """
+        store = DjangoOutcomeStore()
+        store.record(an_outcome(attempt=2**31))
+        [got] = store.latest("c", "s")
+        assert got.attempt == 2**31
+
+    @pytest.mark.parametrize(
+        ("field", "limit"),
+        [("consumer", 128), ("stream_path", 255), ("subject", 255), ("offset", 64)],
+    )
+    def test_a_name_far_longer_than_its_column_round_trips(
+        self, field: str, limit: int
+    ):
+        """No length is refused any more, and this is the case that says so.
+
+        The column is a prefix of an index, so a name ten times its width is cut
+        for indexing and kept whole in the payload. The previous design raised a
+        `ValueError` here.
+        """
+        long_name = "x" * (limit * 10)
+        outcome = an_outcome(**{field: long_name})
+        store = DjangoOutcomeStore()
+        store.record(outcome)
+
+        [got] = store.latest(outcome.consumer, outcome.stream_path)
+        assert getattr(got, field) == long_name
+
+    def test_two_names_sharing_a_cut_key_do_not_leak_into_each_other(self):
+        """What makes cutting safe, stated rather than assumed.
+
+        Both consumers encode to the same 128-character key, so the query returns
+        both rows and only the payload comparison tells them apart. Mutation:
+        drop that comparison from `latest`; each consumer sees the other's
+        outcome.
+        """
+        shared = "x" * 200
+        store = DjangoOutcomeStore()
+        store.record(an_outcome(consumer=shared + "-one", reasons=("mine",)))
+        store.record(an_outcome(consumer=shared + "-two", reasons=("theirs",)))
+
+        assert [o.reasons for o in store.latest(shared + "-one", "s")] == [("mine",)]
+        assert [o.reasons for o in store.latest(shared + "-two", "s")] == [("theirs",)]
+
+    def test_record_refuses_nothing_a_caller_can_construct(self):
+        """Totality, as one case, because `consume` depends on it.
+
+        The consume loop being built alongside this (#248) records from inside
+        its own `except` handler, so a store that raises there converts one
+        poisoned event into a stopped stream — the opposite of what skipping a
+        bad event promises. Every other `OutcomeStore` is total; this pins that
+        this one is too, rather than leaving that loop to grow a guard for the
+        odd backend out.
+        """
+        hostile = "\x00" + "\U0001f600" * 500 + "%2F../\r\n\t" + "\x7f"
+        store = DjangoOutcomeStore()
+        store.record(
+            Outcome(
+                consumer=hostile,
+                stream_path=hostile,
+                subject=hostile,
+                offset=None,
+                sequence_key=hostile,
+                stage="append",
+                status="refused",
+                reasons=(hostile,),
+                params={hostile: hostile},
+                attempt=2**40,
+            )
+        )
+        [got] = store.latest(hostile, hostile)
+        assert got.subject == hostile and got.attempt == 2**40
+
+
+@pytest.mark.django_db
+class TestTheKeysNarrowAndThePayloadDecides:
+    """Both directions of the disagreement, because neither is symmetrical.
+
+    An earlier comment here said "the payload wins", which was only true one way
+    round: a row the keys admit can still be rejected by its payload, but a row
+    the keys exclude is never fetched to be judged. The rule is that the keys
+    locate candidates and the payload decides among them, and a row whose keys do
+    not match is simply not a candidate.
+    """
+
+    def test_a_row_whose_payload_names_another_scope_is_not_reported(self):
+        """The direction the payload decides. Mutation: drop the payload
+        comparison from `latest`; `row-other` appears."""
         from django_rakaia.models import ConsumerOutcome
         from rakaia.outcomes import encode
 
         DjangoOutcomeStore().record(project("0000000001", reasons=("mine",)))
         ConsumerOutcome.objects.create(
-            consumer="c",
-            stream_path="s",
-            subject="row-other",
-            offset="0000000002",
-            attempt=1,
+            consumer_key="c",
+            stream_path_key="s",
+            subject_key="row-other",
+            offset_key="0000000002",
             payload=encode(project("0000000002", consumer="other")),
         )
 
@@ -110,74 +239,26 @@ class TestDjangoOutcomeStoreDurability:
             "0000000001"
         ]
 
+    def test_a_row_whose_keys_name_another_scope_is_never_fetched(self):
+        """The direction the keys decide, and the one nothing pinned.
 
-@pytest.mark.django_db
-class TestBoundedColumnsRefuseTheSameValueOnEveryDatabase:
-    """The divergence ADR 0007 forecast, closed before the database sees it.
-
-    The columns are bounded — `ConsumerCursor`'s widths — and the two databases
-    the suite runs on disagree about what that means: Postgres raises on an
-    over-long value, SQLite keeps it whole. A store that behaves differently
-    depending on which one is underneath is the reference-is-more-permissive
-    defect again, so the length check runs in Python and both databases refuse
-    identically. **These cases pass on SQLite only because of that check**;
-    without it the SQLite run is green and the Postgres run raises `DataError`.
-    """
-
-    @pytest.mark.parametrize(
-        ("field", "limit"),
-        [("consumer", 128), ("stream_path", 255), ("subject", 255), ("offset", 64)],
-    )
-    def test_a_name_longer_than_its_column_is_refused(self, field: str, limit: int):
-        over = "x" * (limit + 1) if field != "offset" else "0" * (limit + 1)
-        with pytest.raises(ValueError, match=f"{field} is {limit + 1} characters"):
-            DjangoOutcomeStore().record(an_outcome(**{field: over}))
-
-    @pytest.mark.parametrize(
-        ("field", "limit"),
-        [("consumer", 128), ("stream_path", 255), ("subject", 255), ("offset", 64)],
-    )
-    def test_a_name_exactly_the_width_of_its_column_is_kept(
-        self, field: str, limit: int
-    ):
-        """The other half, and the half that catches an off-by-one.
-
-        A check written with `>=` would refuse a name the column holds perfectly
-        well, and no refusal test can see that.
+        A row filed under the wrong key is unreachable however good its payload
+        is. That is a property of an index, not a bug — but it is the reason the
+        keys must be derived by `record` and never written by hand, so it is
+        stated here rather than left as a surprise.
         """
-        exact = "x" * limit if field != "offset" else "0" * limit
-        outcome = an_outcome(**{field: exact})
-        store = DjangoOutcomeStore()
-        store.record(outcome)
-
-        [got] = store.latest(outcome.consumer, outcome.stream_path)
-        assert getattr(got, field) == exact
-
-    def test_a_refused_outcome_leaves_no_row_behind(self):
-        """Refusing means nothing was recorded, not that half of it was."""
         from django_rakaia.models import ConsumerOutcome
+        from rakaia.outcomes import encode
 
-        with pytest.raises(ValueError):
-            DjangoOutcomeStore().record(refused("x" * 256))
-        assert ConsumerOutcome.objects.count() == 0
-
-    def test_an_unbounded_field_is_not_length_checked(self):
-        """`reasons`, `params` and `sequence_key` live in the payload only, so
-        this store holds them at whatever length the other two do. Pinned because
-        the cheap fix for the case above — bounding every field — would silently
-        make this backend the strict one."""
-        long_key = "k" * 5000
-        store = DjangoOutcomeStore()
-        store.record(
-            project(
-                "0000000001",
-                sequence_key=long_key,
-                reasons=(long_key,),
-                params={"note": long_key},
-            )
+        ConsumerOutcome.objects.create(
+            consumer_key="somewhere-else",
+            stream_path_key="s",
+            subject_key="row-1",
+            offset_key="0000000001",
+            payload=encode(project("0000000001", reasons=("orphaned",))),
         )
-        [got] = store.latest("c", "s")
-        assert got.sequence_key == long_key and got.reasons == (long_key,)
+
+        assert DjangoOutcomeStore().latest("c", "s") == []
 
 
 @pytest.mark.django_db(databases=["default", "overlay"], transaction=True)

--- a/tests/test_django_rakaia/test_outcome_store_contract.py
+++ b/tests/test_django_rakaia/test_outcome_store_contract.py
@@ -94,6 +94,30 @@ class TestTheKeyColumnsAreADerivedIndex:
     than left to a review round.
     """
 
+    def test_the_table_has_exactly_the_columns_the_only_query_needs(self):
+        """An index nothing reads is the finding this schema already had once.
+
+        `subject_key` and `offset_key` were columns for a round: written by
+        `record`, read by nothing, because `latest` groups by subject and orders
+        by offset in Python from the payload. Pinned as a list rather than left to
+        review, because the cost of an unread derived column is not the write — it
+        is that `subject_key` reads like the subject and is neither the subject nor
+        reliably distinct from another one.
+
+        A column added here should come with the query that reads it. If that
+        query is the operator worklist, this list is the place to notice it
+        arriving.
+        """
+        from django_rakaia.models import ConsumerOutcome
+
+        assert [f.name for f in ConsumerOutcome._meta.concrete_fields] == [
+            "id",
+            "consumer_key",
+            "stream_path_key",
+            "payload",
+            "recorded_at",
+        ]
+
     def test_a_key_column_holds_the_quoted_form_not_the_value(self):
         """The whole design in one assertion.
 
@@ -230,8 +254,6 @@ class TestTheKeysNarrowAndThePayloadDecides:
         ConsumerOutcome.objects.create(
             consumer_key="c",
             stream_path_key="s",
-            subject_key="row-other",
-            offset_key="0000000002",
             payload=encode(project("0000000002", consumer="other")),
         )
 
@@ -253,8 +275,6 @@ class TestTheKeysNarrowAndThePayloadDecides:
         ConsumerOutcome.objects.create(
             consumer_key="somewhere-else",
             stream_path_key="s",
-            subject_key="row-1",
-            offset_key="0000000001",
             payload=encode(project("0000000001", reasons=("orphaned",))),
         )
 

--- a/tests/test_django_rakaia/test_outcome_store_contract.py
+++ b/tests/test_django_rakaia/test_outcome_store_contract.py
@@ -178,3 +178,61 @@ class TestBoundedColumnsRefuseTheSameValueOnEveryDatabase:
         )
         [got] = store.latest("c", "s")
         assert got.sequence_key == long_key and got.reasons == (long_key,)
+
+
+@pytest.mark.django_db(databases=["default", "overlay"], transaction=True)
+class TestWhatSurvivesTheCallersOwnTransaction:
+    """The hole ADR 0007 closes one level in, reopening one level out.
+
+    The decision keeps an outcome out of the *executor's* transaction, so a batch
+    that fails cannot discard the record of its own failure. It says nothing about
+    the caller. A consumer that wraps its whole consume in `transaction.atomic()`
+    and then rolls back takes the outcome with it, because by default the write
+    joins the transaction already open — and the core consume loop cannot see
+    this, since it is stdlib-only and has no idea Django is underneath.
+
+    Both numbers are here rather than one, because the number a reader wants is
+    the difference: on the ambient connection nothing survives, and on an alias
+    the caller's transaction does not cover, the record does.
+    """
+
+    def test_an_outcome_on_the_ambient_connection_rolls_back_with_the_caller(self):
+        from django.db import transaction
+
+        from django_rakaia.models import ConsumerOutcome
+
+        store = DjangoOutcomeStore()
+        with transaction.atomic():
+            store.record(project("0000000001", reasons=("bad_total",)))
+            assert ConsumerOutcome.objects.count() == 1, "written inside the block"
+            transaction.set_rollback(True)
+
+        assert ConsumerOutcome.objects.count() == 0
+        assert store.latest("c", "s") == []
+
+    def test_an_outcome_on_another_alias_survives_the_callers_rollback(self):
+        """`using=` is the escape hatch, and this is what it buys.
+
+        The alias is a connection the caller's `atomic()` does not cover, so the
+        record commits on its own and is still there afterwards. Mutation: drop
+        `.using(self._using)` from `record`; the write lands on `default`, goes
+        back with the rollback, and this reads zero.
+        """
+        from django.db import transaction
+
+        from django_rakaia.models import ConsumerOutcome
+
+        store = DjangoOutcomeStore(using="overlay")
+        try:
+            with transaction.atomic():
+                store.record(project("0000000001", reasons=("bad_total",)))
+                transaction.set_rollback(True)
+
+            assert ConsumerOutcome.objects.using("default").count() == 0
+            assert [o.reasons for o in store.latest("c", "s")] == [("bad_total",)]
+        finally:
+            # `transaction=True` truncates the aliases this test declares, but a
+            # row committed on `overlay` outside the harness's control is exactly
+            # the kind that outlives its test. Clean it up here rather than leave
+            # the next test to discover it.
+            ConsumerOutcome.objects.using("overlay").all().delete()

--- a/tests/test_django_rakaia/test_outcome_store_contract.py
+++ b/tests/test_django_rakaia/test_outcome_store_contract.py
@@ -1,0 +1,180 @@
+"""The database-backed outcome store against the shared contract.
+
+The third run of the same suite, and the first one where the storage has
+constraints of its own. ADR 0007 records why that matters: the codec settles what
+a value *is* and says nothing about how long it may be, so a bounded column is
+the one divergence the shared rendering cannot reach. Run this under
+``RAKAIA_TEST_DB=postgres`` (`just test-pg`) as well as on the default SQLite —
+SQLite does not enforce ``max_length``, so a run there cannot tell a store that
+refuses an over-long name from one that quietly keeps it.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from django_rakaia.outcomes import DjangoOutcomeStore
+from rakaia.outcomes import Outcome
+from tests.outcome_store_contract import OutcomeStoreContract, project, refused
+
+
+def an_outcome(**kw) -> Outcome:
+    """A projection-stage outcome with every bounded name overridable."""
+    base = {
+        "consumer": "c",
+        "stream_path": "s",
+        "subject": "row-1",
+        "offset": "0000000001",
+        "sequence_key": "seq",
+        "stage": "project",
+        "status": "failed",
+    }
+    return Outcome(**{**base, **kw})
+
+
+@pytest.mark.django_db
+class TestDjangoOutcomeStoreContract(OutcomeStoreContract):
+    @pytest.fixture
+    def outcomes(self) -> DjangoOutcomeStore:
+        return DjangoOutcomeStore()
+
+
+@pytest.mark.django_db
+class TestDjangoOutcomeStoreDurability:
+    """What the shared contract cannot ask for, because the in-memory reference
+    cannot satisfy it."""
+
+    def test_outcomes_survive_a_new_store_over_the_same_database(self):
+        DjangoOutcomeStore().record(project("0000000001", reasons=("bad_total",)))
+        [got] = DjangoOutcomeStore().latest("c", "s")
+        assert got.reasons == ("bad_total",)
+
+    def test_the_row_keeps_the_encoded_text_not_a_column_per_field(self):
+        """Decision 6b, pinned where it can actually be undone.
+
+        The columns are an index over the record, not the record. A future change
+        that spread `reasons` and `params` across columns of their own would give
+        this backend a second opinion about what a stored outcome looks like —
+        which is the disagreement the shared codec exists to prevent — and every
+        contract case would stay green, because they all read back through
+        `latest`.
+        """
+        from django_rakaia.models import ConsumerOutcome
+        from rakaia.outcomes import decode
+
+        outcome = project("0000000001", reasons=("bad_total",), params={"row": "3"})
+        DjangoOutcomeStore().record(outcome)
+
+        [row] = ConsumerOutcome.objects.all()
+        assert isinstance(row.payload, str)
+        assert decode(row.payload) == outcome
+
+    def test_a_second_attempt_is_a_new_row_not_an_update(self):
+        """Append-only (Decision 6a), pinned below `latest`.
+
+        `latest` collapses attempts, so an in-place overwrite is invisible through
+        it — the shared contract says so itself. Counting rows is the only place
+        the property is observable, and this is the backend where a well-meaning
+        `update_or_create` would be the obvious thing to write.
+        """
+        from django_rakaia.models import ConsumerOutcome
+
+        store = DjangoOutcomeStore()
+        store.record(project("0000000001", reasons=("first",), attempt=1))
+        store.record(project("0000000001", reasons=("second",), attempt=2))
+
+        assert ConsumerOutcome.objects.count() == 2
+
+    def test_a_row_whose_columns_disagree_with_its_payload_is_not_reported(self):
+        """The payload is the record; the columns are an index over it.
+
+        The file-backed store holds the same rule for the same reason — there,
+        two consumers can share a file on a case-folding filesystem. Here the
+        columns can be written by anything with SQL access, and a row filed under
+        the wrong consumer must not be handed to one it is not about.
+        """
+        from django_rakaia.models import ConsumerOutcome
+        from rakaia.outcomes import encode
+
+        DjangoOutcomeStore().record(project("0000000001", reasons=("mine",)))
+        ConsumerOutcome.objects.create(
+            consumer="c",
+            stream_path="s",
+            subject="row-other",
+            offset="0000000002",
+            attempt=1,
+            payload=encode(project("0000000002", consumer="other")),
+        )
+
+        assert [o.subject for o in DjangoOutcomeStore().latest("c", "s")] == [
+            "0000000001"
+        ]
+
+
+@pytest.mark.django_db
+class TestBoundedColumnsRefuseTheSameValueOnEveryDatabase:
+    """The divergence ADR 0007 forecast, closed before the database sees it.
+
+    The columns are bounded — `ConsumerCursor`'s widths — and the two databases
+    the suite runs on disagree about what that means: Postgres raises on an
+    over-long value, SQLite keeps it whole. A store that behaves differently
+    depending on which one is underneath is the reference-is-more-permissive
+    defect again, so the length check runs in Python and both databases refuse
+    identically. **These cases pass on SQLite only because of that check**;
+    without it the SQLite run is green and the Postgres run raises `DataError`.
+    """
+
+    @pytest.mark.parametrize(
+        ("field", "limit"),
+        [("consumer", 128), ("stream_path", 255), ("subject", 255), ("offset", 64)],
+    )
+    def test_a_name_longer_than_its_column_is_refused(self, field: str, limit: int):
+        over = "x" * (limit + 1) if field != "offset" else "0" * (limit + 1)
+        with pytest.raises(ValueError, match=f"{field} is {limit + 1} characters"):
+            DjangoOutcomeStore().record(an_outcome(**{field: over}))
+
+    @pytest.mark.parametrize(
+        ("field", "limit"),
+        [("consumer", 128), ("stream_path", 255), ("subject", 255), ("offset", 64)],
+    )
+    def test_a_name_exactly_the_width_of_its_column_is_kept(
+        self, field: str, limit: int
+    ):
+        """The other half, and the half that catches an off-by-one.
+
+        A check written with `>=` would refuse a name the column holds perfectly
+        well, and no refusal test can see that.
+        """
+        exact = "x" * limit if field != "offset" else "0" * limit
+        outcome = an_outcome(**{field: exact})
+        store = DjangoOutcomeStore()
+        store.record(outcome)
+
+        [got] = store.latest(outcome.consumer, outcome.stream_path)
+        assert getattr(got, field) == exact
+
+    def test_a_refused_outcome_leaves_no_row_behind(self):
+        """Refusing means nothing was recorded, not that half of it was."""
+        from django_rakaia.models import ConsumerOutcome
+
+        with pytest.raises(ValueError):
+            DjangoOutcomeStore().record(refused("x" * 256))
+        assert ConsumerOutcome.objects.count() == 0
+
+    def test_an_unbounded_field_is_not_length_checked(self):
+        """`reasons`, `params` and `sequence_key` live in the payload only, so
+        this store holds them at whatever length the other two do. Pinned because
+        the cheap fix for the case above — bounding every field — would silently
+        make this backend the strict one."""
+        long_key = "k" * 5000
+        store = DjangoOutcomeStore()
+        store.record(
+            project(
+                "0000000001",
+                sequence_key=long_key,
+                reasons=(long_key,),
+                params={"note": long_key},
+            )
+        )
+        [got] = store.latest("c", "s")
+        assert got.sequence_key == long_key and got.reasons == (long_key,)

--- a/tests/test_rakaia/test_public_api.py
+++ b/tests/test_rakaia/test_public_api.py
@@ -459,6 +459,7 @@ class TestTierTwoIsDeliberatelyNotExported:
             "StreamProducer",
             "StreamOffsetWatermark",
             "ConsumerCursor",
+            "ConsumerOutcome",
         ],
     )
     def test_a_model_is_not_in_the_stable_surface(self, model):


### PR DESCRIPTION
An event a consumer could not apply can now be recorded in a table, alongside the
cursor that says how far that consumer got. It joins the two places outcomes could
already be kept — in memory, and in files on disk — and all three write and read the
same text, so none of them can develop its own idea of what was stored. There is a
migration to run; nothing writes to the table unless a consumer asks for it, and a
consumer that never fails leaves it empty.

Recording never refuses. Whatever a consumer names its streams and subjects, of any
length and any character, the record is kept whole — which matters because the code
that will write these records does so while already handling a failure, and a store
that could refuse would turn one bad event into a stopped stream. The columns beside
the record are an index for finding a row rather than a copy of the values, which is
what makes that possible: they hold the same encoded form the file-backed store
already uses to turn a name into something a filesystem will accept.