### PR TITLE
Give batching a file of its own, with its rules written down

### DIFF
--- a/docs/adr/0007-an-outcome-is-recorded-where-the-cursor-is-committed.md
+++ b/docs/adr/0007-an-outcome-is-recorded-where-the-cursor-is-committed.md
@@ -42,7 +42,7 @@ out the obvious implementation.
 `transaction.atomic` (`src/django_rakaia/effect_executor.py:204`). An outcome row
 written inside that block rolls back with the batch whose failure it exists to
 record. Worse, it could not name the event anyway: a stage-0 pass buffers many events
-into one `apply()` (`_StageBuffer`, `src/rakaia/replay.py:434`), and `RowEffect`
+into one `apply()` (`_StageBuffer`, `src/rakaia/batching.py:62`), and `RowEffect`
 carries `model_label` and `lookup` and nothing else (`src/rakaia/effects.py:176-189`).
 By the time effects reach an executor, which event produced which effect is not
 recoverable.

--- a/src/rakaia/batching.py
+++ b/src/rakaia/batching.py
@@ -1,0 +1,146 @@
+"""Holding a replay pass's effects back so the executor sees few, large batches
+— and flushing the moment holding one back would change the answer.
+
+Replay used to call ``executor.apply()`` once per event, so a batch of one was
+the norm: the contiguous-`Update` collapsing in the Django executor could never
+engage (a run of one is never collapsed), and nine events meant nine
+``transaction.atomic()`` blocks, measured at 18 of the 135 statements one form
+save issues (#207). Widening the batch is only free if the executor cannot tell
+the difference, so **the whole design is in the four rules that force a flush**:
+
+* **Before a reorder.** A batch is applied writes-then-deletes-then-retires (see
+  `_write_order_rank`), so an effect ranking below anything pending would be
+  hoisted across an event boundary — flush before adding it.
+* **Before a collision.** A second write to the same column of the same row is
+  ordinary between events (event 2 supersedes event 1) and an error inside one
+  batch, which `check_disjoint_defaults` raises with nothing applied. Asked
+  through the same `_WrittenFields` that check uses, so there is one rule.
+* **Before a duplicate ``produces=``.** Two producers of one correlation id in a
+  batch is `DuplicateProducesError`; in separate events it is normal.
+* **After a transition retire.** Its transitions are synthesised from the report
+  of the call that applied it, and the replay result's external list is
+  documented in handler-emission order, so nothing may ride along behind it.
+  Opted-in retires are rare, so this costs almost nothing.
+
+Two things the buffer deliberately does *not* preserve, both widenings rather
+than changes: a `Ref` may now bind to a ``produces=`` row from an earlier event
+in the same pass (it used to raise, because refs do not cross an ``apply()``
+call), and the executor sees fewer, larger batches.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Protocol
+
+from .effects import (
+    ApplyReport,
+    Effect,
+    Executor,
+    Retire,
+    Upsert,
+    _write_order_rank,
+    _WrittenFields,
+)
+
+
+def _self_collides(effects: list[Effect]) -> bool:
+    """Whether one event's own effects already write the same column twice.
+
+    That is a bug the executor reports, and it must keep reporting it *for that
+    event alone* — so a self-colliding group is applied on its own, leaving
+    earlier events' effects committed exactly as they were before buffering.
+    """
+    seen = _WrittenFields()
+    for idx, eff in enumerate(effects):
+        if seen.collides(eff) is not None:
+            return True
+        seen.record(eff, idx)
+    return False
+
+
+class _StageBuffer:
+    """Effects held back so a pass reaches the executor as few batches as
+    possible, flushed early by the four rules in this module's docstring.
+
+    Constructed with the executor to apply through and a sink for each call's
+    `ApplyReport`. The buffer owns the ``apply()`` call, so the sink is the only
+    way its caller learns what a batch observed — which is how a transition
+    retire's flips reach the replay result as external effects.
+    """
+
+    def __init__(
+        self, executor: Executor, on_report: Callable[[ApplyReport | None], None]
+    ) -> None:
+        self._executor = executor
+        self._on_report = on_report
+        self._pending: list[Effect] = []
+        self._written = _WrittenFields()
+        self._produces: set[str] = set()
+        self._max_rank = -1
+
+    def add(self, effects: list[Effect]) -> None:
+        """Buffer one event's effects, flushing first if they cannot join."""
+        if not effects:
+            return
+        alone = _self_collides(effects)
+        if self._pending and (alone or self._conflicts(effects)):
+            self.flush()
+        for eff in effects:
+            self._written.record(eff, len(self._pending))
+            self._pending.append(eff)
+            if isinstance(eff, Upsert) and eff.produces is not None:
+                self._produces.add(eff.produces)
+            self._max_rank = max(self._max_rank, _write_order_rank(eff))
+        if alone or any(
+            isinstance(e, Retire) and e.transition is not None for e in effects
+        ):
+            self.flush()
+
+    def _conflicts(self, effects: list[Effect]) -> bool:
+        """Whether adding `effects` to what is pending would change behaviour.
+
+        Checked for the group as a whole, against what is pending only — an
+        event's effects collide with *each other* under the same rules the
+        executor already applies to a batch, and that stays the executor's to
+        report.
+        """
+        if min(_write_order_rank(e) for e in effects) < self._max_rank:
+            return True
+        if any(self._written.collides(e) is not None for e in effects):
+            return True
+        return any(
+            isinstance(e, Upsert)
+            and e.produces is not None
+            and e.produces in self._produces
+            for e in effects
+        )
+
+    def flush(self) -> None:
+        """Apply what is buffered as one batch, and reset."""
+        if not self._pending:
+            return
+        batch = self._pending
+        self._pending = []
+        self._written = _WrittenFields()
+        self._produces = set()
+        self._max_rank = -1
+        self._on_report(self._executor.apply(batch))
+
+
+class _Buffered(Protocol):
+    """Anything carrying the buffer for the pass currently running.
+
+    Named as a protocol so `_drain` can live beside the buffer it empties
+    without this module having to import the replay context — the batching rules
+    do not depend on anything else the orchestrator carries.
+    """
+
+    buffer: _StageBuffer | None
+
+
+def _drain(ctx: _Buffered) -> None:
+    """Apply whatever the pass buffered, and go back to per-event application."""
+    if ctx.buffer is not None:
+        buffer, ctx.buffer = ctx.buffer, None
+        buffer.flush()

