### PR TITLE
Write down the third way a saved position meets the wrong log

### DIFF
--- a/docs/adr/0006-changing-backends-is-a-copy.md
+++ b/docs/adr/0006-changing-backends-is-a-copy.md
@@ -38,14 +38,22 @@ All are symmetric — a format is refused in whichever direction it is carried,
 and accepted in whichever direction too.
 
 **The third row is not a variation of the second, and it is the more reachable
-one.** Two `DjangoStreamStore`s on different database aliases, or two
-`JsonlStreamStore`s at different roots, are two independent logs numbering their
-events from the same start. Nothing about them differs in format, because nothing
+one.** Two `DjangoStreamStore`s on different database aliases are two independent
+logs numbering their events from the same start. Nothing about them differs in format, because nothing
 about them differs at all except where they keep their data — so there is not even
 a format to compare, and a cursor crosses between them as freely as within one.
 Measured on this tree, three events on one alias and ten on another: a position
 saved against the first resumes against the second as `advanced`, delivering seven
 events and skipping three permanently.
+
+Worth knowing while reading the tests: the second row is *modelled* by two
+`JsonlStreamStore`s at different roots, which is literally this third row — the
+file says so, on the grounds that `rakaia.offsets` sees a format rather than a
+class, and for the offset module that is exactly right. What demonstrates the
+second row for real is the pin that `DjangoStreamStore` issues the same format
+this one does (`tests/test_django_rakaia/test_offset_format_pin.py`). So one
+setup has been standing in for both rows, and only the alias case below separates
+them.
 
 It is the more reachable row because this codebase uses that seam on purpose.
 `DjangoStreamStore(using=…)` exists so a from-scratch rebuild can replay into a
@@ -54,7 +62,7 @@ argument, and `rebuild_and_verify` composes all three. Nothing in that path
 resumes a consumer, so nothing is wrong today — but "the same store class" reads
 as "the same store", and it is not.
 
-The second entry is new. Until `JsonlStreamStore` existed, every pair of stores
+The `DjangoStreamStore` ↔ `JsonlStreamStore` entry is new. Until `JsonlStreamStore` existed, every pair of stores
 disagreed about format, so every cross-store cursor was refused by accident of
 shape. That protection is gone for one pair of three, and it was never a designed
 guarantee — `rakaia.offsets` refuses a cursor whose format it can see belongs to

--- a/docs/adr/0006-changing-backends-is-a-copy.md
+++ b/docs/adr/0006-changing-backends-is-a-copy.md
@@ -32,9 +32,27 @@ stores issue the same offset *format*:
 |---|---|
 | in-memory ↔ either other | `ForeignOffset`. Loud, immediate, correct. |
 | `DjangoStreamStore` ↔ `JsonlStreamStore` | **Accepted.** Both issue `PLAIN`. |
+| one store class, two locations | **Accepted.** Not a pair of backends at all. |
 
-Both are symmetric — a format is refused in whichever direction it is carried,
+All are symmetric — a format is refused in whichever direction it is carried,
 and accepted in whichever direction too.
+
+**The third row is not a variation of the second, and it is the more reachable
+one.** Two `DjangoStreamStore`s on different database aliases, or two
+`JsonlStreamStore`s at different roots, are two independent logs numbering their
+events from the same start. Nothing about them differs in format, because nothing
+about them differs at all except where they keep their data — so there is not even
+a format to compare, and a cursor crosses between them as freely as within one.
+Measured on this tree, three events on one alias and ten on another: a position
+saved against the first resumes against the second as `advanced`, delivering seven
+events and skipping three permanently.
+
+It is the more reachable row because this codebase uses that seam on purpose.
+`DjangoStreamStore(using=…)` exists so a from-scratch rebuild can replay into a
+disposable database; `DjangoExecutor` and `DjangoProjectionReader` take the same
+argument, and `rebuild_and_verify` composes all three. Nothing in that path
+resumes a consumer, so nothing is wrong today — but "the same store class" reads
+as "the same store", and it is not.
 
 The second entry is new. Until `JsonlStreamStore` existed, every pair of stores
 disagreed about format, so every cross-store cursor was refused by accident of

--- a/tests/test_django_rakaia/test_using_seam.py
+++ b/tests/test_django_rakaia/test_using_seam.py
@@ -451,6 +451,12 @@ class TestTwoAliasesAreTwoLogs:
     same start. There is nothing for `rakaia.offsets` to compare, so a position
     saved against one is accepted against the other without a rewind.
 
+    Two neighbours already pin the parts this builds on:
+    `tests/test_rakaia/test_cross_backend_cursors.py` for the cross-backend pair,
+    and `tests/test_django_rakaia/test_offset_format_pin.py` for the fact that
+    makes that pair real — that `DjangoStreamStore` issues the same format the
+    file store does. What is new here is the same class at two locations.
+
     Nothing is wrong today — the alias seam exists so a rebuild can replay into a
     disposable database, and nothing on that path resumes a consumer. This asserts
     the defect so that leaving it is a decision, the way

