### PR TITLE
Delete old failure records, on an age the operator names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,23 @@ runnable demo for each.
 
 ### Added
 
+- **`manage.py prune_outcomes` — a retention sweep for the outcome table, plus an
+  index on the timestamp it filters.** Failure records are written only when a
+  consumer cannot apply an event and nothing ever removed them, so an
+  installation with a long-running intermittent problem accumulated them with no
+  way to clear the old ones short of hand-written SQL. The command takes the age
+  to keep and deletes what is older:
+  `python manage.py prune_outcomes --older-than-days 365`.
+
+  **`--older-than-days` has no default and the command refuses to run without
+  it** — the right retention period differs by installation, and a guess destroys
+  the evidence of a problem someone may still be investigating. `--dry-run`
+  reports the count and deletes nothing, deletion is batched (`--batch-size`,
+  default 1000) so a first prune over a backlog is not one long lock, and
+  `--database` targets a named alias. "Older than" is strict: a record stamped
+  exactly on the cutoff is kept. Migration `0011` adds the index the sweep needs;
+  see `docs/deployment.md`. (#253)
+
 - **`JsonlStreamStore` — keep a log in plain text files instead of a database.**
   A stream is a directory of JSON-lines segments; an event is a line. Nothing but
   the filesystem is involved, so a consumer who wants durability without running

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -215,6 +215,39 @@ For an actual deployment, you'd want at least:
 4. **Process supervision.** systemd, s6, or your container orchestrator.
 5. **Static files.** The chat sample has none, but if you add any, run
    `collectstatic` and serve them via the reverse proxy or WhiteNoise.
+6. **A retention policy for outcome records.** Nothing deletes them on its own.
+   See the next section.
+
+## Retention: pruning old outcome records
+
+When a consumer cannot apply an event, the failure is recorded so it can be
+looked at later. Only failures are recorded, so on a healthy system the table
+stays small — but nothing ever removes a row, and an installation that has run
+for years with an intermittent problem will have years of them.
+
+`prune_outcomes` deletes the old ones:
+
+```bash
+# What would go, without deleting anything:
+python manage.py prune_outcomes --older-than-days 365 --dry-run
+
+# Actually delete:
+python manage.py prune_outcomes --older-than-days 365
+```
+
+**There is no default age, and the command refuses to run without one.** How long
+these records are worth keeping is a question about your obligations, not about
+this library: a fortnight is right for one installation and seven years for
+another, and a default would be applied by whoever ran the command without
+reading this page. What it deletes is the evidence of a problem someone may still
+be working through, so the age is yours to state.
+
+"Older than" is strict — a record stamped exactly at the cutoff is kept — and
+deletion is done in batches (`--batch-size`, default 1000) so a first prune over
+a large backlog does not hold one long lock on a table your consumers are still
+writing to. `--database` prunes a named database alias, matching the alias the
+outcome store writes on. Run it from cron or your scheduler at whatever interval
+suits; running it twice deletes nothing the first run did not.
 
 ## Troubleshooting
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -186,6 +186,11 @@ No example exercises these yet — a good place to contribute a demo:
   stores). Exported and supported since #251, so the old reason for this gap —
   that an example would document an unstable surface — has expired. What is
   missing now is simply the example: nothing under `examples/` calls `consume()`.
+- Outcome retention. `manage.py prune_outcomes` deletes old failure records
+  (`docs/deployment.md`), but no example records a failure and then prunes it, so
+  nothing under `examples/` demonstrates the operator's side of the outcome
+  table. It follows the gap above: with no example calling `consume()`, there is
+  nothing for a prune demo to prune.
 
 ## Orientation for contributors
 

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -646,6 +646,37 @@ above has no worked example. That gap is named in
 
 ---
 
