### PR TITLE
Decide the order a batch is applied in once

### DIFF
--- a/src/django_rakaia/effect_executor.py
+++ b/src/django_rakaia/effect_executor.py
@@ -35,6 +35,7 @@ from django.db import DEFAULT_DB_ALIAS, connections, transaction
 from django.db.models import Q
 
 from rakaia.effects import (
+    _WRITE_ORDER_PASSES,
     ApplyReport,
     Delete,
     Effect,
@@ -44,6 +45,7 @@ from rakaia.effects import (
     SpareKeys,
     Update,
     Upsert,
+    _write_order_rank,
     check_disjoint_defaults,
 )
 
@@ -202,43 +204,44 @@ class DjangoExecutor:
         retire_flips: list[tuple[Retire, list[dict[str, Any]]]] = []
         created = written = skipped = 0
         with transaction.atomic(using=self._using):
-            # Writes first, then deletes, then retires: reconcile batches
-            # (upsert current rows, prune/soft-delete the rest) converge
-            # regardless of handler order. Writes apply before deletes/retires,
-            # so a produces= row is always recorded before any later effect that
-            # refs it.
+            # One pass per rank: reconcile batches (upsert current rows,
+            # prune/soft-delete the rest) converge regardless of handler order,
+            # and a produces= row is always recorded before any later effect
+            # that refs it. Which effect lands in which pass is
+            # `_write_order_rank`'s to say, not this loop's.
             # A run of consecutive `Update`s is applied together so a fanned-out
             # change costs one statement instead of one per row (#199). The run
             # is flushed the moment anything else appears, which is what keeps a
             # `Ref` in an update's lookup resolvable: it binds to a row an
             # earlier `Upsert` materialised, so an update must never be hoisted
             # above its producer.
-            pending: list[Update] = []
-            for eff in effects_list:
-                if isinstance(eff, Upsert):
-                    self._flush_updates(pending, resolver)
-                    obj, outcome = self._upsert(resolver.resolve_effect(eff))
-                    if outcome == "created":
-                        created += 1
-                        written += 1
-                    elif outcome == "written":
-                        written += 1
-                    else:
-                        skipped += 1
-                    if eff.produces is not None:
-                        resolver.record(eff.produces, _row_accessor(obj))
-                elif isinstance(eff, Update):
-                    pending.append(eff)
-            self._flush_updates(pending, resolver)
-            for eff in effects_list:
-                if isinstance(eff, Delete):
-                    self._delete(resolver.resolve_effect(eff))
-            for eff in effects_list:
-                if isinstance(eff, Retire):
-                    reff = resolver.resolve_effect(eff)
-                    flipped = self._retire(reff)
-                    if reff.transition is not None:
-                        retire_flips.append((reff, flipped))
+            for rank in _WRITE_ORDER_PASSES:
+                pending: list[Update] = []
+                for eff in effects_list:
+                    if _write_order_rank(eff) != rank:
+                        continue
+                    if isinstance(eff, Upsert):
+                        self._flush_updates(pending, resolver)
+                        obj, outcome = self._upsert(resolver.resolve_effect(eff))
+                        if outcome == "created":
+                            created += 1
+                            written += 1
+                        elif outcome == "written":
+                            written += 1
+                        else:
+                            skipped += 1
+                        if eff.produces is not None:
+                            resolver.record(eff.produces, _row_accessor(obj))
+                    elif isinstance(eff, Update):
+                        pending.append(eff)
+                    elif isinstance(eff, Delete):
+                        self._delete(resolver.resolve_effect(eff))
+                    elif isinstance(eff, Retire):
+                        reff = resolver.resolve_effect(eff)
+                        flipped = self._retire(reff)
+                        if reff.transition is not None:
+                            retire_flips.append((reff, flipped))
+                self._flush_updates(pending, resolver)
         return ApplyReport(
             retire_flips=retire_flips,
             upserts_created=created,

--- a/src/rakaia/effects.py
+++ b/src/rakaia/effects.py
@@ -611,3 +611,37 @@ def check_disjoint_defaults(effects: Iterable[Effect]) -> None:
                 f"{field_name!r} on {eff.model_label} {eff.lookup!r}"
             )
         seen.record(eff, idx)
+
+
+# =============================================================================
+# Write order
+# =============================================================================
+
+
+def _write_order_rank(effect: Effect) -> int:
+    """Which pass of an applied batch `effect` belongs to.
+
+    Every executor applies a batch in three passes — every write, then every
+    delete, then every retire — so that a reconcile batch converges regardless
+    of the order its handlers emitted, and a ``produces=`` row is recorded
+    before any effect that :class:`Ref`s it. That is exactly why effects from
+    two different events cannot simply be poured into one batch: doing so would
+    hoist a later event's write above an earlier event's delete.
+
+    Kept beside `check_disjoint_defaults` and consulted by both executors and by
+    the replay buffer that decides where a batch boundary falls, so the rule has
+    one home rather than three that can drift (#152, #256).
+    """
+    if isinstance(effect, (Upsert, Update)):
+        return 0
+    if isinstance(effect, Delete):
+        return 1
+    return 2
+
+
+_WRITE_ORDER_PASSES = (0, 1, 2)
+"""The passes `_write_order_rank` sorts a batch into, in application order.
+
+An executor loops over this and dispatches on the rank, so a fourth pass would
+be added here and nowhere else.
+"""

--- a/src/rakaia/executors.py
+++ b/src/rakaia/executors.py
@@ -26,6 +26,7 @@ from types import SimpleNamespace
 from typing import Any
 
 from .effects import (
+    _WRITE_ORDER_PASSES,
     ApplyReport,
     Delete,
     Effect,
@@ -35,6 +36,7 @@ from .effects import (
     SpareKeys,
     Update,
     Upsert,
+    _write_order_rank,
     check_disjoint_defaults,
 )
 
@@ -135,28 +137,34 @@ class InMemoryProjections:
         resolver = RefResolver()
         retire_flips: list[tuple[Retire, list[dict[str, Any]]]] = []
         created = written = 0
-        # Writes first, then deletes, then retires — so a reconcile batch
-        # converges regardless of the order its handlers emitted, and a produces=
-        # row is recorded before any later effect Refs it.
-        for eff in effects_list:
-            if isinstance(eff, Upsert):
-                # No skip_unchanged here, so every upsert writes: `skipped` stays
-                # 0 and `written` counts them all, which is what the Django
-                # executor also reports when the option is off.
-                if self._upsert(resolver, resolver.resolve_effect(eff)) == "created":
-                    created += 1
-                written += 1
-            elif isinstance(eff, Update):
-                self._update(resolver.resolve_effect(eff))
-        for eff in effects_list:
-            if isinstance(eff, Delete):
-                self._delete(resolver.resolve_effect(eff))
-        for eff in effects_list:
-            if isinstance(eff, Retire):
-                reff = resolver.resolve_effect(eff)
-                flipped = self._retire(reff)
-                if reff.transition is not None:
-                    retire_flips.append((reff, flipped))
+        # One pass per rank — writes, then deletes, then retires — so a
+        # reconcile batch converges regardless of the order its handlers
+        # emitted, and a produces= row is recorded before any later effect Refs
+        # it. Which effect lands in which pass is `_write_order_rank`'s to say,
+        # not this loop's.
+        for rank in _WRITE_ORDER_PASSES:
+            for eff in effects_list:
+                if _write_order_rank(eff) != rank:
+                    continue
+                if isinstance(eff, Upsert):
+                    # No skip_unchanged here, so every upsert writes: `skipped`
+                    # stays 0 and `written` counts them all, which is what the
+                    # Django executor also reports when the option is off.
+                    if (
+                        self._upsert(resolver, resolver.resolve_effect(eff))
+                        == "created"
+                    ):
+                        created += 1
+                    written += 1
+                elif isinstance(eff, Update):
+                    self._update(resolver.resolve_effect(eff))
+                elif isinstance(eff, Delete):
+                    self._delete(resolver.resolve_effect(eff))
+                elif isinstance(eff, Retire):
+                    reff = resolver.resolve_effect(eff)
+                    flipped = self._retire(reff)
+                    if reff.transition is not None:
+                        retire_flips.append((reff, flipped))
         return ApplyReport(
             retire_flips=retire_flips,
             upserts_created=created,

--- a/src/rakaia/replay.py
+++ b/src/rakaia/replay.py
@@ -86,6 +86,7 @@ from .effects import (
     Retire,
     Update,
     Upsert,
+    _write_order_rank,
     _WrittenFields,
     transition_payload,
 )
@@ -398,22 +399,6 @@ def _synth_transitions(report: ApplyReport | None) -> list[ExternalEffect]:
             for identity in rows
         )
     return out
-
-
-def _write_order_rank(effect: Effect) -> int:
-    """Where `effect` lands in the order an executor applies a batch.
-
-    Every executor applies a batch in three passes — every write, then every
-    delete, then every retire — so that a reconcile batch converges regardless
-    of the order its handlers emitted. That is exactly why effects from two
-    different events cannot simply be poured into one batch: doing so would
-    hoist a later event's write above an earlier event's delete.
-    """
-    if isinstance(effect, (Upsert, Update)):
-        return 0
-    if isinstance(effect, Delete):
-        return 1
-    return 2
 
 
 def _self_collides(effects: list[Effect]) -> bool:

--- a/tests/test_django_rakaia/test_write_order_conformance.py
+++ b/tests/test_django_rakaia/test_write_order_conformance.py
@@ -1,0 +1,122 @@
+"""Writes, then deletes, then retires — decided in one place (#256).
+
+The rule was stated three times: once for the buffer that decides where a batch
+boundary has to fall, and once inside each executor's apply loop. Nothing pinned
+the buffer against either executor, so two of the three could agree while the
+third drifted. This suite asserts all three read the same rule object *and* that
+each of them applies what that object says.
+
+Both halves earn their place. Restoring a local copy to the buffer was caught by
+the identity half only; restoring the three hard-coded passes to an executor left
+the import in place and was caught by the behaviour half only.
+"""
+
+from __future__ import annotations
+
+from importlib import import_module
+from types import ModuleType
+
+import pytest
+
+from django_rakaia.effect_executor import DjangoExecutor
+from rakaia.effects import ApplyReport, Delete, Effect, Upsert
+from rakaia.executors import InMemoryProjections
+from rakaia.registry import HandlerRegistry
+from rakaia.replay import replay
+from rakaia.seed import seed_stream
+from rakaia.store import StreamStore
+
+# Imported by name, not as `from rakaia import replay`: the package re-exports
+# the `replay` *function* under that name, so the attribute lookup would hand
+# back a function and every assertion below would be about the wrong object.
+effects_module = import_module("rakaia.effects")
+replay_module = import_module("rakaia.replay")
+executors_module = import_module("rakaia.executors")
+effect_executor = import_module("django_rakaia.effect_executor")
+
+MATCH = "s"
+
+
+def _retires_first(effect: Effect) -> int:
+    """The shared rule, stood on its head: retires, then deletes, then writes.
+
+    Nothing may depend on the ordering being this one — only on every site
+    reading it from the same place. A site that consults the rule reverses with
+    it; a site carrying its own copy does not.
+    """
+    return 2 - effects_module._write_order_rank(effect)
+
+
+class _Batches:
+    """An executor that records how many calls carried the stage's effects."""
+
+    def __init__(self) -> None:
+        self.batches: list[list[Effect]] = []
+
+    def apply(self, effects) -> ApplyReport:
+        self.batches.append(list(effects))
+        return ApplyReport()
+
+
+@pytest.mark.parametrize(
+    "module",
+    [replay_module, executors_module, effect_executor],
+    ids=["buffer", "in_memory_executor", "django_executor"],
+)
+def test_every_site_reads_the_one_rule(module: ModuleType) -> None:
+    """One rule object, three readers — not three functions that agree today."""
+    assert module._write_order_rank is effects_module._write_order_rank
+
+
+def test_the_buffer_takes_its_batch_boundary_from_the_rule(monkeypatch) -> None:
+    """A delete then a write is two batches only because the rule says a write
+    outranks a delete. Under a reversed rule the pair is orderable as emitted,
+    so the buffer must hold them in one batch."""
+    monkeypatch.setattr(replay_module, "_write_order_rank", _retires_first)
+    store = StreamStore()
+    seed_stream("s", [{"id": "e0", "n": 0}, {"id": "e1", "n": 1}], store=store)
+    registry = HandlerRegistry()
+    registry.register(
+        name="h",
+        event_match=MATCH,
+        fn=lambda ev: (
+            Delete("app.R", {"id": "x"})
+            if ev["n"] == 0
+            else Upsert("app.R", {"id": "x"}, {"n": 1})
+        ),
+        effective_from=0,
+        stage=0,
+    )
+    ex = _Batches()
+
+    replay(store, "s", ex, handler_registry=registry, event_match=MATCH)
+
+    assert [len(b) for b in ex.batches] == [2]
+
+
+def test_the_in_memory_executor_takes_its_passes_from_the_rule(monkeypatch) -> None:
+    """Write then delete leaves no row; reversed, the delete runs first and the
+    write survives."""
+    monkeypatch.setattr(executors_module, "_write_order_rank", _retires_first)
+    ex = InMemoryProjections()
+
+    ex.apply([Upsert("app.R", {"id": "x"}, {"n": 1}), Delete("app.R", {"id": "x"})])
+
+    assert [(r["id"], r["n"]) for r in ex.rows("app.R")] == [("x", 1)]
+
+
+@pytest.mark.django_db
+def test_the_django_executor_takes_its_passes_from_the_rule(monkeypatch) -> None:
+    """The same batch, the same reversal, on the durable executor."""
+    monkeypatch.setattr(effect_executor, "_write_order_rank", _retires_first)
+    from tests.test_django_rakaia.models import Alert
+
+    lookup = {"stream_key": "s", "alert_type": "a", "field_key": ""}
+    DjangoExecutor().apply(
+        [
+            Upsert("test_django_rakaia.Alert", lookup, {"message": "kept"}),
+            Delete("test_django_rakaia.Alert", lookup),
+        ]
+    )
+
+    assert [a.message for a in Alert.objects.all()] == ["kept"]


### PR DESCRIPTION
A batch of changes reaches storage as writes, then deletes, then retires. That ordering was written out three separate times — once where replay decides how many events can share a batch, and once inside each of the two things that write one — so two of the three could agree while the third quietly drifted, and nothing in the suite would have caught it. The rule now lives beside the other batch-level rule it belongs with, and all three read it from there.

Nothing about the order itself changes, so nobody using the library sees a difference and there is no changelog entry: by long precedent that file documents the library, not the internal structure. A new conformance test pins each of the three readers to the shared rule and was watched fail with each one put back on its own copy in turn; the evidence is in a comment below.

Closes #256