### PR TITLE
Cut 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ runnable demo for each.
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-09-08
+
 ### Changed
 
 - **Two modules renamed for what they serve.** `rakaia.handler` is the Durable

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -15,7 +15,7 @@ ones you are crossing.
 
 ---
 
-# Unreleased
+# 0.4.0
 
 ## Two module paths changed, and there is no shim
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 # PyPI by an unrelated placeholder. The import name is unaffected:
 #   pip install rakaia-streams   ->   import rakaia
 name = "rakaia-streams"
-version = "0.3.1"
+version = "0.4.0"
 description = "Python server implementation of the Durable Streams protocol"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -1215,7 +1215,7 @@ wheels = [
 
 [[package]]
 name = "rakaia-streams"
-version = "0.3.1"
+version = "0.4.0"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
Six changes since the last release, and the shape of them is one story: the library now delivers events to a consumer and keeps an honest record of what happened to each one. A consumer is something you build once and run rather than six arguments repeated at every call, and it cannot be built in the shape that quietly records nothing; an administrator has a screen for the failures and a command to expire the old ones on an age they name, with no default because a wrong guess destroys evidence; and every failure the library raises itself now carries a short code that renaming something internal cannot change.

The rest is groundwork that shows through. Two files are named after what they serve rather than after things they are not, the rule deciding what order writes reach the database lives in one place instead of three, and there is at last a worked example that runs the whole loop against real shapes and demonstrates each of the ways an event can fail to be applied. This is the prep only — version, changelog and upgrade notes — with the tag to follow once it lands.