--- a/tests/test_django_rakaia/test_using_seam.py
+++ b/tests/test_django_rakaia/test_using_seam.py
@@ -9,15 +9,20 @@ instead of a bespoke in-memory engine.
 
 from __future__ import annotations
 
+import json
+
 import pytest
 
+from django_rakaia.django_store import DjangoStreamStore
 from django_rakaia.effect_executor import DjangoExecutor
 from django_rakaia.projection_reader import DjangoProjectionReader
 from django_rakaia.store import get_store
 from rakaia.effects import Ref, Upsert
+from rakaia.offsets import format_of
 from rakaia.registry import HandlerRegistry, UpcasterRegistry
 from rakaia.replay import replay
 from rakaia.seed import seed_stream
+from rakaia.subscription import poll
 
 from .models import Area, FinanceLine
 
@@ -434,3 +439,52 @@ class TestTheDefaultAliasIsUnchanged:
         store.append("s", b'{"n": 1}')
 
         assert [m.data for m in store.read("s")[0]] == [b'{"n": 1}']
+
+
+@pytest.mark.django_db(transaction=True, databases=["default", "overlay"])
+class TestTwoAliasesAreTwoLogs:
+    """One store class at two locations is two logs, and a cursor crosses freely.
+
+    The third row of ADR 0006's table, and the one that is not a pair of backends
+    at all: `DjangoStreamStore()` and `DjangoStreamStore(using="overlay")` are the
+    same class, issue the same offset format, and number their events from the
+    same start. There is nothing for `rakaia.offsets` to compare, so a position
+    saved against one is accepted against the other without a rewind.
+
+    Nothing is wrong today — the alias seam exists so a rebuild can replay into a
+    disposable database, and nothing on that path resumes a consumer. This asserts
+    the defect so that leaving it is a decision, the way
+    `tests/test_rakaia/test_cross_backend_cursors.py` does for the backend pair.
+    #232 is what changes it, and this is where that change announces itself.
+    """
+
+    @staticmethod
+    def _seed(store: DjangoStreamStore, count: int) -> None:
+        store.create("s")
+        for i in range(count):
+            store.append("s", json.dumps({"n": i}).encode())
+
+    def test_a_cursor_from_one_alias_skips_events_on_the_other(self) -> None:
+        self._seed(DjangoStreamStore(), 3)
+        self._seed(DjangoStreamStore(using="overlay"), 10)
+
+        cursor = poll(DjangoStreamStore(), "s", None).cursor
+        resumed = poll(DjangoStreamStore(using="overlay"), "s", cursor)
+
+        assert resumed.rewound is False, "a rewind here would make this loud"
+        assert resumed.status == "advanced"
+        # Seven of ten. The first three exist on the overlay and are never
+        # delivered, because the position from the other log claims they were.
+        delivered = [json.loads(m.data)["n"] for m in resumed.messages]
+        assert delivered == [3, 4, 5, 6, 7, 8, 9]
+
+    def test_the_offsets_are_indistinguishable(self) -> None:
+        """Why nothing catches it: there is no format difference to see."""
+        self._seed(DjangoStreamStore(), 2)
+        self._seed(DjangoStreamStore(using="overlay"), 2)
+
+        mine = poll(DjangoStreamStore(), "s", None).cursor
+        theirs = poll(DjangoStreamStore(using="overlay"), "s", None).cursor
+
+        assert mine == theirs
+        assert format_of(mine) is format_of(theirs)

--- a/tests/test_rakaia/test_cross_backend_cursors.py
+++ b/tests/test_rakaia/test_cross_backend_cursors.py
@@ -16,6 +16,12 @@ A table in a Markdown file rots. This pins it where it is decided, the way
 gives `JsonlStreamStore` its own offset format, or lands #232, these go red and
 the ADR has to be amended rather than quietly left wrong.
 
+One store class at two locations is a *third* row of that table, and it is
+pinned in `tests/test_django_rakaia/test_using_seam.py` — it needs two database
+aliases, so it cannot live in this package (the same reason
+`test_offset_format_pin.py` was split out). Note that the modelling below is
+itself an instance of that third row.
+
 The two entry-counting stores are modelled here by two `JsonlStreamStore`s at
 different roots. That is not a stand-in for the durable store: the behaviour
 under test belongs to `rakaia.offsets`, which sees a *format*, not a class, and


### PR DESCRIPTION
The decision record about changing where a log is kept carries a table of what a consumer's saved position does when it meets the wrong store, and that table was missing a case: the same kind of store in two places. Two databases, or two directories, hold two independent logs numbering their events from the same start — so there is not even a difference of format to notice, and a saved position crosses between them more freely than it does between two different kinds of store.

It is the most reachable of the three cases, because this codebase uses that seam deliberately: a from-scratch rebuild replays into a disposable database precisely so it can be verified without touching the real one. Nothing on that path resumes a consumer, so nothing is broken today. This changes no behaviour — it adds the row to the table and pins it with tests, the way the other rows are pinned, so that leaving it is a decision rather than an oversight. Found while investigating #232, which is what would change it.