### PR TITLE
An administrator can look at the failure records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,20 @@ runnable demo for each.
 
 ### Added
 
+- **A screen for the outcome records.** The database-backed store keeps a row for
+  every event a consumer could not apply, and until now reading one meant querying
+  the table by hand. The Django admin lists them newest first, with the consumer,
+  the stream, the subject, the position, the stage, the status and the reasons —
+  decoded from the stored record rather than read off the two index columns beside
+  it, which hold a percent-encoded form of the value and would show
+  `submission%2Ftf611` for a stream named `submission/tf611`.
+
+  Read-only on purpose: nothing can be added, changed or deleted from it. These
+  are a record of what happened, and clearing them out is a retention job rather
+  than a button. A record written by a version this one cannot read still gets a
+  row, marked as unreadable, because a dropped record is the failure the table
+  exists to prevent. (#252)
+
 - **`JsonlStreamStore` — keep a log in plain text files instead of a database.**
   A stream is a directory of JSON-lines segments; an event is a line. Nothing but
   the filesystem is involved, so a consumer who wants durability without running

--- a/src/django_rakaia/admin.py
+++ b/src/django_rakaia/admin.py
@@ -336,14 +336,20 @@ class ConsumerOutcomeAdmin(admin.ModelAdmin):
         nothing and said so as an empty page — an operator reads that as "there
         is no record", which is the one conclusion this table exists to prevent.
 
-        Escaping the term the same way the payload was escaped makes the two
-        comparable. For a term that is already ASCII this is the identity, and a
-        term carrying a quote or a backslash is escaped to exactly the form the
-        payload stores.
+        **Only the characters that were escaped are escaped back, one at a
+        time.** Escaping the whole term through `json.dumps` was the first
+        attempt and it broke quoted phrases: Django splits the search box on
+        spaces and *then* strips the quotes around a bit, so a term arriving as
+        ``\"two words\"`` never matches that branch and is searched literally,
+        which returned nothing at all for a query that used to work. Anything
+        already ASCII is left exactly as the operator typed it, so every search
+        that worked before this method existed still works, character for
+        character.
         """
-        return super().get_search_results(
-            request, queryset, json.dumps(search_term)[1:-1]
+        escaped = "".join(
+            char if char.isascii() else json.dumps(char)[1:-1] for char in search_term
         )
+        return super().get_search_results(request, queryset, escaped)
 
     def has_add_permission(self, request) -> bool:  # noqa: ARG002
         return False

--- a/src/django_rakaia/admin.py
+++ b/src/django_rakaia/admin.py
@@ -302,7 +302,11 @@ class ConsumerOutcomeAdmin(admin.ModelAdmin):
     # `recorded_at` can tie — a batch of failures lands in one transaction — so
     # the primary key breaks it, and the newest row is first either way.
     ordering = ["-recorded_at", "-pk"]
-    date_hierarchy = "recorded_at"
+    # No `date_hierarchy`. It costs two `COUNT(*)`s and a `SELECT DISTINCT` over
+    # a truncated `recorded_at` on every page load, none of which an index on
+    # that column can serve, and this table has no bound on its size until a
+    # retention job is scheduled. Newest-first ordering answers the question the
+    # hierarchy was there for.
     # The payload is the record, so searching it searches every field of every
     # outcome at once, in the values the consumer passed rather than the keys.
     search_fields = ["payload"]
@@ -322,6 +326,24 @@ class ConsumerOutcomeAdmin(admin.ModelAdmin):
         "payload",
     ]
     readonly_fields = fields
+
+    def get_search_results(self, request, queryset, search_term):
+        """Search the payload for what the consumer passed, not for its spelling.
+
+        `encode_outcome` renders with `json.dumps`, which escapes anything
+        outside ASCII, so a stream a consumer named `café/tf611` sits in the
+        column as ``caf\u00e9/tf611``. Searching the term as typed matched
+        nothing and said so as an empty page — an operator reads that as "there
+        is no record", which is the one conclusion this table exists to prevent.
+
+        Escaping the term the same way the payload was escaped makes the two
+        comparable. For a term that is already ASCII this is the identity, and a
+        term carrying a quote or a backslash is escaped to exactly the form the
+        payload stores.
+        """
+        return super().get_search_results(
+            request, queryset, json.dumps(search_term)[1:-1]
+        )
 
     def has_add_permission(self, request) -> bool:  # noqa: ARG002
         return False

--- a/src/django_rakaia/admin.py
+++ b/src/django_rakaia/admin.py
@@ -6,7 +6,7 @@ in the Django admin.
 """
 
 import json
-from typing import Any
+from typing import Any, cast
 
 from django.contrib import admin
 from django.utils.html import format_html, format_html_join
@@ -17,7 +17,8 @@ from django_rakaia.event_message import (
     event_label,
     event_label_display,
 )
-from django_rakaia.models import Stream, StreamEntry, StreamEvent
+from django_rakaia.models import ConsumerOutcome, Stream, StreamEntry, StreamEvent
+from rakaia.outcomes import Outcome, decode_outcome
 
 
 @admin.register(Stream)
@@ -227,6 +228,179 @@ class StreamEntryAdmin(admin.ModelAdmin):
     @admin.display(description="Type")
     def event_type_badge(self, obj) -> SafeString:
         return _event_badge(obj.event.event_type)
+
+
+_ABSENT = "—"
+"""What a field that is legitimately empty shows. An em-dash, not a blank cell,
+for the same reason a labelless badge is one: a blank reads as a rendering fault."""
+
+_STATUS_COLORS = {
+    "failed": "#dc3545",
+    "refused": "#ffc107",
+    "skipped": "#6c757d",
+}
+
+
+_DECODED_ATTR = "_rakaia_decoded"
+_NOT_DECODED = object()
+
+
+def _decoded(obj: ConsumerOutcome) -> Outcome | None:
+    """The record in `obj.payload`, or ``None`` if this version cannot build it.
+
+    Cached on the instance because a row is eight columns wide and every one of
+    them asks the same question; `decode_outcome` also logs each time it drops a
+    payload, and one unreadable row should be one line in the log, not eight.
+    """
+    cached = getattr(obj, _DECODED_ATTR, _NOT_DECODED)
+    if cached is _NOT_DECODED:
+        cached = decode_outcome(obj.payload)
+        setattr(obj, _DECODED_ATTR, cached)
+    return cast("Outcome | None", cached)
+
+
+def _outcome_field(obj: ConsumerOutcome, name: str) -> str:
+    """One field of the decoded record, as text a cell can hold."""
+    outcome = _decoded(obj)
+    if outcome is None:
+        return _ABSENT
+    value = getattr(outcome, name)
+    return _truncate(str(value)) if value else _ABSENT
+
+
+@admin.register(ConsumerOutcome)
+class ConsumerOutcomeAdmin(admin.ModelAdmin):
+    """What a consumer could not apply, newest first, and why.
+
+    The one screen this app's operational bookkeeping gets — `ConsumerCursor`,
+    `StreamOffsetWatermark` and `StreamProducer` deliberately have none, because
+    bookkeeping is not browsed. Looking at these *is* the feature, which is the
+    exception ADR 0007 argues for rather than a precedent for the others.
+
+    Every column here comes out of `payload` through `decode_outcome`, and none
+    of them is a model field. The two ``_key`` columns are a scope index holding
+    a percent-encoded, possibly truncated form of the value — printing them would
+    show `submission%2Ftf611` for a stream a consumer named `submission/tf611`,
+    which is the mistake the row's shape invites. A payload this version cannot
+    build still gets a row, marked as unreadable, because a record dropped from
+    the page is the failure the whole table exists to prevent.
+
+    Read-only throughout, and not only by convention: these are a record of what
+    happened. Removing them is a retention job, not a button.
+    """
+
+    list_display = [
+        "recorded_at",
+        "consumer",
+        "stream_path",
+        "subject",
+        "offset",
+        "stage",
+        "status_badge",
+        "reasons",
+    ]
+    # `recorded_at` can tie — a batch of failures lands in one transaction — so
+    # the primary key breaks it, and the newest row is first either way.
+    ordering = ["-recorded_at", "-pk"]
+    date_hierarchy = "recorded_at"
+    # The payload is the record, so searching it searches every field of every
+    # outcome at once, in the values the consumer passed rather than the keys.
+    search_fields = ["payload"]
+    list_per_page = 50
+    fields = [
+        "recorded_at",
+        "consumer",
+        "stream_path",
+        "subject",
+        "offset",
+        "sequence_key",
+        "stage",
+        "status_badge",
+        "reasons",
+        "params",
+        "attempt",
+        "payload",
+    ]
+    readonly_fields = fields
+
+    def has_add_permission(self, request) -> bool:  # noqa: ARG002
+        return False
+
+    def has_change_permission(self, request, obj=None) -> bool:  # noqa: ARG002
+        return False
+
+    def has_delete_permission(self, request, obj=None) -> bool:  # noqa: ARG002
+        return False
+
+    @admin.display(description="Consumer")
+    def consumer(self, obj: ConsumerOutcome) -> str:
+        return _outcome_field(obj, "consumer")
+
+    @admin.display(description="Stream")
+    def stream_path(self, obj: ConsumerOutcome) -> str:
+        return _outcome_field(obj, "stream_path")
+
+    @admin.display(description="Subject")
+    def subject(self, obj: ConsumerOutcome) -> str:
+        return _outcome_field(obj, "subject")
+
+    @admin.display(description="Offset")
+    def offset(self, obj: ConsumerOutcome) -> str:
+        # Absent at ``stage="append"``: the event never reached the log, so it
+        # has no position to name.
+        return _outcome_field(obj, "offset")
+
+    @admin.display(description="Sequence")
+    def sequence_key(self, obj: ConsumerOutcome) -> str:
+        return _outcome_field(obj, "sequence_key")
+
+    @admin.display(description="Stage")
+    def stage(self, obj: ConsumerOutcome) -> str:
+        return _outcome_field(obj, "stage")
+
+    @admin.display(description="Attempt")
+    def attempt(self, obj: ConsumerOutcome) -> str:
+        return _outcome_field(obj, "attempt")
+
+    @admin.display(description="Status")
+    def status_badge(self, obj: ConsumerOutcome) -> SafeString:
+        """The status, or the fact that the payload could not be read.
+
+        This column carries the unreadable case because it is the one every row
+        has: the rest go to an em-dash, and a row of em-dashes and nothing else
+        looks like a bug rather than a record from another version.
+        """
+        outcome = _decoded(obj)
+        status = outcome.status if outcome is not None else "unreadable"
+        return format_html(
+            '<span style="background-color: {}; color: white; padding: 3px 8px; '
+            'border-radius: 3px; font-size: 11px; font-weight: bold;">{}</span>',
+            _STATUS_COLORS.get(status, "#6c757d"),
+            status.upper(),
+        )
+
+    @admin.display(description="Reasons")
+    def reasons(self, obj: ConsumerOutcome) -> str:
+        """The consumer's own codes, all of them.
+
+        One event can breach several rules at once, and showing the first would
+        make a row look like a single problem when it is several.
+        """
+        outcome = _decoded(obj)
+        if outcome is None or not outcome.reasons:
+            return _ABSENT
+        return _truncate(", ".join(outcome.reasons))
+
+    @admin.display(description="Params")
+    def params(self, obj: ConsumerOutcome) -> SafeString | str:
+        outcome = _decoded(obj)
+        if outcome is None or not outcome.params:
+            return _ABSENT
+        return format_html_join(
+            mark_safe("<br>"),
+            "<code>{}</code> = {}",
+            sorted(outcome.params.items()),
+        )
 
 
 def register_stream_event_admin(event_model_class):

--- a/src/django_rakaia/models.py
+++ b/src/django_rakaia/models.py
@@ -6,6 +6,7 @@ for efficient querying and real-time updates via Unix sockets.
 """
 
 from typing import TYPE_CHECKING
+from urllib.parse import unquote
 
 from django.core.serializers.json import DjangoJSONEncoder
 from django.db import models
@@ -496,4 +497,12 @@ class ConsumerOutcome(models.Model):
     def __str__(self) -> str:
         # The scope plus the row id: a scope holds many outcomes and nothing here
         # is unique on its own, so naming a subject would suggest otherwise.
-        return f"{self.consumer_key}@{self.stream_path_key}#{self.pk}"
+        #
+        # Unquoted, because this is the one place the row is read by a person.
+        # Django puts `str(obj)` in the admin change page's title, its breadcrumb
+        # and its action labels, so printing the stored key would show
+        # `submission%2Ftf611` for a stream a consumer named `submission/tf611`
+        # — the exact confusion the `_key` suffix exists to warn about, on the
+        # screen most likely to be believed. The key columns stay encoded; only
+        # this rendering is turned back.
+        return f"{unquote(self.consumer_key)}@{unquote(self.stream_path_key)}#{self.pk}"

--- a/tests/test_django_rakaia/test_admin.py
+++ b/tests/test_django_rakaia/test_admin.py
@@ -704,11 +704,34 @@ class TestTheOutcomeScreenReadsThePayload:
         )
         assert found.count() == 1
 
+    def test_a_quoted_phrase_still_searches_as_a_phrase(self) -> None:
+        # Django splits the box on spaces and *then* strips the quotes around a
+        # bit. Escaping the whole term first turns the operator's quotes into
+        # something that branch no longer recognises, and the phrase is searched
+        # literally — nothing matches, which is the empty page this override was
+        # written to prevent, reintroduced by the override itself.
+        self._record(subject="alpha beta")
+        self._record(subject="beta alpha")
+        request, _ = _changelist(self.admin)
+
+        phrase, _ = self.admin.get_search_results(
+            request, ConsumerOutcome.objects.all(), '"alpha beta"'
+        )
+        loose, _ = self.admin.get_search_results(
+            request, ConsumerOutcome.objects.all(), "alpha beta"
+        )
+
+        assert phrase.count() == 1
+        assert loose.count() == 2
+
     def test_the_page_title_shows_the_value_not_the_encoded_key(self) -> None:
         # Django puts `str(obj)` in the change page's title and breadcrumb, so
         # the screen that exists to stop `submission%2Ftf611` being read as a
-        # stream name must not print it there either.
-        self._record()
+        # stream name must not print it there either. Both halves of the title
+        # carry a character the index encodes, because a consumer named `ledger`
+        # encodes to itself and leaves half the rendering unwatched.
+        self._record(consumer="ledger 100%", stream_path="submission/tf611")
         row = ConsumerOutcome.objects.get()
         assert "submission/tf611" in str(row)
-        assert "%2F" not in str(row)
+        assert "ledger 100%" in str(row)
+        assert "%2F" not in str(row) and "%25" not in str(row)

--- a/tests/test_django_rakaia/test_admin.py
+++ b/tests/test_django_rakaia/test_admin.py
@@ -681,3 +681,34 @@ class TestTheOutcomeScreenReadsThePayload:
         assert len(rows) == 2
         # And it has to say so: an all-blank row reads as a rendering fault.
         assert any("unreadable" in row.lower() for row in rows)
+
+    def test_a_search_finds_a_value_that_is_not_ascii(self) -> None:
+        # `encode_outcome` renders with `json.dumps`, which escapes anything
+        # outside ASCII, so this stream sits in the column as `café/...`.
+        # Searching what the operator can see on the screen has to find it;
+        # an empty page reads as "there is no record", which is the one
+        # conclusion this table exists to prevent.
+        self._record(stream_path="café/tf611")
+        request, _ = _changelist(self.admin)
+        found, _ = self.admin.get_search_results(
+            request, ConsumerOutcome.objects.all(), "café"
+        )
+        assert found.count() == 1
+
+    def test_a_search_for_an_ordinary_value_still_finds_it(self) -> None:
+        # The other half: escaping the term must be the identity for ASCII.
+        self._record()
+        request, _ = _changelist(self.admin)
+        found, _ = self.admin.get_search_results(
+            request, ConsumerOutcome.objects.all(), "submission/tf611"
+        )
+        assert found.count() == 1
+
+    def test_the_page_title_shows_the_value_not_the_encoded_key(self) -> None:
+        # Django puts `str(obj)` in the change page's title and breadcrumb, so
+        # the screen that exists to stop `submission%2Ftf611` being read as a
+        # stream name must not print it there either.
+        self._record()
+        row = ConsumerOutcome.objects.get()
+        assert "submission/tf611" in str(row)
+        assert "%2F" not in str(row)

--- a/tests/test_django_rakaia/test_admin.py
+++ b/tests/test_django_rakaia/test_admin.py
@@ -6,18 +6,24 @@ short-data path), link builders, translation status, and the dynamic
 ``register_stream_event_admin`` guard.
 """
 
+from datetime import UTC, datetime
+
 import pytest
 from django.contrib import admin as django_admin
+from django.contrib.admin.templatetags.admin_list import result_list
 from django.test import RequestFactory
 
 from django_rakaia.admin import (
+    ConsumerOutcomeAdmin,
     StreamAdmin,
     StreamEntryAdmin,
     StreamEventAdmin,
     register_stream_event_admin,
 )
 from django_rakaia.event_message import NO_LABEL_DISPLAY
-from django_rakaia.models import Stream, StreamEntry, StreamEvent
+from django_rakaia.models import ConsumerOutcome, Stream, StreamEntry, StreamEvent
+from django_rakaia.outcomes import DjangoOutcomeStore
+from rakaia.outcomes import Outcome
 from tests.test_django_rakaia.models import AppStreamEvent
 
 pytestmark = pytest.mark.django_db
@@ -565,3 +571,113 @@ class TestRelabellingTheFilterChangedNothingElseAboutIt:
             ("create (1)", "?_facets=True&event_type=create"),
             ("delete (1)", "?_facets=True&event_type=delete"),
         ]
