### PR TITLE
Give a failure record a name that does not move

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,19 @@ runnable demo for each.
 
 ### Added
 
+- **A failure record now names the failure, not a class name.** Everything rakaia
+  raises while applying an event carries a short, stable reason code, and those
+  codes are a published closed set. The loop records the code rather than the
+  exception's class name, so renaming something internal no longer rewrites the
+  vocabulary an operator has been counting and filtering on. Anything that is not
+  rakaia's own — a bug in your own apply — is recorded under one code,
+  `unhandled`, with the exception's type name beside it and its message left out.
+  Three failures in a replay that used to arrive as a bare `ValueError` (a staged
+  replay with no reader, an event that will not decode, a missing or unusable
+  merge key) now have names of their own; each still subclasses `ValueError`, so
+  code already catching that keeps working. Catch `RakaiaError` to catch anything
+  the library raises from an apply in one clause. (#257)
+
 - **`Consumer` and `django_consumer()` — the consume loop as a thing you hold.**
   `consume()` takes the store, the stream, the consumer name, somewhere to load
   the cursor, somewhere to commit it and somewhere to keep outcomes on every

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -32,6 +32,20 @@ either submodule directly — `from rakaia.handler import ServerOptions` — cha
 path. The failure is an `ImportError` at the import, so nothing gets past a first
 run.
 
+## Recorded reason codes changed value, and nothing raises about it
+
+A failure the loop recorded used to carry the exception's class name as its reason
+code — `HandlerGapError`, `UpcasterChainError`, `ValueError`. It now carries a
+short code from a published closed set: `handler_gap`, `upcaster_chain`,
+`undecodable_event`, and so on, with anything that is not rakaia's own recorded as
+`unhandled` and its type name in `params` under `exception_type`.
+
+Nothing warns and nothing breaks at import. A dashboard, alert or query filtering
+on the old strings simply stops matching, and under this library's own model an
+absent record reads as nothing having gone wrong — which is the failure worth
+naming here. Records already stored keep the old values; only new ones use the new
+codes. Update whatever reads them, and see the reference for the full set.
+
 ## Outcomes are part of the stable surface now
 
 `Outcome`, `OutcomeStatus`, `Stage`, `OutcomeStore`, `InMemoryOutcomeStore`,

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -44,7 +44,8 @@ Nothing warns and nothing breaks at import. A dashboard, alert or query filterin
 on the old strings simply stops matching, and under this library's own model an
 absent record reads as nothing having gone wrong — which is the failure worth
 naming here. Records already stored keep the old values; only new ones use the new
-codes. Update whatever reads them, and see the reference for the full set.
+codes. Update whatever reads them; the full set is tabulated in
+`docs/subscriber-cursors.md`, under "The reason codes rakaia records for itself".
 
 ## Outcomes are part of the stable surface now
 

--- a/docs/adr/0007-an-outcome-is-recorded-where-the-cursor-is-committed.md
+++ b/docs/adr/0007-an-outcome-is-recorded-where-the-cursor-is-committed.md
@@ -218,22 +218,6 @@ will eventually disagree with the first. So outcomes are append-only and attempt
 and "is this still failing?" is the latest outcome for the key, not a column. `unresolved`
 is therefore a derived query, not stored state.
 
-**6c. Rakaia's own codes are a promised set. A consumer's are still the consumer's.**
-Decision 6 says the codes are opaque to rakaia, and it was answering the question of what a
-*consumer* records. It never addressed the case where rakaia itself is what failed, and the
-loop was answering that with `type(exc).__name__` — so the vocabulary an operator reads was
-the internal class names, and any rename rewrote it silently. Everything rakaia raises from
-an apply now inherits one base type and carries a written-out `code`; the set of them is
-closed, published in `rakaia.REASON_CODES`, and changed with the care any other public name
-gets. The code is never derived from the class name, which is the whole defect.
-
-Anything outside that set is recorded as `unhandled` with the exception's type name in
-`params`, and nothing else from it — an exception's message is exactly where a field value
-would leak, which Decision 6 already refused. That keeps the vocabulary countable rather than
-an open set of class names, while still telling two unanticipated bugs apart. None of this
-touches Decision 6: reason codes on an outcome a consumer records remain the consumer's, and
-rakaia still has no opinion about them.
-
 **6b. One translation decides what a stored outcome looks like, and every backend uses it.**
 `encode_outcome`/`decode_outcome` is the only crossing between an outcome and its stored form, the in-memory
 reference included. That store previously kept the object as handed to it while the durable
@@ -253,6 +237,22 @@ something. And a line this version cannot rebuild is dropped with a log rather t
 exception, because one such line must not cost the whole report; it is only logged and not
 yet counted, which is a weaker answer than this decision would like given that unnoticed
 absence is the thing it exists to prevent.
+
+**6c. Rakaia's own codes are a promised set. A consumer's are still the consumer's.**
+Decision 6 says the codes are opaque to rakaia, and it was answering the question of what a
+*consumer* records. It never addressed the case where rakaia itself is what failed, and the
+loop was answering that with `type(exc).__name__` — so the vocabulary an operator reads was
+the internal class names, and any rename rewrote it silently. Everything rakaia raises from
+an apply now inherits one base type and carries a written-out `code`; the set of them is
+closed, published in `rakaia.REASON_CODES`, and changed with the care any other public name
+gets. The code is never derived from the class name, which is the whole defect.
+
+Anything outside that set is recorded as `unhandled` with the exception's type name in
+`params`, and nothing else from it — an exception's message is exactly where a field value
+would leak, which Decision 6 already refused. That keeps the vocabulary countable rather than
+an open set of class names, while still telling two unanticipated bugs apart. None of this
+touches Decision 6: reason codes on an outcome a consumer records remain the consumer's, and
+rakaia still has no opinion about them.
 
 **7. Sequencing is recorded, not enforced.** An outcome carries a `sequence_key`.
 Rakaia does not yet refuse an event whose sequence has an unresolved failure; the field

--- a/docs/adr/0007-an-outcome-is-recorded-where-the-cursor-is-committed.md
+++ b/docs/adr/0007-an-outcome-is-recorded-where-the-cursor-is-committed.md
@@ -218,6 +218,22 @@ will eventually disagree with the first. So outcomes are append-only and attempt
 and "is this still failing?" is the latest outcome for the key, not a column. `unresolved`
 is therefore a derived query, not stored state.
 
+**6c. Rakaia's own codes are a promised set. A consumer's are still the consumer's.**
+Decision 6 says the codes are opaque to rakaia, and it was answering the question of what a
+*consumer* records. It never addressed the case where rakaia itself is what failed, and the
+loop was answering that with `type(exc).__name__` — so the vocabulary an operator reads was
+the internal class names, and any rename rewrote it silently. Everything rakaia raises from
+an apply now inherits one base type and carries a written-out `code`; the set of them is
+closed, published in `rakaia.REASON_CODES`, and changed with the care any other public name
+gets. The code is never derived from the class name, which is the whole defect.
+
+Anything outside that set is recorded as `unhandled` with the exception's type name in
+`params`, and nothing else from it — an exception's message is exactly where a field value
+would leak, which Decision 6 already refused. That keeps the vocabulary countable rather than
+an open set of class names, while still telling two unanticipated bugs apart. None of this
+touches Decision 6: reason codes on an outcome a consumer records remain the consumer's, and
+rakaia still has no opinion about them.
+
 **6b. One translation decides what a stored outcome looks like, and every backend uses it.**
 `encode_outcome`/`decode_outcome` is the only crossing between an outcome and its stored form, the in-memory
 reference included. That store previously kept the object as handed to it while the durable
@@ -257,6 +273,9 @@ This is why `subject` is a separate field rather than the same one. The subject 
 thing an outcome is about; the sequence key is what that particular refusal actually parked.
 They coincide often enough to be mistaken for one field, and the cases where they do not are
 the ones that matter.
+
+`sequence_key` is accepted as-is for now: nothing reads it, and removing it stopped being
+free once it was exported — enforcement is revisited on demand, not on schedule.
 
 ## Observations, refusals, and the record that one happened
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -227,6 +227,9 @@ page is the contract.
 | Name | Import from | Signature | What it does |
 |---|---|---|---|
 | `__version__` | `rakaia` | — | — |
+| `REASON_CODES` | `rakaia` | — | — |
+| `UNHANDLED` | `rakaia` | — | — |
+| `EXCEPTION_TYPE_KEY` | `rakaia` | — | — |
 | `HANDLERS_META_STREAM` | `rakaia` | — | — |
 | `REDUCERS_META_STREAM` | `rakaia` | — | — |
 | `UPCASTERS_META_STREAM` | `rakaia` | — | — |
@@ -236,6 +239,7 @@ page is the contract.
 
 | Name | Import from | Signature | What it does |
 |---|---|---|---|
+| `RakaiaError` | `rakaia` | — | Base for every failure rakaia raises from the apply path. |
 | `StreamError` | `rakaia` | — | Base for store failures a protocol server maps to a status. |
 | `StreamNotFound` | `rakaia` | — | The stream does not exist, or has expired. |
 | `SequenceConflict` | `rakaia` | — | An append's `Stream-Seq` is not above the stream's last seq. |
@@ -253,11 +257,14 @@ page is the contract.
 | `DuplicateProducesError` | `rakaia` | — | Two effects in one batch declare the same `produces` id. The id would silently bind to the second producer's row, orphaning the first — always a bug, so it is rejected rather than resolved to the… |
 | `UpcasterChainError` | `rakaia` | — | Cannot upcast: missing or ambiguous link in the upcaster chain. |
 | `UpcasterConflictError` | `rakaia` | — | Two upcasters were registered for the same (event_match, from_version). |
+| `MissingReaderError` | `rakaia` | — | A staged replay was asked to run with no projection reader. |
+| `UndecodableEventError` | `rakaia` | — | An event's stored bytes are not decodable JSON. |
+| `MergeKeyError` | `rakaia` | — | A merge cannot order its events: the order key is missing from an event, or its values are not mutually comparable across them. |
 
 ---
 
 ## Appendix — coverage
 
-162 exported names across 15 sections. 143 carry a docstring; 19 do not and show `—` above.
+169 exported names across 15 sections. 147 carry a docstring; 22 do not and show `—` above.
 
-Undocumented: `AnyEffect`, `DEFAULT_NORMALIZERS`, `ENVELOPE_TS`, `Effect`, `GREEN`, `HANDLERS_META_STREAM`, `Normalizer`, `OnErrorPolicy`, `OutcomeStatus`, `PollStatus`, `ProducerValidationResult`, `RED`, `REDUCERS_META_STREAM`, `SCRATCH_PATH`, `Stage`, `UPCASTERS_META_STREAM`, `VACUOUS`, `__version__`, `app`.
+Undocumented: `AnyEffect`, `DEFAULT_NORMALIZERS`, `ENVELOPE_TS`, `EXCEPTION_TYPE_KEY`, `Effect`, `GREEN`, `HANDLERS_META_STREAM`, `Normalizer`, `OnErrorPolicy`, `OutcomeStatus`, `PollStatus`, `ProducerValidationResult`, `REASON_CODES`, `RED`, `REDUCERS_META_STREAM`, `SCRATCH_PATH`, `Stage`, `UNHANDLED`, `UPCASTERS_META_STREAM`, `VACUOUS`, `__version__`, `app`.

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -189,6 +189,10 @@ No example exercises these yet — a good place to contribute a demo:
   nothing under `examples/` calls `consume()` or builds a `Consumer`. #255 added
   the consumer object the example should be written against, which is the shape
   a demo should show rather than the six loose arguments underneath it.
+- Reason codes for a failure rakaia raised (`RakaiaError`, `REASON_CODES`). No
+  example catches the base type or reads a code off a failure record, for the same
+  reason as the gap above: nothing under `examples/` runs the consume loop, so
+  there is no recorded failure to read a code from.
 - Outcome retention. `manage.py prune_outcomes` deletes old failure records
   (`docs/deployment.md`), but no example records a failure and then prunes it, so
   nothing under `examples/` demonstrates the operator's side of the outcome

--- a/docs/subscriber-cursors.md
+++ b/docs/subscriber-cursors.md
@@ -115,6 +115,32 @@ than described. Outside Django, build a `rakaia.Consumer` directly and pass your
 own `ConsumerCursorStore` and `OutcomeStore`; `InMemoryConsumerCursorStore` and
 `InMemoryOutcomeStore` are the reference pair.
 
+## The reason codes rakaia records for itself
+
+A record's `reasons` are codes rather than a sentence, so "how many failed for
+this reason" is something you count rather than grep. The codes on an outcome
+*your* consumer records are yours — rakaia never looks at them. These ten are the
+ones rakaia writes when the failure is its own, and they are a closed, published
+set: adding one is a public API change, and renaming one breaks whatever an
+operator has been counting.
+
+| code | what failed |
+| --- | --- |
+| `handler_gap` | no handler version covers the event's position |
+| `upcaster_chain` | the chain of upcasters could not carry the event to the current version |
+| `effect_collision` | two effects in one batch write the same field of the same row |
+| `unresolved_ref` | an effect pointed at a row the batch never created |
+| `duplicate_produces` | two effects in one batch claimed the same name |
+| `handler_drift` | a handler's source changed since it was registered |
+| `missing_reader` | a staged replay was run without the reader its later stages need |
+| `undecodable_event` | the event's payload is not readable as JSON |
+| `merge_key` | a merged stream's events lack, or disagree about, the ordering key |
+| `unhandled` | anything else — your `apply` raised, and the exception's type is in `params` |
+
+The last one is deliberately the only place a Python type name appears, and it
+appears as a parameter rather than as the code, so a rename inside rakaia can
+never rewrite what an operator has been reading.
+
 ## Rewind detection
 
 If the stored cursor sorts *after* the current head, the log shrank beneath it,

--- a/docs/subscriber-cursors.md
+++ b/docs/subscriber-cursors.md
@@ -127,9 +127,9 @@ operator has been counting.
 | code | what failed |
 | --- | --- |
 | `handler_gap` | no handler version covers the event's position |
-| `upcaster_chain` | the chain of upcasters could not carry the event to the current version |
+| `upcaster_chain` | the chain of upcasters could not carry the event to the version asked for — a missing link, two that both match, or an event already above it |
 | `effect_collision` | two effects in one batch write the same field of the same row |
-| `unresolved_ref` | an effect pointed at a row the batch never created |
+| `unresolved_ref` | an effect pointed at a row no earlier effect in its batch produced, or at a field that row does not have |
 | `duplicate_produces` | two effects in one batch claimed the same name |
 | `handler_drift` | a handler's source changed since it was registered |
 | `missing_reader` | a staged replay was run without the reader its later stages need |

--- a/scripts/gen_api_reference.py
+++ b/scripts/gen_api_reference.py
@@ -201,12 +201,16 @@ GROUPS: dict[str, tuple[str, ...]] = {
     ),
     "Constants": (
         "__version__",
+        "REASON_CODES",
+        "UNHANDLED",
+        "EXCEPTION_TYPE_KEY",
         "HANDLERS_META_STREAM",
         "REDUCERS_META_STREAM",
         "UPCASTERS_META_STREAM",
         "SCRATCH_PATH",
     ),
     "Errors": (
+        "RakaiaError",
         "StreamError",
         "StreamNotFound",
         "SequenceConflict",
@@ -224,6 +228,9 @@ GROUPS: dict[str, tuple[str, ...]] = {
         "DuplicateProducesError",
         "UpcasterChainError",
         "UpcasterConflictError",
+        "MissingReaderError",
+        "UndecodableEventError",
+        "MergeKeyError",
     ),
 }
 

--- a/src/rakaia/__init__.py
+++ b/src/rakaia/__init__.py
@@ -82,6 +82,12 @@ if TYPE_CHECKING:
         Upsert,
         check_disjoint_defaults,
     )