--- a/src/rakaia/replay.py
+++ b/src/rakaia/replay.py
@@ -69,6 +69,7 @@ from collections.abc import Iterable, Iterator
 from dataclasses import dataclass, field
 from typing import Any
 
+from .batching import _drain, _StageBuffer
 from .drift import DriftLedger
 
 # `HandlerDriftError` and `OnDriftPolicy` live in `rakaia.drift` with the check
@@ -86,8 +87,6 @@ from .effects import (
     Retire,
     Update,
     Upsert,
-    _write_order_rank,
-    _WrittenFields,
     transition_payload,
 )
 from .protocols import ProjectionReader, ReadableStore
@@ -308,7 +307,7 @@ def run_passes(
         # effects can be batched. A stage > 0 handler *is* handed a reader, and
         # both readers go straight to storage — a buffered write would be
         # invisible to one, silently — so those passes keep applying per event.
-        ctx.buffer = _StageBuffer(ctx) if stage in (None, 0) else None
+        ctx.buffer = _make_buffer(ctx) if stage in (None, 0) else None
         dispatched = 0
         try:
             for seq, match_str, event in source:
@@ -401,116 +400,17 @@ def _synth_transitions(report: ApplyReport | None) -> list[ExternalEffect]:
     return out
 
 
-def _self_collides(effects: list[Effect]) -> bool:
-    """Whether one event's own effects already write the same column twice.
+def _make_buffer(ctx: _ReplayCtx) -> _StageBuffer:
+    """A buffer for one pass, wired to this replay's executor and result.
 
-    That is a bug the executor reports, and it must keep reporting it *for that
-    event alone* — so a self-colliding group is applied on its own, leaving
-    earlier events' effects committed exactly as they were before buffering.
+    The buffer owns the ``apply()`` call, so the transitions a batch's retires
+    flipped come back through the sink rather than to the dispatch site — which
+    is what keeps the external list in handler-emission order.
     """
-    seen = _WrittenFields()
-    for idx, eff in enumerate(effects):
-        if seen.collides(eff) is not None:
-            return True
-        seen.record(eff, idx)
-    return False
-
-
-class _StageBuffer:
-    """Effects held back so a stage reaches the executor as few batches as
-    possible — flushed early the moment holding one back would change anything.
-
-    Replay used to call ``executor.apply()`` once per event, so a batch of one
-    was the norm and the contiguous-`Update` collapsing in the Django executor
-    could never engage: a run of one is never collapsed. Nine events also meant
-    nine ``transaction.atomic()`` blocks, measured at 18 of the 135 statements
-    one form save issues (#207).
-
-    **The whole design is in when it flushes.** Widening the batch is only free
-    if the executor cannot tell, so each of these forces a flush first:
-
-    * **A write behind a delete.** See `_write_order_rank` — a batch is applied
-      writes-then-deletes-then-retires, so an incoming effect that ranks below
-      anything pending would be reordered across an event boundary.
-    * **A second write to the same column of the same row.** Ordinary between
-      events (event 2 supersedes event 1) and an error within one batch, which
-      `check_disjoint_defaults` raises with nothing applied. Consulted through
-      the same `_WrittenFields` that check uses, so there is one rule.
-    * **A repeated ``produces=`` id.** Two producers of one correlation id in a
-      batch is `DuplicateProducesError`; in separate events it is normal.
-    * **A retire that asked for notifications.** Its transitions are synthesised
-      from the report of the call that applied it, and `ReplayResult.external`
-      is documented in handler-emission order. Flushing on one keeps that list
-      byte-identical. Opted-in retires are rare, so this costs almost nothing.
-
-    Two things it deliberately does *not* try to preserve, both widenings rather
-    than changes: a `Ref` may now bind to a ``produces=`` row from an earlier
-    event in the same stage (it used to raise, because refs do not cross an
-    ``apply()`` call), and the executor sees fewer, larger batches.
-    """
-
-    def __init__(self, ctx: _ReplayCtx) -> None:
-        self._ctx = ctx
-        self._pending: list[Effect] = []
-        self._written = _WrittenFields()
-        self._produces: set[str] = set()
-        self._max_rank = -1
-
-    def add(self, effects: list[Effect]) -> None:
-        """Buffer one event's effects, flushing first if they cannot join."""
-        if not effects:
-            return
-        alone = _self_collides(effects)
-        if self._pending and (alone or self._conflicts(effects)):
-            self.flush()
-        for eff in effects:
-            self._written.record(eff, len(self._pending))
-            self._pending.append(eff)
-            if isinstance(eff, Upsert) and eff.produces is not None:
-                self._produces.add(eff.produces)
-            self._max_rank = max(self._max_rank, _write_order_rank(eff))
-        if alone or any(
-            isinstance(e, Retire) and e.transition is not None for e in effects
-        ):
-            self.flush()
-
-    def _conflicts(self, effects: list[Effect]) -> bool:
-        """Whether adding `effects` to what is pending would change behaviour.
-
-        Checked for the group as a whole, against what is pending only — an
-        event's effects collide with *each other* under the same rules the
-        executor already applies to a batch, and that stays the executor's to
-        report.
-        """
-        if min(_write_order_rank(e) for e in effects) < self._max_rank:
-            return True
-        if any(self._written.collides(e) is not None for e in effects):
-            return True
-        return any(
-            isinstance(e, Upsert)
-            and e.produces is not None
-            and e.produces in self._produces
-            for e in effects
-        )
-
-    def flush(self) -> None:
-        """Apply what is buffered as one batch, and reset."""
-        if not self._pending:
-            return
-        batch = self._pending
-        self._pending = []
-        self._written = _WrittenFields()
-        self._produces = set()
-        self._max_rank = -1
-        report = self._ctx.executor.apply(batch)
-        self._ctx.result.external.extend(_synth_transitions(report))
-
-
-def _drain(ctx: _ReplayCtx) -> None:
-    """Apply whatever the pass buffered, and go back to per-event application."""
-    if ctx.buffer is not None:
-        buffer, ctx.buffer = ctx.buffer, None
-        buffer.flush()
+    return _StageBuffer(
+        ctx.executor,
+        lambda report: ctx.result.external.extend(_synth_transitions(report)),
+    )
 
 
 def _apply_effects(ctx: _ReplayCtx, effects: list[AnyEffect]) -> None:

--- a/tests/test_django_rakaia/test_write_order_conformance.py
+++ b/tests/test_django_rakaia/test_write_order_conformance.py
@@ -31,6 +31,7 @@ from rakaia.store import StreamStore
 # back a function and every assertion below would be about the wrong object.
 effects_module = import_module("rakaia.effects")
 replay_module = import_module("rakaia.replay")
+batching_module = import_module("rakaia.batching")
 executors_module = import_module("rakaia.executors")
 effect_executor = import_module("django_rakaia.effect_executor")
 
@@ -60,7 +61,7 @@ class _Batches:
 
 @pytest.mark.parametrize(
     "module",
-    [replay_module, executors_module, effect_executor],
+    [batching_module, executors_module, effect_executor],
     ids=["buffer", "in_memory_executor", "django_executor"],
 )
 def test_every_site_reads_the_one_rule(module: ModuleType) -> None:
@@ -72,7 +73,7 @@ def test_the_buffer_takes_its_batch_boundary_from_the_rule(monkeypatch) -> None:
     """A delete then a write is two batches only because the rule says a write
     outranks a delete. Under a reversed rule the pair is orderable as emitted,
     so the buffer must hold them in one batch."""
-    monkeypatch.setattr(replay_module, "_write_order_rank", _retires_first)
+    monkeypatch.setattr(batching_module, "_write_order_rank", _retires_first)
     store = StreamStore()
     seed_stream("s", [{"id": "e0", "n": 0}, {"id": "e1", "n": 1}], store=store)
     registry = HandlerRegistry()

--- a/tests/test_rakaia/test_batching.py
+++ b/tests/test_rakaia/test_batching.py
@@ -1,0 +1,200 @@
+"""The four flush rules, pinned at the buffer's own interface (#264).
+
+`test_replay_batching.py` reaches these rules through a whole `replay()` — a
+store, a seeded stream, a handler registry — which is the right shape for
+proving the orchestrator wires them up, and the wrong shape for saying what the
+rules *are*. These tests hand effects straight to the buffer, so each one names
+a single rule and the batch boundary it forces.
+
+Each test names the mutation it is pinned by; every one was applied to
+`rakaia.batching` and watched go red.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from rakaia.batching import _StageBuffer
+from rakaia.effects import (
+    ApplyReport,
+    Delete,
+    Effect,
+    EffectCollisionError,
+    Retire,
+    Transition,
+    Upsert,
+    check_disjoint_defaults,
+)
+
+
+class BatchRecorder:
+    """An `Executor` that records the *shape* of each call it was handed.
+
+    It runs the same disjointness check a real executor runs before its first
+    write, so a buffer that handed it a colliding pair would raise here rather
+    than quietly record one batch too few.
+    """
+
+    def __init__(self) -> None:
+        self.batches: list[list[Effect]] = []
+
+    def apply(self, effects: Any) -> ApplyReport:
+        batch = list(effects)
+        check_disjoint_defaults(batch)
+        self.batches.append(batch)
+        return ApplyReport()
+
+
+def _buffer() -> tuple[_StageBuffer, BatchRecorder, list[ApplyReport | None]]:
+    ex = BatchRecorder()
+    reports: list[ApplyReport | None] = []
+    return _StageBuffer(ex, reports.append), ex, reports
+
+
+def _sizes(ex: BatchRecorder) -> list[int]:
+    return [len(b) for b in ex.batches]
+
+
+def test_effects_that_cannot_tell_the_difference_ride_in_one_batch() -> None:
+    """The baseline the four rules are exceptions to: disjoint rows, disjoint
+    columns, one rank, no transition — one `apply()` carries them all.
+
+    Mutation: make `add` flush unconditionally and this reads [1, 1, 1].
+    """
+    buf, ex, _ = _buffer()
+
+    for n in range(3):
+        buf.add([Upsert("app.R", {"id": f"r{n}"}, {"n": n})])
+    buf.flush()
+
+    assert _sizes(ex) == [3]
+
+
+def test_a_write_behind_a_delete_starts_a_new_batch() -> None:
+    """Rule one — reorder. A batch is applied writes-then-deletes, so an
+    incoming write joining a pending delete would be hoisted above it.
+
+    Mutation: drop the `_write_order_rank` arm of `_conflicts` and this reads
+    [2], with the write applied before the delete that preceded it.
+    """
+    buf, ex, _ = _buffer()
+
+    buf.add([Delete("app.R", {"id": "x"})])
+    buf.add([Upsert("app.R", {"id": "y"}, {"n": 1})])
+    buf.flush()
+
+    assert _sizes(ex) == [1, 1]
+    assert isinstance(ex.batches[0][0], Delete)
+
+
+def test_a_second_write_to_the_same_column_starts_a_new_batch() -> None:
+    """Rule two — collision. Normal between events (the second supersedes the
+    first) and an error inside one batch, so the boundary has to fall between.
+
+    Mutation: drop the `_written.collides` arm of `_conflicts` and this raises
+    `EffectCollisionError` out of the recorder's disjointness check.
+    """
+    buf, ex, _ = _buffer()
+
+    buf.add([Upsert("app.R", {"id": "x"}, {"n": 1})])
+    buf.add([Upsert("app.R", {"id": "x"}, {"n": 2})])
+    buf.flush()
+
+    assert _sizes(ex) == [1, 1]
+
+
+def test_a_repeated_produces_id_starts_a_new_batch() -> None:
+    """Rule three — duplicate ``produces=``. Two producers of one correlation id
+    in a batch is an error; in separate events it is ordinary.
+
+    Mutation: drop the `_produces` arm of `_conflicts` and this reads [2].
+    """
+    buf, ex, _ = _buffer()
+
+    buf.add([Upsert("app.A", {"id": "a"}, {"n": 1}, produces="p")])
+    buf.add([Upsert("app.B", {"id": "b"}, {"n": 1}, produces="p")])
+    buf.flush()
+
+    assert _sizes(ex) == [1, 1]
+
+
+def test_a_retire_asking_for_notifications_ends_its_batch() -> None:
+    """Rule four — flush *after* a transition retire. Its transitions are
+    synthesised from the report of the call that applied it, so the effects
+    emitted after it must not ride along and reorder the external list.
+
+    The effect that follows is a second retire, so no other rule would separate
+    them: same rank, no column written, no correlation id.
+
+    Mutation: drop the `Transition` arm at the end of `add` and this reads [2],
+    with the second retire inside the first one's batch.
+    """
+    buf, ex, _ = _buffer()
+
+    buf.add(
+        [
+            Retire(
+                "app.R",
+                {"id": "x"},
+                {"resolved_at": 1},
+                transition=Transition(kind="resolved", key_fields=("id",)),
+            )
+        ]
+    )
+    buf.add([Retire("app.R", {"id": "y"}, {"resolved_at": 1})])
+    buf.flush()
+
+    assert _sizes(ex) == [1, 1]
+
+
+def test_an_event_that_collides_with_itself_is_applied_alone() -> None:
+    """A self-colliding group is a bug the executor reports for that event, and
+    it must keep reporting it for that event alone — so what was buffered ahead
+    of it is applied first and survives the raise.
+
+    Mutation: drop `_self_collides` from `add` and the earlier effect is still
+    pending when the group raises, so nothing has been applied at all.
+    """
+    buf, ex, _ = _buffer()
+
+    buf.add([Upsert("app.R", {"id": "a"}, {"n": 1})])
+    with pytest.raises(EffectCollisionError):
+        buf.add(
+            [
+                Upsert("app.R", {"id": "x"}, {"n": 1}),
+                Upsert("app.R", {"id": "x"}, {"n": 2}),
+            ]
+        )
+
+    assert _sizes(ex) == [1]
+
+
+def test_every_applied_batch_hands_its_report_back() -> None:
+    """The buffer owns the `apply()` call, so its caller only sees a report
+    through the sink it passed in — that is how a transition retire's externals
+    reach the replay result.
+
+    Mutation: stop calling the sink in `flush` and this reads [].
+    """
+    buf, _, reports = _buffer()
+
+    buf.add([Upsert("app.R", {"id": "x"}, {"n": 1})])
+    buf.flush()
+
+    assert len(reports) == 1
+    assert isinstance(reports[0], ApplyReport)
+
+
+def test_flushing_nothing_calls_no_executor() -> None:
+    """An empty buffer flushed is a no-op, which is what lets the drain at the
+    end of a pass be unconditional."""
+    buf, ex, reports = _buffer()
+
+    buf.flush()
+    buf.add([])
+    buf.flush()
+
+    assert ex.batches == []
+    assert reports == []

--- a/tests/test_rakaia/test_tier_boundary.py
+++ b/tests/test_rakaia/test_tier_boundary.py
@@ -37,6 +37,7 @@ SRC = pathlib.Path(__file__).resolve().parents[2] / "src" / "rakaia"
 #: consumer builds on, and what would become the "projections" package.
 FRAMEWORK = {
     "append",
+    "batching",
     "context",
     "drift",
     "effects",


### PR DESCRIPTION
When events are replayed the changes they produce are gathered into batches rather than sent one at a time, and four rules decide when a batch has to be sent before carrying on. Those rules lived in the middle of the file that walks through events and calls a handler for each one, so the only way to learn them was to read past eight hundred lines they have nothing to do with. They now sit in a file named after what they do, with all four stated together at the top.

Nothing about how a replay behaves changes — the same effects reach the database in the same batches, and the tests that pin those boundaries through a whole replay pass untouched. What is new is a set of tests that exercise the rules directly, without a stream or a handler in sight, so a change to one of them fails on the rule it broke rather than somewhere downstream. Nothing here is visible to anyone using the library, so there is no changelog entry: by long precedent that file documents the library, not the workshop.

Closes #264