### PR TITLE
Name the change labels and metadata keys an event carries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,14 @@ runnable demo for each.
   name the event's position in the log — two kinds of thing in one column, on the
   screen where comparing them is the whole point. The worked example passes both
   and asserts that every record it produces names a row. (#272)
+- **The change label and the event metadata now have named types.**
+  `ChangeLabel` lists the four labels rakaia acts on (`insert`, `create`,
+  `update`, `delete`), and `EnvelopeMetadata` lists the metadata keys it reads or
+  writes (`user`, `url`, `causation`). The `label` and `metadata` fields on
+  `AppendOptions` and `StreamMessage` are annotated with them, so an editor can
+  offer the known values. Both still accept any string or dictionary, so an
+  application label such as `import`, or an extra metadata key, is not a type
+  error — and for the same reason a misspelling is not one either. (#277, #278)
 
 ### Changed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,9 @@
   the lockfile. Do **not** set it to `latest`, which this file used to advise:
   pyright nags that a newer release exists, and taking its suggestion typechecks
   against a different pyright than CI — the nag is cosmetic, the divergence is
-  not. Django's synthesised attributes are declared explicitly (see the
+  not. The recipe silences the nag; a bare `uv run pyright` still prints it.
+  Upgrading pyright is its own change: bump the pin in `pyproject.toml` and the
+  `justfile` together. Django's synthesised attributes are declared explicitly (see the
   `if TYPE_CHECKING` blocks in `django_rakaia/models.py`) rather than waved
   through with ignores.
 - **Lint and format take no path arguments.** `[tool.ruff]` in `pyproject.toml`
@@ -65,6 +67,14 @@
   only by `just check`. If you add or remove an exported name, run
   `just api-reference` and commit the result — and rebase before merging, since
   the count line at the bottom is a single line two branches will both rewrite.
+  The check compares against the last commit, so run it *after* committing;
+  before that, a correctly regenerated file still reads as out of date.
+- **Adding a public name touches five places.** `_EXPORTS` in the package
+  `__init__` (and, for `rakaia`, its `if TYPE_CHECKING` import block), the
+  expected set in `tests/test_rakaia/test_public_api.py`, `GROUPS` in
+  `scripts/gen_api_reference.py`, then `just api-reference`. Two of those fail
+  nothing when missed: a name absent from `GROUPS` lands under *Everything else*,
+  and one absent from the `TYPE_CHECKING` block is invisible to type checkers.
 - To reproduce the **full** CI gate locally you also need the docs extra
   (`zensical` isn't in `dev`/`django`): `uv sync --extra dev --extra django --extra docs`,
   then `uv run zensical build`. Without `--extra docs` that step fails with

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -46,11 +46,13 @@ page is the contract.
 | `migrate_all` | `rakaia` | `(source: 'ReadableStore', target: 'WritableStore', *, batch_size: 'int' = 500) -> 'list[Migration]'` | Copy every stream `source` can list, in listing order. |
 | `Migration` | `rakaia` | `(path: 'str', events: 'int', offsets_preserved: 'bool', head_preserved: 'bool', notes: 'tuple[str, ...]' = <factory>) -> None` | What one stream's copy achieved, and what it could not carry. |
 | `create_stream_event` | `django_rakaia` | `(stream_paths: str \| list[str] \| collections.abc.Callable[[django.db.models.base.Model], str \| list[str]], to_dataclass: collections.abc.Callable[[django.db.models.base.Model], typing.Any], instance: django.db.models.base.Model, action: str, using: str \| None = None) -> django_rakaia.models.StreamEvent` | Create a stream event for the given model instance. |
-| `AppendOptions` | `rakaia` | `(seq: 'str \| None' = None, content_type: 'str \| None' = None, producer_id: 'str \| None' = None, producer_epoch: 'int \| None' = None, producer_seq: 'int \| None' = None, close: 'bool' = False, label: 'str' = '', metadata: 'dict \| None' = None, event_ts: 'float \| None' = None) -> None` | Options for append operations. |
+| `AppendOptions` | `rakaia` | `(seq: 'str \| None' = None, content_type: 'str \| None' = None, producer_id: 'str \| None' = None, producer_epoch: 'int \| None' = None, producer_seq: 'int \| None' = None, close: 'bool' = False, label: 'ChangeLabel \| str' = '', metadata: 'EnvelopeMetadata \| dict[str, Any] \| None' = None, event_ts: 'float \| None' = None) -> None` | Options for append operations. |
 | `AppendResult` | `rakaia` | `(message: 'StreamMessage \| None' = None, producer_result: 'ProducerValidationResult \| None' = None, stream_closed: 'bool' = False) -> None` | Result of an append operation. |
 | `CloseResult` | `rakaia` | `(final_offset: 'str' = '', already_closed: 'bool' = False, producer_result: 'ProducerValidationResult \| None' = None) -> None` | Result of a close operation. |
 | `ClosedBy` | `rakaia` | `(producer_id: 'str', epoch: 'int', seq: 'int') -> None` | Tracks which producer tuple closed a stream (for idempotent close). |
-| `StreamMessage` | `rakaia` | `(data: 'bytes', offset: 'str', timestamp: 'float', event_ts: 'float \| None' = None, label: 'str' = '', metadata: 'dict \| None' = None) -> None` | A single message in a stream. |
+| `StreamMessage` | `rakaia` | `(data: 'bytes', offset: 'str', timestamp: 'float', event_ts: 'float \| None' = None, label: 'ChangeLabel \| str' = '', metadata: 'EnvelopeMetadata \| dict[str, Any] \| None' = None) -> None` | A single message in a stream. |
+| `ChangeLabel` | `rakaia` | — | — |
+| `EnvelopeMetadata` | `rakaia` | — | The metadata keys rakaia reads or writes on an event. |
 | `Poll` | `rakaia` | `(messages: 'list[StreamMessage]', cursor: 'str \| None', status: 'PollStatus') -> None` | The result of polling a stream from a cursor. |
 | `PollStatus` | `rakaia` | — | — |
 | `poll` | `rakaia` | `(store: 'CursorStore', path: 'str', cursor: 'str \| None') -> 'Poll'` | Read `path` forward from `cursor`, detecting a rewound log. |
@@ -151,7 +153,7 @@ page is the contract.
 | `get_provenance` | `rakaia` | `() -> 'dict[str, Any]'` | The current ambient provenance (a copy; empty dict if none is set). |
 | `ProvenanceMiddleware` | `django_rakaia` | `(get_response: 'Callable[[Any], Any]') -> 'None'` | Stamp the acting user + request path onto envelope metadata per request. |
 | `envelope_actor` | `rakaia` | `(msg: 'StreamMessage', event: 'dict[str, Any]', *, owner_key: 'str' = 'user_id') -> 'Any'` | The acting user: the envelope's ``metadata['user']`` (the editor), falling back to the payload's own owner FK (``event[owner_key]``) when there is no request-context actor (bulk import, management… |
-| `label_marker` | `rakaia` | `(label: 'str') -> 'str'` | Map an envelope label to the `/history` diff marker `+` / `~` / `-`. |
+| `label_marker` | `rakaia` | `(label: 'ChangeLabel \| str') -> 'str'` | Map an envelope label to the `/history` diff marker `+` / `~` / `-`. |
 | `materialize_history` | `django_rakaia` | `(store: 'Any', path: 'str', model_label: 'str', *, subject_of: 'Callable[[dict[str, Any]], Any]', defaults_of: 'Callable[[Any, dict[str, Any]], dict[str, Any]]', subject_field: 'str' = 'subject', version_field: 'str' = 'version', version_of: 'Callable[[Any], Any] \| None' = None, executor: 'Any \| None' = None) -> 'list[Effect]'` | Read `path` and materialise its `/history` audit rows into `model_label`. |
 | `history_effects` | `rakaia` | `(messages: 'Sequence[StreamMessage]', model_label: 'str', *, subject_of: 'Callable[[dict[str, Any]], Any]', defaults_of: 'Callable[[StreamMessage, dict[str, Any]], dict[str, Any]]', subject_field: 'str' = 'subject', version_field: 'str' = 'version', version_of: 'Callable[[StreamMessage], Any] \| None' = None) -> 'list[Effect]'` | One idempotent audit-row upsert per event in `messages`. |
 | `ENVELOPE_TS` | `rakaia` | — | — |
@@ -266,6 +268,6 @@ page is the contract.
 
 ## Appendix — coverage
 
-170 exported names across 15 sections. 148 carry a docstring; 22 do not and show `—` above.
+172 exported names across 15 sections. 149 carry a docstring; 23 do not and show `—` above.
 
-Undocumented: `AnyEffect`, `DEFAULT_NORMALIZERS`, `ENVELOPE_TS`, `EXCEPTION_TYPE_KEY`, `Effect`, `GREEN`, `HANDLERS_META_STREAM`, `Normalizer`, `OnErrorPolicy`, `OutcomeStatus`, `PollStatus`, `ProducerValidationResult`, `REASON_CODES`, `RED`, `REDUCERS_META_STREAM`, `SCRATCH_PATH`, `Stage`, `UNHANDLED`, `UPCASTERS_META_STREAM`, `VACUOUS`, `__version__`, `app`.
+Undocumented: `AnyEffect`, `ChangeLabel`, `DEFAULT_NORMALIZERS`, `ENVELOPE_TS`, `EXCEPTION_TYPE_KEY`, `Effect`, `GREEN`, `HANDLERS_META_STREAM`, `Normalizer`, `OnErrorPolicy`, `OutcomeStatus`, `PollStatus`, `ProducerValidationResult`, `REASON_CODES`, `RED`, `REDUCERS_META_STREAM`, `SCRATCH_PATH`, `Stage`, `UNHANDLED`, `UPCASTERS_META_STREAM`, `VACUOUS`, `__version__`, `app`.

--- a/justfile
+++ b/justfile
@@ -437,8 +437,10 @@ fmt:
 # `latest`. pyright-python nags when a newer release exists and suggests
 # `latest`, which silently typechecks against a different pyright than CI — the
 # one thing a gate must not do. Bump this with the `pyright` pin in pyproject.
+# `PYRIGHT_PYTHON_IGNORE_WARNINGS` silences that nag, which prints after the
+# results and pushes real errors out of a `| tail`; it changes nothing that runs.
 typecheck:
-    PYRIGHT_PYTHON_FORCE_VERSION=1.1.411 uv run pyright src/
+    PYRIGHT_PYTHON_IGNORE_WARNINGS=1 PYRIGHT_PYTHON_FORCE_VERSION=1.1.411 uv run pyright src/
 
 # Regenerate docs/api-reference.md from what the packages actually export.
 # Commit the result; `api-reference-check` fails if it drifts.

--- a/scripts/gen_api_reference.py
+++ b/scripts/gen_api_reference.py
@@ -61,6 +61,8 @@ GROUPS: dict[str, tuple[str, ...]] = {
         "CloseResult",
         "ClosedBy",
         "StreamMessage",
+        "ChangeLabel",
+        "EnvelopeMetadata",
         "Poll",
         "PollStatus",
         "poll",

--- a/src/rakaia/__init__.py
+++ b/src/rakaia/__init__.py
@@ -169,10 +169,12 @@ if TYPE_CHECKING:
     from .types import (
         AppendOptions,
         AppendResult,
+        ChangeLabel,
         ClosedBy,
         CloseResult,
         ContentTypeMismatch,
         EmptyJsonArray,
+        EnvelopeMetadata,
         InvalidJson,
         InvalidOffset,
         ProducerAccepted,
@@ -246,6 +248,9 @@ _EXPORTS: dict[str, str] = {
     "AppendOptions": "rakaia.types",
     "AppendResult": "rakaia.types",
     "CloseResult": "rakaia.types",
+    # The event-sourcing envelope's known values
+    "ChangeLabel": "rakaia.types",
+    "EnvelopeMetadata": "rakaia.types",
     # Producer validation
     "ProducerValidationResult": "rakaia.types",
     "ProducerAccepted": "rakaia.types",

--- a/src/rakaia/context.py
+++ b/src/rakaia/context.py
@@ -22,7 +22,7 @@ per-append annotation.
 from __future__ import annotations
 
 import contextlib
-from collections.abc import Iterator
+from collections.abc import Iterator, Mapping
 from contextvars import ContextVar
 from typing import Any
 
@@ -51,7 +51,7 @@ def get_provenance() -> dict[str, Any]:
     return dict(_provenance.get() or {})
 
 
-def merge_provenance(explicit: dict[str, Any] | None) -> dict[str, Any] | None:
+def merge_provenance(explicit: Mapping[str, Any] | None) -> dict[str, Any] | None:
     """Merge ambient provenance *under* `explicit` metadata (explicit wins).
 
     Returns None when both are empty, so a plain append with no provenance and

--- a/src/rakaia/history.py
+++ b/src/rakaia/history.py
@@ -23,10 +23,10 @@ from collections.abc import Callable, Sequence
 from typing import Any
 
 from .effects import Effect, Upsert
-from .types import StreamMessage
+from .types import ChangeLabel, StreamMessage
 
 
-def label_marker(label: str) -> str:
+def label_marker(label: ChangeLabel | str) -> str:
     """Map an envelope label to the `/history` diff marker `+` / `~` / `-`.
 
     ``insert``/``create`` → ``+``, ``delete`` → ``-``, everything else (incl.
@@ -48,9 +48,9 @@ def envelope_actor(
     request-context actor (bulk import, management command, migration). Returns
     None when neither is present.
     """
-    meta = msg.metadata or {}
-    if meta.get("user") is not None:
-        return meta["user"]
+    actor = (msg.metadata or {}).get("user")
+    if actor is not None:
+        return actor
     return event.get(owner_key)
 
 

--- a/src/rakaia/types.py
+++ b/src/rakaia/types.py
@@ -8,7 +8,7 @@ and protocol constants.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Literal
+from typing import Any, Literal, TypedDict
 
 # =============================================================================
 # Protocol constants
@@ -115,6 +115,38 @@ class InvalidOffset(StreamError, ValueError):
 
 
 # =============================================================================
+# The event-sourcing envelope
+# =============================================================================
+
+ChangeLabel = Literal["insert", "create", "update", "delete"]
+"""The change labels rakaia itself acts on.
+
+`history.label_marker` turns ``insert``/``create`` into ``+``, ``delete`` into
+``-`` and anything else into ``~``, and `@stream_model` writes ``create``,
+``update`` and ``delete``. The ``label`` fields accept these *or any string*:
+an application label such as ``import`` is legitimate and lands on ``~``, so
+naming the set lets an editor offer it without making other labels an error.
+"""
+
+
+class EnvelopeMetadata(TypedDict, total=False):
+    """The metadata keys rakaia reads or writes on an event.
+
+    ``user`` is the actor — `django_rakaia.append_event` writes it and
+    `history.envelope_actor` reads it. ``url`` and ``causation`` are what a
+    request-scoped `provenance()` block conventionally carries.
+
+    The ``metadata`` fields accept this *or any* ``dict[str, Any]``, so extra
+    keys are not an error. ``total=False`` on the class rather than
+    ``NotRequired`` per key keeps it importable on Python 3.10.
+    """
+
+    user: Any
+    url: str
+    causation: str
+
+
+# =============================================================================
 # Data structures
 # =============================================================================
 
@@ -147,13 +179,15 @@ class StreamMessage:
     sets ``event_ts`` to the original historical event time while its transport
     ``timestamp`` is ≈now. ``merge_replay(order_key=ENVELOPE_TS)`` orders on this."""
 
-    label: str = ""
+    label: ChangeLabel | str = ""
     """Optional event-sourcing envelope: the change label (e.g. create/update/
-    delete → +/~/-). Empty for pure-protocol messages; ignored by the transport."""
+    delete → +/~/-; see `ChangeLabel`). Empty for pure-protocol messages;
+    ignored by the transport."""
 
-    metadata: dict | None = None
-    """Optional event-sourcing envelope: an open metadata dict (actor, url,
-    causation, …). None for pure-protocol messages; ignored by the transport."""
+    metadata: EnvelopeMetadata | dict[str, Any] | None = None
+    """Optional event-sourcing envelope: an open metadata dict (``user``,
+    ``url``, ``causation``, …; see `EnvelopeMetadata`). None for pure-protocol
+    messages; ignored by the transport."""
 
 
 @dataclass
@@ -314,9 +348,9 @@ class AppendOptions:
     producer_epoch: int | None = None
     producer_seq: int | None = None
     close: bool = False
-    label: str = ""
+    label: ChangeLabel | str = ""
     """Event-sourcing envelope label to record on the appended message."""
-    metadata: dict | None = None
+    metadata: EnvelopeMetadata | dict[str, Any] | None = None
     """Event-sourcing envelope metadata to record on the appended message."""
     event_ts: float | None = None
     """Event-sourcing envelope timestamp: the event's **logical** time (e.g. a

--- a/tests/test_rakaia/test_history.py
+++ b/tests/test_rakaia/test_history.py
@@ -3,13 +3,14 @@
 from __future__ import annotations
 
 import json
+from typing import get_args
 
 from rakaia.history import (
     envelope_actor,
     history_effects,
     label_marker,
 )
-from rakaia.types import StreamMessage
+from rakaia.types import ChangeLabel, EnvelopeMetadata, StreamMessage
 
 
 def _msg(
@@ -31,6 +32,31 @@ class TestLabelMarker:
         assert label_marker("delete") == "-"
         assert label_marker("update") == "~"
         assert label_marker("") == "~"  # raw append → update marker
+
+    def test_change_label_names_every_label_the_marker_distinguishes(self):
+        # `ChangeLabel` is documentation for a type checker, so nothing else
+        # notices if it and `label_marker` drift apart. Every label the marker
+        # special-cases must be in the set, and the set must hold nothing that
+        # only reaches the fallback except `update`, which `@stream_model` writes.
+        labels = set(get_args(ChangeLabel))
+        assert labels == {"insert", "create", "update", "delete"}
+        assert {label_marker(label) for label in labels} == {"+", "~", "-"}
+
+    def test_a_label_outside_the_set_is_still_accepted(self):
+        assert label_marker("import") == "~"
+        assert _msg({}, label="import").label == "import"
+
+
+class TestEnvelopeMetadata:
+    def test_names_the_key_envelope_actor_reads(self):
+        assert "user" in EnvelopeMetadata.__optional_keys__
+        assert not EnvelopeMetadata.__required_keys__
+        metadata: EnvelopeMetadata = {"user": 42}
+        assert envelope_actor(_msg({}, metadata=dict(metadata)), {}) == 42
+
+    def test_extra_keys_are_still_accepted(self):
+        msg = _msg({}, metadata={"user": 1, "tenant": "acme"})
+        assert msg.metadata == {"user": 1, "tenant": "acme"}
 
 
 class TestEnvelopeActor:

--- a/tests/test_rakaia/test_public_api.py
+++ b/tests/test_rakaia/test_public_api.py
@@ -48,6 +48,8 @@ RAKAIA_PUBLIC = {
     # types
     "AppendOptions",
     "AppendResult",
+    "ChangeLabel",
+    "EnvelopeMetadata",
     "ClosedBy",
     "CloseResult",
     "ProducerState",


### PR DESCRIPTION
An event's change label and its metadata were typed as a bare string and a bare dictionary, so nothing told a reader which labels the history view recognises or which metadata key holds the actor. This adds two named types listing the values rakaia itself reads and writes: the four change labels, and the `user` / `url` / `causation` metadata keys. The append options and stored messages now use them, so an editor offers the known values.

Both types stay open on purpose. An application label such as `import`, or an extra metadata key, is still accepted — which also means a misspelling is still not a type error. That was a deliberate choice: the library's own code and tests use labels outside the four, so enforcing the set would have been a breaking change. Closes #277, closes #278.