+
+
+class TestTheOutcomeScreenReadsThePayload:
+    """The one screen operational bookkeeping gets, and why it cannot read columns.
+
+    `ConsumerCursor`, `StreamOffsetWatermark` and `StreamProducer` have no admin
+    because bookkeeping is not browsed; this table is the deviation ADR 0007
+    argues for, because looking at it *is* the feature. What makes it a screen
+    rather than a `list_display` of the model's fields is that the row is not
+    field-shaped: two derived percent-encoded key columns and a payload holding
+    the whole record. `submission/tf611` is indexed as `submission%2Ftf611`, so a
+    screen printing the column prints something no consumer ever passed.
+
+    Each case asks what the changelist *renders*, through the same
+    `result_list` the template calls, rather than what a display method returns.
+    """
+
+    def setup_method(self) -> None:
+        self.admin = ConsumerOutcomeAdmin(ConsumerOutcome, django_admin.site)
+
+    def _record(self, **overrides: object) -> None:
+        fields: dict[str, object] = {
+            "consumer": "ledger",
+            "stream_path": "submission/tf611",
+            "subject": "row-9",
+            "offset": "42",
+            "sequence_key": "tf611",
+            "stage": "project",
+            "status": "refused",
+            "reasons": ("missing_total", "bad_date"),
+        }
+        fields.update(overrides)
+        DjangoOutcomeStore().record(Outcome(**fields))  # type: ignore[arg-type]
+
+    def _rendered_rows(self) -> list[str]:
+        """One string per row, as the changelist template renders its cells."""
+        _, changelist = _changelist(self.admin)
+        # `changelist_view` sets this before rendering; nothing on this screen is
+        # editable, so it is the None that view would have set.
+        changelist.formset = None
+        return [
+            " ".join(str(cell) for cell in row)
+            for row in result_list(changelist)["results"]
+        ]
+
+    def test_the_changelist_renders(self) -> None:
+        self._record()
+        assert len(self._rendered_rows()) == 1
+
+    def test_the_newest_record_is_first(self) -> None:
+        # Written oldest-first and then dated in the opposite order, so a
+        # screen falling back to insertion order gets this exactly backwards.
+        for subject in ("newest", "middle", "oldest"):
+            self._record(subject=subject)
+        for row, day in zip(
+            ConsumerOutcome.objects.order_by("pk"), (3, 2, 1), strict=True
+        ):
+            ConsumerOutcome.objects.filter(pk=row.pk).update(
+                recorded_at=datetime(2026, 1, day, tzinfo=UTC)
+            )
+
+        shown = [
+            next(s for s in ("newest", "middle", "oldest") if s in row)
+            for row in self._rendered_rows()
+        ]
+        assert shown == ["newest", "middle", "oldest"]
+
+    def test_the_screen_shows_the_values_not_the_encoded_keys(self) -> None:
+        self._record()
+        (row,) = self._rendered_rows()
+
+        # The value the consumer passed, not the column it was indexed under.
+        assert "submission/tf611" in row
+        assert "submission%2Ftf611" not in row
+        for value in ("ledger", "row-9", "42", "project", "REFUSED"):
+            assert value in row
+        assert "missing_total" in row and "bad_date" in row
+
+    def test_a_record_from_before_the_log_renders_without_an_offset(self) -> None:
+        # `stage="append"` means the event never reached the log, so it has no
+        # position to name — an absence, not the word Python prints for one.
+        self._record(stage="append", status="failed", offset=None)
+        (row,) = self._rendered_rows()
+        assert "FAILED" in row and "append" in row
+        assert "None" not in row
+
+    def test_nothing_can_be_added_changed_or_deleted(self) -> None:
+        self._record()
+        request, _ = _changelist(self.admin)
+        row = ConsumerOutcome.objects.get()
+        assert self.admin.has_add_permission(request) is False
+        assert self.admin.has_change_permission(request) is False
+        assert self.admin.has_change_permission(request, row) is False
+        assert self.admin.has_delete_permission(request) is False
+        assert self.admin.has_delete_permission(request, row) is False
+
+    def test_a_payload_this_version_cannot_read_still_renders(self) -> None:
+        # A row from a version whose outcome had fields this one requires.
+        # `decode_outcome` returns None for it, and the page must survive.
+        self._record()
+        ConsumerOutcome.objects.create(
+            consumer_key="ledger",
+            stream_path_key="submission%2Ftf611",
+            payload='{"consumer": "ledger"}',
+        )
+        rows = self._rendered_rows()
+
+        assert len(rows) == 2
+        # And it has to say so: an all-blank row reads as a rendering fault.
+        assert any("unreadable" in row.lower() for row in rows)


### PR DESCRIPTION
The library keeps a record of every event a consumer could not process, and until now the only way to read one was to query the database directly. There is now a page in the Django admin listing them newest first, showing the consumer, the stream, the subject, the position, the stage, the status and the reasons behind it.

The values shown come out of the stored record, not the two index columns beside it — those hold a percent-encoded form of the name and would print something no consumer ever passed. The page is read-only throughout: these are a record of what happened, and clearing them out is the retention job in #253 rather than a button here. A record written by a version this one cannot read still gets a row, marked as unreadable, because a record dropped from the page is the failure the whole table exists to prevent.

Closes #252
