### PR TITLE
One recorder in the core for what a replay wrote

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,18 @@ runnable demo for each.
 
 ### Added
 
+- **`RecordingExecutor` — apply for real, and keep what you applied.** A replay
+  reports how many effects it applied, never which ones, so anything needing the
+  detail had to wrap the executor itself; that workaround lived privately in the
+  Django package, which meant the core could not answer a question about its own
+  replay. `RecordingExecutor(inner)` wraps any executor, applies through it and
+  holds the effects it passed on in `.effects`. It is transparent by contract:
+  the wrapped executor's report comes back unchanged, an exception it raises
+  propagates, and the batch is materialised so a generator is never recorded and
+  then applied nowhere. `rebuild_and_verify` now composes it in place of its
+  private copy, with no change to the report it returns. `CollectingExecutor` is
+  unaffected — it stays the terminal, writes-nothing case. (#265)
+
 - **`Consumer` and `django_consumer()` — the consume loop as a thing you hold.**
   `consume()` takes the store, the stream, the consumer name, somewhere to load
   the cursor, somewhere to commit it and somewhere to keep outcomes on every

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -112,6 +112,7 @@ page is the contract.
 |---|---|---|---|
 | `Executor` | `rakaia` | `(*args, **kwargs)` | Applies a batch of effects to durable storage. |
 | `CollectingExecutor` | `rakaia` | `() -> 'None'` | An Executor that records effects instead of applying them. |
+| `RecordingExecutor` | `rakaia` | `(inner: 'Executor') -> 'None'` | Applies through another `Executor` **and** keeps what it passed on. |
 | `DjangoExecutor` | `django_rakaia` | `(*, skip_unchanged: 'bool' = False, using: 'str \| None' = None, normalizers: 'Sequence[Normalizer] \| None' = None, batch_updates: 'bool' = False) -> 'None'` | Apply Effects via Django's ORM. |
 | `InMemoryProjections` | `rakaia` | `() -> 'None'` | An in-memory `Executor` **and** `ProjectionReader` over dict-backed tables. |
 | `ProjectionReader` | `rakaia` | `(*args, **kwargs)` | Read-only view over materialised projections. |
@@ -254,16 +255,10 @@ page is the contract.
 | `UpcasterChainError` | `rakaia` | — | Cannot upcast: missing or ambiguous link in the upcaster chain. |
 | `UpcasterConflictError` | `rakaia` | — | Two upcasters were registered for the same (event_match, from_version). |
 
-## Everything else
-
-| Name | Import from | Signature | What it does |
-|---|---|---|---|
-| `RecordingExecutor` | `rakaia` | `(inner: 'Executor') -> 'None'` | Applies through another `Executor` **and** keeps what it passed on. |
-
 ---
 
 ## Appendix — coverage
 
-163 exported names across 16 sections. 144 carry a docstring; 19 do not and show `—` above.
+163 exported names across 15 sections. 144 carry a docstring; 19 do not and show `—` above.
 
 Undocumented: `AnyEffect`, `DEFAULT_NORMALIZERS`, `ENVELOPE_TS`, `Effect`, `GREEN`, `HANDLERS_META_STREAM`, `Normalizer`, `OnErrorPolicy`, `OutcomeStatus`, `PollStatus`, `ProducerValidationResult`, `RED`, `REDUCERS_META_STREAM`, `SCRATCH_PATH`, `Stage`, `UPCASTERS_META_STREAM`, `VACUOUS`, `__version__`, `app`.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -254,10 +254,16 @@ page is the contract.
 | `UpcasterChainError` | `rakaia` | — | Cannot upcast: missing or ambiguous link in the upcaster chain. |
 | `UpcasterConflictError` | `rakaia` | — | Two upcasters were registered for the same (event_match, from_version). |
 
+## Everything else
+
+| Name | Import from | Signature | What it does |
+|---|---|---|---|
+| `RecordingExecutor` | `rakaia` | `(inner: 'Executor') -> 'None'` | Applies through another `Executor` **and** keeps what it passed on. |
+
 ---
 
 ## Appendix — coverage
 
-162 exported names across 15 sections. 143 carry a docstring; 19 do not and show `—` above.
+163 exported names across 16 sections. 144 carry a docstring; 19 do not and show `—` above.
 
 Undocumented: `AnyEffect`, `DEFAULT_NORMALIZERS`, `ENVELOPE_TS`, `Effect`, `GREEN`, `HANDLERS_META_STREAM`, `Normalizer`, `OnErrorPolicy`, `OutcomeStatus`, `PollStatus`, `ProducerValidationResult`, `RED`, `REDUCERS_META_STREAM`, `SCRATCH_PATH`, `Stage`, `UPCASTERS_META_STREAM`, `VACUOUS`, `__version__`, `app`.

--- a/docs/dry-run-and-executors.md
+++ b/docs/dry-run-and-executors.md
@@ -50,7 +50,7 @@ from rakaia import RecordingExecutor
 
 rec = RecordingExecutor(DjangoExecutor(using="rebuild"))
 replay(store, "submissions", rec, reader=DjangoProjectionReader(using="rebuild"))
-rec.effects  # every effect that reached the database, in order
+rec.effects  # every effect handed to the inner executor, in order
 ```
 
 That is exactly the shape of a guarded rebuild: a stage > 0 handler can only read
@@ -61,15 +61,26 @@ that reason.
 It is transparent by contract. The wrapped executor's report comes back
 unchanged, an exception it raises propagates, and the batch is materialised
 before either sees it, so a generator is never consumed by the recording and then
-applied nowhere. `tests/executor_contract.py` runs the whole executor conformance
-suite a second time through a `RecordingExecutor`, so anything the wrap reordered
-or swallowed would fail there.
+applied nowhere. `tests/test_rakaia/test_executor_contract.py` runs the whole
+executor conformance suite a second time through a `RecordingExecutor`, so
+anything the wrap reordered or swallowed would fail there.
+
+What it keeps is what it *handed on*, which is not always what committed: a batch
+that raises partway through is recorded and never lands. That is deliberate — a
+rebuild gate diffs what a replay meant to write — and it is why the wording here
+is "handed to the inner executor" rather than "written".
 
 `CollectingExecutor` stays separate rather than becoming
 `RecordingExecutor(some_no_op)`. It is the *terminal* case, not a wrapper: its
 promise is that no writing code exists to run, which is what makes it safe to
 point at production, and expressing that as "wrap an executor that does nothing"
 would put a real `apply()` call in the path of a dry run to buy nothing.
+
+The sharper version of that argument is about what a reader can check. A
+`RecordingExecutor` takes any `Executor`, so whether a run writes is a property of
+what the call site passed, discoverable only by following the argument.
+`CollectingExecutor()` is the guarantee at the point of use — greppable, and true
+of the class rather than of one construction of it.
 
 ### Applying effects without a database
 

--- a/docs/dry-run-and-executors.md
+++ b/docs/dry-run-and-executors.md
@@ -23,19 +23,53 @@ flowchart LR
   S[("Stream")] -->|replay| H["Handlers"] --> E["Effects<br/>(descriptions)"]
   E --> DE["DjangoExecutor"] -->|writes| DB[("Database")]
   E --> CE["CollectingExecutor"] -->|records| L["ex.effects list<br/>(no writes)"]
+  E --> RE["RecordingExecutor"] -->|records, then| DE
 ```
 
 `replay()` calls `apply()` with each batch of effects a handler produces. Rakaia
-ships three implementations:
+ships four implementations:
 
 | Executor | Package | What it does |
 |---|---|---|
 | `DjangoExecutor` | `django_rakaia.effect_executor` | Applies effects for real — an `Upsert` via `update_or_create`, an `Update`, a `Delete`, a `Retire`. |
 | `CollectingExecutor` | `rakaia.executors` | Records effects into `.effects` **without applying them**. The building block for a dry run. |
+| `RecordingExecutor` | `rakaia.executors` | Wraps any other executor: applies **through** it, and keeps what it passed on in `.effects`. |
 | `InMemoryProjections` | `rakaia.executors` | Applies effects to in-memory dicts, and reads them back — an `Executor` and a `ProjectionReader` in one, with no database. |
 
 You can write your own — anything that satisfies the protocol works (e.g. an
 executor that streams effects to a log, or applies them to a non-Django store).
+
+### Asking what a replay actually wrote
+
+A replay reports how many effects it applied, not which ones. `RecordingExecutor`
+is the answer when you need both halves at once — the writes really happening,
+*and* the list of them afterwards:
+
+```python
+from rakaia import RecordingExecutor
+
+rec = RecordingExecutor(DjangoExecutor(using="rebuild"))
+replay(store, "submissions", rec, reader=DjangoProjectionReader(using="rebuild"))
+rec.effects  # every effect that reached the database, in order
+```
+
+That is exactly the shape of a guarded rebuild: a stage > 0 handler can only read
+what stage 0 wrote if the writes are real, and the effects are what gets diffed
+against the live rows afterwards. `rebuild_and_verify` composes this executor for
+that reason.
+
+It is transparent by contract. The wrapped executor's report comes back
+unchanged, an exception it raises propagates, and the batch is materialised
+before either sees it, so a generator is never consumed by the recording and then
+applied nowhere. `tests/executor_contract.py` runs the whole executor conformance
+suite a second time through a `RecordingExecutor`, so anything the wrap reordered
+or swallowed would fail there.
+
+`CollectingExecutor` stays separate rather than becoming
+`RecordingExecutor(some_no_op)`. It is the *terminal* case, not a wrapper: its
+promise is that no writing code exists to run, which is what makes it safe to
+point at production, and expressing that as "wrap an executor that does nothing"
+would put a real `apply()` call in the path of a dry run to buy nothing.
 
 ### Applying effects without a database
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -177,6 +177,9 @@ No example exercises these yet — a good place to contribute a demo:
 - `DjangoExecutor(skip_unchanged=True)`.
 - `rebuild_and_verify` (the one-call guarded rebuild-and-diff). The
   `projection_cookbook` demo composes the pieces by hand instead.
+- `RecordingExecutor` — applying for real while keeping the effects. The demos
+  either write (`DjangoExecutor`) or preview (`CollectingExecutor`); none needs
+  both at once, which is the case this executor exists for.
 - `migrate_stream` / `migrate_all` — moving a log between backends. `polyglot`
   runs *on* the file-backed store but was seeded there, never copied onto it.
 - `DjangoExecutor(batch_updates=True)` and `DjangoExecutor(normalizers=...)`.

--- a/scripts/gen_api_reference.py
+++ b/scripts/gen_api_reference.py
@@ -110,6 +110,7 @@ GROUPS: dict[str, tuple[str, ...]] = {
     "Applying changes (executors and readers)": (
         "Executor",
         "CollectingExecutor",
+        "RecordingExecutor",
         "DjangoExecutor",
         "InMemoryProjections",
         "ProjectionReader",

--- a/src/django_rakaia/rebuild.py
+++ b/src/django_rakaia/rebuild.py
@@ -26,18 +26,20 @@ against the **live** rows. The ``into`` alias is not the thing being diffed — 
 exists so a stage > 0 handler can read what stage 0 wrote, which is a fact a
 :class:`~rakaia.executors.CollectingExecutor` cannot supply. Both are needed at
 once, and `ReplayResult` reports a *count* of effects applied rather than the
-effects themselves, which is why the executor here is a recording tee.
+effects themselves, which is why the executor here is wrapped in a
+:class:`~rakaia.executors.RecordingExecutor`.
 
 See ADR 0003 (``docs/adr/0003-handler-hermeticity.md``).
 """
 
 from __future__ import annotations
 
-from collections.abc import Iterable, Sequence
+from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from rakaia.effects import Effect, Executor
+from rakaia.effects import Executor
+from rakaia.executors import RecordingExecutor
 from rakaia.replay import replay
 from rakaia.types import StreamMessage
 
@@ -104,27 +106,6 @@ class _Drained:
         # rather than of this use of it.
         del path, offset
         return list(self.messages), True
-
-
-class _RecordingExecutor:
-    """Applies through ``inner`` **and** keeps what it applied.
-
-    Both halves are needed: applying is what lets a stage > 0 handler read what
-    stage 0 wrote, and the effects are what the diff compares against the live
-    rows. `ReplayResult.effects_applied` is a count, so the effects have to be
-    captured on the way past.
-    """
-
-    def __init__(self, inner: Executor) -> None:
-        self._inner = inner
-        self.effects: list[Effect] = []
-
-    def apply(self, effects: Iterable[Effect]):
-        # Materialise once: `inner.apply` would otherwise consume a generator
-        # this has already walked, and apply nothing at all.
-        batch = list(effects)
-        self.effects.extend(batch)
-        return self._inner.apply(batch)
 
 
 def _prove_read_guard_armed(alias: str) -> None:
@@ -223,7 +204,7 @@ def rebuild_and_verify(
     log = source if source is not None else DjangoStreamStore(using=live_using)
     drained = _Drained(list(log.read(stream_path)[0]))
 
-    recorder = _RecordingExecutor(_django_executor(into))
+    recorder = RecordingExecutor(_django_executor(into))
 
     # The write guard goes outside, and covers the diff as well as the replay: it
     # counts rows rather than intercepting statements, so it tolerates the diff's

--- a/src/rakaia/__init__.py
+++ b/src/rakaia/__init__.py
@@ -82,7 +82,11 @@ if TYPE_CHECKING:
         Upsert,
         check_disjoint_defaults,
     )
-    from .executors import CollectingExecutor, InMemoryProjections
+    from .executors import (
+        CollectingExecutor,
+        InMemoryProjections,
+        RecordingExecutor,
+    )
     from .history import (
         envelope_actor,
         history_effects,
@@ -270,6 +274,7 @@ _EXPORTS: dict[str, str] = {
     "check_disjoint_defaults": "rakaia.effects",
     "CollectingExecutor": "rakaia.executors",
     "InMemoryProjections": "rakaia.executors",
+    "RecordingExecutor": "rakaia.executors",
     # Versioned handlers — projections
     "reconcile_by_key": "rakaia.projections",
     "reconcile_children": "rakaia.projections",

--- a/src/rakaia/executors.py
+++ b/src/rakaia/executors.py
@@ -2,13 +2,17 @@
 Reusable Executor implementations.
 
 The `Executor` protocol (see effects.py) is applied by `replay()` to every batch
-of effects it produces. Two implementations live here, neither of which needs a
+of effects it produces. Three implementations live here, none of which needs a
 database:
 
 * `CollectingExecutor` records effects instead of applying them — the building
   block for a dry run and for migration verification: run `replay()` with one
   and inspect `.effects` to see exactly what a real executor would write, with
   zero side effects.
+* `RecordingExecutor` wraps another executor, applies through it and keeps what
+  it passed on — the answer to "what did this replay actually write?", which
+  `ReplayResult` reports only as a count. It is what a rebuild gate needs when it
+  must both write (so a later stage can read an earlier one) and diff.
 * `InMemoryProjections` actually applies them, to dict-backed "tables", and reads
   them back through the same object — an `Executor` and a `ProjectionReader` in
   one. It is what lets a test, a demo or an example exercise the full
@@ -31,6 +35,7 @@ from .effects import (
     Delete,
     Effect,
     Exclude,
+    Executor,
     RefResolver,
     Retire,
     SpareKeys,
@@ -60,6 +65,37 @@ class CollectingExecutor:
         self.effects.extend(effects)
         # Records effects without applying them, so it observes no retire flips.
         return ApplyReport()
+
+
+class RecordingExecutor:
+    """Applies through another `Executor` **and** keeps what it passed on.
+
+    `ReplayResult.effects_applied` is a count, so "what did this replay actually
+    write?" has no answer once the run is over. Wrapping the real executor is the
+    answer: the effects go past on their way to it, and `.effects` holds them in
+    the order they arrived. Both halves matter for a rebuild gate — applying is
+    what lets a stage > 0 handler read what stage 0 wrote, and the recording is
+    what the diff compares against the live rows, which a `CollectingExecutor`
+    cannot supply because it never writes::
+
+        rec = RecordingExecutor(DjangoExecutor(using="rebuild"))
+        replay(store, "submissions", rec)
+        rec.effects  # every effect that reached the database
+
+    Transparent, deliberately: the wrapped executor's report is returned
+    unchanged, and an exception it raises propagates. The batch is materialised
+    before either sees it, so a one-shot iterable is not consumed by the
+    recording and then applied nowhere.
+    """
+
+    def __init__(self, inner: Executor) -> None:
+        self.inner = inner
+        self.effects: list[Effect] = []
+
+    def apply(self, effects: Iterable[Effect]) -> ApplyReport | None:
+        batch = list(effects)
+        self.effects.extend(batch)
+        return self.inner.apply(batch)
 
 
 class InMemoryProjections:

--- a/tests/test_django_rakaia/test_rebuild.py
+++ b/tests/test_django_rakaia/test_rebuild.py
@@ -437,26 +437,51 @@ class TestStagedHandlersReadTheScratchAlias:
 
 
 class TestTheRecordingTee:
-    def test_it_applies_a_generator_it_has_also_recorded(self):
-        # The tee walks the batch before handing it on, so a one-shot iterable
-        # would otherwise reach the inner executor already exhausted -- recorded
-        # as verified, applied nowhere.
-        from django_rakaia.rebuild import _RecordingExecutor
-        from rakaia.effects import Upsert
-        from rakaia.executors import CollectingExecutor
+    """The gate applies through a recorder and diffs what it recorded, and that
+    recorder is now the core package's, not a private copy here (#265)."""
 
-        inner = CollectingExecutor()
-        tee = _RecordingExecutor(inner)
-        effect = Upsert(
-            model_label="test_django_rakaia.FinanceLine",
-            lookup={"submission_id": "a"},
-            defaults={"delta": 1},
+    def test_the_gate_records_through_the_shared_recorder(self, monkeypatch):
+        import django_rakaia.rebuild as rebuild_mod
+        from rakaia.executors import RecordingExecutor
+
+        assert rebuild_mod.RecordingExecutor is RecordingExecutor
+
+        built: list[object] = []
+
+        class Spy(RecordingExecutor):
+            def __init__(self, inner):
+                super().__init__(inner)
+                built.append(inner)
+
+        monkeypatch.setattr(rebuild_mod, "RecordingExecutor", Spy)
+
+        rows = [{"id": "a", "suku": "s1", "delta": 1}]
+        _seed_log(*rows)
+        _live(*rows)
+
+        report = rebuild_and_verify(
+            PATH, into="overlay", live_models=[FinanceLine], registry=_registry()
         )
 
-        tee.apply(e for e in [effect])
+        assert report.certified
+        assert len(built) == 1
 
-        assert tee.effects == [effect]
-        assert inner.effects == [effect]
+    def test_the_diff_report_is_what_the_private_tee_produced(self):
+        """The swap's evidence: the same three scenarios, the same verdicts and
+        the same compared counts as before the recorder moved into the core."""
+        rows = [
+            {"id": "a", "suku": "s1", "delta": 1},
+            {"id": "b", "suku": "s2", "delta": 2},
+        ]
+        _seed_log(*rows)
+        _live(rows[0], {"id": "b", "suku": "s2", "delta": 999})
+
+        report = rebuild_and_verify(
+            PATH, into="overlay", live_models=[FinanceLine], registry=_registry()
+        )
+
+        assert (report.verdict, report.compared, len(report.problems)) == (RED, 2, 1)
+        assert [r.lookup["submission_id"] for r in report.problems] == ["b"]
 
 
 class TestWhatItForwardsToReplay:

--- a/tests/test_rakaia/test_executor_contract.py
+++ b/tests/test_rakaia/test_executor_contract.py
@@ -1,10 +1,11 @@
-"""In-memory InMemoryProjections against the shared Executor conformance contract."""
+"""In-memory InMemoryProjections against the shared Executor conformance contract,
+and the same contract again through a `RecordingExecutor` wrapping it."""
 
 from __future__ import annotations
 
 import pytest
 
-from rakaia.executors import InMemoryProjections
+from rakaia.executors import InMemoryProjections, RecordingExecutor
 from tests.executor_contract import ExecutorContract, ExecutorSeam
 
 
@@ -15,3 +16,31 @@ class TestInMemoryProjectionsExecutorContract(ExecutorContract):
         # Executor and reader are the same object; the model label is arbitrary
         # because the tables are created on demand.
         return ExecutorSeam(executor=projections, reader=projections, model="app.Alert")
+
+
+class TestRecordingExecutorIsTransparent(ExecutorContract):
+    """The whole contract, run through the recorder.
+
+    Transparency is the recorder's only promise, and the cheapest way to hold it
+    is to make every executor invariant the suite already pins -- the three
+    ordered passes, one resolver per batch, collision detection before the first
+    write, the upsert counts, the retire flips -- have to survive the wrap. A
+    recorder that reordered, deduplicated, swallowed or re-batched anything fails
+    here rather than in a consumer's rebuild gate.
+    """
+
+    @pytest.fixture
+    def seam(self) -> ExecutorSeam:
+        projections = InMemoryProjections()
+        return ExecutorSeam(
+            executor=RecordingExecutor(projections),
+            reader=projections,
+            model="app.Alert",
+        )
+
+    def test_the_contract_run_left_a_recording(self, seam):
+        """The suite reads rows, so nothing else in it would notice an empty
+        recording."""
+        seam.executor.apply([self._upsert(seam, "a")])
+
+        assert [e.lookup["field_key"] for e in seam.executor.effects] == ["a"]

--- a/tests/test_rakaia/test_executors.py
+++ b/tests/test_rakaia/test_executors.py
@@ -1,11 +1,16 @@
-"""Tests for rakaia.executors: the CollectingExecutor (dry-run / verification)."""
+"""Tests for rakaia.executors: the CollectingExecutor (dry-run / verification)
+and the RecordingExecutor (apply through, and keep what went past)."""
 
 from __future__ import annotations
 
 import pytest
 
-from rakaia.effects import Effect, Upsert
-from rakaia.executors import CollectingExecutor
+from rakaia.effects import ApplyReport, Effect, Upsert
+from rakaia.executors import (
+    CollectingExecutor,
+    InMemoryProjections,
+    RecordingExecutor,
+)
 from rakaia.registry import HandlerRegistry
 from rakaia.replay import replay
 from rakaia.seed import seed_stream
@@ -53,3 +58,87 @@ def test_apply_length_matches_input(n: int):
     ex = CollectingExecutor()
     ex.apply([_eff(i) for i in range(n)])
     assert len(ex.effects) == n
+
+
+class _Boom(Exception):
+    pass
+
+
+class _Inner:
+    """A minimal inner executor: keeps each batch, and can be told to raise."""
+
+    def __init__(self, report=None, raise_on=None):
+        self.batches: list[list[Effect]] = []
+        self._report = report
+        self._raise_on = raise_on
+
+    def apply(self, effects):
+        batch = list(effects)
+        self.batches.append(batch)
+        if self._raise_on is not None and len(self.batches) == self._raise_on:
+            raise _Boom("inner executor failed")
+        return self._report
+
+
+class TestRecordingExecutor:
+    def test_records_what_reached_the_inner_executor_in_order(self):
+        inner = _Inner()
+        rec = RecordingExecutor(inner)
+        rec.apply([_eff(1), _eff(2)])
+        rec.apply([_eff(3)])
+
+        assert [e.lookup["id"] for e in rec.effects] == [1, 2, 3]
+        assert [[e.lookup["id"] for e in b] for b in inner.batches] == [[1, 2], [3]]
+
+    def test_starts_empty(self):
+        assert RecordingExecutor(_Inner()).effects == []
+
+    def test_the_inner_report_passes_through_unchanged(self):
+        report = ApplyReport(upserts_created=1, upserts_written=2, upserts_skipped=3)
+        rec = RecordingExecutor(_Inner(report=report))
+
+        assert rec.apply([_eff(1)]) is report
+
+    def test_a_none_report_passes_through_as_none(self):
+        assert RecordingExecutor(_Inner()).apply([_eff(1)]) is None
+
+    def test_a_generator_is_materialised_before_the_inner_executor_sees_it(self):
+        """The recorder walks the batch, so a one-shot iterable would otherwise
+        reach the inner executor already exhausted -- recorded as verified,
+        applied nowhere."""
+        inner = _Inner()
+        rec = RecordingExecutor(inner)
+        rec.apply(e for e in [_eff(1), _eff(2)])
+
+        assert [e.lookup["id"] for e in rec.effects] == [1, 2]
+        assert [e.lookup["id"] for e in inner.batches[0]] == [1, 2]
+
+    def test_an_inner_exception_propagates_and_what_reached_it_stays_recorded(self):
+        rec = RecordingExecutor(_Inner(raise_on=2))
+        rec.apply([_eff(1)])
+        with pytest.raises(_Boom):
+            rec.apply([_eff(2)])
+
+        assert [e.lookup["id"] for e in rec.effects] == [1, 2]
+
+    def test_replay_through_the_recorder_records_and_applies(self):
+        store = StreamStore()
+        reg = HandlerRegistry()
+
+        def h(event):
+            return Upsert(
+                model_label="x.X",
+                lookup={"id": event["id"]},
+                defaults={"name": event["name"]},
+            )
+
+        reg.register("h", "s", h, 0, None)
+        seed_stream("s", [{"id": 1, "name": "a"}, {"id": 2, "name": "b"}], store=store)
+
+        proj = InMemoryProjections()
+        rec = RecordingExecutor(proj)
+        result = replay(store, "s", rec, handler_registry=reg)
+
+        assert result.effects_applied == 2
+        assert [e.lookup["id"] for e in rec.effects] == [1, 2]
+        assert [r["name"] for r in proj.rows("x.X")] == ["a", "b"]

--- a/tests/test_rakaia/test_public_api.py
+++ b/tests/test_rakaia/test_public_api.py
@@ -77,6 +77,7 @@ RAKAIA_PUBLIC = {
     # effects
     "CollectingExecutor",
     "InMemoryProjections",
+    "RecordingExecutor",
     "DuplicateProducesError",
     "Effect",
     "AnyEffect",


### PR DESCRIPTION
A replay tells you how many changes it applied, never which ones. Anything that needed the detail had to wrap the thing doing the writing in its own recorder, and the only version of that lived in the Django half of the library — so the core could not answer a question about its own replay, and the same idea existed twice under two names. There is now one recorder in the core package: it wraps any writer, applies through it, and keeps what it passed on. Comparing a replay against the live rows no longer needs Django, which is the point, since nothing about that question is Django-shaped.

It is deliberately invisible from the outside. Whatever the wrapped writer reports comes straight back, an error it raises still reaches the caller, and the batch is read once so a one-shot sequence is never recorded and then applied nowhere. The guarded rebuild now uses this instead of its private copy and produces the same report as before. The dry-run recorder that writes nothing is unchanged: it is the case where no writing code exists to run, which is what makes it safe to point at production.

Closes #265
