### PR TITLE
Write down what the last two releases changed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           # Pin uv itself, not just the action. Unpinned, CI takes whatever is
           # latest and rewrites uv.lock in its newer style — a version-bump PR
           # once carried a few hundred lines of unrelated marker churn (#118).
-          version: "0.11.32"
+          version: "0.12.10"
 
       - name: Set up Python 3.12
         run: uv python install 3.12
@@ -120,7 +120,7 @@ jobs:
       - uses: astral-sh/setup-uv@v9.0.0
         with:
           enable-cache: true
-          version: "0.11.32"
+          version: "0.12.10"
 
       - name: Set up Python 3.12
         run: uv python install 3.12
@@ -144,7 +144,7 @@ jobs:
       - uses: astral-sh/setup-uv@v9.0.0
         with:
           enable-cache: true
-          version: "0.11.32"
+          version: "0.12.10"
 
       - name: Set up Python 3.12
         run: uv python install 3.12

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -38,7 +38,7 @@ jobs:
           # Pin uv itself, not just the action. Unpinned, CI takes whatever is
           # latest and rewrites uv.lock in its newer style — a version-bump PR
           # once carried a few hundred lines of unrelated marker churn (#118).
-          version: "0.11.32"
+          version: "0.12.10"
 
       - name: Set up Python 3.12
         run: uv python install 3.12

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,7 +40,7 @@ jobs:
           # Pin uv itself, not just the action. Unpinned, CI takes whatever is
           # latest and rewrites uv.lock in its newer style — a version-bump PR
           # once carried a few hundred lines of unrelated marker churn (#118).
-          version: "0.11.32"
+          version: "0.12.10"
 
       - name: Set up Python 3.12
         run: uv python install 3.12

--- a/.gitignore
+++ b/.gitignore
@@ -46,8 +46,10 @@ db.sqlite3
 # runtime the way db.sqlite3 above is.
 examples/polyglot/streams/
 
-# Collected static files (chat sample → WhiteNoise)
+# Collected static files (chat and polyglot samples → WhiteNoise).
+# `just polyglot-serve` runs collectstatic before starting hypercorn.
 examples/chat/staticfiles/
+examples/polyglot/staticfiles/
 
 # Zensical build output
 /site/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,110 @@ All notable changes to Rakaia are documented here. The format is based on
 New here? The [guided tour](docs/whats-new.md) walks these capabilities with a
 runnable demo for each.
 