+    from .errors import (
+        EXCEPTION_TYPE_KEY,
+        REASON_CODES,
+        UNHANDLED,
+        RakaiaError,
+    )
     from .executors import CollectingExecutor, InMemoryProjections
     from .history import (
         envelope_actor,
@@ -139,7 +145,15 @@ if TYPE_CHECKING:
         reset_default_registries,
         upcast,
     )
-    from .replay import ENVELOPE_TS, ReplayResult, TouchedSubject, merge_replay
+    from .replay import (
+        ENVELOPE_TS,
+        MergeKeyError,
+        MissingReaderError,
+        ReplayResult,
+        TouchedSubject,
+        UndecodableEventError,
+        merge_replay,
+    )
     from .response_cursor import (
         CursorOptions,
         calculate_cursor,
@@ -303,6 +317,9 @@ _EXPORTS: dict[str, str] = {
     "merge_replay": "rakaia.replay",
     "ENVELOPE_TS": "rakaia.replay",
     "ReplayResult": "rakaia.replay",
+    "MissingReaderError": "rakaia.replay",
+    "UndecodableEventError": "rakaia.replay",
+    "MergeKeyError": "rakaia.replay",
     "TouchedSubject": "rakaia.replay",
     "DriftLedger": "rakaia.drift",
     # Subscriber cursors
@@ -313,6 +330,11 @@ _EXPORTS: dict[str, str] = {
     "consume": "rakaia.subscription",
     "Consumed": "rakaia.subscription",
     "OnErrorPolicy": "rakaia.subscription",
+    # What the apply path raises, and the codes an outcome records for it
+    "RakaiaError": "rakaia.errors",
+    "REASON_CODES": "rakaia.errors",
+    "UNHANDLED": "rakaia.errors",
+    "EXCEPTION_TYPE_KEY": "rakaia.errors",
     "Outcome": "rakaia.outcomes",
     "OutcomeStatus": "rakaia.outcomes",
     "Stage": "rakaia.outcomes",

--- a/src/rakaia/drift.py
+++ b/src/rakaia/drift.py
@@ -32,6 +32,7 @@ import logging
 from dataclasses import dataclass, field
 from typing import Any, Literal
 
+from .errors import RakaiaError
 from .source_hash import hash_function_source
 
 # Deliberately the logger `replay()` has always warned through: `RAKAIA_DRIFT`
@@ -42,8 +43,10 @@ OnDriftPolicy = Literal["warn", "raise"]
 """What to do when a rule's source no longer matches its registered hash."""
 
 
-class HandlerDriftError(Exception):
+class HandlerDriftError(RakaiaError):
     """A handler/upcaster's source body differs from its registered hash."""
+
+    code = "handler_drift"
 
 
 @dataclass

--- a/src/rakaia/effects.py
+++ b/src/rakaia/effects.py
@@ -33,6 +33,8 @@ from dataclasses import field as dc_field
 from dataclasses import replace as dc_replace
 from typing import Any, NoReturn, Protocol, TypeVar, cast, runtime_checkable
 
+from .errors import RakaiaError
+
 # =============================================================================
 # Symbolic refs — bind to a sibling effect's generated key
 # =============================================================================
@@ -283,22 +285,28 @@ AnyEffect = Upsert | Update | Delete | Retire | ExternalEffect
 # =============================================================================
 
 
-class EffectCollisionError(Exception):
+class EffectCollisionError(RakaiaError):
     """
     Two sibling effects target the same (model_label, lookup) row with
     overlapping keys in `defaults`, violating the disjoint-defaults invariant.
     """
 
+    code = "effect_collision"
 
-class UnresolvedRefError(Exception):
+
+class UnresolvedRefError(RakaiaError):
     """A `Ref` names a `produces` id no earlier effect in the batch produced
     (a forward reference or a typo)."""
 
+    code = "unresolved_ref"
 
-class DuplicateProducesError(Exception):
+
+class DuplicateProducesError(RakaiaError):
     """Two effects in one batch declare the same `produces` id. The id would
     silently bind to the second producer's row, orphaning the first — always a
     bug, so it is rejected rather than resolved to the wrong row."""
+
+    code = "duplicate_produces"
 
 
 # =============================================================================

--- a/src/rakaia/errors.py
+++ b/src/rakaia/errors.py
@@ -1,0 +1,74 @@
+"""The base type for what the apply path raises, and the codes it promises.
+
+Everything rakaia raises from an apply inherits `RakaiaError` and carries a
+`code` — a short, stable string an operator reads on a failure record. The codes
+are a closed, published set (`REASON_CODES`) and are changed with the care any
+other public name gets: they are the vocabulary a failure screen counts and
+filters on, so moving one silently rewrites history someone is already reading.
+
+The code is **written out**, never derived from the class name. A derivation
+would tie an operator's vocabulary to an internal rename, which is the defect
+this module exists to remove; `tests/test_rakaia/test_error_codes.py` renames
+every class and asserts the code stays put. ADR 0007 Decision 6 is unchanged by
+any of this: reason codes a *consumer* records remain the consumer's and stay
+opaque to rakaia. This only covers the case where rakaia itself is what failed.
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar, Final
+
+UNHANDLED: Final = "unhandled"
+"""Recorded for anything that is not one of rakaia's own.
+
+A consumer's own exception is not rakaia's to name, so the loop records this one
+code and puts the exception's type name in `params` under `EXCEPTION_TYPE_KEY`.
+That keeps the vocabulary countable — one code rather than an open set of class
+names — while leaving enough to tell two unanticipated bugs apart.
+"""
+
+EXCEPTION_TYPE_KEY: Final = "exception_type"
+"""The `params` key holding the type name of an `unhandled` exception.
+
+A documented key, because an operator filtering on it needs it to be stable. The
+type *name* only: an exception's message is where field values leak, and this
+library is used on submissions carrying personal and financial data.
+"""
+
+
+class RakaiaError(Exception):
+    """Base for every failure rakaia raises from the apply path.
+
+    Catch this to catch anything the library itself can raise from an apply,
+    instead of enumerating the concrete classes across three modules. Each
+    subclass sets `code` to its own promised member of `REASON_CODES`; the code
+    lives on the class rather than the instance because it is a property of the
+    failure kind, so a reader can look it up without constructing one.
+
+    The base defaults to `UNHANDLED` so an exception from outside this closed
+    set can never break the recording path, and a test walks the subclasses to
+    ensure no rakaia error is left sitting on that default.
+    """
+
+    code: ClassVar[str] = UNHANDLED
+
+
+REASON_CODES: Final = frozenset(
+    {
+        "handler_gap",
+        "upcaster_chain",
+        "effect_collision",
+        "unresolved_ref",
+        "duplicate_produces",
+        "handler_drift",
+        "missing_reader",
+        "undecodable_event",
+        "merge_key",
+        UNHANDLED,
+    }
+)
+"""Every reason code rakaia records for a failure of its own, plus `unhandled`.
+
+Closed and published. Adding one is a public API change; removing or renaming
+one breaks whatever an operator has been counting.
+"""

--- a/src/rakaia/registry.py
+++ b/src/rakaia/registry.py
@@ -26,6 +26,7 @@ from typing import Any, ClassVar
 # where callers have always imported it from — keeps working.
 from .drift import DriftLedger
 from .drift import HandlerDriftError as HandlerDriftError
+from .errors import RakaiaError
 from .protocols import WritableStore
 from .registration_log import RegistrationLog
 from .source_hash import hash_function_source, is_importable, unwrap_handler
@@ -44,16 +45,20 @@ class HandlerOverlapError(Exception):
     """Two versions of the same handler claim overlapping sequence ranges."""
 
 
-class HandlerGapError(Exception):
+class HandlerGapError(RakaiaError):
     """No registered version of a handler covers the requested sequence."""
+
+    code = "handler_gap"
 
 
 class UpcasterConflictError(Exception):
     """Two upcasters were registered for the same (event_match, from_version)."""
 
 
-class UpcasterChainError(Exception):
+class UpcasterChainError(RakaiaError):
     """Cannot upcast: missing or ambiguous link in the upcaster chain."""
+
+    code = "upcaster_chain"
 
 
 # =============================================================================

--- a/src/rakaia/replay.py
+++ b/src/rakaia/replay.py
@@ -755,9 +755,13 @@ def merge_replay(
     `HandlerGapError` under merge (the merged range is longer). Version merged
     handlers by content or open ranges.
 
-    Raises `ValueError` on duplicate `stream_paths`, when an event lacks the
-    requested order key (payload field, or `event_ts` under `ENVELOPE_TS`), or
-    when the order-key values aren't mutually comparable across events.
+    Raises `MergeKeyError` when an event lacks the requested order key (payload
+    field, or `event_ts` under `ENVELOPE_TS`), and when the order-key values
+    aren't mutually comparable across events. Duplicate `stream_paths` raises a
+    plain `ValueError`: it is an argument that cannot be right, checked before a
+    single event is read, so it is not a failure the consume loop can record a
+    code for. `MergeKeyError` is itself a `ValueError`, so one `except ValueError`
+    still catches all three.
 
     How far it gets before failing: **nothing is applied unless everything
     decodes.** Unlike a single-pass `replay()`, a merge has to read every stream

--- a/src/rakaia/replay.py
+++ b/src/rakaia/replay.py
@@ -90,6 +90,7 @@ from .effects import (
     _WrittenFields,
     transition_payload,
 )
+from .errors import RakaiaError
 from .protocols import ProjectionReader, ReadableStore
 from .registry import (
     HandlerRegistry,
@@ -98,6 +99,34 @@ from .registry import (
     get_default_registry,
     get_default_upcaster_registry,
 )
+
+# =============================================================================
+# Errors
+# =============================================================================
+#
+# Each also subclasses `ValueError`, which is what these sites raised before
+# they were named. Adding a type is then additive: a caller already catching
+# `ValueError` around a merge or a decode keeps catching it, and gains the
+# option of catching the specific failure or `RakaiaError` instead.
+
+
+class MissingReaderError(RakaiaError, ValueError):
+    """A staged replay was asked to run with no projection reader."""
+
+    code = "missing_reader"
+
+
+class UndecodableEventError(RakaiaError, ValueError):
+    """An event's stored bytes are not decodable JSON."""
+
+    code = "undecodable_event"
+
+
+class MergeKeyError(RakaiaError, ValueError):
+    """A merge cannot order its events: the order key is missing from an event,
+    or its values are not mutually comparable across them."""
+
+    code = "merge_key"
 
 
 class _EnvelopeTs:
@@ -267,7 +296,7 @@ def require_reader(ctx: _ReplayCtx, what: str = "Replay") -> None:
     here beats failing inside the first handler that dereferences `None`.
     """
     if is_staged(ctx) and ctx.reader is None:
-        raise ValueError(
+        raise MissingReaderError(
             f"{what} has stage > 0 handlers or reducers but no reader was "
             f"provided; pass reader= so they can read earlier stages' projections."
         )
@@ -762,7 +791,7 @@ def merge_replay(
             )
             if order_key is ENVELOPE_TS:
                 if msg.event_ts is None:
-                    raise ValueError(
+                    raise MergeKeyError(
                         f"Event at offset={offset} in stream={path!r} has no "
                         f"envelope event_ts; cannot merge on ENVELOPE_TS. (A store "
                         f"always sets it — is this a hand-built StreamMessage?)"
@@ -770,7 +799,7 @@ def merge_replay(
                 sort_value: Any = msg.event_ts
             else:
                 if order_key not in upcasted:
-                    raise ValueError(
+                    raise MergeKeyError(
                         f"Event at offset={offset} in stream={path!r} has no "
                         f"order_key={order_key!r} in its payload; cannot merge "
                         f"deterministically."
@@ -781,7 +810,7 @@ def merge_replay(
     try:
         tagged.sort(key=lambda item: item[0])
     except TypeError as exc:
-        raise ValueError(
+        raise MergeKeyError(
             f"Cannot merge deterministically: order_key={order_key!r} values are "
             f"not mutually comparable across events (mixed types or None?): {exc}"
         ) from exc
@@ -801,7 +830,7 @@ def _decode_event(data: bytes, stream_path: str, seq: int) -> dict:
     try:
         return json.loads(data)
     except (ValueError, UnicodeDecodeError) as exc:
-        raise ValueError(
+        raise UndecodableEventError(
             f"Cannot decode event at seq={seq} in stream={stream_path!r} as JSON: {exc}"
         ) from exc
 

--- a/src/rakaia/replay.py
+++ b/src/rakaia/replay.py
@@ -561,7 +561,7 @@ def replay(
     before.
 
     How far it gets before failing: a single pass decodes one event at a time, so
-    a malformed event at offset N raises `ValueError` with the first N already
+    a malformed event at offset N raises `UndecodableEventError` with the first N already
     applied. A staged replay needs the whole range before its second pass, so it
     decodes up front and the same event applies nothing. See `EventSource`.
     """
@@ -633,13 +633,13 @@ def merge_replay(
             - a **string** (default ``"ts"``) reads a field out of the **decoded
               payload body** (``event[order_key]``). This is *not* the transport
               or envelope timestamp — it is whatever field the producer wrote into
-              the JSON. A missing key raises a ValueError.
+              the JSON. A missing key raises `MergeKeyError`.
             - the ``ENVELOPE_TS`` sentinel reads the first-class **envelope**
               timestamp (``StreamMessage.event_ts`` — the producer's logical event
               time, defaulting to append time). Prefer this: it is unambiguous and
               does not require the producer to duplicate a timestamp into the
               payload. A message with no ``event_ts`` (only a hand-built one; a
-              store always sets it) raises a ValueError.
+              store always sets it) raises `MergeKeyError`.
         handler_registry / upcaster_registry: default to the process-wide ones.
         event_match: Match string for handler routing + upcasting. Default None
             uses each event's **source stream path** as its match string, so
@@ -659,9 +659,11 @@ def merge_replay(
     field, or `event_ts` under `ENVELOPE_TS`), and when the order-key values
     aren't mutually comparable across events. Duplicate `stream_paths` raises a
     plain `ValueError`: it is an argument that cannot be right, checked before a
-    single event is read, so it is not a failure the consume loop can record a
-    code for. `MergeKeyError` is itself a `ValueError`, so one `except ValueError`
-    still catches all three.
+    single event is read, so a code for it would be one the published set carries
+    and no outcome can ever hold. Called from inside an `apply` it still reaches
+    the consume loop, which records it as `unhandled` with the type in `params` —
+    which is what an argument fault should look like. `MergeKeyError` is itself a
+    `ValueError`, so one `except ValueError` still catches all three.
 
     How far it gets before failing: **nothing is applied unless everything
     decodes.** Unlike a single-pass `replay()`, a merge has to read every stream

--- a/src/rakaia/subscription.py
+++ b/src/rakaia/subscription.py
@@ -37,6 +37,7 @@ from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 from typing import Literal
 
+from .errors import EXCEPTION_TYPE_KEY, UNHANDLED, RakaiaError
 from .offsets import after as offsets_after
 from .outcomes import Outcome
 from .protocols import CursorStore, OutcomeStore
@@ -275,6 +276,7 @@ def consume(
         try:
             emitted = apply(message)
         except Exception as exc:
+            code = exc.code if isinstance(exc, RakaiaError) else UNHANDLED
             _record(
                 Outcome(
                     consumer=consumer,
@@ -286,7 +288,17 @@ def consume(
                     # recovers it — the first row of ADR 0007's recovery table.
                     stage="project",
                     status="failed",
-                    reasons=(type(exc).__name__,),
+                    reasons=(code,),
+                    # Only for what rakaia cannot name. A class name is not a
+                    # promised code — it moves when the class is renamed — so
+                    # anything outside `REASON_CODES` is counted as one code
+                    # with the type recorded beside it, message and all field
+                    # values left out.
+                    params=(
+                        {EXCEPTION_TYPE_KEY: type(exc).__name__}
+                        if code == UNHANDLED
+                        else {}
+                    ),
                 )
             )
             if on_error == "halt":

--- a/tests/test_rakaia/test_error_codes.py
+++ b/tests/test_rakaia/test_error_codes.py
@@ -182,9 +182,15 @@ class TestTheSetIsClosed:
 
         seen: set[type[RakaiaError]] = set()
 
+        def ours(cls: type[RakaiaError]) -> bool:
+            # `rakaia` itself has no dot, so a prefix test on "rakaia." misses a
+            # class defined in the package root — the same blind spot this walk
+            # was widened to close, one module short of where it was found.
+            return cls.__module__ == "rakaia" or cls.__module__.startswith("rakaia.")
+
         def walk(cls: type[RakaiaError]) -> None:
             for sub in cls.__subclasses__():
-                if sub.__module__.startswith("rakaia."):
+                if ours(sub):
                     seen.add(sub)
                     walk(sub)
 

--- a/tests/test_rakaia/test_error_codes.py
+++ b/tests/test_rakaia/test_error_codes.py
@@ -13,8 +13,14 @@ fixed, so a rename must not move it.
 
 from __future__ import annotations
 
+import importlib
+import pkgutil
+import re
+from pathlib import Path
+
 import pytest
 
+import rakaia
 from rakaia.drift import HandlerDriftError
 from rakaia.effects import (
     DuplicateProducesError,
@@ -164,6 +170,16 @@ class TestTheSetIsClosed:
     def test_every_rakaia_error_in_the_tree_declares_a_promised_code(self) -> None:
         """A new exception that forgets its code would otherwise record
         `unhandled` — quietly, and only in production."""
+        # Import every module in the package first. `__subclasses__` only sees
+        # what has been imported, and `rakaia/__init__.py` resolves names lazily,
+        # so a subclass in a module nothing happened to touch is invisible here —
+        # the walk passed while the very thing it guards against sat in the tree.
+        # Measured: a codeless subclass appended to `rakaia.append` left this file
+        # green on its own and only reddened under the full run, by the luck of
+        # another test importing that module.
+        for info in pkgutil.walk_packages(rakaia.__path__, f"{rakaia.__name__}."):
+            importlib.import_module(info.name)
+
         seen: set[type[RakaiaError]] = set()
 
         def walk(cls: type[RakaiaError]) -> None:
@@ -236,3 +252,23 @@ class TestTheRealRaisingSitesRaiseTheNewTypes:
                 handler_registry=HandlerRegistry(),
                 upcaster_registry=UpcasterRegistry(),
             )
+
+
+class TestTheTableInTheDocsIsTheSet:
+    """The published table lists exactly the published codes.
+
+    The set is a promise, and a promise nobody can read is not one — the codes
+    live in `errors.py`, and the generated reference cannot render the docstring
+    under a module-level assignment, so the only place a reader meets them is a
+    table in prose. A table in prose rots. This is what stops it.
+    """
+
+    def test_the_documented_table_matches_reason_codes(self) -> None:
+        page = (
+            Path(__file__).resolve().parents[2] / "docs" / "subscriber-cursors.md"
+        ).read_text()
+        section = page.split("## The reason codes rakaia records for itself", 1)[1]
+        section = section.split("\n## ", 1)[0]
+        documented = set(re.findall(r"^\| `([a-z_]+)` \|", section, re.MULTILINE))
+
+        assert documented == set(REASON_CODES)

--- a/tests/test_rakaia/test_error_codes.py
+++ b/tests/test_rakaia/test_error_codes.py
@@ -1,0 +1,238 @@
+"""Reason codes for the failures rakaia raises itself.
+
+ADR 0007 Decision 6 leaves a consumer's reason codes opaque to rakaia. It never
+said what happens when *rakaia* is what failed, and the loop was answering with
+``type(exc).__name__`` — so a rename of an internal class rewrote a code an
+operator had been reading, and every unanticipated bug arrived as ``ValueError``,
+indistinguishable from a decode failure.
+
+The codes are a promised, closed set. The test that carries the whole point is
+`TestACodeSurvivesARename`: a code derived from a class name is the defect being
+fixed, so a rename must not move it.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from rakaia.drift import HandlerDriftError
+from rakaia.effects import (
+    DuplicateProducesError,
+    EffectCollisionError,
+    UnresolvedRefError,
+)
+from rakaia.errors import REASON_CODES, UNHANDLED, RakaiaError
+from rakaia.executors import CollectingExecutor
+from rakaia.outcomes import InMemoryOutcomeStore, Outcome
+from rakaia.registry import HandlerGapError, UpcasterChainError
+from rakaia.replay import MergeKeyError, MissingReaderError, UndecodableEventError
+from rakaia.store import StreamStore
+from rakaia.subscription import consume
+from rakaia.types import StreamMessage
+
+#: Every class rakaia raises from the apply path, against the code it promises.
+#: Nine sites, and the pairing is the promise — not a derivation from a name.
+THE_NINE: list[tuple[type[RakaiaError], str]] = [
+    (HandlerGapError, "handler_gap"),
+    (UpcasterChainError, "upcaster_chain"),
+    (EffectCollisionError, "effect_collision"),
+    (UnresolvedRefError, "unresolved_ref"),
+    (DuplicateProducesError, "duplicate_produces"),
+    (HandlerDriftError, "handler_drift"),
+    (MissingReaderError, "missing_reader"),
+    (UndecodableEventError, "undecodable_event"),
+    (MergeKeyError, "merge_key"),
+]
+
+
+def _reasons_and_params(exc: BaseException) -> tuple[tuple[str, ...], dict[str, str]]:
+    """Run one failing apply through the loop and return what it recorded."""
+    store = StreamStore()
+    store.create("s")
+    store.append("s", b'{"a": 1}')
+    outcomes = InMemoryOutcomeStore()
+
+    def apply(_message: StreamMessage) -> None:
+        raise exc
+
+    result = consume(
+        store,
+        "s",
+        apply,
+        consumer="c",
+        on_error="skip",
+        outcomes=outcomes,
+    )
+    assert len(result.outcomes) == 1
+    assert outcomes.latest("c", "s") == list(result.outcomes)
+    return result.outcomes[0].reasons, dict(result.outcomes[0].params)
+
+
+class TestEachSiteRecordsItsOwnCode:
+    @pytest.mark.parametrize(
+        ("cls", "code"), THE_NINE, ids=[c.__name__ for c, _ in THE_NINE]
+    )
+    def test_the_loop_records_the_class_s_promised_code(
+        self, cls: type[RakaiaError], code: str
+    ) -> None:
+        reasons, params = _reasons_and_params(cls("boom"))
+        assert reasons == (code,)
+        assert params == {}
+
+    def test_the_nine_codes_are_distinct(self) -> None:
+        codes = [code for _, code in THE_NINE]
+        assert len(set(codes)) == len(codes)
+
+    def test_every_promised_code_is_in_the_closed_set(self) -> None:
+        assert {code for _, code in THE_NINE} | {UNHANDLED} == set(REASON_CODES)
+
+
+class TestAnythingElseIsUnhandled:
+    def test_a_consumer_s_own_exception_records_unhandled(self) -> None:
+        class ConsumerBlewUp(RuntimeError):
+            pass
+
+        reasons, params = _reasons_and_params(ConsumerBlewUp("nope"))
+        assert reasons == (UNHANDLED,)
+        assert params == {"exception_type": "ConsumerBlewUp"}
+
+    def test_a_bare_value_error_is_no_longer_confusable_with_a_decode_failure(
+        self,
+    ) -> None:
+        """The defect in the issue: everything unanticipated looked like a decode."""
+        bare, _ = _reasons_and_params(ValueError("something else entirely"))
+        decode, _ = _reasons_and_params(UndecodableEventError("bad json"))
+        assert bare != decode
+
+    def test_the_type_name_is_the_only_thing_carried(self) -> None:
+        """No interpolated message — Decision 6 forbids it, and this is the path
+        where a field value would most easily leak."""
+        _, params = _reasons_and_params(ValueError("row 7 for taxpayer 12345"))
+        assert params == {"exception_type": "ValueError"}
+
+
+class TestACodeSurvivesARename:
+    """The whole point. A code derived from `__name__` moves when a class is
+    renamed, which is what silently rewrote the vocabulary operators read."""
+
+    @pytest.mark.parametrize(
+        ("cls", "code"), THE_NINE, ids=[c.__name__ for c, _ in THE_NINE]
+    )
+    def test_renaming_the_class_does_not_move_the_code(
+        self, cls: type[RakaiaError], code: str
+    ) -> None:
+        renamed = type("ThoroughlyDifferentName", (cls,), {})
+        assert renamed.__name__ != cls.__name__
+        assert renamed.code == code
+        reasons, _ = _reasons_and_params(renamed("boom"))
+        assert reasons == (code,)
+
+    def test_no_code_is_spelled_the_way_a_name_derivation_would_spell_it(self) -> None:
+        """A derivation that happened to agree would pass the rename test by
+        luck for one class; this fails if any code is literally its class name."""
+        for cls, code in THE_NINE:
+            assert code != cls.__name__
+
+
+class TestOneClauseCatchesThemAll:
+    @pytest.mark.parametrize(
+        "cls", [c for c, _ in THE_NINE], ids=[c.__name__ for c, _ in THE_NINE]
+    )
+    def test_the_base_type_catches_every_one_of_the_nine(
+        self, cls: type[RakaiaError]
+    ) -> None:
+        with pytest.raises(RakaiaError):
+            raise cls("boom")
+
+    def test_the_base_type_is_exported_from_the_package_root(self) -> None:
+        import rakaia
+
+        assert rakaia.RakaiaError is RakaiaError
+
+    @pytest.mark.parametrize(
+        "cls", [MissingReaderError, UndecodableEventError, MergeKeyError]
+    )
+    def test_the_replay_errors_are_still_value_errors(
+        self, cls: type[RakaiaError]
+    ) -> None:
+        """Additive, not breaking: a caller already catching `ValueError` from a
+        merge or a decode keeps catching it."""
+        assert issubclass(cls, ValueError)
+
+
+class TestTheSetIsClosed:
+    def test_every_rakaia_error_in_the_tree_declares_a_promised_code(self) -> None:
+        """A new exception that forgets its code would otherwise record
+        `unhandled` — quietly, and only in production."""
+        seen: set[type[RakaiaError]] = set()
+
+        def walk(cls: type[RakaiaError]) -> None:
+            for sub in cls.__subclasses__():
+                if sub.__module__.startswith("rakaia."):
+                    seen.add(sub)
+                    walk(sub)
+
+        walk(RakaiaError)
+        assert seen == {cls for cls, _ in THE_NINE}
+        for cls in seen:
+            assert cls.code in REASON_CODES
+            assert cls.code != UNHANDLED
+
+    def test_an_outcome_will_accept_every_promised_code(self) -> None:
+        """The codes have to survive `encode_outcome`'s string check."""
+        for code in REASON_CODES:
+            Outcome(
+                consumer="c",
+                stream_path="s",
+                subject="1",
+                offset="1",
+                sequence_key="1",
+                stage="project",
+                status="failed",
+                reasons=(code,),
+            )
+
+
+class TestTheRealRaisingSitesRaiseTheNewTypes:
+    def test_a_staged_replay_with_no_reader_raises_missing_reader(self) -> None:
+        from rakaia.registry import HandlerRegistry, UpcasterRegistry
+        from rakaia.replay import build_pipeline, require_reader
+
+        registry = HandlerRegistry()
+
+        def handler(_event: dict, _reader: object) -> None:
+            return None
+
+        registry.register("h", "x.*", handler, 0, stage=1)
+        ctx = build_pipeline(
+            handler_registry=registry,
+            upcaster_registry=UpcasterRegistry(),
+            executor=CollectingExecutor(),
+            reader=None,
+            on_drift="warn",
+        )
+        with pytest.raises(MissingReaderError):
+            require_reader(ctx)
+
+    def test_an_undecodable_event_raises_undecodable_event(self) -> None:
+        from rakaia.replay import _decode_event
+
+        with pytest.raises(UndecodableEventError):
+            _decode_event(b"not json at all", "s", 0)
+
+    def test_a_missing_merge_key_raises_merge_key(self) -> None:
+        from rakaia.registry import HandlerRegistry, UpcasterRegistry
+        from rakaia.replay import merge_replay
+
+        store = StreamStore()
+        store.create("a")
+        store.append("a", b'{"type": "x.done"}')
+        with pytest.raises(MergeKeyError):
+            merge_replay(
+                store,
+                ["a"],
+                CollectingExecutor(),
+                order_key="when",
+                handler_registry=HandlerRegistry(),
+                upcaster_registry=UpcasterRegistry(),
+            )

--- a/tests/test_rakaia/test_public_api.py
+++ b/tests/test_rakaia/test_public_api.py
@@ -130,6 +130,14 @@ RAKAIA_PUBLIC = {
     "TouchedSubject",
     "merge_replay",
     "replay",
+    # what the apply path raises, and the codes an outcome records for it
+    "EXCEPTION_TYPE_KEY",
+    "MergeKeyError",
+    "MissingReaderError",
+    "REASON_CODES",
+    "RakaiaError",
+    "UNHANDLED",
+    "UndecodableEventError",
     # subscriptions
     "Poll",
     "PollStatus",

--- a/tests/test_rakaia/test_tier_boundary.py
+++ b/tests/test_rakaia/test_tier_boundary.py
@@ -73,7 +73,10 @@ PROTOCOL_SERVER = {
 #: format rules (`json_mode`, `offsets`) both tiers must agree on. ADR 0002 calls
 #: these out as the reason the tiers "genuinely share types today" — they are the
 #: substance of the split question, so a change here is the thing to look at.
-SHARED = {"types", "protocols", "json_mode", "offsets", "outcomes"}
+SHARED = {"types", "protocols", "json_mode", "offsets", "outcomes", "errors"}
+# `errors` is shared for the same reason `outcomes` is: the framework tier
+# raises the exceptions and the consume loop, in the server tier, reads the
+# code off one to record it. Neither tier owns the vocabulary.
 
 #: Deliberate, documented crossings. Keep this empty if you can; every entry is a
 #: thing a package split would have to resolve, so the list is the running cost


### PR DESCRIPTION
A record of an event that could not be applied used to carry the name of whatever class was raised. That meant renaming something internal quietly rewrote the vocabulary an operator had been counting and filtering on, and a genuine bug in a consumer's own code was recorded under the same name as a bad merge key. Everything rakaia raises while applying an event now carries a short code from a published, closed set — written out, never derived from a class name — and anything that is not rakaia's own is recorded under one code with the exception's type beside it and its message left out.

Three failures inside a replay that used to arrive as a bare, unnameable error now have names of their own, and one clause catches anything the library raises from an apply instead of importing six classes from three modules. Nothing that was being raised changed name or stopped being catchable the way it was, so this is additive for anyone already handling these. What does change is the value stored on new failure records, which is why the upgrade notes call it out.

Closes #257
