### PR TITLE
Cut 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ runnable demo for each.
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-09-10
+
 ### Added
 
 - **A consumer can say how the records written for it are named.**

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -187,6 +187,9 @@ No example exercises these yet — a good place to contribute a demo:
 - `migrate_stream` / `migrate_all` — moving a log between backends. `polyglot`
   runs *on* the file-backed store but was seeded there, never copied onto it.
 - `DjangoExecutor(batch_updates=True)` and `DjangoExecutor(normalizers=...)`.
+- `ChangeLabel` and `EnvelopeMetadata` — the named types for an event's change
+  label and metadata keys. They annotate fields every example already writes, but
+  no example imports them or shows an editor offering the known values.
 - `DriftLedger` as an object. `orders` triggers drift detection via
   `on_drift="raise"` but never reads the ledger.
 - The file-backed and in-memory outcome stores (`JsonlOutcomeStore`,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 # PyPI by an unrelated placeholder. The import name is unaffected:
 #   pip install rakaia-streams   ->   import rakaia
 name = "rakaia-streams"
-version = "0.4.0"
+version = "0.5.0"
 description = "Python server implementation of the Durable Streams protocol"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -1215,7 +1215,7 @@ wheels = [
 
 [[package]]
 name = "rakaia-streams"
-version = "0.4.0"
+version = "0.5.0"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
Two changes since the last release, both about naming things a consumer already
writes. A consumer can now say how the failure records written on its behalf are
named, so the screen that lists them compares like with like instead of mixing
rows with log positions. And the label and metadata an event carries have named
types, so an editor can offer the values the library acts on — while still
accepting an application's own label, which means a misspelling is not caught.

Nothing breaks and nothing works differently without saying so, so there is no
upgrading note; the release is documentation of names that were already
conventions. The two new types have no example using them yet, and are listed as
a known gap rather than left for the coverage matrix to imply.