+## [Unreleased]
+
+### Added
+
+- **`JsonlStreamStore` — keep a log in plain text files instead of a database.**
+  A stream is a directory of JSON-lines segments; an event is a line. Nothing but
+  the filesystem is involved, so a consumer who wants durability without running
+  Postgres now has a third option beside the in-memory store (which loses the log
+  on restart) and the database-backed one. Select it from Django with
+  `RAKAIA_STORE = "jsonl"` and `RAKAIA_JSONL_ROOT` pointing at the directory;
+  `RAKAIA_JSONL_SEGMENT_SIZE` (default 10,000 events per segment) and
+  `RAKAIA_JSONL_FSYNC` (default on) tune the trade between durability and speed.
+
+  It holds the same store contract the other two do, including cross-process
+  concurrent appends and `wait_for_messages`, which it implements by watching the
+  directory — so live updates work across processes with no broker. A Django
+  system check fails startup if `RAKAIA_STORE` is `"jsonl"` without a root set.
+  See `docs/store-streams-in-files.md`. (#238)
+
+- **`migrate_stream`, `migrate_all` and `Migration` — move a log between
+  backends.** Changing `RAKAIA_STORE` and restarting does not move anything: the
+  app comes up against an empty log while every saved position is still
+  syntactically valid, so consumers resume into silence rather than failing.
+  Moving a log is a copy, and now there is a call that performs one and reports
+  what it could not carry — whether offsets and the head position survived, in
+  `Migration.notes`. ADR 0006 records the reasoning. (#238, #239)
+
+- **`get_asgi_app()` and `reset_store_cache()` in `django_rakaia`.** The ASGI
+  entry point resolved its store internally, so the only way to drive it was to
+  reconfigure a process-wide cache — which is why it had no tests. It accepts a
+  store now, as the replay entry point already did, and the store cache has a
+  documented way to be dropped instead of tests reaching into a private
+  dict. (#237)
+
+- **A record of what happened to an event a consumer tried to apply.** A cursor
+  says how far a consumer got, not whether it got there cleanly, so an event that
+  was skipped, refused or lost looks exactly like one that worked. ADR 0007
+  proposes what to record instead, and this adds the record, the seam a backend
+  implements, and two backends held to one shared suite.
+
+  **Deliberately partial and not exported.** The loop that would write these
+  records, a database-backed place to keep them, and retrying a failure are all
+  absent, and the ADR marks which of its parts describe code and which it only
+  proposes. Adopting it today means importing below the stable surface on
+  purpose. (#243)
+
+### Changed
+
+- **Importing `rakaia` no longer builds a server or a store.** The package root
+  imported everything eagerly, so reaching for the event-sourcing half pulled in
+  all ten protocol-server modules, and `app = create_app()` at module scope built
+  an in-memory store in every process that imported the package — served a
+  request or not. Measured at 80 ms and one unwanted store, against 37 ms for the
+  framework alone.
+
+  Names resolve on first use now (PEP 562), the way the Django package already
+  did. A framework consumer loads no server module and pays 3 ms; a server
+  consumer loads the seven it needs; `uvicorn rakaia:app` still gets one object,
+  built under a lock so concurrent first access cannot produce several. Every
+  public name still imports from `rakaia` exactly as before. One exception is
+  deliberate: `replay` is both an export and a submodule, so it stays bound
+  eagerly rather than resolving to a function or a module depending on import
+  order. (#240)
+
+- **The server no longer decides what another store's positions look like.** The
+  check in front of the protocol server was described as a guard against junk in
+  a web address and was really a list of rakaia's own two position formats —
+  so anyone plugging their own storage in behind the same server, which this
+  library invites, had positions refused before their storage was ever asked.
+  This had already happened in-house once, when the database-backed store could
+  sit behind the server and every resume failed on a position the server had
+  itself just issued.
+
+  The rule now says what the specification says: a position is a single opaque
+  token, must not contain the five characters that would split it across query
+  parameters, and should be short and URL-safe. Nothing about shape. Widening it
+  lets nothing through that was not already refused one layer down — a store
+  still rejects a position it did not issue, with the same status. (#241)
+
+- **A resolved-item notification has one definition.** The payload was invented
+  in the replay orchestrator with its state written as a bare literal, while the
+  `Transition` that requests one is defined elsewhere. It now has a single
+  definition beside that request. (#237)
+
+- **The polyglot example keeps its log in files and serves live updates from
+  rakaia's own protocol server**, mounted alongside Django rather than going
+  through the channel layer. A save from any process now reaches every open
+  browser, so the stress command's `--direct` mode is no longer live-blind, and
+  the example runs multi-worker off one log with no broker between the
+  workers. (#242)
+
+- **Two stores now issue the same position format**, so a position can no longer
+  be told apart by its shape. That was never a designed guarantee, only an
+  accident of the two formats having differed; ADR 0005 now says so, and which
+  pairs of formats refuse each other is pinned by tests rather than left as
+  prose. (#239, #241)
+
+- **The framework/protocol-server split question is settled: the two halves stay
+  in one distribution.** ADR 0002's trigger fired, and the question has now been
+  measured twice with the same answer. The last argument for splitting was that
+  importing the framework dragged the whole server in, and that is fixed, so a
+  consumer already pays only for the half it uses. The spent trigger is replaced
+  with four that would each make a split buy something. (#240)
+
 ## [0.3.1] - 2026-08-24
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,6 +88,33 @@
   claims they modify.
 - Research notes live in `docs/research/` and are deliberately **not** in the
   nav. They are dated and are not decisions; decisions go in `docs/adr/`.
+- **A release updates four files, and a PR updates the first of them.** These
+  drifted apart across `0.3.0`/`0.3.1`, which is what this rule exists to stop:
+  - `CHANGELOG.md` — for anything a consumer of the library could notice, under
+    `[Unreleased]`, in the PR that makes the change. Repo tooling is out of scope
+    by long precedent: the uv pin, the lint config and the CI matrix have never
+    been changelogged, because the file documents the library, not the workshop.
+    Never leave `[Unreleased]` absent: the release-prep PR renames it and
+    immediately adds an empty one back. Reconstructing a release from the git log
+    at tag time is how `whats-new.md` got skipped for two releases.
+  - `UPGRADING.md` — if anything breaks, *or* if something works differently in a
+    way that fails quietly. A trap that raises nothing (changing `RAKAIA_STORE`
+    moves no data) belongs here even though it breaks no signature.
+  - `docs/whats-new.md` — if a headline capability landed. It is a **cumulative**
+    tour: append a numbered section, never rewrite the earlier ones. Every
+    section owes the reader a problem, a snippet, and a one-command demo.
+  - `docs/examples.md` — if an example changed, and always check *Known gaps*.
+    A new public API with no example is a gap; say so there rather than letting
+    the matrix imply coverage that does not exist.
+- **Doc code samples are checked against the real signature, not from memory.**
+  Every name in a snippet must resolve and every keyword must exist —
+  `rebuild_and_verify` was documented with three wrong arguments on the first
+  pass here. `docs/api-reference.md` is generated and is the cheapest place to
+  confirm a signature.
+- **`just demos` does not cover `chat` or `polyglot`.** They need a running
+  server, so CI never touches them and only a manual run finds a break. If you
+  change either — or the store, SSE or URL wiring underneath them — start the
+  server and exercise the real endpoint before claiming they work.
 
 ## Writing it up
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -15,6 +15,96 @@ ones you are crossing.
 
 ---
 
+# Unreleased
+
+## Changing `RAKAIA_STORE` does not move your log
+
+This is not a break in the usual sense — nothing that worked stops working — but
+it is the one trap the new file-backed store introduces, and it fails quietly.
+
+Switching the setting and restarting brings the app up against a **different,
+empty log**. Every consumer position you have saved is still syntactically valid,
+because two of the three backends issue the same position format, so nothing
+raises: consumers resume into silence and a dashboard shows an empty stream next
+to a database still full of rows.
+
+**What to do.** Treat a backend change as a copy, and run it before you switch
+the setting:
+
+```python
+from rakaia import migrate_all
+
+for result in migrate_all(old_store, new_store):
+    print(result.path, result.events, result.offsets_preserved, result.notes)
+```
+
+`Migration.notes` names anything the copy could not carry. `migrate_stream` does
+one stream if you would rather move them individually. The reasoning is in
+[ADR 0006](docs/adr/0006-changing-backends-is-a-copy.md).
+
+## `import rakaia` no longer imports every submodule eagerly
+
+Public names are unaffected: `from rakaia import Upsert, replay, StreamStore` and
+every other exported name resolves exactly as before, and `uvicorn rakaia:app`
+still works. The change is that the package root resolves names on first use
+rather than importing all ten protocol-server modules at import time.
+
+**What to check.** Only one pattern is affected: reaching a **submodule** through
+the package without importing it first. `import rakaia` followed by
+`rakaia.jsonl_store.something` worked incidentally before, because some other
+module had already imported it; it now depends on what else your process has
+imported. Import the submodule explicitly instead:
+
+```python
+import rakaia.jsonl_store  # not: import rakaia; rakaia.jsonl_store...
+```
+
+`rakaia.replay` is deliberately exempt and stays bound eagerly, because it is both
+an export and a submodule, and resolving it lazily would return a function or a
+module depending on import order.
+
+## A third-party store behind the protocol server no longer has its positions refused
+
+The server's validation of an incoming position was a list of rakaia's own two
+formats. If you plug your own storage in behind the same server, positions it
+issued were rejected before your store was ever consulted. The rule now matches
+the specification — an opaque token, short, URL-safe, without the five characters
+that would split it across query parameters — and the store remains the authority
+on whether it issued a given position.
+
+This is a widening, so no action is needed unless you were relying on the server
+to reject a shape on your behalf. It no longer does; your store's own rejection is
+what answers now, with the same status.
+
+---
+
+# 0.3.1
+
+Both changes in this release are fixes, and neither needs action if you include
+`django_rakaia.urls` as shipped. One matters if you have copied those routes into
+your own URLconf.
+
+## If you copied the stream routes, the catch-all must be listed last
+
+Stream names may contain a slash — `_scratch/fold` is one the library generates
+itself — so the routes now use Django's `path` converter where they used `str`.
+`path` is greedy where `str` is not, so the catch-all stream-detail route has to
+come **last** in your list or it claims `api/streams/<name>/` as a stream called
+`api/streams/<name>`, and the read API starts returning HTML.
+
+A test that reverses a URL name will agree with that mistake. Resolve real paths
+instead if you want cover for it.
+
+## Polling no longer requires `channels`
+
+If you only read streams by polling, you no longer need `channels` installed (nor
+a Redis channel layer on a production tier) to include `django_rakaia.urls`. The
+SSE route is loaded behind the same gate `apps.py` uses, so `RAKAIA_ENABLE_SSE`
+now works as documented. Opting *in* without the extra installed still fails
+loudly, which is intended.
+
+---
+
 # 0.3.0
 
 ## A replay applies a whole pass of effects at once, not one event at a time

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -175,6 +175,15 @@ No example exercises these yet — a good place to contribute a demo:
   with `Delete`+`Exclude`).
 - `replay_stream` (the Django convenience wrapper).
 - `DjangoExecutor(skip_unchanged=True)`.
+- `rebuild_and_verify` (the one-call guarded rebuild-and-diff). The
+  `projection_cookbook` demo composes the pieces by hand instead.
+- `migrate_stream` / `migrate_all` — moving a log between backends. `polyglot`
+  runs *on* the file-backed store but was seeded there, never copied onto it.
+- `DjangoExecutor(batch_updates=True)` and `DjangoExecutor(normalizers=...)`.
+- `DriftLedger` as an object. `orders` triggers drift detection via
+  `on_drift="raise"` but never reads the ledger.
+- The outcome record (`rakaia.outcomes`) — deliberately unexported and partial,
+  so an example would be documenting an unstable surface.
 
 ## Orientation for contributors
 

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -452,6 +452,152 @@ suite in CI. It passes the full protocol surface today except the stream
 
 ---
 
+## 14. A rebuild that checks its own work
+
+**The problem.** "Can this log rebuild my tables, and do the rows match?" is the
+question that decides whether event sourcing is actually working for you. Asking
+it by hand meant composing six interfaces in the right order — move the log off
+the database being guarded, arm the write guard outside and the read guard
+inside, record effects while still applying them, replay, build a reader, diff —
+and then remembering the part written down nowhere: *a pass means nothing unless
+the guards were actually armed*. A green result with the guard unwired looks
+exactly like a green result.
+
+**What rakaia does.** `rebuild_and_verify()` does the composition and checks its
+own work. It trips the read guard on purpose and raises `GuardNotArmed` if
+nothing happens, so a clean verdict cannot be obtained with the guard off.
+
+```python
+from django_rakaia import rebuild_and_verify
+
+from forms.models import Submission
+
+report = rebuild_and_verify(
+    "submissions",
+    into="scratch",  # a disposable database alias
+    live_models=[Submission],  # required, not defaulted
+)
+print(report.verdict)  # GREEN, or VACUOUS when nothing was actually compared
+```
+
+`live_models` is required rather than defaulted to empty, because defaulting it
+would disarm the write guard without saying so. It also refuses a from-scratch
+claim it cannot honour, raising `ScratchAliasNotEmpty` when the disposable alias
+still holds rows from an earlier run.
+
+Read `verdict`, not `ok`. `ok` answers "did anything disagree?", which is
+vacuously true when nothing was compared — an empty effect list from a store on
+the wrong backend or a stream path that was renamed prints a clean bill of health
+with nothing behind it. `verdict` separates `GREEN` from `VACUOUS`, and
+`raise_if_diff()` refuses to certify a zero population.
+
+→ Deep dive: [Dry-run & executors](dry-run-and-executors.md) · Demo: `just cookbook-demo`
+
+## 15. `DriftLedger` — one object that knows whether a rule changed
+
+**The problem.** Warning that the code behind a stored handler, reducer or
+upcaster has been edited since it was registered used to be three near-identical
+checks. The entry point into the third took two options that had to agree: pass
+the report callback without the hash memo and every event re-read the source;
+pass the memo without the callback and the check was skipped in silence.
+
+**What rakaia does.** One object owns all three questions — has this rule
+drifted, have I already said so, what have I hashed — so there is one check
+reached three ways and one option to pass.
+
+`ReplayResult.warnings` and `.drift_detected` read the same as before, but they
+are now views onto `ReplayResult.drift` rather than lists of their own, so the
+result and the log cannot disagree. Constructing a `ReplayResult` with
+`warnings=` or `drift_detected=` is no longer accepted — pass
+`drift=DriftLedger(...)`. `upcast()`, which normalises one event on read outside
+a replay, takes a `drift=` ledger too and is silent without one.
+
+→ Deep dive: [Versioned handlers](versioned-handlers.md) · Demo: `just orders-demo`
+
+## 16. A replay applies a whole pass at once
+
+**The problem.** A replay applied effects one event at a time, so rebuilding a
+projection over a large log issued one statement per event per table, most of
+them identical in shape.
+
+**What rakaia does.** A replay now hands the executor a whole stage's changes at
+once, and `DjangoExecutor(batch_updates=True)` collapses a fanned-out `Update`
+into a single statement where it is provably safe to do so.
+
+**Off by default.** The rows come out the same either way, and that is checked by
+running the same effects down both paths and comparing every column. But the rule
+deciding what may collapse was wrong four times during development, and each time
+it wrote wrong data rather than raising — so a consumer opts in knowingly, and a
+suspected write anomaly stays bisectable against the flag. Anything the rule
+cannot prove safe (an `F()` expression, a composite lookup, a `NULL` match, a
+`Decimal`, a date) is applied one statement at a time exactly as before.
+Declining costs a statement, never a wrong row.
+
+→ Deep dive: [Dry-run & executors](dry-run-and-executors.md)
+
+## 17. Streams in plain files — no database, no broker
+
+**The problem.** The in-memory store loses the log on restart, and the durable
+one needs a database. Between them there was nothing for a consumer who wants the
+log to survive a restart without running Postgres for it.
+
+**What rakaia does.** `JsonlStreamStore` keeps a stream as a directory of
+JSON-lines segments — one line per event, nothing involved but the filesystem.
+
+```python
+# settings.py
+RAKAIA_STORE = "jsonl"
+RAKAIA_JSONL_ROOT = BASE_DIR / "streams"
+RAKAIA_JSONL_FSYNC = True  # off trades durability for speed
+```
+
+It holds the same store contract the other two do, including concurrent appends
+from several processes and `wait_for_messages`, which it implements by watching
+the directory. That last part is what makes **live updates work across processes
+with no broker at all** — the `polyglot` example now runs four workers off one
+log, serving SSE from rakaia's own protocol server, with no Redis between them.
+
+**Changing `RAKAIA_STORE` does not move your log.** Restarting against a
+different backend brings the app up on an empty one while every saved consumer
+position is still syntactically valid, so consumers resume into silence rather
+than failing loudly. Moving a log is a copy, and there is a call for it:
+
+```python
+from rakaia import migrate_stream
+
+result = migrate_stream(source_store, target_store, "submissions")
+print(result.offsets_preserved, result.head_preserved, result.notes)
+```
+
+`migrate_all` does the same for every stream the source can list.
+
+→ Deep dive: [Store streams in files](store-streams-in-files.md) ·
+[ADR 0006](adr/0006-changing-backends-is-a-copy.md) ·
+Demo: `just polyglot-dev` → http://localhost:8001
+
+## 18. Importing the framework no longer starts a server
+
+**The problem.** `import rakaia` pulled in all ten protocol-server modules, and
+`app = create_app()` at module scope built an in-memory store in every process
+that imported the package — whether it ever served a request or not. Measured at
+80 ms and one unwanted store, against 37 ms for the framework alone.
+
+**What rakaia does.** Names resolve on first use. A framework consumer loads no
+server module at all and pays 3 ms; a server consumer loads the seven it needs.
+`uvicorn rakaia:app` still gets one object, built under a lock so concurrent
+first access cannot produce several stores.
+
+Nothing changes at your call sites — every public name still imports from
+`rakaia` exactly as before. This is also what settled the long-open question of
+whether to split the two halves into separate distributions: the last argument
+for splitting was that importing one dragged in the other, and that is now fixed,
+so the halves stay in one package.
+
+→ Deep dive: [Framework vs. protocol server](framework-vs-protocol-server.md) ·
+[ADR 0002](adr/0002-framework-vs-protocol-server-boundary.md)
+
+---
+
 ## Where to go next
 
 - Want the reference for handlers, upcasters and drift? → [Versioned handlers](versioned-handlers.md)

--- a/examples/polyglot/README.md
+++ b/examples/polyglot/README.md
@@ -118,9 +118,8 @@ just polyglot-serve workers=4
 Uses `polyglot_project.settings_prod` (DEBUG=False, WhiteNoise
 CompressedManifest). Four workers all serve live updates from one log
 with no message broker between them: writers coordinate with `flock` on
-the stream directory and readers tail the files. Redis is still started
-by the `redis-up` recipe and the channel layer is still configured, but
-nothing in this demo rides on it any more.
+the stream directory and readers tail the files. Nothing here needs
+Redis, and the recipe no longer starts one.
 
 That works because every worker is on one machine. `flock` is not
 dependable over NFS or another network filesystem, so this arrangement

--- a/examples/polyglot/polyglot_project/settings_prod.py
+++ b/examples/polyglot/polyglot_project/settings_prod.py
@@ -2,8 +2,14 @@
 
 Run with:
 
-    just polyglot-serve              # multi-worker hypercorn + Redis
+    just polyglot-serve              # multi-worker hypercorn, no broker
     just polyglot-serve workers=8    # override worker count
+
+There is no channel layer here on purpose. This demo's log is a folder of files
+and its SSE comes from the protocol server mounted in `asgi.py`, so the workers
+share state through the filesystem rather than through a broker. `settings.py`
+leaves an in-memory channel layer configured for `channels` itself; nothing in
+this app sends on it.
 """
 
 import os
@@ -22,17 +28,6 @@ ALLOWED_HOSTS = [
     for h in os.environ.get("DJANGO_ALLOWED_HOSTS", "localhost,127.0.0.1").split(",")
     if h.strip()
 ]
-
-REDIS_URL = os.environ.get("REDIS_URL", "redis://localhost:6379/0")
-
-CHANNEL_LAYERS = {
-    "default": {
-        "BACKEND": "channels_redis.core.RedisChannelLayer",
-        "CONFIG": {
-            "hosts": [REDIS_URL],
-        },
-    },
-}
 
 STORAGES = {
     "default": {

--- a/justfile
+++ b/justfile
@@ -223,20 +223,20 @@ polyglot-dev:
     cd {{POLYGLOT_DIR}} && uv run python manage.py migrate
     cd {{POLYGLOT_DIR}} && uv run python manage.py runserver 0.0.0.0:8001
 
-# Multi-worker hypercorn run for the polyglot sample
-polyglot-serve workers="4" host="0.0.0.0" port="8001": redis-up
+# Multi-worker hypercorn run for the polyglot sample.
+# No broker: the workers share one file-backed log, so there is no `redis-up`
+# dependency here. Writers coordinate with `flock` on the stream directory and
+# readers tail the files.
+polyglot-serve workers="4" host="0.0.0.0" port="8001":
     @echo "Starting polyglot on http://{{host}}:{{port}} ({{workers}} worker(s))"
     cd {{POLYGLOT_DIR}} && \
         DJANGO_SETTINGS_MODULE=polyglot_project.settings_prod \
-        REDIS_URL={{REDIS_URL}} \
         uv run python manage.py migrate --noinput
     cd {{POLYGLOT_DIR}} && \
         DJANGO_SETTINGS_MODULE=polyglot_project.settings_prod \
-        REDIS_URL={{REDIS_URL}} \
         uv run python manage.py collectstatic --noinput
     cd {{POLYGLOT_DIR}} && \
         DJANGO_SETTINGS_MODULE=polyglot_project.settings_prod \
-        REDIS_URL={{REDIS_URL}} \
         uv run hypercorn \
             --bind {{host}}:{{port}} \
             --workers {{workers}} \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,7 +84,15 @@ build-backend = "hatchling.build"
 # once carried a few hundred lines of unrelated dependency-marker churn purely
 # because CI ran a newer uv than the author (#118). CI pins the same version in
 # every workflow; this is the local half, and it refuses rather than rewrites.
-required-version = ">=0.11.32,<0.12"
+#
+# The range needs revisiting when uv moves a minor, and the failure mode is
+# quiet: package managers carry only the latest uv, so a stale ceiling stops
+# being installable at all rather than failing loudly. That is what happened to
+# `<0.12` — `brew install uv` could no longer produce anything satisfying it.
+# Bumping is a coordinated edit of this line and the five workflow pins; check
+# first that the new version leaves `uv.lock` untouched (0.11.32 and 0.12.10
+# were verified to emit byte-identical lockfiles, both at `revision = 3`).
+required-version = ">=0.12.10,<0.13"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/rakaia", "src/django_rakaia"]


### PR DESCRIPTION
The guided tour was last updated the day before the first of the last two
releases was tagged, so nothing from either one ever reached it, and the seven
changes merged since had no record anywhere. This writes them all down across the
tour, the changelog and the upgrade notes — including the one trap that fails
silently: pointing the library at a different place to keep its log does not move
the log you already have, and every saved reading position stays valid, so
consumers resume into an empty stream instead of failing. It also records the
rule that would have caught the gap, namely which files a release has to touch.

Two things found while checking that the examples still work. The translations
example demanded a message broker its production command no longer uses, which
locked out anyone without the container tool installed; that is gone. And the
package tool version we require could no longer be installed at all, because the
usual package manager carries only the newest release and our range excluded it,
so the range now covers the current version.

https://claude.ai/code/session_01DmUw5DmbdDmzzE67KVQrEm