### PR TITLE
Document what the release added, and make the bundle keep up on its own

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ runnable demo for each.
 
 ## [Unreleased]
 
+### Changed
+
+- **Documentation for what 0.4.0 added.** The failure-record screen had no page
+  outside the release notes, and the reason codes had no entry in the guided
+  tour; both are written up now, the screen beside the retention command it
+  belongs with. The machine-readable knowledge bundle under `okf/` gained the
+  consuming loop as a seventh concept group — it had no entry for any of it —
+  and two checks so it cannot drift again: every example directory must have a
+  page there, and the names in its prose are swept for resolution along with the
+  rest of the documentation.
+
 ## [0.4.0] - 2026-09-08
 
 ### Changed

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -216,7 +216,42 @@ For an actual deployment, you'd want at least:
 5. **Static files.** The chat sample has none, but if you add any, run
    `collectstatic` and serve them via the reverse proxy or WhiteNoise.
 6. **A retention policy for outcome records.** Nothing deletes them on its own.
-   See the next section.
+   See [Retention](#retention-pruning-old-outcome-records); the screen for reading
+   them is the section before it.
+
+## Looking at the failure records
+
+The records are only useful if somebody reads them, so they get a screen — the
+one piece of this library's operational bookkeeping that does. Cursors, producer
+registrations and offset watermarks deliberately have no admin, because
+bookkeeping is not browsed; looking at these *is* the feature, which is the
+exception [ADR 0007](adr/0007-an-outcome-is-recorded-where-the-cursor-is-committed.md)
+argues for.
+
+It appears under **Django Rakaia → Consumer outcomes** once `django_rakaia` is in
+`INSTALLED_APPS`, with no wiring of your own. Newest first, one row per failure,
+showing the consumer, the stream, what the record is about, the position in the
+log if the event ever reached it, and the reason codes.
+
+**It is read-only, and not merely by convention** — adding, changing and deleting
+are all refused. These are a record of what happened; removing them is the
+retention job below, not a button. Two things about the rows are worth knowing
+before you read one:
+
+- **What you see is not what is stored.** A record is kept as one encoded
+  payload, with two derived columns beside it purely as an index. Those columns
+  hold a percent-encoded, possibly shortened form of the value — `submission/tf611`
+  is indexed as `submission%2Ftf611` — so the screen decodes the payload for every
+  column rather than printing the index. Searching does the same in reverse, so a
+  name with an accent in it is found by typing the accent.
+- **A record this version cannot read still gets a row**, marked `UNREADABLE`
+  rather than dropped. A record vanishing from the page is the exact failure the
+  table exists to prevent.
+
+The reason codes are listed in
+[Read a stream incrementally](subscriber-cursors.md#the-reason-codes-rakaia-records-for-itself).
+A code of `unhandled` means the failure came from your own code, and the
+exception's type is recorded beside it.
 
 ## Retention: pruning old outcome records
 

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -752,6 +752,50 @@ an operator would see the next morning.
 → Deep dive: [Examples](examples.md) ·
 [ADR 0007](adr/0007-an-outcome-is-recorded-where-the-cursor-is-committed.md)
 
+## 23. A failure record says *why* in a word you can count
+
+**The problem.** A record of a failure is only worth keeping if you can ask
+questions of it, and the first question is always "how many, and why". That needs
+the reason to be a short code rather than a sentence — a sentence has to be
+grepped, and it leaks whatever it interpolated, which on a submission means
+somebody's name or their bank details. Rakaia kept codes from the start for the
+reasons a *consumer* records. For its own failures it wrote down the name of
+whatever Python class had been raised, which is not a vocabulary: rename the
+class and every count an operator had built quietly changes meaning.
+
+**What rakaia does.** Everything the library raises while applying an event now
+carries a stable code, and the ten of them are a published, closed set. The loop
+records the code; renaming anything inside rakaia cannot change it. Your own
+exceptions are not in that set and are not pretended into it — they are recorded
+under one code, `unhandled`, with the exception's type beside it and its message
+left out.
+
+```python
+from rakaia import RakaiaError, REASON_CODES
+
+try:
+    replay("submissions", store=store, executor=executor)
+except RakaiaError as exc:
+    print(exc.code)  # e.g. "handler_gap" — one clause for anything rakaia raises
+```
+
+The full table, with a line each for what failed, is in
+[Read a stream incrementally](subscriber-cursors.md#the-reason-codes-rakaia-records-for-itself).
+
+**See it.** The worked example records a real failure of each kind and prints the
+codes:
+
+```bash
+just intake-demo
+```
+
+Its `[2] HALT` step shows the boundary directly — `unhandled, UnknownSuku` — a
+consumer's own exception recorded under rakaia's code with the consumer's class
+name kept beside it, where a rename cannot rewrite what anyone has been counting.
+
+→ Deep dive: [Read a stream incrementally](subscriber-cursors.md) ·
+[ADR 0007](adr/0007-an-outcome-is-recorded-where-the-cursor-is-committed.md)
+
 ---
 
 ## Where to go next

--- a/okf/concepts/consuming-and-outcomes.md
+++ b/okf/concepts/consuming-and-outcomes.md
@@ -1,0 +1,99 @@
+---
+type: Concept
+title: Consuming a stream & failure records
+description: One loop that reads, applies, records what it could not apply, and commits the reading position.
+tags: [concept, consuming, outcomes, cursors]
+status: stable
+generated: { by: claude-code/opus-5, at: 2026-09-08T00:00:00Z }
+---
+
+# Definition
+
+A durable log already carries positions, so "give me what changed since I last
+looked" is *remember the last offset, read after it*. `poll` is that read.
+`consume` is the loop around it — poll, apply, record anything that could not be
+applied, commit the position, in that order — and `Consumer` holds the five
+things the loop needs so a consumer is built once rather than assembled at every
+call.
+
+The record is the point. A position says how far a consumer got, never whether it
+got there cleanly, so without one an event that was skipped, refused or lost is
+indistinguishable from one applied without incident: **absence of a record reads
+as success**. An `Outcome` closes that gap. Only failures are recorded — the
+position is the success record — so a clean run writes nothing at all.
+
+Two orderings are load-bearing and neither is enforceable from inside the loop.
+The record is written *outside* whatever transaction the apply used, because a
+record written inside rolls back with the batch whose failure it exists to
+record. And the position is committed *last, per message*, which is what makes
+`on_error="halt"` mean anything: the watermark stays below the event that failed,
+so the event is still pending. Redelivery is expected either way, so **an apply
+must be idempotent**.
+
+# Public API
+
+Imported from `rakaia`:
+
+* `poll(store, path, cursor) -> Poll` — the incremental read. `PollStatus` is
+  `fresh` / `advanced` / `caught_up` / `rewound` / `absent`; `rewound` means the
+  log shrank beneath the cursor and derived state must be reset first.
+* `consume(...) -> Consumed` — the loop. `on_error` is `OnErrorPolicy`
+  (`"skip"` for a live consumer, `"halt"` for a rebuild) and has **no default**,
+  deliberately: the two modes have opposite invariants.
+* `Consumer(store, path, name, cursors, outcomes)` with `run(apply, on_error=…)`
+  — the loop as one object. `outcomes` is required, so the shape that records
+  nothing cannot be built.
+* `ConsumerCursorStore` protocol and `InMemoryConsumerCursorStore` — where the
+  reading position is kept between runs. Distinct from `CursorStore`, which is
+  the *event* store a subscriber polls.
+* `Outcome` — one event's failure to apply, as an immutable value: `stage`
+  (`append` / `project`) says how far the event got, `status` (`failed` /
+  `refused` / `skipped`) says what happened, and together they name the recovery.
+  `reasons` are codes, never an interpolated message; `params` is a flat string
+  map.
+* `OutcomeStore` protocol with three implementations: `InMemoryOutcomeStore`,
+  `JsonlOutcomeStore`, and Django's `DjangoOutcomeStore`. `encode_outcome` /
+  `decode_outcome` is the one translation all three share.
+* `RakaiaError` with `code`, `REASON_CODES` (the closed, published set of ten),
+  `UNHANDLED` and `EXCEPTION_TYPE_KEY` — the reason codes rakaia records for its
+  own failures. A consumer's own exception is recorded as `unhandled` with its
+  type in `params`, never its message.
+
+Imported from `django_rakaia`:
+
+* `django_consumer(store, path, name, using=…)` → a `DjangoConsumer` with the
+  durable cursor and outcome stores wired in. Its `run` raises
+  `CallerTransactionOpen` when the caller already has a transaction open on the
+  alias the records are written to — the one hazard the dependency-free core
+  cannot see.
+* `DjangoConsumerCursorStore`, `DjangoOutcomeStore`, `load_cursor`,
+  `commit_cursor`.
+* `manage.py prune_outcomes --older-than-days N` — retention. No default age:
+  the right period differs per installation and a wrong guess deletes evidence.
+* A read-only admin for the records, the one screen this library's operational
+  bookkeeping gets.
+
+# Demonstrated by
+
+* [partisipa_intake](../examples/partisipa-intake.md) — the whole loop end to
+  end: an event refused before the log, one that failed to apply, one skipped on
+  purpose, `halt` versus `skip`, and everything read back after a restart.
+* [protocol_streams](../examples/protocol-streams.md) — `poll` on its own, with
+  no Django.
+
+# Not yet covered by an example
+
+* `JsonlOutcomeStore` and `InMemoryOutcomeStore` as an example's own choice — the
+  intake example keeps both the position and the records in the database, because
+  what it is demonstrating is what survives a restart.
+* Reading a code off a record: catching `RakaiaError`, or branching on the code a
+  record carries, which is what an operator's own tooling would do with them.
+
+# Decisions
+
+* [ADR 0007](../../docs/adr/0007-an-outcome-is-recorded-where-the-cursor-is-committed.md)
+  — why the record is written where the position is committed, and why there is
+  no query for "what is missing".
+* [ADR 0002](../../docs/adr/0002-framework-vs-protocol-server-boundary.md) — how
+  far this library goes into handling an event, and what stays out: retrying,
+  re-driving a recorded failure, and holding events back behind a failed one.

--- a/okf/concepts/effects-and-executors.md
+++ b/okf/concepts/effects-and-executors.md
@@ -36,7 +36,9 @@ Imported from `rakaia`:
   `UnresolvedRefError`, `DuplicateProducesError` on misuse.
 * `check_disjoint_defaults` — raise `EffectCollisionError` if two write effects
   write the same column of the same row (the multi-owner guard).
-* `Executor` protocol; `CollectingExecutor` (dry-run).
+* `Executor` protocol; `CollectingExecutor` (dry-run); `RecordingExecutor`
+  (wraps any executor, applies through it and keeps what it handed on — what a
+  rebuild gate diffs).
 * Django: `DjangoExecutor` (applies to the ORM, resolves `Ref`s);
   `diff_effects_against_rows` (verify replay reproduces existing rows).
 

--- a/okf/concepts/index.md
+++ b/okf/concepts/index.md
@@ -1,6 +1,6 @@
 # Concepts
 
-Rakaia's public API surface, grouped into six areas. Each concept doc lists the
+Rakaia's public API surface, grouped into seven areas. Each concept doc lists the
 APIs it covers, the examples that demonstrate it, and any still-uncovered APIs.
 
 * [Protocol layer & streams](protocol-and-streams.md) - `StreamStore`, producer fencing, close, subscriber/CDN cursors, no-op suppression.
@@ -8,4 +8,5 @@ APIs it covers, the examples that demonstrate it, and any still-uncovered APIs.
 * [Effects & executors](effects-and-executors.md) - `Upsert`/`Update`/`Delete`/`Retire`, `ExternalEffect`, `Ref`/`RefResolver`, `CollectingExecutor`/`DjangoExecutor`, verification.
 * [Projections & fan-out](projections-and-fan-out.md) - `reconcile_children`/`_by_key`/`_tree`/`_aggregate`, `project_latest`.
 * [Event envelope & provenance](event-envelope-and-provenance.md) - envelope fields, `provenance()`, history read-model.
+* [Consuming a stream & failure records](consuming-and-outcomes.md) - `poll`/`consume`, `Consumer`, `Outcome` and the three outcome stores, reason codes, retention.
 * [Django integration](django-integration.md) - `@stream_model`, `create_stream_event`, durable store, SSE.

--- a/okf/index.md
+++ b/okf/index.md
@@ -11,7 +11,7 @@ and tools.
 
 It catalogs two things:
 
-* **Concepts** — rakaia's public API surface, grouped into six areas, each with
+* **Concepts** — rakaia's public API surface, grouped into seven areas, each with
   the APIs it covers and the examples that demonstrate it.
 * **Examples** — every runnable demo in `examples/`, what it proves, the one
   command that runs it, and which concepts it exercises. Demos verified green are
@@ -27,6 +27,7 @@ concept coverage"); this bundle is its structured, cross-linked counterpart.
 * [Effects & executors](concepts/effects-and-executors.md) - effect data, executors, dry-run, symbolic refs.
 * [Projections & fan-out](concepts/projections-and-fan-out.md) - orphan-free child/aggregate reconcile helpers.
 * [Event envelope & provenance](concepts/event-envelope-and-provenance.md) - the event envelope and history read-model.
+* [Consuming a stream & failure records](concepts/consuming-and-outcomes.md) - one loop that reads, applies, records what it could not apply, and commits the position.
 * [Django integration](concepts/django-integration.md) - stream events from models, live SSE.
 
 ## Examples

--- a/okf/log.md
+++ b/okf/log.md
@@ -1,5 +1,18 @@
 # Directory Update Log
 
+## 2026-09-08
+
+* **Creation**: [Consuming a stream & failure records](concepts/consuming-and-outcomes.md) — a seventh
+  concept group, for the loop that reads a stream and the record of what it could not apply
+  (`poll`/`consume`, `Consumer`, `Outcome` and the three outcome stores, the published reason codes,
+  the retention command and the screen).
+* **Update**: [Effects & executors](concepts/effects-and-executors.md) — `RecordingExecutor`.
+* **Creation**: [partisipa_intake](examples/partisipa-intake.md) — the worked example of the whole
+  consuming loop (added with the example itself, logged here now).
+* **Note**: a test now fails if an `examples/` directory has no page in this bundle, and the names
+  in these pages are swept for resolution along with the rest of the documentation. Until today
+  nothing checked either, and this log had not been written to since the bundle was created.
+
 ## 2026-07-28
 
 * **Creation**: Rakaia knowledge bundle ([index](index.md)) — initial OKF catalog of rakaia's concepts and examples.

--- a/tests/test_django_rakaia/test_docs_names_resolve.py
+++ b/tests/test_django_rakaia/test_docs_names_resolve.py
@@ -41,6 +41,7 @@ _SWEPT: tuple[str, ...] = (
     "src/django_rakaia/**/*.py",
     "examples/**/*.py",
     "examples/**/*.md",
+    "okf/**/*.md",
     "scripts/**/*.py",
     "tests/**/*.py",
 )
@@ -211,6 +212,7 @@ class TestTheDocsNameThingsThatExist:
                 "src/django_rakaia/**/*.py",
                 "examples/**/*.py",
                 "examples/**/*.md",
+                "okf/**/*.md",
                 "scripts/**/*.py",
                 "tests/**/*.py",
             ),
@@ -271,4 +273,36 @@ class TestTheDocsNameThingsThatExist:
         )
         assert _offenders("rakaia.no_such_module", {elsewhere}) == [elsewhere], (
             "a name with no exemption at all must have every mention reported"
+        )
+
+
+class TestTheKnowledgeBundleKeepsUp:
+    """`okf/` claims to catalogue every runnable demo. Nothing checked that it does.
+
+    The bundle is machine-facing — it is what an agent reads to find out what this
+    library can do and which demo proves it — so a missing page is not a cosmetic
+    gap, it is a capability the catalogue says does not exist. It stayed current
+    through the release only because somebody noticed the directory by hand.
+
+    The check runs one way on purpose. Every example directory must have a page;
+    a page with no directory of its own is allowed, because the bundle also
+    describes variants that live inside another example (`formkit-submission-stream`
+    is one). Requiring the converse would forbid that on no evidence.
+    """
+
+    def test_every_example_has_a_page_in_the_bundle(self) -> None:
+        directories = {
+            p.name
+            for p in (_ROOT / "examples").iterdir()
+            if p.is_dir() and not p.name.startswith(("_", "."))
+        }
+        pages = {
+            p.stem.replace("-", "_") for p in (_ROOT / "okf" / "examples").glob("*.md")
+        }
+        missing = sorted(directories - pages)
+
+        assert not missing, (
+            f"these examples have no page in the knowledge bundle: {missing}. "
+            "Add one under okf/examples/ naming what it proves and the command "
+            "that runs it, and note it in okf/log.md."
         )


### PR DESCRIPTION
Two things the last release shipped had no home outside the release notes. The screen an administrator uses to read what a consumer could not apply was described nowhere at all, which is a poor result for the most operator-facing thing in it; it now sits beside the command that expires those records, because the same person needs both. And the short codes a failure is recorded under had no entry in the guided tour — deferred at the time because the tour requires a runnable demo per entry and nothing demonstrated them, a reason that expired when the worked example landed in the same release.

The machine-readable bundle under `okf/` had drifted further, because nothing checked it: no entry for the consuming loop, the failure records, the codes, the retention command or the screen, and an update log untouched since the day it was created. It gains all of that as a seventh concept group, plus two checks so the next gap is loud rather than silent — every example directory must have a page there, and the names in its prose are swept for resolution along with the rest of the documentation. It only stayed current this week because somebody happened to notice the directory by hand.