### PR TITLE
Let a consumer name the records written on its behalf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ runnable demo for each.
 
 ## [Unreleased]
 
+### Added
+
+- **A consumer can say how the records written for it are named.**
+  `django_consumer()` now takes `subject_of` and `sequence_of` and passes them to
+  the loop, which has always accepted them. Without this the records a consumer
+  writes itself name a row while the records the loop writes for a failed apply
+  name the event's position in the log — two kinds of thing in one column, on the
+  screen where comparing them is the whole point. The worked example passes both
+  and asserts that every record it produces names a row. (#272)
+
 ### Changed
 
 - **Documentation for what 0.4.0 added.** The failure-record screen had no page

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -181,7 +181,7 @@ page is the contract.
 | Name | Import from | Signature | What it does |
 |---|---|---|---|
 | `Consumer` | `rakaia` | `(store: 'CursorStore', path: 'str', name: 'str', cursors: 'ConsumerCursorStore', outcomes: 'OutcomeStore', subject_of: 'Callable[[StreamMessage], str] \| None' = None, sequence_of: 'Callable[[StreamMessage], str] \| None' = None) -> None` | One consumer of one stream, with everywhere it keeps things attached. |
-| `django_consumer` | `django_rakaia` | `(store: 'CursorStore', path: 'str', name: 'str', *, using: 'str \| None' = None) -> 'DjangoConsumer'` | A consumer of `path`, named `name`, keeping both its cursor and its outcomes in the database. |
+| `django_consumer` | `django_rakaia` | `(store: 'CursorStore', path: 'str', name: 'str', *, using: 'str \| None' = None, subject_of: 'Callable[[StreamMessage], str] \| None' = None, sequence_of: 'Callable[[StreamMessage], str] \| None' = None) -> 'DjangoConsumer'` | A consumer of `path`, named `name`, keeping both its cursor and its outcomes in the database. |
 | `DjangoConsumer` | `django_rakaia` | `(store: 'CursorStore', path: 'str', name: 'str', cursors: 'ConsumerCursorStore', outcomes: 'OutcomeStore', subject_of: 'Callable[[StreamMessage], str] \| None' = None, sequence_of: 'Callable[[StreamMessage], str] \| None' = None) -> None` | A `Consumer` that checks the caller has no transaction open. |
 | `ConsumerCursorStore` | `rakaia` | `(*args, **kwargs)` | Somewhere to keep a consumer's watermark between runs. |
 | `InMemoryConsumerCursorStore` | `rakaia` | `() -> 'None'` | Watermarks in a dict: the reference `ConsumerCursorStore`, for tests and demos. |

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -165,7 +165,7 @@ example exercises it yet (see [known gaps](#known-gaps)).
 | Live SSE broadcast (Channels) | `chat` |
 | Durable `DjangoStreamStore` (log persisted in the DB) | `formkit_submissions` (stream) |
 | File-backed `JsonlStreamStore` under Django, with the protocol server mounted alongside it for live SSE | `polyglot` |
-| The consuming loop — `Consumer`, `django_consumer`, `run(on_error=…)` | `partisipa_intake` |
+| The consuming loop — `Consumer`, `django_consumer`, `run(on_error=…)`, and naming a record with `subject_of` / `sequence_of` | `partisipa_intake` |
 | Durable reading position (`ConsumerCursor`, `load_cursor`) and the run's status | `partisipa_intake` |
 | The outcome record — `Outcome`, `DjangoOutcomeStore`, the `append`/`project` stages and all three statuses | `partisipa_intake` |
 

--- a/docs/subscriber-cursors.md
+++ b/docs/subscriber-cursors.md
@@ -109,6 +109,12 @@ consumer = django_consumer(store, "submissions", "reporting")
 result = consumer.run(apply, on_error="skip")
 ```
 
+`django_consumer` also takes `subject_of` and `sequence_of` — how to name what a
+record is about, and what it is ordered within — which is worth passing whenever
+your consumer records outcomes of its own: without them the records the loop
+writes name the event's position while yours name a row, and both land in one
+column on one screen.
+
 `django_consumer` fills in the durable cursor and outcome stores, and refuses to
 run inside a transaction you opened — the third bullet above, enforced rather
 than described. Outside Django, build a `rakaia.Consumer` directly and pass your

--- a/examples/partisipa_intake/README.md
+++ b/examples/partisipa_intake/README.md
@@ -38,14 +38,27 @@ is still pending and the next run delivers it again. Under `on_error="skip"` the
 position advances past it and the record is how it is found later. The demo runs
 both against the same kind of failure and prints the two positions.
 
-**One thing the final table shows that is worth reading rather than tidying
-away.** Two records name a row, two name a position in the log. A record this
-consumer writes itself — the refusal, and the row that landed in a closed month —
-can say what the row was called. The two the loop wrote when an apply raised
-cannot: `django_consumer` does not yet let a caller say how to name a message, so
-the loop falls back to the one name it always has. That gap is
-[#272](https://github.com/joshbrooks/rakaia/issues/272); the example shows it as
-it is rather than hiding it behind a subject the loop cannot really supply.
+**Every record names a row, and that takes one argument.** A record this consumer
+writes itself — the refusal, and the row that landed in a closed month — names the
+row because the consumer chose the name. The two the loop writes when an apply
+raises would otherwise name the event's position in the log, because the position
+is the only name the loop has on its own. Passing `subject_of` to
+`django_consumer` tells it the row's name instead, and `sequence_of` says what
+that row is ordered within:
+
+```python
+django_consumer(
+    store,
+    STREAM,
+    CONSUMER,
+    subject_of=lambda message: json.loads(message.data)["row_key"],
+    sequence_of=lambda message: json.loads(message.data)["form_key"],
+)
+```
+
+Worth doing whenever a consumer records outcomes of its own, because both kinds
+end up in one column on one screen, and comparing them is why somebody opened
+it.
 
 ## Run
 

--- a/examples/partisipa_intake/intake/management/commands/demo_intake.py
+++ b/examples/partisipa_intake/intake/management/commands/demo_intake.py
@@ -100,7 +100,17 @@ class Command(BaseCommand):
             ReportingPeriod.objects.create(period=period, closed=closed)
 
     def _consumer(self) -> Any:
-        return django_consumer(DjangoStreamStore(), STREAM, CONSUMER)
+        # Name a record after the row it is about, the same way this consumer
+        # names the ones it writes itself. Without this the loop falls back to
+        # the event's position in the log, and the final table reads as two kinds
+        # of thing in one column.
+        return django_consumer(
+            DjangoStreamStore(),
+            STREAM,
+            CONSUMER,
+            subject_of=lambda message: json.loads(message.data)["row_key"],
+            sequence_of=lambda message: json.loads(message.data)["form_key"],
+        )
 
     def _run(self, on_error: str) -> tuple[Consumed, int]:
         apply = CountedApply(make_apply(DatabaseRows(), consumer=CONSUMER, path=STREAM))
@@ -311,7 +321,7 @@ class Command(BaseCommand):
     def _check_durable(self, store: DjangoStreamStore) -> None:
         # Nothing from the runs above is reused: a new store object, a new
         # consumer, as a restarted process would build.
-        fresh = django_consumer(DjangoStreamStore(), STREAM, CONSUMER)
+        fresh = self._consumer()
         records = fresh.outcomes.latest(CONSUMER, STREAM)
         committed = fresh.cursors.load(CONSUMER, STREAM)
 
@@ -322,15 +332,18 @@ class Command(BaseCommand):
                 f"{', '.join(record.reasons)}"
             )
         self.stdout.write(f"    position {committed}")
-        # Two of these name a row and two name a position, and the difference is
-        # worth reading rather than tidying away. A record this consumer writes
-        # itself can say what the row was called; the two the loop wrote for an
-        # apply that raised cannot, because `django_consumer` does not yet let a
-        # caller say how to name a message (#272). Until it does, the loop falls
-        # back to the one name it always has — where the event sits in the log.
+        # Every one of them names a row, whichever side of the log it came from
+        # and whoever wrote it — the two this consumer wrote itself, and the two
+        # the loop wrote when an apply raised. That is the comparison someone
+        # opens this list to make, so it is asserted rather than admired.
+        positional = [r.subject for r in records if "/" not in r.subject]
+        if positional:
+            raise CommandError(
+                f"these records name a position rather than a row: {positional}"
+            )
         self.stdout.write(
-            "    (rows are named where this consumer wrote the record itself; "
-            "the loop names a position — see #272)"
+            "    (every record names a row — the consumer's own and the loop's "
+            "alike, because the consumer said how)"
         )
 
         if committed != store.get_current_offset(STREAM):

--- a/okf/concepts/consuming-and-outcomes.md
+++ b/okf/concepts/consuming-and-outcomes.md
@@ -61,8 +61,11 @@ Imported from `rakaia`:
 
 Imported from `django_rakaia`:
 
-* `django_consumer(store, path, name, using=…)` → a `DjangoConsumer` with the
-  durable cursor and outcome stores wired in. Its `run` raises
+* `django_consumer(store, path, name, using=…, subject_of=…, sequence_of=…)` → a
+  `DjangoConsumer` with the durable cursor and outcome stores wired in.
+  `subject_of` names what a record the loop writes is about — without it the loop
+  can only name the event's position, which reads as a different kind of thing
+  beside a record the consumer named itself. Its `run` raises
   `CallerTransactionOpen` when the caller already has a transaction open on the
   alias the records are written to — the one hazard the dependency-free core
   cannot see.

--- a/src/django_rakaia/consumer.py
+++ b/src/django_rakaia/consumer.py
@@ -141,6 +141,8 @@ def django_consumer(
     name: str,
     *,
     using: str | None = None,
+    subject_of: Callable[[StreamMessage], str] | None = None,
+    sequence_of: Callable[[StreamMessage], str] | None = None,
 ) -> DjangoConsumer:
     """A consumer of `path`, named `name`, keeping both its cursor and its
     outcomes in the database.
@@ -154,6 +156,18 @@ def django_consumer(
             transaction the caller has open, which is exactly what `run` refuses
             to start inside; a separate alias commits independently, and is the
             way out described in `django_rakaia.outcomes`.
+        subject_of: what a record written for a failed apply is *about*, given
+            the message. Defaults to the event's position in the log.
+
+            Worth passing whenever the consumer records outcomes of its own,
+            because the two end up in one column on one screen: a record the
+            consumer writes can name the row, and without this the records the
+            loop writes for it name a position instead. Comparing those is the
+            reason someone opens that screen.
+        sequence_of: what a message is ordered *within*, given the message.
+            Defaults to the subject. Recorded and not yet acted on — see ADR 0007
+            Decision 7 — so passing it costs nothing now and saves re-deriving a
+            grouping later.
     """
     return DjangoConsumer(
         store=store,
@@ -161,4 +175,6 @@ def django_consumer(
         name=name,
         cursors=DjangoConsumerCursorStore(using=using),
         outcomes=DjangoOutcomeStore(using=using),
+        subject_of=subject_of,
+        sequence_of=sequence_of,
     )

--- a/src/django_rakaia/consumer.py
+++ b/src/django_rakaia/consumer.py
@@ -164,10 +164,24 @@ def django_consumer(
             consumer writes can name the row, and without this the records the
             loop writes for it name a position instead. Comparing those is the
             reason someone opens that screen.
+
+            Two things follow from it being yours to choose. It is called **only
+            when an apply fails**, so an exception from it surfaces on the path
+            you least want to be surprised on, and it propagates out of the run
+            rather than being recorded. And the subject is part of what makes a
+            record distinct: `latest` keeps the newest per subject, so a
+            function that gives two different events the same name shows one
+            record where two were written. The default could not do either — an
+            offset is always readable and always unique.
         sequence_of: what a message is ordered *within*, given the message.
-            Defaults to the subject. Recorded and not yet acted on — see ADR 0007
-            Decision 7 — so passing it costs nothing now and saves re-deriving a
-            grouping later.
+            Defaults to the subject.
+
+            Nothing reads it yet (ADR 0007 Decision 7), which is a weaker reason
+            to pass it than it first appears: the field is written on every
+            record either way, so leaving this out does not omit the grouping, it
+            stores a copy of the subject in its place. The choice is between
+            recording something true and recording noise. It is also shown, as
+            "Sequence", on a record's detail page.
     """
     return DjangoConsumer(
         store=store,

--- a/tests/test_django_rakaia/test_consumer_entry.py
+++ b/tests/test_django_rakaia/test_consumer_entry.py
@@ -15,6 +15,8 @@ in `CLAUDE.md`, arriving from the other side.
 
 from __future__ import annotations
 
+import json
+
 import pytest
 from django.db import transaction
 
@@ -186,3 +188,70 @@ class TestTheAliasIsAskedOfTheStores:
             result = consumer.run(apply, on_error="skip")
 
         assert len(result.outcomes) == 1
+
+
+@pytest.mark.django_db(transaction=True)
+class TestNamingWhatTheLoopRecords:
+    """A caller can say what a record is about, and what it is ordered within.
+
+    The loop has always accepted both; the entry point did not pass them on, so a
+    record written *for* a consumer named the event's position while a record
+    written *by* it named the row. That is two kinds of thing in one column, on
+    the screen where the comparison is the whole point (#272).
+    """
+
+    @staticmethod
+    def _payloads() -> list[bytes]:
+        return [b'{"row": "Fatuberliu/WATER", "form": "prog-2026-01"}']
+
+    def test_a_record_is_named_by_the_caller(self) -> None:
+        consumer = django_consumer(
+            _store_with("submissions", self._payloads()),
+            "submissions",
+            "reporting",
+            subject_of=lambda message: json.loads(message.data)["row"],
+        )
+
+        def apply(_message: StreamMessage) -> None:
+            raise ValueError("no")
+
+        consumer.run(apply, on_error="skip")
+
+        (record,) = DjangoOutcomeStore().latest("reporting", "submissions")
+        assert record.subject == "Fatuberliu/WATER"
+        # The position is still recorded — it is how a replay finds the event.
+        assert record.offset is not None
+
+    def test_the_sequence_a_record_belongs_to_is_the_callers_too(self) -> None:
+        consumer = django_consumer(
+            _store_with("submissions", self._payloads()),
+            "submissions",
+            "reporting",
+            subject_of=lambda message: json.loads(message.data)["row"],
+            sequence_of=lambda message: json.loads(message.data)["form"],
+        )
+
+        def apply(_message: StreamMessage) -> None:
+            raise ValueError("no")
+
+        consumer.run(apply, on_error="skip")
+
+        (record,) = DjangoOutcomeStore().latest("reporting", "submissions")
+        assert record.sequence_key == "prog-2026-01"
+
+    def test_saying_nothing_still_names_the_position(self) -> None:
+        """The default is unchanged, and honest: every event this loop sees is
+        already in the log, so its position is a name it always has."""
+        consumer = django_consumer(
+            _store_with("submissions", self._payloads()),
+            "submissions",
+            "reporting",
+        )
+
+        def apply(_message: StreamMessage) -> None:
+            raise ValueError("no")
+
+        consumer.run(apply, on_error="skip")
+
+        (record,) = DjangoOutcomeStore().latest("reporting", "submissions")
+        assert record.subject == record.offset

--- a/tests/test_django_rakaia/test_consumer_entry.py
+++ b/tests/test_django_rakaia/test_consumer_entry.py
@@ -239,6 +239,29 @@ class TestNamingWhatTheLoopRecords:
         (record,) = DjangoOutcomeStore().latest("reporting", "submissions")
         assert record.sequence_key == "prog-2026-01"
 
+    def test_the_sequence_defaults_to_the_subject(self) -> None:
+        """The other half of saying nothing, and it was asserted by nothing.
+
+        Review mutated `sequence_of = sequence_of or subject_of` in the loop to a
+        constant and the whole suite stayed green: the docstring promised the
+        default and no test read it. Passing only `subject_of` is the case that
+        can see it.
+        """
+        consumer = django_consumer(
+            _store_with("submissions", self._payloads()),
+            "submissions",
+            "reporting",
+            subject_of=lambda message: json.loads(message.data)["row"],
+        )
+
+        def apply(_message: StreamMessage) -> None:
+            raise ValueError("no")
+
+        consumer.run(apply, on_error="skip")
+
+        (record,) = DjangoOutcomeStore().latest("reporting", "submissions")
+        assert record.sequence_key == record.subject == "Fatuberliu/WATER"
+
     def test_saying_nothing_still_names_the_position(self) -> None:
         """The default is unchanged, and honest: every event this loop sees is
         already in the log, so its position is a name it always has."""


### PR DESCRIPTION
A failure record names the thing it is about, and until now a consumer could only choose that name for the records it wrote itself. The ones the loop wrote when the work raised fell back to the event's position in the log, because that is the only name the loop has on its own. The result was a list meant to be read as one thing that held two kinds, and comparing them is exactly why somebody opens it.

The loop has always accepted both a way to name what a record is about and a way to say what it is ordered within; the Django entry point simply did not pass them on, and now does. The worked example passes both and asserts that every record it produces names a row — so the thing it used to point at as a known gap is now the thing it demonstrates.

Closes #272.