+## 20. Old failure records can be cleared out, on your terms
+
+**The problem.** Failure records are written only when something goes wrong, so
+the table stays small on a healthy system and nobody thinks about it. An
+installation with an intermittent problem is the other case: the records
+accumulate for years and nothing removes them. Clearing the old ones meant
+writing SQL against a table you were told not to read directly.
+
+**What rakaia does.** A management command deletes records older than an age you
+name. Ask it what would go first:
+
+```bash
+python manage.py prune_outcomes --older-than-days 365 --dry-run
+```
+
+That prints the cutoff date and the count and changes nothing. Drop `--dry-run`
+to delete. The age has **no default and the command refuses to run without one** —
+how long these are worth keeping is a question about your obligations rather
+than about this library, and what a wrong guess destroys is the evidence of a
+problem someone may still be working through. A record stamped exactly on the
+cutoff is kept, deletion runs in batches so a first prune over a long backlog is
+not one long lock, and `--database` points it at a named alias.
+
+The timestamp gained an index in the same change. The table deliberately carries
+only the indexes its real queries need, and this sweep is the first query to ask
+about age.
+
+→ Deep dive: [Deployment — retention](deployment.md#retention-pruning-old-outcome-records)
+
+---
+
 ## Where to go next
 
 - Want the reference for handlers, upcasters and drift? → [Versioned handlers](versioned-handlers.md)

--- a/src/django_rakaia/management/commands/prune_outcomes.py
+++ b/src/django_rakaia/management/commands/prune_outcomes.py
@@ -1,0 +1,119 @@
+"""
+`manage.py prune_outcomes --older-than-days N` — delete `ConsumerOutcome` rows
+recorded more than N days ago.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from typing import Any
+
+from django.core.management.base import BaseCommand, CommandError, CommandParser
+from django.db import DEFAULT_DB_ALIAS
+from django.utils import timezone
+
+from django_rakaia.models import ConsumerOutcome
+
+
+class Command(BaseCommand):
+    """Retention for the outcome table, with the age supplied by the operator.
+
+    ``--older-than-days`` has no default and the command refuses to run without
+    it. Every plausible default is wrong somewhere: a row here is the record of
+    an event a consumer could not apply, and the installation that keeps two
+    weeks of them and the one that keeps seven years are both right about their
+    own obligations. A default would be applied by whoever ran the command
+    without reading it, and what it destroys is the evidence someone is still
+    working from.
+
+    ``--dry-run`` counts the same rows without deleting them, so the age can be
+    checked against a real table before it is trusted in a cron entry. Deletion
+    is batched because the table's size is unbounded in exactly the case this
+    command exists for — an installation that has never pruned — and one
+    statement over a year of rows is a long lock on a table the consume loop
+    writes to from inside its own error handler.
+    """
+
+    help = "Delete consumer outcome records older than a given age."
+
+    def add_arguments(self, parser: CommandParser) -> None:
+        parser.add_argument(
+            "--older-than-days",
+            dest="older_than_days",
+            type=int,
+            default=None,
+            help=(
+                "Delete outcomes recorded more than this many days ago. "
+                "Required — there is deliberately no default."
+            ),
+        )
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Report how many rows would be deleted, and delete nothing.",
+        )
+        parser.add_argument(
+            "--batch-size",
+            dest="batch_size",
+            type=int,
+            default=1000,
+            help="Rows to delete per statement. Default: 1000.",
+        )
+        parser.add_argument(
+            "--database",
+            dest="database",
+            default=DEFAULT_DB_ALIAS,
+            help=f"Database alias to prune. Default: {DEFAULT_DB_ALIAS!r}.",
+        )
+
+    def handle(self, *args: Any, **options: Any) -> None:  # noqa: ARG002
+        days = options["older_than_days"]
+        if days is None:
+            raise CommandError(
+                "--older-than-days is required and has no default. The right "
+                "retention period differs by installation, and a guess deletes "
+                "the record of a failure someone may still be investigating. "
+                "Pass the age you mean, e.g. --older-than-days 365."
+            )
+        if days < 0:
+            raise CommandError(
+                f"--older-than-days must not be negative (got {days}). An age "
+                "in the future selects no rows and is more likely a typo than a "
+                "request."
+            )
+        batch_size = options["batch_size"]
+        if batch_size < 1:
+            raise CommandError(f"--batch-size must be at least 1 (got {batch_size}).")
+
+        alias = options["database"]
+        dry_run = options["dry_run"]
+        cutoff = timezone.now() - timedelta(days=days)
+        # Strictly older: a row stamped exactly on the cutoff is not older than
+        # the age given, and keeping it is the reading that never deletes more
+        # than the operator asked for.
+        stale = ConsumerOutcome.objects.using(alias).filter(recorded_at__lt=cutoff)
+
+        if dry_run:
+            deleted = stale.count()
+        else:
+            deleted = 0
+            while True:
+                # Re-selecting the primary keys each pass rather than deleting
+                # the sliced queryset directly: a queryset with a LIMIT cannot be
+                # deleted, and the filter is on a timestamp that only ever moves
+                # rows *into* the selection, so a fresh pass cannot loop forever.
+                pks = list(stale.values_list("pk", flat=True)[:batch_size])
+                if not pks:
+                    break
+                ConsumerOutcome.objects.using(alias).filter(pk__in=pks).delete()
+                deleted += len(pks)
+
+        mode = "DRY RUN" if dry_run else "DELETED"
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"[{mode}] older-than-days={days} "
+                f"cutoff={cutoff.isoformat()} "
+                f"database={alias!r} "
+                f"deleted={deleted}"
+            )
+        )

--- a/src/django_rakaia/migrations/0011_outcome_recorded_at_index.py
+++ b/src/django_rakaia/migrations/0011_outcome_recorded_at_index.py
@@ -1,0 +1,22 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    """An index on the outcome timestamp, for the retention sweep that filters on it.
+
+    The table shipped with one index, over the scope `latest` queries by, and
+    deliberately no others — see the model for why an index nothing queries is a
+    cost rather than a spare. `manage.py prune_outcomes` is the first query on
+    ``recorded_at``, so the index lands with it.
+    """
+
+    dependencies = [
+        ("django_rakaia", "0010_consumeroutcome"),
+    ]
+
+    operations = [
+        migrations.AddIndex(
+            model_name="consumeroutcome",
+            index=models.Index(fields=["recorded_at"], name="rakaia_outcome_age_idx"),
+        ),
+    ]

--- a/src/django_rakaia/models.py
+++ b/src/django_rakaia/models.py
@@ -450,17 +450,22 @@ class ConsumerOutcome(models.Model):
     a capacity, and why nothing here can refuse a name for being too long.
 
     **There are exactly two because `latest(consumer, stream_path)` is the only
-    query.** `subject` and `offset` were columns for one round and were written
-    and never read: `latest` groups by subject and orders by offset in Python,
-    from the payload. An index nothing queries is not free — it is two derived
-    writes per record, and a ``subject_key`` holding a cut, percent-encoded
-    string is a trap for the next reader, who will take it for the subject and
-    get a value that is neither the subject nor reliably distinct from another
-    one. When the operator worklist ADR 0007 sketches arrives it can add the
-    column the query actually wants; the ADR's own complaint about the motivating
-    consumer is that it has "neither a retention policy nor an index supporting
-    the query its two hot paths run", which is an argument for indexes that match
-    real queries and against carrying ones that match imagined queries.
+    query that needs a scope.** `subject` and `offset` were columns for one round
+    and were written and never read: `latest` groups by subject and orders by
+    offset in Python, from the payload. An index nothing queries is not free — it
+    is two derived writes per record, and a ``subject_key`` holding a cut,
+    percent-encoded string is a trap for the next reader, who will take it for
+    the subject and get a value that is neither the subject nor reliably distinct
+    from another one. When the operator worklist ADR 0007 sketches arrives it can
+    add the column the query actually wants; the ADR's own complaint about the
+    motivating consumer is that it has "neither a retention policy nor an index
+    supporting the query its two hot paths run", which is an argument for indexes
+    that match real queries and against carrying ones that match imagined
+    queries.
+
+    ``recorded_at`` earns the second index on the same terms. It carried none
+    until `manage.py prune_outcomes` gave it a query — a retention sweep filtering
+    on age — and the index landed with that command rather than ahead of it.
 
     ``attempt`` is not a column either, for the same reason plus one more. It is
     a counter rather than a name, `latest` reads it from the payload, and as an
@@ -483,6 +488,7 @@ class ConsumerOutcome(models.Model):
     """The whole outcome, as `rakaia.outcomes.encode_outcome` wrote it. The record."""
 
     recorded_at = models.DateTimeField(auto_now_add=True)
+    """When the row was appended. Indexed, because `prune_outcomes` filters on it."""
 
     class Meta:
         db_table = "rakaia_consumeroutcome"
@@ -490,7 +496,14 @@ class ConsumerOutcome(models.Model):
             models.Index(
                 fields=["consumer_key", "stream_path_key"],
                 name="rakaia_outcome_scope_idx",
-            )
+            ),
+            # The retention sweep's `recorded_at__lt` — the second real query,
+            # and the reason this index exists rather than the timestamp having
+            # carried one since the table was created.
+            models.Index(
+                fields=["recorded_at"],
+                name="rakaia_outcome_age_idx",
+            ),
         ]
 
     def __str__(self) -> str:

--- a/tests/test_django_rakaia/test_prune_outcomes_command.py
+++ b/tests/test_django_rakaia/test_prune_outcomes_command.py
@@ -1,0 +1,180 @@
+"""Tests for the `manage.py prune_outcomes` management command.
+
+The command deletes `ConsumerOutcome` rows older than an age the operator has to
+name. The tests that matter most are the ones about *not* deleting: an omitted
+age changes nothing, and the row sitting exactly on the cutoff survives.
+"""
+
+from __future__ import annotations
+
+import io
+from datetime import timedelta
+
+import pytest
+from django.core.management import call_command
+from django.core.management.base import CommandError
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
+from django.utils import timezone
+
+from django_rakaia.management.commands import prune_outcomes
+from django_rakaia.models import ConsumerOutcome
+
+
+class _FrozenClock:
+    """Just enough of `django.utils.timezone` for the command to read the clock.
+
+    The boundary case cannot be pinned against a moving clock: a row stamped
+    ``now() - 30d`` is already microseconds past a cutoff the command computes an
+    instant later, so "exactly on the cutoff" is unreachable unless both sides
+    agree on one instant.
+    """
+
+    def __init__(self, at):
+        self._at = at
+
+    def now(self):
+        return self._at
+
+
+def _at(when) -> int:
+    """Create one outcome row stamped exactly `when`, and return its pk."""
+    row = ConsumerOutcome.objects.create(
+        consumer_key="c", stream_path_key="s", payload="{}"
+    )
+    ConsumerOutcome.objects.filter(pk=row.pk).update(recorded_at=when)
+    return row.pk
+
+
+def _outcome(*, age: timedelta, consumer: str = "c", stream: str = "s") -> int:
+    """Create one outcome row aged `age` into the past, and return its pk.
+
+    ``recorded_at`` is ``auto_now_add``, so it cannot be set on create — the row
+    is stamped now and then backdated with an ``update()``, which auto_now_add
+    does not touch.
+    """
+    row = ConsumerOutcome.objects.create(
+        consumer_key=consumer, stream_path_key=stream, payload="{}"
+    )
+    ConsumerOutcome.objects.filter(pk=row.pk).update(recorded_at=timezone.now() - age)
+    return row.pk
+
+
+@pytest.mark.django_db
+class TestPruneOutcomesCommand:
+    def test_no_age_refuses_and_deletes_nothing(self):
+        """No default age: without one the command fails and the table is untouched."""
+        _outcome(age=timedelta(days=3650))
+
+        with pytest.raises(CommandError) as excinfo:
+            call_command("prune_outcomes", stdout=io.StringIO())
+
+        # The message has to say *why* there is no default, or the next operator
+        # will read the refusal as a missing flag and guess a number.
+        assert "--older-than-days" in str(excinfo.value)
+        assert ConsumerOutcome.objects.count() == 1
+
+    def test_deletes_only_rows_older_than_the_age(self):
+        old = _outcome(age=timedelta(days=400))
+        recent = _outcome(age=timedelta(days=10))
+
+        out = io.StringIO()
+        call_command("prune_outcomes", "--older-than-days", "365", stdout=out)
+
+        assert list(ConsumerOutcome.objects.values_list("pk", flat=True)) == [recent]
+        assert not ConsumerOutcome.objects.filter(pk=old).exists()
+        assert "deleted=1" in out.getvalue()
+
+    def test_row_on_the_cutoff_is_kept(self, monkeypatch):
+        """ "Older than" is strict: the row stamped exactly on the cutoff survives."""
+        frozen = timezone.now()
+        monkeypatch.setattr(prune_outcomes, "timezone", _FrozenClock(frozen))
+        cutoff = frozen - timedelta(days=30)
+
+        older = _at(cutoff - timedelta(microseconds=1))
+        on_cutoff = _at(cutoff)
+        newer = _at(cutoff + timedelta(microseconds=1))
+
+        call_command("prune_outcomes", "--older-than-days", "30", stdout=io.StringIO())
+
+        survivors = set(ConsumerOutcome.objects.values_list("pk", flat=True))
+        assert survivors == {on_cutoff, newer}
+        assert older not in survivors
+
+    def test_zero_days_is_an_age_and_is_honoured(self):
+        """0 is a real answer — delete everything recorded before now — not a missing one."""
+        _outcome(age=timedelta(days=1))
+
+        call_command("prune_outcomes", "--older-than-days", "0", stdout=io.StringIO())
+
+        assert ConsumerOutcome.objects.count() == 0
+
+    def test_negative_age_is_refused(self):
+        _outcome(age=timedelta(days=1))
+
+        with pytest.raises(CommandError) as excinfo:
+            call_command(
+                "prune_outcomes", "--older-than-days", "-1", stdout=io.StringIO()
+            )
+
+        assert "--older-than-days" in str(excinfo.value)
+
+        assert ConsumerOutcome.objects.count() == 1
+
+    def test_dry_run_reports_the_count_and_deletes_nothing(self):
+        _outcome(age=timedelta(days=400))
+        _outcome(age=timedelta(days=10))
+
+        out = io.StringIO()
+        call_command(
+            "prune_outcomes",
+            "--older-than-days",
+            "365",
+            "--dry-run",
+            stdout=out,
+        )
+
+        assert ConsumerOutcome.objects.count() == 2
+        text = out.getvalue()
+        assert "DRY RUN" in text
+        assert "deleted=1" in text
+
+    def test_deletes_across_more_than_one_batch(self):
+        for _ in range(5):
+            _outcome(age=timedelta(days=400))
+        kept = _outcome(age=timedelta(days=1))
+
+        out = io.StringIO()
+        with CaptureQueriesContext(connection) as queries:
+            call_command(
+                "prune_outcomes",
+                "--older-than-days",
+                "365",
+                "--batch-size",
+                "2",
+                stdout=out,
+            )
+
+        assert list(ConsumerOutcome.objects.values_list("pk", flat=True)) == [kept]
+        assert "deleted=5" in out.getvalue()
+        # Five stale rows at two per pass is three statements, not one. Counting
+        # them is what makes this a test of the batching rather than of the
+        # filter — one big DELETE leaves the same rows behind.
+        deletes = [q for q in queries.captured_queries if "DELETE" in q["sql"].upper()]
+        assert len(deletes) == 3
+
+    def test_reports_the_cutoff_it_used(self):
+        out = io.StringIO()
+        call_command("prune_outcomes", "--older-than-days", "7", stdout=out)
+
+        # An operator reading a cron log needs to see the date, not just the age.
+        cutoff = timezone.now() - timedelta(days=7)
+        assert cutoff.date().isoformat() in out.getvalue()
+
+
+@pytest.mark.django_db
+class TestRecordedAtIndex:
+    def test_recorded_at_is_indexed(self):
+        """The command's filter is the first real query on the timestamp."""
+        indexed = {tuple(index.fields) for index in ConsumerOutcome._meta.indexes}
+        assert ("recorded_at",) in indexed

--- a/tests/test_django_rakaia/test_prune_outcomes_command.py
+++ b/tests/test_django_rakaia/test_prune_outcomes_command.py
@@ -178,3 +178,86 @@ class TestRecordedAtIndex:
         """The command's filter is the first real query on the timestamp."""
         indexed = {tuple(index.fields) for index in ConsumerOutcome._meta.indexes}
         assert ("recorded_at",) in indexed
+
+
+@pytest.mark.django_db(transaction=True, databases=["default", "overlay"])
+class TestTheDatabaseFlag:
+    """`--database` decides which database is pruned, and nothing else is touched.
+
+    ``transaction=True`` because this is alias-aware: under a plain marker
+    pytest-django has already opened a transaction on every declared alias, which
+    is what `CLAUDE.md` records as hiding a missing ``using=`` (#180). There is no
+    ``atomic()`` in this command for that to mask today, and the marker is what
+    keeps that true if one ever appears.
+    """
+
+    def _stale_on(self, alias: str) -> int:
+        row = ConsumerOutcome.objects.using(alias).create(
+            consumer_key="c", stream_path_key="s", payload="{}"
+        )
+        ConsumerOutcome.objects.using(alias).filter(pk=row.pk).update(
+            recorded_at=timezone.now() - timedelta(days=400)
+        )
+        return row.pk
+
+    def test_only_the_named_database_is_pruned(self):
+        self._stale_on("default")
+        self._stale_on("overlay")
+
+        call_command(
+            "prune_outcomes", "--older-than-days", "365", "--database", "overlay"
+        )
+
+        assert ConsumerOutcome.objects.using("overlay").count() == 0
+        # The row the operator did not name. Drop `.using(alias)` from either
+        # queryset in the command and this is the row that goes instead.
+        assert ConsumerOutcome.objects.using("default").count() == 1
+
+    def test_a_dry_run_counts_the_named_database(self):
+        self._stale_on("default")
+        self._stale_on("overlay")
+        self._stale_on("overlay")
+
+        out = io.StringIO()
+        call_command(
+            "prune_outcomes",
+            "--older-than-days",
+            "365",
+            "--database",
+            "overlay",
+            "--dry-run",
+            stdout=out,
+        )
+
+        assert "deleted=2" in out.getvalue()
+        assert ConsumerOutcome.objects.using("overlay").count() == 2
+
+
+@pytest.mark.django_db
+class TestTheBatchSize:
+    """A batch size below one is refused rather than quietly doing nothing.
+
+    ``--batch-size 0`` slices ``[:0]``, finds nothing, breaks on the first pass
+    and reports ``deleted=0`` — a cron entry that looks like it ran and pruned an
+    empty table. ``-1`` reaches Django and raises about negative indexing.
+    """
+
+    def test_zero_is_refused_and_deletes_nothing(self):
+        _outcome(age=timedelta(days=400))
+
+        with pytest.raises(CommandError, match="--batch-size"):
+            call_command(
+                "prune_outcomes", "--older-than-days", "365", "--batch-size", "0"
+            )
+
+        assert ConsumerOutcome.objects.count() == 1
+
+    def test_negative_is_refused_and_deletes_nothing(self):
+        _outcome(age=timedelta(days=400))
+
+        with pytest.raises(CommandError, match="--batch-size"):
+            call_command(
+                "prune_outcomes", "--older-than-days", "365", "--batch-size", "-1"
+            )
+
+        assert ConsumerOutcome.objects.count() == 1


### PR DESCRIPTION
Closes #253.

A record is written whenever a consumer cannot apply an event, and nothing ever removed one — so an installation carrying a long-running intermittent problem accumulated years of them, with no way to clear the old ones short of writing SQL by hand. There is now a command that deletes records older than an age you give it: `python manage.py prune_outcomes --older-than-days 365`. It will tell you what would go before anything does (`--dry-run` prints the cutoff date and the count and changes nothing), it deletes in batches so a first pass over a long backlog is not one long lock on a table consumers are still writing to, and the timestamp it filters on gained an index in the same change.

The age has no default and the command refuses to run without one. How long these records are worth keeping is a question about an installation's own obligations rather than about this library, and a default would be applied by whoever ran the command without reading the page — what a wrong guess destroys is the evidence of a problem someone may still be working through. Deployment guidance now has a retention section, and the guided tour has a section for the new command.
